### PR TITLE
disable CI caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,40 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Grant All Perms to Make Cache Restoring Possible
-        run: |
-          sudo mkdir -p /usr/local/etc/roswell
-          sudo chown "${USER}" /usr/local/etc/roswell
-          # Here the ros binary will be restored:
-          sudo chown "${USER}" /usr/local/bin
-      - name: Get Current Month
-        id: current-month
-        run: |
-          echo "::set-output name=value::$(date -u "+%Y-%m")"
-      - name: Cache Roswell Setup
-        id: cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-roswell
-        with:
-          path: |
-            /usr/local/bin/ros
-            ~/.cache/common-lisp/
-            ~/.roswell
-            /usr/local/etc/roswell
-            .qlot
-          key: "${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-${{ runner.os }}-${{ hashFiles('qlfile.lock') }}-${{ matrix.COALTON_ENV }}-3"
-      - name: Restore Path To Cached Files
-        run: |
-          echo $HOME/.roswell/bin >> $GITHUB_PATH
-          echo .qlot/bin >> $GITHUB_PATH
-        if: steps.cache.outputs.cache-hit == 'true'
       - uses: 40ants/setup-lisp@v1
         with:
           asdf-system: coalton
-        if: steps.cache.outputs.cache-hit != 'true'
-
       - uses: 40ants/run-tests@v2
         env:
           COALTON_ENV: ${{ matrix.COALTON_ENV }}


### PR DESCRIPTION
Caching is broken. I tried loading `40ants-ci` but got build failures (probably due to missing dependencies). So I'm just deleting the caching stuff for now; we don't have high-volume committing activity for the time being anyway.