### PR TITLE
re-implement lexicals using `GLOBAL-VARS`

### DIFF
--- a/src/global-lexical.lisp
+++ b/src/global-lexical.lisp
@@ -7,20 +7,24 @@
 
 (defun get-lexical-cell (symbol)
   (or (lexical-cell symbol)
+      ;; Stash away the symbol so we don't have to cons up a new
+      ;; string every time.
       (setf (lexical-cell symbol)
             ;; Intentionally obtuse name.
-            (intern (format nil "(lexical) ~A::~A"
-                            (package-name (symbol-package symbol))
-                            symbol)
-                    '#:coalton-global-symbols))))
+            (alexandria:format-symbol '#:coalton-global-symbols
+                                      "(lexical) ~A::~A"
+                                      (package-name (symbol-package symbol))
+                                      symbol))))
 
-(defmacro lexical-value (var)
-  `(symbol-value ',(get-lexical-cell var)))
-
-;;; TODO: Allow the type to be declared.
-(defmacro define-global-lexical (var val)
-  `(progn
-     (eval-when (:compile-toplevel :load-toplevel :execute)
-       (define-symbol-macro ,var (lexical-value ,var)))
-     (setf (lexical-value ,var) ,val)
-     ',var))
+(defmacro define-global-lexical (var val &key (type t)
+                                              documentation)
+  (let ((cell (get-lexical-cell var)))
+    `(progn
+       (declaim (type ,type ,cell))
+       (global-vars:define-global-var* ,cell ,val)
+       (eval-when (:compile-toplevel :load-toplevel :execute)
+         (define-symbol-macro ,var ,cell))
+       ,@(when documentation
+           (list
+            `(setf (documentation ',var 'cl:variable) ,documentation)))
+       ',var)))


### PR DESCRIPTION
Also add a `:TYPE` and `:DOCUMENTATION` option to `DEFINE-GLOBAL-LEXICAL`.

In principle, this is optimizing in the same way `serapeum:def` does, but this works in our use-case. (See issue #54.)

This will ostensibly make Coalton code faster, but I didn't benchmark.