### PR TITLE
Add Iso typeclass

### DIFF
--- a/src/library/classes.lisp
+++ b/src/library/classes.lisp
@@ -112,7 +112,14 @@
   (define-class (Into :a :b)
     (into (:a -> :b)))
 
+
+  ;; Opting into this marker typeclass imples that the instances for
+  ;; (Into :a :b) and (Into :b :a) form an isomorphism
+  (define-class ((Into :a :b) (Into :b :a) => (Iso :a :b)))
+
   (define-instance (Into :a :a)
-    (define (into x) x)))
+    (define (into x) x))
+
+  (define-instance (Iso :a :a)))
 
 

--- a/src/library/result.lisp
+++ b/src/library/result.lisp
@@ -87,4 +87,12 @@
     (define (into res)
       (match res
 	((Ok x) (Some x))
-	((Err _) None)))))
+	((Err _) None))))
+
+  (define-instance (Into (Optional :b) (Result Unit :b))
+    (define (into opt)
+      (match opt
+	((Some x) (Ok x))
+	((None) (Err Unit)))))
+
+  (define-instance (Iso (Result Unit :a) (Optional :a))))

--- a/src/library/string.lisp
+++ b/src/library/string.lisp
@@ -65,4 +65,6 @@
     (define into unpack-string))
 
   (define-instance (Into (List Char) String)
-    (define into pack-string)))
+    (define into pack-string))
+
+  (define-instance (Iso (List Char) String)))


### PR DESCRIPTION
Iso can be defined in coalton without cyclic superclasses.