### PR TITLE
Fix a mapcan call

### DIFF
--- a/src/ast/free-variables.lisp
+++ b/src/ast/free-variables.lisp
@@ -46,9 +46,8 @@ NOTE: Just because a variable shows up in the list does *NOT* mean all occurrenc
                                (union bv (pattern-variables
                                           (match-branch-pattern branch)))))))
 		 (node-seq
-		  (mapcan (lambda (node)
-			    (analyze node bv))
-			  (node-seq-subnodes expr))))))
+                  (dolist (subnode (node-seq-subnodes expr))
+                    (analyze subnode bv))))))
       (analyze value nil)
       fv)))
 


### PR DESCRIPTION
The MAPCAN fix is done in the first commit and should not be controversial.

The COALTON-SAFE package adds sanity to the whole system and makes MAPCAN safe everywhere at the expense of efficiency.