### PR TITLE
Fix type errors not being displayed correctly in coalton macros

### DIFF
--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -105,17 +105,18 @@
 
 (defmacro coalton:coalton (form)
   (let ((parsed-form (parse-form form (make-shadow-realm) *package*)))
-    (multiple-value-bind (type preds typed-node substs)
-        (derive-expression-type parsed-form *global-environment* nil)
-      (declare (ignore type))
-      (let* ((env (coalton-impl/typechecker::apply-substitution substs *global-environment*))
-             (preds (coalton-impl/typechecker::apply-substitution substs preds))
-             (preds (coalton-impl/typechecker::reduce-context env preds))
-             (typed-node (coalton-impl/typechecker::apply-substitution substs typed-node)))
+    (coalton-impl/typechecker::with-type-context ("COALTON")
+      (multiple-value-bind (type preds typed-node substs)
+          (derive-expression-type parsed-form *global-environment* nil)
+        (declare (ignore type))
+        (let* ((env (coalton-impl/typechecker::apply-substitution substs *global-environment*))
+               (preds (coalton-impl/typechecker::apply-substitution substs preds))
+               (preds (coalton-impl/typechecker::reduce-context env preds))
+               (typed-node (coalton-impl/typechecker::apply-substitution substs typed-node)))
 
-        (assert (null preds))
-        (setf *global-environment* env)
-        (coalton-impl/codegen::compile-expression typed-node nil *global-environment*)))))
+          (assert (null preds))
+          (setf *global-environment* env)
+          (coalton-impl/codegen::compile-expression typed-node nil *global-environment*))))))
 
 (defun process-coalton-toplevel (toplevel-forms &optional (env *global-environment*))
   "Top-level definitions for use within Coalton."


### PR DESCRIPTION
Fixes type errors being shown like `Failed to reduce context for DIVIDABLE SINGLE-FLOAT #T23575348`