### PR TITLE
Fix stack allocation warnings in development

### DIFF
--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -22,11 +22,11 @@
   ;; application are not removed by the pointfree transform
   (let* ((node (direct-application-transform node optimizer))
          ;; Classes cannot be stack allocated
-         (node (if (eql coalton-impl:*interaction-mode* ':release)
-                   (pointfree-transform node optimizer)
-                   node))
+         (node (pointfree-transform node optimizer))
          (node (direct-application-transform node optimizer))
-         (node (match-constructor-lift-transform node optimizer)))
+         (node (if (eql coalton-impl:*interaction-mode* ':release)
+                   (match-constructor-lift-transform node optimizer)
+                   node)))
 
 
     ;; Ensure that the node is still valid after transformations are


### PR DESCRIPTION
I accidently disabled the wrong optimization in development mode.