### PR TITLE
Fix mgu on predicates

### DIFF
--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -563,8 +563,8 @@
     (error "Class ~S does not exist." class))
 
   (fset:do-seq (inst (lookup-class-instances env class :no-error t) :index index)
-    (when (handler-case (or (predicate-mgu (ty-class-instance-predicate inst)
-                                           (ty-class-instance-predicate value))
+    (when (handler-case (or (predicate-mgu (ty-class-instance-predicate value)
+                                           (ty-class-instance-predicate inst))
                             t)
 	    (predicate-unification-error () nil))
 

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -76,10 +76,15 @@ apply s type1 == type2")
                (ty-predicate-class pred2))
     (error 'predicate-unification-error :pred1 pred1 :pred2 pred2))
   (handler-case
-      (reduce #'merge-substitution-lists
-              (loop :for pred-type1 :in (ty-predicate-types pred1)
-                    :for pred-type2 :in (ty-predicate-types pred2)
-                    :collect (mgu pred-type1 pred-type2)))
+      (let ((subs nil))
+        (reduce #'merge-substitution-lists
+                (loop :for pred-type1 :in (ty-predicate-types pred1)
+                      :for pred-type2 :in (ty-predicate-types pred2)
+                      :collect (setf subs
+                                     (compose-substitution-lists
+                                      (mgu (apply-substitution subs pred-type1)
+                                           (apply-substitution subs pred-type2))
+                                      subs)))))
     (coalton-type-error ()
       (error 'predicate-unification-error :pred1 pred1 :pred2 pred2))))
 
@@ -90,9 +95,14 @@ apply s type1 == type2")
                (ty-predicate-class pred2))
     (error 'predicate-unification-error :pred1 pred1 :pred2 pred2))
   (handler-case
-      (reduce #'merge-substitution-lists
-              (loop :for pred-type1 :in (ty-predicate-types pred1)
-                    :for pred-type2 :in (ty-predicate-types pred2)
-                    :collect (match pred-type1 pred-type2)))
+      (let ((subs nil))
+        (reduce #'merge-substitution-lists
+                (loop :for pred-type1 :in (ty-predicate-types pred1)
+                      :for pred-type2 :in (ty-predicate-types pred2)
+                      :collect (setf subs
+                                     (compose-substitution-lists
+                                      (match (apply-substitution subs pred-type1)
+                                           (apply-substitution subs pred-type2))
+                                      subs)))))
     (coalton-type-error ()
       (error 'predicate-unification-error :pred1 pred1 :pred2 pred2))))


### PR DESCRIPTION
Fixes #68

The previous implementation failed to error on invalid unification of
multitype predicates. This fixes that.