### PR TITLE
Fix THIH tests and add back in to coalton tests

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -96,7 +96,8 @@
   :license "MIT"
   :depends-on (#:coalton
                #:fiasco
-               #:quil-coalton/tests)
+               #:quil-coalton/tests
+               #:thih-coalton/tests)
   :perform (asdf:test-op (o s) nil)
   :pathname "tests/"
   :serial t

--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -367,7 +367,7 @@
   ;; Class Environments
 
   (define-type ClassEnv
-    (ClassEnv (MonadFail :m => (Id -> (:m Class))) (List Type)))
+    (ClassEnv (Id -> (Optional Class)) (List Type)))
 
   (declare classes (ClassEnv -> (Id -> (Optional Class))))
   (define (classes env)
@@ -620,7 +620,7 @@
                   (member e vs))
                 (tv qt)))
           (ks (map kind vs_))
-          (gens (map TGen (range (length vs_))))
+          (gens (map TGen (range 0 (- (length vs_) 1))))
           (s (Subst (zip vs_ gens))))
       (Forall ks (apply s qt))))
 

--- a/examples/thih/tests/thih-coalton-tests.lisp
+++ b/examples/thih/tests/thih-coalton-tests.lisp
@@ -30,5 +30,5 @@
                    (Forall
                     (make-list Star)
                     (Qual Nil
-                          (mkFn (TGen 1)
-                                (TGen 1)))))))))
+                          (mkFn (TGen 0)
+                                (TGen 0)))))))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -3,7 +3,8 @@
 (defun run-coalton-tests ()
   (run-package-tests
    :packages '(:coalton-tests
-               :quil-coalton-tests)
+               :quil-coalton-tests
+               :thih-coalton-tests)
    :interactive t))
 
 (defun set-equalp (set1 set2)


### PR DESCRIPTION
Fixes #4 

- Fix incorrect type signature in ClassEnv in thih
- Fix incorrect usage of range in thih
- Fix incorrect expected value in thih tests
- Add thih tests as a dependency for coalton tests
- Add thih tests to be run with coalton tests