### PR TITLE
Add variable capture to lisp nodes

### DIFF
--- a/examples/quil-coalton/src/parser.lisp
+++ b/examples/quil-coalton/src/parser.lisp
@@ -9,7 +9,7 @@
 
   (declare incomplete-parse-error (String -> ParseError))
   (define (incomplete-parse-error str)
-    (Error (lisp String (cl:format cl:nil "Parser did not complete: ~A" str))))
+    (Error (lisp String (str) (cl:format cl:nil "Parser did not complete: ~A" str))))
 
   (define-type (Parser :a)
     (Parser (StringView -> (Result ParseError (Tuple :a StringView)))))

--- a/examples/quil-coalton/src/string-view.lisp
+++ b/examples/quil-coalton/src/string-view.lisp
@@ -7,7 +7,7 @@
 
   (declare make-string-view (String -> StringView))
   (define (make-string-view str)
-    (lisp StringView
+    (lisp StringView (str)
       (StringView
        (coalton:veil
         (cl:make-array (cl:length (cl:the (cl:vector cl:character) str))
@@ -17,7 +17,7 @@
 
   (declare next-char (StringView -> (Optional (Tuple Char StringView))))
   (define (next-char str)
-    (lisp (Optional (Tuple Char StringView))
+    (lisp (Optional (Tuple Char StringView)) (str)
       (cl:let* ((arr (coalton:unveil (cl:slot-value str '_0))))
         (cl:declare (cl:type (cl:vector cl:character) arr)
                     ;; Muffle sbcl wanting to optimize aref. This cannot be optimized.
@@ -40,11 +40,11 @@
 
   (declare string-view-get (StringView -> String))
   (define (string-view-get str)
-    (lisp String (coalton:unveil (cl:slot-value str '_0))))
+    (lisp String (str) (coalton:unveil (cl:slot-value str '_0))))
 
   (declare string-view-empty-p (StringView -> Boolean))
   (define (string-view-empty-p str)
-    (lisp Boolean
+    (lisp Boolean (str)
       (cl:let* ((arr (coalton:unveil (cl:slot-value str '_0))))
         (cl:declare (cl:type (cl:vector cl:character) arr))
         (cl:if (cl:= 0 (cl:length arr))

--- a/examples/quil-coalton/src/value-parsers.lisp
+++ b/examples/quil-coalton/src/value-parsers.lisp
@@ -10,7 +10,8 @@
     (Parser
      (fn (str)
        (match (next-char str)
-         ((Some (Tuple read-char _)) (Err (Error (lisp String (cl:format cl:nil "Unexpected character '~A' expected EOF" read-char)))))
+         ((Some (Tuple read-char _)) (Err (Error (lisp String (read-char)
+						   (cl:format cl:nil "Unexpected character '~A' expected EOF" read-char)))))
          ((None) (Ok (Tuple Unit str)))))))
 
   (declare take (Parser Char))
@@ -31,7 +32,7 @@
           (let ((read-char (fst t_)))
             (if (== c read-char)
                 (Ok t_)
-                (Err (Error (lisp String (cl:format cl:nil "Unexpected character '~A' expected '~A'" read-char c)))))))
+                (Err (Error (lisp String (read-char c) (cl:format cl:nil "Unexpected character '~A' expected '~A'" read-char c)))))))
          ((None) (Err parse-error-eof))))))
 
   (declare not-char (Char -> (Parser Char)))
@@ -42,7 +43,7 @@
          ((Some t_)
           (let ((read-char (fst t_)))
             (if (== c read-char)
-                (Err (Error (lisp String (cl:format cl:nil "Unexpected character '~A' expected not '~A'" read-char c))))
+                (Err (Error (lisp String (read-char c) (cl:format cl:nil "Unexpected character '~A' expected not '~A'" read-char c))))
                 (Ok t_))))
          ((None) (Err parse-error-eof))))))
 

--- a/src/ast/node.lisp
+++ b/src/ast/node.lisp
@@ -99,8 +99,9 @@
 (serapeum:defstruct-read-only
     (node-lisp
      (:include node)
-     (:constructor node-lisp (unparsed type form)))
+     (:constructor node-lisp (unparsed type variables form)))
   (type :type t)
+  (variables :type list)
   (form :type t))
 
 #+sbcl

--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -49,5 +49,5 @@
 (define-coalton-editor-macro coalton:let (bindings &body form)
   "A lexical LET binding.")
 
-(define-coalton-editor-macro coalton:lisp (type &body lisp-expr)
+(define-coalton-editor-macro coalton:lisp (type vars &body lisp-expr)
   "An escape from Coalton into the Lisp world.")

--- a/src/library/builtin.lisp
+++ b/src/library/builtin.lisp
@@ -11,18 +11,18 @@
   
   (define-instance (Show Int)
     (define (show x)
-      (lisp String (cl:write-to-string x))))
+      (lisp String (x) (cl:write-to-string x))))
 
   (define-instance (Eq Int)
     (define (== a b)
-      (lisp Boolean
+      (lisp Boolean (a b)
         (to-boolean (cl:= a b))))
     (define (/= a b)
       (not (== a b))))
 
   (define-instance (Ord Int)
       (define (<=> a b)
-        (lisp Ord
+        (lisp Ord (a b)
           (cl:cond
             ((cl:< a b)
              LT)
@@ -33,36 +33,36 @@
 
   (define-instance (Num Int)
     (define (+ a b)
-      (lisp Int (cl:+ a b)))
+      (lisp Int (a b) (cl:+ a b)))
     (define (- a b)
-      (lisp Int (cl:- a b)))
+      (lisp Int (a b) (cl:- a b)))
     (define (* a b)
-      (lisp Int (cl:* a b)))
+      (lisp Int (a b) (cl:* a b)))
     (define (fromInt x) x))
 
   (declare expt (Int -> Int -> Int))
   (define (expt base power)
-    (lisp Int (cl:expt base power)))
+    (lisp Int (base power) (cl:expt base power)))
 
   (declare mod (Int -> Int -> Int))
   (define (mod num base)
-    (lisp Int (cl:mod num base)))
+    (lisp Int (num base) (cl:mod num base)))
 
   (declare even (Int ->  Boolean))
   (define (even n)
-    (lisp Boolean (to-boolean (cl:evenp n))))
+    (lisp Boolean (n) (to-boolean (cl:evenp n))))
 
   (declare odd (Int -> Boolean))
   (define (odd n)
-    (lisp Boolean (to-boolean (cl:oddp n))))
+    (lisp Boolean (n) (to-boolean (cl:oddp n))))
 
   (declare gcd (Int -> Int -> Int))
   (define (gcd a b)
-    (lisp Int (cl:gcd a b)))
+    (lisp Int (a b) (cl:gcd a b)))
 
   (declare lcm (Int -> Int -> Int))
   (define (lcm a b)
-    (lisp Int (cl:lcm a b)))
+    (lisp Int (a b) (cl:lcm a b)))
 
 
   ;;
@@ -71,7 +71,7 @@
 
   (define-instance (Eq Char)
     (define (== x y)
-      (lisp Boolean (to-boolean (cl:char= x y))))
+      (lisp Boolean (x y) (to-boolean (cl:char= x y))))
     (define (/= x y)
       (not (== x y))))
 
@@ -79,7 +79,7 @@
     (define (<=> x y)
       (if (== x y)
           EQ
-          (if (lisp Boolean (to-boolean (cl:char> x y)))
+          (if (lisp Boolean (x y) (to-boolean (cl:char> x y)))
               GT
               LT))))
 
@@ -90,7 +90,6 @@
 
   (define-instance (Eq String)
     (define (== s1 s2)
-      (lisp Boolean (to-boolean (cl:string= s1 s2))))
+      (lisp Boolean (s1 s2) (to-boolean (cl:string= s1 s2))))
     (define (/= s1 s2)
-      (not (== s1 s2))))
-  )
+      (not (== s1 s2)))))

--- a/src/library/functions.lisp
+++ b/src/library/functions.lisp
@@ -4,7 +4,7 @@
 
   (declare error (String -> :a))
   (define (error str)
-    (lisp :a (cl:error str)))
+    (lisp :a (str) (cl:error str)))
   
   ;;
   ;; Function combinators

--- a/src/library/macros.lisp
+++ b/src/library/macros.lisp
@@ -11,7 +11,7 @@
                 (cl:if (cl:null (cl:cdr exprs))
                        `(coalton:if ,(cl:caar exprs)
                                     ,(cl:cadar exprs)
-                                    (lisp :a (cl:error "Non-exhaustive COND")))
+                                    (lisp :a ()  (cl:error "Non-exhaustive COND")))
                        `(coalton:if ,(cl:caar exprs)
                                     ,(cl:cadar exprs)
                                     ,(build-calls (cl:cdr exprs))))))

--- a/src/library/optional.lisp
+++ b/src/library/optional.lisp
@@ -11,18 +11,18 @@
   (define (fromSome str opt)
     (match opt
       ((Some x) x)
-      ((None) (lisp :a (cl:error str)))))
+      ((None) (lisp :a (str) (cl:error str)))))
 
   (declare isSome ((Optional :a) -> Boolean))
   (define (isSome x)
-    (lisp Boolean
+    (lisp Boolean (x)
       (cl:etypecase x
         (Optional/Some True)
 	(Optional/None False))))
 
   (declare isNone ((Optional :a) -> Boolean))
   (define (isNone x)
-    (lisp Boolean
+    (lisp Boolean (x)
       (cl:etypecase x
 	(Optional/None True)
 	(Optional/Some False))))

--- a/src/library/result.lisp
+++ b/src/library/result.lisp
@@ -11,14 +11,14 @@
 
   (declare isOk ((Result :a :b) -> Boolean))
   (define (isOk x)
-    (lisp Boolean
+    (lisp Boolean (x)
       (cl:etypecase x
 	(Result/Ok True)
 	(Result/Err False))))
 
   (declare isErr ((Result :a :b) -> Boolean))
   (define (isErr x)
-    (lisp Boolean
+    (lisp Boolean (x)
       (cl:etypecase x
 	(Result/Err True)
 	(Result/Ok False))))

--- a/src/library/string.lisp
+++ b/src/library/string.lisp
@@ -7,19 +7,19 @@
 
   (declare concat-string (String -> String -> String))
   (define (concat-string str1 str2)
-    (lisp String
+    (lisp String (str1 str2)
       (cl:concatenate 'cl:string str1 str2)))
 
   (declare unpack-string (String -> (List Char)))
   (define (unpack-string str)
-    (lisp (List Char)
+    (lisp (List Char) (str)
       (cl:reduce
        (cl:lambda (x xs) (Cons x xs))
        (cl:coerce str 'cl:list) :from-end cl:t :initial-value Nil)))
 
   (declare pack-string ((List Char) -> String))
   (define (pack-string xs)
-    (lisp String
+    (lisp String (xs)
       (cl:labels ((f (xs)
                     (cl:if (cl:typep xs 'List/Nil)
                            ""
@@ -32,7 +32,7 @@
 
   (declare parse-int (String -> (Optional Int)))
   (define (parse-int str)
-    (lisp (Optional Int)
+    (lisp (Optional Int) (str)
       (cl:let ((x (cl:parse-integer str :junk-allowed cl:t)))
 	(cl:if x
 	       (Some x)
@@ -43,17 +43,17 @@
 
   (define-instance (Eq String)
     (define (== a b)
-      (lisp Boolean (to-boolean (cl:string= a b))))
+      (lisp Boolean (a b) (to-boolean (cl:string= a b))))
     (define (/= a b)
       (not (== a b))))
 
   (define-instance (Ord String)
     (define (<=> a b)
-      (lisp Ord
-	(cl:cond
-	  ((cl:string> a b) GT)
-	  ((cl:string< a b) LT)
-	  (cl:t EQ)))))
+      (lisp Ord (a b)
+	 (cl:cond
+	   ((cl:string> a b) GT)
+	   ((cl:string< a b) LT)
+	   (cl:t EQ)))))
 
   (define-instance (Semigroup String)
     (define (<> a b) (concat-string a b)))

--- a/src/library/types.lisp
+++ b/src/library/types.lisp
@@ -6,7 +6,7 @@
   ;; Unit
   ;;
 
-  (define Unit (lisp Unit 'Unit))
+  (define Unit (lisp Unit () 'Unit))
   
   (define-type Boolean
     True
@@ -48,4 +48,4 @@
     None)
 
   (define (undefined x)
-    (lisp :a (cl:error "Undefined"))))
+    (lisp :a ()  (cl:error "Undefined"))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -54,6 +54,7 @@
    #:node-lisp				; STRUCT
    #:node-lisp-type			; ACCESSOR
    #:node-lisp-form			; ACCESSOR
+   #:node-lisp-variables		; ACCESSOR
    #:node-match                         ; STRUCT
    #:node-match-expr                    ; ACCESSOR
    #:node-match-branches                ; ACCESSOR
@@ -146,6 +147,7 @@
    #:typed-node-lisp                          ; STRUCT
    #:typed-node-lisp-type                     ; ACCESSOR
    #:typed-node-lisp-form                     ; ACCESSOR
+   #:typed-node-lisp-variables		      ; ACCESSOR
    #:typed-node-match                         ; STRUCT
    #:typed-node-match-expr                    ; ACCESSOR
    #:typed-node-match-branches                ; ACCESSOR

--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -43,6 +43,7 @@ Returns (VALUES type predicate-list typed-node subs)")
               (typed-node-lisp
 	       (to-scheme qual-type)
 	       (node-unparsed value)
+	       (node-lisp-variables value)
 	       (node-lisp-form value))
               substs)))
 


### PR DESCRIPTION
Previously lisp nodes were rewritten with a code walker to allow them to
access renamed variables. This seemed to fragile so lisp nodes now must
declare which local variables they wish to use. The lisp node's form
will then be wrapped in a let block during codegen which will unrename
the requested variables.

Fixes #5