### PR TITLE
Improve pointfree transform

### DIFF
--- a/src/codegen/direct-application.lisp
+++ b/src/codegen/direct-application.lisp
@@ -59,10 +59,16 @@
 
   (:method ((node typed-node-direct-application) inlineable-functions env)
     (declare (type list inlineable-functions)
-             (type environment env)
-             (ignore inlineable-functions env))
-
-    (coalton-impl::coalton-bug "Direct application nodes should not appear in DIRECT-APPLICATION transformation"))
+             (type environment env))
+    (typed-node-direct-application
+     (typed-node-type node)
+     (typed-node-unparsed node)
+     (typed-node-direct-application-rator-type node)
+     (typed-node-direct-application-rator node)
+     (mapcar
+      (lambda (node)
+        (direct-application node inlineable-functions env))
+      (typed-node-direct-application-rands node))))
 
   (:method ((node typed-node-abstraction) inlineable-functions env)
     (declare (type list inlineable-functions)

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -18,7 +18,10 @@
   ;; Ensure that the node is valid
   (coalton-impl/typechecker::check-node-type node (optimizer-env optimizer))
 
-  (let* ((node (pointfree-transform node optimizer))
+  ;; Run direct application twice so that options for direct
+  ;; application are not removed by the pointfree transform
+  (let* ((node (direct-application-transform node optimizer))
+         (node (pointfree-transform node optimizer))
          (node (direct-application-transform node optimizer))
          (node (match-constructor-lift-transform node optimizer)))
 

--- a/src/codegen/pointfree-transform.lisp
+++ b/src/codegen/pointfree-transform.lisp
@@ -4,19 +4,24 @@
   (pointfree node (optimizer-env optimizer)))
 
 (defgeneric pointfree (node env)
-  (:documentation "Transform pointfree definitions to their equivelent pointful style to reduce currying at runtime.")
+  (:documentation "Transform pointfree definitions to their equivelent
+  pointful style to reduce currying at runtime. This transform is only
+  run on toplevel bindings and let bindings.")
   (:method ((node typed-node-variable) env)
     (let*  ((qualified-type (coalton-impl/typechecker::fresh-inst (typed-node-type node)))
             (type (coalton-impl/typechecker::qualified-ty-type qualified-type))
             (arguments (coalton-impl/typechecker::function-type-arguments type))
-            (named-argument-schemes
+            (argument-schemes
               (loop :for arg :in arguments
                     :collect (cons
                               (gensym)
                               (coalton-impl/typechecker::to-scheme
                                (coalton-impl/typechecker::qualify nil arg)))))
-            (named-argument-nodes
-              (loop :for (name . type) :in named-argument-schemes
+            (argument-name-map
+              (loop :for arg :in arguments
+                    :collect (cons arg arg)))
+            (argument-nodes
+              (loop :for (name . type) :in argument-schemes
                     :collect
                     (typed-node-variable
                      type
@@ -29,7 +34,7 @@
       (typed-node-abstraction
        (typed-node-type node)
        '@@SOURCE-UNKNOWN@@
-       named-argument-schemes
+       argument-schemes
        (typed-node-application
         (coalton-impl/typechecker::to-scheme
          (coalton-impl/typechecker::qualify
@@ -37,16 +42,28 @@
           (coalton-impl/typechecker::function-return-type type)))
         '@@SOURCE-UNKNOWN@@
         node
-        named-argument-nodes)
-       nil)))
+        argument-nodes)
+       argument-name-map)))
 
   (:method ((node typed-node-abstraction) env)
     (unless (coalton-impl/typechecker::typed-node-application-p
              (typed-node-abstraction-subexpr node))
-      (return-from pointfree node))
+      (return-from pointfree
+        (typed-node-abstraction
+         (typed-node-type node)
+         (typed-node-unparsed node)
+         (typed-node-abstraction-vars node)
+         (pointfree-traverse (typed-node-abstraction-subexpr node) env)
+         (typed-node-abstraction-name-map node))))
 
     (unless (function-type-p (typed-node-type (typed-node-abstraction-subexpr node)))
-      (return-from pointfree node))
+      (return-from pointfree
+        (typed-node-abstraction
+         (typed-node-type node)
+         (typed-node-unparsed node)
+         (typed-node-abstraction-vars node)
+         (pointfree-traverse (typed-node-abstraction-subexpr node) env)
+         (typed-node-abstraction-name-map node))))
 
 
     (let* ((subexpr (typed-node-abstraction-subexpr node))
@@ -61,8 +78,9 @@
                                   (coalton-impl/typechecker::to-scheme
                                    (coalton-impl/typechecker::qualify nil arg)))))
            (argument-name-map
-             :for arg :in arguments
-             :collect (cons arg arg))
+             (loop
+               :for arg :in arguments
+               :collect (cons arg arg)))
            (argument-nodes
              (loop :for (name . type) :in argument-schemes
                    :collect (typed-node-variable
@@ -79,15 +97,138 @@
        (typed-node-application
         (coalton-impl/typechecker::function-return-type subexpr-scheme)
         (typed-node-unparsed subexpr)
-        (typed-node-application-rator subexpr)
+        (pointfree-traverse (typed-node-application-rator subexpr) node)
         (append
-         (typed-node-application-rands subexpr)
+         (mapcar
+          (lambda (node)
+            (pointfree-traverse node env))
+          (typed-node-application-rands subexpr))
          argument-nodes))
        (append
         (typed-node-abstraction-name-map node)
         argument-name-map))))
 
-  (:method (node env)
+  (:method ((node typed-node-application) env)
+    (unless (function-type-p (typed-node-type node))
+      (return-from pointfree
+        (typed-node-application
+         (typed-node-type node)
+         (typed-node-unparsed node)
+         (pointfree-traverse (typed-node-application-rator node) env)
+         (mapcar
+          (lambda (node)
+            (pointfree-traverse node env))
+          (typed-node-application-rands node)))))
+
+    (let* ((return-type
+             (coalton-impl/typechecker::function-return-type (typed-node-type node)))
+           (arguments
+             (coalton-impl/typechecker::function-type-arguments
+              (typed-node-type node)))
+           (argument-schemes
+             (loop :for arg :in arguments
+                   :collect (cons (gensym)
+                                  (coalton-impl/typechecker::to-scheme
+                                   (coalton-impl/typechecker::qualify nil arg)))))
+           (argument-name-map
+             (loop
+               :for arg :in arguments
+               :collect (cons arg arg)))
+           (argument-nodes
+             (loop :for (name . type) :in argument-schemes
+                   :collect (typed-node-variable
+                             type
+                             '@@SOURCE-UNKNOWN@@
+                             name))))
+
+      (typed-node-abstraction
+       (typed-node-type node)
+       '@@SOURCE-UNKNOWN@@
+       argument-schemes
+       (typed-node-application
+        return-type
+        (typed-node-unparsed node)
+        (pointfree-traverse (typed-node-application-rator node) env)
+        (append
+         (mapcar
+          (lambda (node)
+            (pointfree-traverse node env))
+          (typed-node-application-rands node))
+         argument-nodes))
+       argument-name-map)))
+
+  (:method ((node typed-node) env)
+    (pointfree-traverse node env)))
+
+(defgeneric pointfree-traverse (node env)
+  (:method ((node typed-node-application) env)
+    (typed-node-application
+     (typed-node-type node)
+     (typed-node-unparsed node)
+     (pointfree-traverse (typed-node-application-rator node) env)
+     (mapcar
+      (lambda (node)
+        (pointfree-traverse node env))
+      (typed-node-application-rands node))))
+
+  (:method ((node typed-node-direct-application) env)
+    (typed-node-direct-application
+     (typed-node-type node)
+     (typed-node-unparsed node)
+     (typed-node-direct-application-rator-type node)
+     (typed-node-direct-application-rator node)
+     (mapcar
+      (lambda (node)
+        (pointfree-traverse node env))
+      (typed-node-direct-application-rands node))))
+
+  (:method ((node typed-node-abstraction) env)
+    (typed-node-abstraction
+     (typed-node-type node)
+     (typed-node-unparsed node)
+     (typed-node-abstraction-vars node)
+     (pointfree-traverse (typed-node-abstraction-subexpr node) env)
+     (typed-node-abstraction-name-map node)))
+
+  (:method ((node typed-node-let) env)
+    (typed-node-let
+     (typed-node-type node)
+     (typed-node-unparsed node)
+     (loop :for (name . node) :in (typed-node-let-bindings node)
+           :collect (cons name (pointfree node env)))
+     (pointfree-traverse (typed-node-let-subexpr node) env)
+     (typed-node-let-sorted-bindings node)
+     (typed-node-let-dynamic-extent-bindings node)
+     (typed-node-let-name-map node)))
+
+  (:method ((node typed-node-match) env)
+    (typed-node-match
+     (typed-node-type node)
+     (typed-node-unparsed node)
+     (pointfree-traverse (typed-node-match-expr node) env)
+     (mapcar
+      (lambda (node)
+        (pointfree-traverse node env))
+      (typed-node-match-branches node))))
+
+  (:method ((branch typed-match-branch) env)
+    (typed-match-branch
+     (typed-match-branch-unparsed branch)
+     (typed-match-branch-pattern branch)
+     (pointfree-traverse (typed-match-branch-subexpr branch) env)
+     (typed-match-branch-bindings branch)
+     (typed-match-branch-name-map branch)))
+
+  (:method ((node typed-node-seq) env)
+    (typed-node-seq
+     (typed-node-type node)
+     (typed-node-unparsed node)
+     (mapcar
+      (lambda (node)
+        (pointfree-traverse node env))
+      (typed-node-seq-subnodes node))))
+
+  (:method ((node typed-node) env)
     (declare (ignore env))
     node))
 

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -88,6 +88,9 @@
 (defmethod function-return-type ((type qualified-ty))
   (qualify nil (function-return-type (qualified-ty-type type))))
 
+(defmethod function-type-arguments ((type qualified-ty))
+  (function-type-arguments (qualified-ty-type type)))
+
 ;;;
 ;;; Pretty printing
 ;;;

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -85,6 +85,9 @@
 (defmethod function-return-type ((type ty-scheme))
   (to-scheme (function-return-type (fresh-inst type))))
 
+(defmethod function-type-arguments ((type ty-scheme))
+  (function-type-arguments (fresh-inst type)))
+
 ;;;
 ;;; Pretty printing
 ;;;

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -202,12 +202,13 @@
       (+ 1 (function-type-arity (function-type-to ty)))
       0))
 
-(defun function-type-arguments (ty)
-  (if (function-type-p ty)
-      (cons (function-type-from ty)
-            (function-type-arguments
-             (function-type-to ty)))
-      nil))
+(defgeneric function-type-arguments (ty)
+  (:method ((ty ty))
+    (if (function-type-p ty)
+        (cons (function-type-from ty)
+              (function-type-arguments
+               (function-type-to ty)))
+        nil)))
 
 (defgeneric function-return-type (ty)
   (:method ((ty ty))


### PR DESCRIPTION
Add an additional transform pattern

(define f (map (+ 1))) -> (define (f xs) (map (+ 1) xs))

Also allows the pointfree transform to traverse down the ast and
transform values defined in let expressions.

See #37