### PR TITLE
Add the intro blogpost as an additional documentation resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Lastly and importantly, we maintain a collection of documentation about Coalton 
 
 **Test**: Run `(asdf:test-system :coalton)`.
 
-**Learn**: We recommend starting with the [*Intro to Coalton*](docs/intro-to-coalton.md), and then taking a peek in the [examples directory](examples/).
+**Learn**: We recommend starting with the [*Intro to Coalton*](docs/intro-to-coalton.md) document, and then taking a peek in the [examples directory](examples/). It may also be helpful to check out the [Introducing Coalton Blog Post](https://coalton-lang.github.io/20211010-introducing-coalton/) (external).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,7 @@
 * [Standard Library Reference](./reference.md)
 * [Adding a new Early Type](./adding-new-early-type.md)
 * [Design Docs](./design-docs) - Initial design doc work for Coalton.
+
+## Additional Resources
+
+* [Introducing Coalton](https://coalton-lang.github.io/20211010-introducing-coalton/) - external, blog post.


### PR DESCRIPTION
When I looked at the repo yesterday, I didn't realize there was a blog post. It's probably helpful to link to it from this repo.