### PR TITLE
Codegen Fixes

### DIFF
--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -74,8 +74,10 @@
 	   (type environment env))
   (let* ((var-names (mapcar #'car vars))
 
-	 (preds (remove-duplicates (remove-if #'static-predicate-p (scheme-predicates type))
-                                   :test #'equalp))
+	 (preds (reduce-context
+		 env
+		 (remove-duplicates (remove-if #'static-predicate-p (scheme-predicates type))
+				    :test #'equalp)))
 
 	 (dict-context (mapcar (lambda (pred) (cons pred (gensym))) preds))
 
@@ -85,7 +87,7 @@
 				(cdr dict-context)))
 			     dict-context))
 
-    (params (append (mapcar #'cdr dict-context) var-names)))
+	 (params (append (mapcar #'cdr dict-context) var-names)))
     `((defun ,name ,params
 	(declare (ignorable ,@params)
 		 ,@(when *emit-type-annotations*


### PR DESCRIPTION
In several places codegen was calling `(remove-if #'static-predicate-p)`
when it should have been calling `(reduce-context ...)` this caused
instances such as `Iso :a :a` to lead to erroneous typeclass dictionary
parameters.

This commit also fixes an issue where variables with predicates in a let
expression were codegened as a lambda when they should have been a
function entry.