### PR TITLE
allow displaced strings in coalton-string

### DIFF
--- a/examples/quil-coalton/src/string-view.lisp
+++ b/examples/quil-coalton/src/string-view.lisp
@@ -38,10 +38,6 @@
                                                                    :displaced-to arr
                                                                    :displaced-index-offset (cl:1+ displaced-index-offset)))))))))))))
 
-  ;; NOTE: Strings in Coalton are declared as simple-string which
-  ;; should not be a displaced array. StringViews use displaced
-  ;; arrays, on high optimization levels this may miscompile (in sbcl)
-  ;; due to pointer aliasing issues
   (declare string-view-get (StringView -> String))
   (define (string-view-get str)
     (match str

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -145,7 +145,7 @@
           ('coalton:String
            (type-entry
             :name 'coalton:String
-            :runtime-type 'cl:simple-string
+            :runtime-type 'cl:string
             :type tString
             :enum-repr nil
             :newtype nil))


### PR DESCRIPTION
and remove a note about a bug caused by coalton using `simple-string`