### PR TITLE
add SEXP-FMT for formatting S-expressions qualifiedly

### DIFF
--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -587,9 +587,10 @@ EXPL-DECLARATIONS is a HASH-TABLE from SYMBOL to SCHEME"
   ;; its variables overlap with the names of constructors
   (loop :for (_ . var) :in name-map :do
     (when (lookup-constructor env var :no-error t)
-      (alexandria:simple-style-warning "Pattern variable ~S matches name of known constructor. If
-      you meant to match against the constructor then use (~S)" var
-      var)))
+      (alexandria:simple-style-warning
+       "Pattern variable ~/coalton-impl::sexp-fmt/ matches name of known ~
+        constructor. If you meant to match against the constructor then ~
+        use ~/coalton-impl::sexp-fmt/ instead." var (list var))))
 
 
   (multiple-value-bind (var pat-preds bindings new-subs)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -36,6 +36,17 @@
          :reason-control reason-control
          :reason-args reason-args))
 
+(defun sexp-fmt (stream object &optional colon-modifier at-modifier)
+  "A formatter for qualified S-expressions. Use like
+
+    (format t \"~/coalton-impl::sexp-fmt/\" '(:x y 5))
+
+and it will print a flat S-expression with all symbols qualified."
+  (declare (ignore colon-modifier at-modifier))
+  (let ((*print-pretty* nil)
+        (*package* (find-package "KEYWORD")))
+    (prin1 object stream)))
+
 (defmacro include-if (condition &body body)
   `(when ,condition
      (list ,@ (remove nil body))))


### PR DESCRIPTION
make an error message nicer

example, this warning prints like:

```
; caught COMMON-LISP:STYLE-WARNING:
;   Pattern variable COALTON-LIBRARY::EDGE matches name of known constructor. If you meant to match against the constructor then use (COALTON-LIBRARY::EDGE)
; 
; caught COMMON-LISP:STYLE-WARNING:
;   Pattern variable COALTON-LIBRARY::EDGE matches name of known constructor. If you meant to match against the constructor then use (COALTON-LIBRARY::EDGE)
; 
; caught COMMON-LISP:STYLE-WARNING:
;   Pattern variable COALTON-LIBRARY::EDGE matches name of known constructor. If you meant to match against the constructor then use (COALTON-LIBRARY::EDGE)
```

Note the symbols now have package qualifiers.