### PR TITLE
add short-circuiting AND and OR

### DIFF
--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -271,7 +271,7 @@ Match expressions can be used to pattern-match and deconstruct algebraic data ty
       (_ False))))
 ```
 
-The operator `coalton:if` can be used as a shorthand when matching on booleans
+The operator `coalton-library:if` can be used as a shorthand when matching on booleans
 
 ```lisp
 (coalton-toplevel
@@ -286,7 +286,7 @@ The operator `coalton:if` can be used as a shorthand when matching on booleans
         (is-even (- x 1)))))
 ```
 
-Several `if` expressions can be combined with a `coalton:cond`:
+Several `if` expressions can be combined with a `cond`:
 
 ```lisp
 (coalton-toplevel
@@ -302,18 +302,27 @@ Several `if` expressions can be combined with a `coalton:cond`:
       (True (show n)))))
 ```
 
-Coalton also has `coalton:unless` and `coalton:when` which work similary to their definitions in Lisp. We recommend only using these operators for conditionalizing stateful operations.
+The boolean operators `and` and `or` (of `coalton-library`) are actually variadic macros that short-circuit. Their functional counterparts are `boolean-and` and `boolean-or`.
 
+```lisp
+(coalton
+  (or (cheap 5) True (really-expensive (expt 2 1000000))))
 ```
+
+In this case, `really-expensive` will never get called due to short-circuiting. Also note that both `and` and `or` can take any number of arguments, including zero.
+
+Coalton also has `unless` and `when` (of `coalton-library`) which work similary to their definitions in Lisp. We recommend only using these operators for conditionalizing stateful operations.
+
+```lisp
 (coalton-toplevel
   (define (f x)
     (when (== x 5)
       (error "I only want the number 5"))))
 ```
 
-## `COALTON:PROGN`
+## `COALTON-LIBRARY:PROGN`
 
-Coalton has a `coalton:progn` construct similar to lisp.
+Coalton has a `coalton-library:progn` construct similar to lisp.
 
 ```lisp
 (coalton-toplevel

--- a/src/library/boolean.lisp
+++ b/src/library/boolean.lisp
@@ -7,33 +7,41 @@
 ;;; Boolean is defined in types.lisp
 
 (coalton-toplevel
-  (declare not (Boolean -> Boolean))
-  (define (not x)
+  (declare boolean-not (Boolean -> Boolean))
+  (define (boolean-not x)
     "Is X False?"
     (match x
       ((True) False)
       ((False) True)))
 
-  (declare or (Boolean -> Boolean -> Boolean))
-  (define (or x y)
-    "Is X or Y True?"
+  (declare boolean-or (Boolean -> Boolean -> Boolean))
+  (define (boolean-or x y)
+    "Is X or Y True? Note that this is a *function* which means both X and Y will be evaluated. Use the OR macro for short-circuiting behavior."
     (match x
       ((True) True)
       ((False) y)))
 
-  (declare and (Boolean -> Boolean -> Boolean))
-  (define (and x y)
-    "Are X and Y True?"
+  (declare boolean-and (Boolean -> Boolean -> Boolean))
+  (define (boolean-and x y)
+    "Are X and Y True? Note that this is a *function* which means both X and Y will be evaluated. Use the AND macro for short-circuiting behavior."
     (match x
       ((True) y)
       ((False) False)))
 
-  (declare xor (Boolean -> Boolean -> Boolean))
-  (define (xor x y)
+  (declare boolean-xor (Boolean -> Boolean -> Boolean))
+  (define (boolean-xor x y)
     "Are X or Y True, but not both?"
     (match x
-      ((True) (not y))
-      ((False) y))))
+      ((True) (boolean-not y))
+      ((False) y)))
+
+  (define not
+    "Synonym for BOOLEAN-NOT."
+    boolean-not)
+
+  (define xor
+    "Synonym for BOOLEAN-XOR."
+    boolean-xor))
 
 (coalton-toplevel
   ;;

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -400,13 +400,12 @@
   (:export
    #:fn #:λ
    #:match
-   #:let #:=
-   #:if #:unless #:when #:cond
+   #:let
+   #:=                                  ; Syntax
    #:lisp
-   #:do #:<-
+   #:<-                                 ; Syntax
    #:_
    #:seq
-   #:progn
    #:the)
   (:import-from
    #:coalton-impl
@@ -436,6 +435,8 @@
    #:if
    #:unless
    #:when
+   #:and
+   #:or
    #:cond
    #:nest
    #:pipe
@@ -447,10 +448,10 @@
   (:export
    #:Unit
    #:Boolean #:True #:False
-   #:not
-   #:or
-   #:and
-   #:xor
+   #:boolean-not #:not
+   #:boolean-or
+   #:boolean-and
+   #:boolean-xor #:xor
    #:List #:Cons #:Nil
    #:Tuple
    #:Result #:Err #:Ok


### PR DESCRIPTION
- Defines AND and OR as short-circuiting macros
- Adds BOOLEAN-AND and BOOLEAN-OR
- Also BOOLEAN-XOR and BOOLEAN-NOT as synonyms
- Removes library functionality from COALTON package

Fixes #146 