### PR TITLE
Test for and fix issue 199

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: test
+.PHONY: test test-safe
 test:
 	sbcl --non-interactive \
+	     --eval "(asdf:test-system :coalton)"
+
+test-safe:
+	sbcl --non-interactive \
+	     --eval "(sb-ext:restrict-compiler-policy 'safety 3)" \
 	     --eval "(asdf:test-system :coalton)"
 
 .PHONY: docs

--- a/coalton.asd
+++ b/coalton.asd
@@ -120,4 +120,5 @@
                (:file "tarjan-scc-tests")
                (:file "type-inference-tests")
                (:file "environment-persist-tests")
-               (:file "graph-tests")))
+               (:file "graph-tests")
+               (:file "letrec-order-tests")))

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -100,10 +100,13 @@
 
        ;; Define ...
        ,@(reshuffle-definitions (append
-                                 ;; ... instance structs
-                                 (compile-instance-definitions instance-definitions optimizer)
                                  ;; ... functions and variables
-                                 (compile-toplevel-sccs bindings sccs env)))
+                                 (compile-toplevel-sccs bindings sccs env)
+                                 ;; ... instance structs
+                                 ;; unlike other definitions, instances may read eagerly
+                                 ;; from variables. so initialize them last, after all
+                                 ;; the variables have been defined.
+                                 (compile-instance-definitions instance-definitions optimizer)))
 
        ;; Emit documentation
        ,@(compile-docstring-forms docstrings)

--- a/tests/letrec-order-tests.lisp
+++ b/tests/letrec-order-tests.lisp
@@ -1,0 +1,18 @@
+(in-package #:coalton-tests)
+
+(deftest test-letrec-order ()
+  "Test that bindings are initialized in a correct order so that constructing instance structs never reads an uninitialized variable.
+
+From coalton-lang/coalton issue #199"
+  (with-toplevel-compilation ()
+    (coalton-toplevel
+      (define-type TestLetrecOrder
+        TestLetrecOrder))
+
+    (coalton-toplevel
+      (declare testLetrecOrderToString (TestLetrecOrder -> String))
+      (define (testLetrecOrderToString x)
+        "TestLetrecOrder")
+
+      (define-instance (Into TestLetrecOrder String)
+        (define into testLetrecOrderToString)))))

--- a/tests/letrec-order-tests.lisp
+++ b/tests/letrec-order-tests.lisp
@@ -15,4 +15,12 @@ From coalton-lang/coalton issue #199"
         "TestLetrecOrder")
 
       (define-instance (Into TestLetrecOrder String)
-        (define into testLetrecOrderToString)))))
+        (define into testLetrecOrderToString)))
+
+    (coalton-toplevel
+      (declare getTestLetrecString (Unit -> String))
+      (define (getTestLetrecString unit)
+        (into TestLetRecOrder))))
+
+  (is (equal "TestLetrecOrder"
+             (coalton-test-user::getTestLetrecString Unit))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -30,6 +30,7 @@
 
 (defun reintern (form package)
   (typecase form
+    (keyword form)
     (symbol (intern (symbol-name form) package))
     (list (mapcar (lambda (subform) (reintern subform package))
                   form))
@@ -47,7 +48,8 @@
       :close-stream
       (uiop:with-temporary-file (:pathname compiled-file
                                  :type "fasl")
-        (handler-bind ((style-warning #'muffle-warning))
+        (handler-bind ((style-warning #'muffle-warning)
+                       #+sbcl (sb-ext:compiler-note #'muffle-warning))
           (compile-file source-file
                         :output-file compiled-file
                         :print nil
@@ -56,5 +58,3 @@
 
 (defmacro with-toplevel-compilation ((&key (package :coalton-test-user)) &body body)
   `(compile-and-load-tempfile ',package ',body))
-
-

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -27,3 +27,34 @@
 
 (defun run-coalton-typechecker (toplevel)
   (coalton-impl::process-coalton-toplevel toplevel coalton-impl::*initial-environment*))
+
+(defun reintern (form package)
+  (typecase form
+    (symbol (intern (symbol-name form) package))
+    (list (mapcar (lambda (subform) (reintern subform package))
+                  form))
+    (t form)))
+
+(defun compile-and-load-tempfile (package-name form
+                                  &aux (package (find-package package-name)))
+  (uiop:with-safe-io-syntax (:package package) 
+    (uiop:with-temporary-file (:stream out
+                               :pathname source-file
+                               :type "lisp"
+                               :direction :output)
+      (dolist (expr form)
+        (prin1 (reintern expr package) out))
+      :close-stream
+      (uiop:with-temporary-file (:pathname compiled-file
+                                 :type "fasl")
+        (handler-bind ((style-warning #'muffle-warning))
+          (compile-file source-file
+                        :output-file compiled-file
+                        :print nil
+                        :verbose nil))
+        (load compiled-file)))))
+
+(defmacro with-toplevel-compilation ((&key (package :coalton-test-user)) &body body)
+  `(compile-and-load-tempfile ',package ',body))
+
+


### PR DESCRIPTION
I reordered the definitions emitted by `codegen-program` so that instances come last, as they're the only things that eagerly read from variables at load time. I think. Reviewer: is that actually the case, or will other `coalton-codgen` `setf` forms read from Coalton variables at load time?

In any case, I built a test case which fails prior to the final commit in this PR, and passes after. I also wrote a slick macro in tests/utilities.lisp which automates writing forms into temporary files so they can be compiled as top-level forms.

cheers,
phoebe