### PR TITLE
Remove Show

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -143,7 +143,6 @@ Constructors:
 - [`EQ`](#EQ) [`FRACTION`](#FRACTION)
 - [`NUM`](#NUM) [`FRACTION`](#FRACTION)
 - [`ORD`](#ORD) [`FRACTION`](#FRACTION)
-- [`SHOW`](#SHOW) [`FRACTION`](#FRACTION)
 - [`DIVIDABLE`](#DIVIDABLE) [`INTEGER`](#INTEGER) [`FRACTION`](#FRACTION)
 
 </details>
@@ -168,7 +167,6 @@ Constructors:
 - [`ORD :A`](#ORD) `=>` [`ORD`](#ORD) [`(OPTIONAL :A)`](#OPTIONAL)
 - [`INTO`](#INTO) [`(RESULT :A :B)`](#RESULT) [`(OPTIONAL :B)`](#OPTIONAL)
 - [`INTO`](#INTO) [`(OPTIONAL :A)`](#OPTIONAL) [`(RESULT UNIT :A)`](#RESULT)
-- [`SHOW :A`](#SHOW) `=>` [`SHOW`](#SHOW) [`(OPTIONAL :A)`](#OPTIONAL)
 - [`MONAD`](#MONAD) [`OPTIONAL`](#OPTIONAL)
 - [`MONOID :A`](#MONOID) `=>` [`MONOID`](#MONOID) [`(OPTIONAL :A)`](#OPTIONAL)
 - [`FUNCTOR`](#FUNCTOR) [`OPTIONAL`](#OPTIONAL)
@@ -293,7 +291,7 @@ Methods:
 ***
 
 #### `NUM` <sup><sub>[CLASS]</sub></sup><a name="NUM"></a>
-[`EQ :A`](#EQ) [`SHOW :A`](#SHOW) `=>` [`NUM`](#NUM) [`:A`](#:A)
+[`EQ :A`](#EQ) `=>` [`NUM`](#NUM) [`:A`](#:A)
 
 Types which have numeric operations defined.
 
@@ -396,38 +394,6 @@ Methods:
 - [`INTO`](#INTO) [`I32`](#I32) [`INTEGER`](#INTEGER)
 - [`INTO`](#INTO) [`INTEGER`](#INTEGER) [`I32`](#I32)
 - [`INTO`](#INTO) [`:A`](#:A) [`:A`](#:A)
-
-</details>
-
-
-***
-
-#### `SHOW` <sup><sub>[CLASS]</sub></sup><a name="SHOW"></a>
-[`SHOW`](#SHOW) [`:A`](#:A)
-
-Types which can be shown in string representation.
-
-Methods:
-- `SHOW :: (:A → STRING)`
-
-<details>
-<summary>Instances</summary>
-
-- [`SHOW`](#SHOW) [`NODEINDEX`](#NODEINDEX)
-- [`SHOW`](#SHOW) [`EDGEINDEX`](#EDGEINDEX)
-- [`SHOW :A`](#SHOW) `=>` [`SHOW`](#SHOW) [`(CELL :A)`](#CELL)
-- [`SHOW :A`](#SHOW) `=>` [`SHOW`](#SHOW) [`(OPTIONAL :A)`](#OPTIONAL)
-- [`SHOW`](#SHOW) [`CHAR`](#CHAR)
-- [`SHOW`](#SHOW) [`DOUBLE-FLOAT`](#DOUBLE-FLOAT)
-- [`SHOW`](#SHOW) [`SINGLE-FLOAT`](#SINGLE-FLOAT)
-- [`SHOW`](#SHOW) [`INTEGER`](#INTEGER)
-- [`SHOW`](#SHOW) [`U64`](#U64)
-- [`SHOW`](#SHOW) [`U32`](#U32)
-- [`SHOW`](#SHOW) [`U8`](#U8)
-- [`SHOW`](#SHOW) [`I64`](#I64)
-- [`SHOW`](#SHOW) [`I32`](#I32)
-- [`SHOW`](#SHOW) [`FRACTION`](#FRACTION)
-- [`SHOW`](#SHOW) [`BOOLEAN`](#BOOLEAN)
 
 </details>
 
@@ -675,6 +641,14 @@ Returns the lesser element of X and Y.
 
 ### Functions
 
+#### `ERROR` <sup><sub>[FUNCTION]</sub></sup><a name="ERROR"></a>
+`∀ :A. (STRING → :A)`
+
+Signal an error by calling CL:ERROR
+
+
+***
+
 #### `UNDEFINED` <sup><sub>[FUNCTION]</sub></sup><a name="UNDEFINED"></a>
 `∀ :A :B. (:A → :B)`
 
@@ -791,6 +765,11 @@ The sign of X.
 
 #### `NEGATE` <sup><sub>[FUNCTION]</sub></sup><a name="NEGATE"></a>
 `∀ :A. NUM :A ⇒ (:A → :A)`
+
+***
+
+#### `INTEGER->STRING` <sup><sub>[FUNCTION]</sub></sup><a name="INTEGER->STRING"></a>
+`(INTEGER → STRING)`
 
 ***
 
@@ -1356,14 +1335,6 @@ A function that always returns its first argument
 
 ***
 
-#### `ERROR` <sup><sub>[FUNCTION]</sub></sup><a name="ERROR"></a>
-`∀ :A. (STRING → :A)`
-
-Signal an error by calling CL:ERROR
-
-
-***
-
 #### `TRACE` <sup><sub>[FUNCTION]</sub></sup><a name="TRACE"></a>
 `(STRING → UNIT)`
 
@@ -1418,7 +1389,6 @@ Constructors:
 - [`NUM :A`](#NUM) `=>` [`NUM`](#NUM) [`(CELL :A)`](#CELL)
 - [`INTO`](#INTO) [`(CELL :A)`](#CELL) [`:A`](#:A)
 - [`INTO`](#INTO) [`:A`](#:A) [`(CELL :A)`](#CELL)
-- [`SHOW :A`](#SHOW) `=>` [`SHOW`](#SHOW) [`(CELL :A)`](#CELL)
 - [`FUNCTOR`](#FUNCTOR) [`CELL`](#CELL)
 - [`SEMIGROUP :A`](#SEMIGROUP) `=>` [`SEMIGROUP`](#SEMIGROUP) [`(CELL :A)`](#CELL)
 - [`APPLICATIVE`](#APPLICATIVE) [`CELL`](#CELL)
@@ -1919,7 +1889,6 @@ Constructors:
 
 - [`EQ`](#EQ) [`EDGEINDEX`](#EDGEINDEX)
 - [`INTO`](#INTO) [`EDGEINDEX`](#EDGEINDEX) [`INTEGER`](#INTEGER)
-- [`SHOW`](#SHOW) [`EDGEINDEX`](#EDGEINDEX)
 
 </details>
 
@@ -1946,18 +1915,12 @@ Constructors:
 
 - [`EQ`](#EQ) [`NODEINDEX`](#NODEINDEX)
 - [`INTO`](#INTO) [`NODEINDEX`](#NODEINDEX) [`INTEGER`](#INTEGER)
-- [`SHOW`](#SHOW) [`NODEINDEX`](#NODEINDEX)
 
 </details>
 
 ***
 
 ### Functions
-
-#### `GRAPH-VIZ` <sup><sub>[FUNCTION]</sub></sup><a name="GRAPH-VIZ"></a>
-`∀ :A :B. SHOW :A ⇒ ((GRAPH :A :B) → STRING)`
-
-***
 
 #### `MAKE-GRAPH` <sup><sub>[FUNCTION]</sub></sup><a name="MAKE-GRAPH"></a>
 `∀ :A :B. (UNIT → (GRAPH :A :B))`

--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -9,10 +9,9 @@
   (define-type Id
     (Id String))
 
-  (define-instance (Show Id)
-      (define (show i)
-        (match i
-          ((Id str) str))))
+  (define (id->string id)
+    (match id
+      ((Id s) s)))
 
   (define-instance (Eq Id)
       (define (== x y)
@@ -26,7 +25,7 @@
 
   (declare enumId (Integer -> Id))
   (define (enumId n)
-    (Id (concat-string "v" (show n))))
+    (Id (concat-string "v" (integer->string n))))
 
 
   ;;
@@ -641,7 +640,7 @@
   (define (find i xs)
     (match xs
       ((Nil)
-       (fail (concat-string "Unbound identifier: " (show i))))
+       (fail (concat-string "Unbound identifier: " (id->string i))))
       ((Cons (Assump i_ sc) as)
        (if (== i i_)
            (pure sc)

--- a/src/library/arith.lisp
+++ b/src/library/arith.lisp
@@ -22,10 +22,6 @@
 
 (cl:defmacro %define-number-stuff (coalton-type)
   `(coalton-toplevel
-     (define-instance (Show ,coalton-type)
-       (define (show x)
-         (lisp String (x) (cl:prin1-to-string x))))
-
      (define-instance (Eq ,coalton-type)
        (define (== a b)
          (lisp Boolean (a b)
@@ -170,7 +166,12 @@
       (cl:if (cl:or (float-features:float-infinity-p x)
                     (float-features:float-nan-p x))
              None
-             (Some (cl:round x))))))
+             (Some (cl:round x)))))
+
+  (declare integer->string (Integer -> String))
+  (define (integer->string n)
+    (lisp String (n)
+      (cl:format cl:nil "~A" n))))
 
 (coalton-toplevel
   (define-instance (Eq Fraction)

--- a/src/library/boolean.lisp
+++ b/src/library/boolean.lisp
@@ -11,12 +11,6 @@
   ;; Boolean instances
   ;;
 
-  (define-instance (Show Boolean)
-    (define (show x)
-      (match x
-        ((True) "True")
-        ((False) "False"))))
-
   (define-instance (Eq Boolean)
     (define (== x y)
       (not (/= x y))))

--- a/src/library/builtin.lisp
+++ b/src/library/builtin.lisp
@@ -3,4 +3,9 @@
 (coalton-toplevel
   (define (undefined x)
     "A function which can be used in place of any value, throwing an error at runtime."
-    (lisp :a () (cl:error "Undefined"))))
+    (lisp :a () (cl:error "Undefined")))
+
+  (declare error (String -> :a))
+  (define (error str)
+    "Signal an error by calling CL:ERROR"
+    (lisp :a (str) (cl:error str))))

--- a/src/library/cell.lisp
+++ b/src/library/cell.lisp
@@ -48,10 +48,6 @@
   (define (cell-update f cell)
     (cell-write (f (cell-read cell)) cell))
 
-  (define-instance (Show :a => (Show (Cell :a)))
-    (define (show x)
-      (concat-string (concat-string "Cell<" (show (cell-read x))) ">")))
-
   (define-instance (Eq :a => (Eq (Cell :a)))
     (define (== c1 c2)
       (== (cell-read c1) (cell-read c2))))

--- a/src/library/char.lisp
+++ b/src/library/char.lisp
@@ -1,11 +1,6 @@
 (in-package #:coalton-library)
 
 (coalton-toplevel
-  (define-instance (Show Char)
-    (define (show x)
-      (lisp String (x)
-        (cl:string x))))
-
   (define-instance (Eq Char)
     (define (== x y)
       (lisp Boolean (x y) (to-boolean (cl:char= x y)))))

--- a/src/library/classes.lisp
+++ b/src/library/classes.lisp
@@ -3,14 +3,6 @@
 (coalton-toplevel
 
   ;;
-  ;; Show
-  ;;
-
-  (define-class (Show :a)
-    "Types which can be shown in string representation."
-    (show (:a -> String)))
-
-  ;;
   ;; Eq
   ;;
 
@@ -81,7 +73,7 @@
   ;; Num
   ;;
 
-  (define-class ((Eq :a) (Show :a) => (Num :a))
+  (define-class ((Eq :a) => (Num :a))
     "Types which have numeric operations defined."
     (+ (:a -> :a -> :a))
     (- (:a -> :a -> :a))

--- a/src/library/fraction.lisp
+++ b/src/library/fraction.lisp
@@ -11,9 +11,4 @@
   (define (denominator q)
     "The denominator of a fraction Q."
     (match q
-      ((%Fraction _ d) d)))
-
-  (define-instance (Show Fraction)
-    (define (show q)
-      (lisp String (q)
-        (cl:format cl:nil "~D/~D" (numerator q) (denominator q))))))
+      ((%Fraction _ d) d))))

--- a/src/library/functions.lisp
+++ b/src/library/functions.lisp
@@ -2,10 +2,6 @@
 
 (coalton-toplevel
 
-  (declare error (String -> :a))
-  (define (error str)
-    "Signal an error by calling CL:ERROR"
-    (lisp :a (str) (cl:error str)))
 
   (declare trace (String -> Unit))
   (define (trace str)

--- a/src/library/graph.lisp
+++ b/src/library/graph.lisp
@@ -81,18 +81,8 @@
         ((Tuple (EdgeIndex a) (EdgeIndex b))
          (== a b)))))
 
-  (define-instance (Show EdgeIndex)
-    (define (show x)
-      (match x
-        ((EdgeIndex x) (show x)))))
-
   (define-type NodeIndex
     (NodeIndex Integer))
-
-  (define-instance (Show NodeIndex)
-    (define (show x)
-      (match x
-        ((NodeIndex x) (show x)))))
 
   (declare node-index-value (NodeIndex -> Integer))
   (define (node-index-value idx)
@@ -448,41 +438,6 @@
              (progn
                (change-edge-links swap swapped-edge (IndexPair (Some index) (Some index)) graph)
                (Some (edge-data edge_))))))))
-
-  ;; TODO: add function to output graphviz where subgraphs are sccs
-  (declare graph-viz (Show :node-data => ((Graph :node-data :edge-data) -> String)))
-  (define (graph-viz graph_)
-    (progn
-      (let elements = (make-vector Unit))
-      (if (graph-is-directed graph_)
-          (vector-push "digraph {" elements)
-          (vector-push "graph {" elements))
-      (vector-foreach-index
-       (fn (i node)
-         (vector-push
-          (msum
-           (make-list
-            (show i)
-            " [label=\""
-            (show (node-data node))
-            "\"]"))
-          elements))
-       (graph-nodes graph_))
-      (vector-foreach
-       (fn (edge)
-         (vector-push
-          (msum
-           (make-list
-            (show (edge-from-index edge))
-            (if (graph-is-directed graph_)
-                " -> "
-                " -- ")
-            (show (edge-to-index edge))))
-          elements))
-       (graph-edges graph_))
-      (vector-push "}" elements)
-      (msum (intersperse (show #\NEWLINE) (into (the (Vector String) elements))))))
-
 
   ;;
   ;; Tarjan strongly connected components algorithm

--- a/src/library/optional.lisp
+++ b/src/library/optional.lisp
@@ -34,12 +34,6 @@
   ;; Optional instances
   ;;
 
-  (define-instance (Show :a => (Show (Optional :a)))
-    (define (show x)
-      (match x
-        ((Some a) (concat-string "Some " (show a)))
-        ((None) "None"))))
-
   (define-instance (Eq :a => (Eq (Optional :a)))
     (define (== x y)
       (match (Tuple x y)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -490,10 +490,14 @@
    #:TryInto)
   ;; Builtin
   (:export
+   #:undefined
+   #:error)
+  (:export
    #:single-float->integer
    #:double-float->integer
    #:integer->single-float
    #:integer->double-float
+   #:integer->string
    #:negate
    #:abs
    #:ash

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -368,12 +368,17 @@
 
 (deftest test-seq ()
   (check-coalton-types
-   '((coalton:define (f x)
+   '((coalton:define-class (Show :a))
+
+     (coalton:declare show (Show :a => (:a -> String)))
+     (coalton:define (show x) "not impl")
+
+     (coalton:define (f x)
        (coalton:seq
         (coalton-library:Ok "hello")
         (coalton-library:map (coalton-library:+ 1) (coalton-library:make-list 1 2 3 4))
-        (coalton-library:show x))))
-   '((f . (coalton-library:Show :a => (:a -> String))))))
+        (show x))))
+   '((f . (Show :a => (:a -> String))))))
 
 
 (deftest test-the ()


### PR DESCRIPTION
The Show type class is almost entirely unused because values can already
be printed in the REPL. The definition of Show is slow because it
requires repeatedly concatenating strings in memory.

In the future other type classes for printing structures should be
explored. They should use string streams or another way of only building
a complete string once.

Also multiple printing classes similar to Debug and Display in Rust
should be explored.