### PR TITLE
Improve monomorphism restriction error message on toplevel variables

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -223,6 +223,7 @@
    #:type-construction-error            ; SIGNAL
    #:overlapping-instance-error         ; SIGNAL
    #:cyclic-class-definitions-error     ; SIGNAL
+   #:toplevel-monomorphism-restriction  ; SIGNAL
    )
   (:export
    #:process-toplevel-definitions       ; FUNCTION

--- a/src/typechecker/type-errors.lisp
+++ b/src/typechecker/type-errors.lisp
@@ -307,3 +307,21 @@
        (format s "Declared type ~A has extra predicates~{ ~A~}."
                (declared-type-additional-predicates-type c)
                (declared-type-additional-predicates-preds c))))))
+
+(define-condition toplevel-monomorphism-restriction (coalton-type-error)
+  ((name :initarg :name
+         :reader toplevel-monomorphism-restriction-name)
+   (type :initarg :type
+         :reader toplevel-monomorphism-restriction-type))
+  (:report
+   (lambda (c s)
+     (let* ((*print-circle* nil) ; Prevent printing using reader macros
+            (name (toplevel-monomorphism-restriction-name c))
+            (type (toplevel-monomorphism-restriction-type c))
+            (preds (qualified-ty-predicates type)))
+       (format s "Unable to resolve ambiguous constraint~p~{ ~A~} in definition of ~A~%   with type ~A~%~%This can be resolved by giving ~A an explicit type declaration.~%"
+               (length preds)
+               preds
+               name
+               type
+               name)))))


### PR DESCRIPTION
- Defer monomorphism restriction checking for toplevel until all types
  are resolved.
- Add new condition with better error message for monomorphism
  restriction.

Resolves #137 

The new error message looks like this:
```
Unable to resolve ambiguous constraint NUM :A in definition of BAR
   with type NUM :A ⇒ (:A → :A → :A)

This can be resolved by giving BAR an explicit type declaration.
```