### PR TITLE
Add initial pointfree transform.

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -62,6 +62,7 @@
                              (:file "optimizer")
                              (:file "direct-application")
                              (:file "match-constructor-lift")
+                             (:file "pointfree-transform")
                              (:file "compile-pattern")
                              (:file "compile-typeclass-dicts")
                              (:file "compile-expression")

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -18,7 +18,8 @@
   ;; Ensure that the node is valid
   (coalton-impl/typechecker::check-node-type node (optimizer-env optimizer))
 
-  (let* ((node (direct-application-transform node optimizer))
+  (let* ((node (pointfree-transform node optimizer))
+         (node (direct-application-transform node optimizer))
          (node (match-constructor-lift-transform node optimizer)))
 
 

--- a/src/codegen/pointfree-transform.lisp
+++ b/src/codegen/pointfree-transform.lisp
@@ -1,0 +1,93 @@
+(in-package #:coalton-impl/codegen)
+
+(defun pointfree-transform (node optimizer)
+  (pointfree node (optimizer-env optimizer)))
+
+(defgeneric pointfree (node env)
+  (:documentation "Transform pointfree definitions to their equivelent pointful style to reduce currying at runtime.")
+  (:method ((node typed-node-variable) env)
+    (let*  ((qualified-type (coalton-impl/typechecker::fresh-inst (typed-node-type node)))
+            (type (coalton-impl/typechecker::qualified-ty-type qualified-type))
+            (arguments (coalton-impl/typechecker::function-type-arguments type))
+            (named-argument-schemes
+              (loop :for arg :in arguments
+                    :collect (cons
+                              (gensym)
+                              (coalton-impl/typechecker::to-scheme
+                               (coalton-impl/typechecker::qualify nil arg)))))
+            (named-argument-nodes
+              (loop :for (name . type) :in named-argument-schemes
+                    :collect
+                    (typed-node-variable
+                     type
+                     '@@SOURCE-UNKNOWN@@
+                     name))))
+
+      (unless (function-type-p type)
+        (return-from pointfree node))
+
+      (typed-node-abstraction
+       (typed-node-type node)
+       '@@SOURCE-UNKNOWN@@
+       named-argument-schemes
+       (typed-node-application
+        (coalton-impl/typechecker::to-scheme
+         (coalton-impl/typechecker::qualify
+          nil
+          (coalton-impl/typechecker::function-return-type type)))
+        '@@SOURCE-UNKNOWN@@
+        node
+        named-argument-nodes)
+       nil)))
+
+  (:method ((node typed-node-abstraction) env)
+    (unless (coalton-impl/typechecker::typed-node-application-p
+             (typed-node-abstraction-subexpr node))
+      (return-from pointfree node))
+
+    (unless (function-type-p (typed-node-type (typed-node-abstraction-subexpr node)))
+      (return-from pointfree node))
+
+
+    (let* ((subexpr (typed-node-abstraction-subexpr node))
+           (subexpr-scheme (typed-node-type subexpr))
+           (subexpr-type
+             (coalton-impl/typechecker::qualified-ty-type
+              (coalton-impl/typechecker::fresh-inst subexpr-scheme)))
+           (arguments (coalton-impl/typechecker::function-type-arguments subexpr-type))
+           (argument-schemes
+             (loop :for arg :in arguments
+                   :collect (cons (gensym)
+                                  (coalton-impl/typechecker::to-scheme
+                                   (coalton-impl/typechecker::qualify nil arg)))))
+           (argument-name-map
+             :for arg :in arguments
+             :collect (cons arg arg))
+           (argument-nodes
+             (loop :for (name . type) :in argument-schemes
+                   :collect (typed-node-variable
+                             type
+                             '@@SOURCE-UNKNOWN@@
+                             name))))
+
+      (typed-node-abstraction
+       (typed-node-type node)
+       (typed-node-unparsed node)
+       (append
+        (typed-node-abstraction-vars node)
+        argument-schemes)
+       (typed-node-application
+        (coalton-impl/typechecker::function-return-type subexpr-scheme)
+        (typed-node-unparsed subexpr)
+        (typed-node-application-rator subexpr)
+        (append
+         (typed-node-application-rands subexpr)
+         argument-nodes))
+       (append
+        (typed-node-abstraction-name-map node)
+        argument-name-map))))
+
+  (:method (node env)
+    (declare (ignore env))
+    node))
+

--- a/src/typechecker/check-types.lisp
+++ b/src/typechecker/check-types.lisp
@@ -165,7 +165,10 @@
          (type1 (qualified-ty-type qual1))
          (type2 (qualified-ty-type qual2))
 
-         (subs (match type2 type1)))
+         (subs (handler-case
+                   (match type2 type1)
+                 (coalton-type-error ()
+                   (return-from sub-ty-scheme-p nil)))))
     (loop :for pred :in (qualified-ty-predicates qual2) :do
         (unless (entail env
                         (qualified-ty-predicates qual1)

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -82,6 +82,11 @@
 (defmethod kind-of ((type qualified-ty))
   (kind-of (qualified-ty-type type)))
 
+(defmethod function-type-p ((type qualified-ty))
+  (function-type-p (qualified-ty-type type)))
+
+(defmethod function-return-type ((type qualified-ty))
+  (qualify nil (function-return-type (qualified-ty-type type))))
 
 ;;;
 ;;; Pretty printing

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -79,6 +79,12 @@
 (defmethod kind-of ((type ty-scheme))
   (kind-of (fresh-inst type)))
 
+(defmethod function-type-p ((type ty-scheme))
+  (function-type-p (fresh-inst type)))
+
+(defmethod function-return-type ((type ty-scheme))
+  (to-scheme (function-return-type (fresh-inst type))))
+
 ;;;
 ;;; Pretty printing
 ;;;

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -182,11 +182,12 @@
       (make-function-type (car args)
                           (make-function-type* (cdr args) to))))
 
-(defun function-type-p (ty)
-  (declare (type ty ty))
-  (and (tapp-p ty)
-       (tapp-p (tapp-from ty))
-       (equalp tArrow (tapp-from (tapp-from ty)))))
+(defgeneric function-type-p (ty)
+  (:method ((ty ty))
+    (declare (type ty ty))
+    (and (tapp-p ty)
+         (tapp-p (tapp-from ty))
+         (equalp tArrow (tapp-from (tapp-from ty))))))
 
 (defun function-type-from (ty)
   (declare (type tapp ty))
@@ -207,6 +208,12 @@
             (function-type-arguments
              (function-type-to ty)))
       nil))
+
+(defgeneric function-return-type (ty)
+  (:method ((ty ty))
+    (if (function-type-p ty)
+        (function-return-type (tapp-to ty))
+        ty)))
 
 ;;;
 ;;; Pretty printing


### PR DESCRIPTION
Add an initial pointfree transform which can handle the following cases

(define m map) -> (define (m a b) (map a b))

(define (m x) (map x)) -> (define (m x a) (m map x a))

See #37