### PR TITLE
remove unsafe/, add Quantizable class, add division convenience functions

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -96,6 +96,7 @@
                              (:file "tuple")
                              (:file "result")
                              (:file "functions")
+                             (:file "quantize")
                              (:file "cell")
                              (:file "vector")
                              (:file "slice")
@@ -125,4 +126,5 @@
                (:file "runtime-tests")
                (:file "environment-persist-tests")
                (:file "slice-tests")
+               (:file "quantize-tests")
                (:file "graph-tests")))

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -494,11 +494,11 @@ establishes that division of two `Single-Float`s can result in a `Single-Float`.
 
 Note that `Dividable` does *not* establish a default result type; you must constrain the result type yourself.
 
-See also: `/`
+The function / is partial, and will error produce a run-time error if the divisor is zero.
 
 
 Methods:
-- `UNSAFE/ :: (:A → :A → :B)`
+- `/ :: (:A → :A → :B)`
 
 <details>
 <summary>Instances</summary>
@@ -764,7 +764,7 @@ Is N even?
 #### `EXPT` <sup><sub>[FUNCTION]</sub></sup><a name="EXPT"></a>
 `(INTEGER → INTEGER → INTEGER)`
 
-Exponentiate BASE to the POWER.
+Exponentiate BASE to a non-negative POWER.
 
 
 ***
@@ -1409,19 +1409,6 @@ Print a line to *STANDARD-OUTPUT* in the form "{STR}: {ITEM}"
 
 ### Functions
 
-#### `/` <sup><sub>[FUNCTION]</sub></sup><a name="/"></a>
-`∀ :A :B. DIVIDABLE :A :B ⇒ (:A → :A → (OPTIONAL :B))`
-
-Divide X by Y, returning None if Y is zero.
-
-This operator requires the resulting type to be known and constrained.
-
-Some monomorphic convenience variants: `exact/`, `floor/`, `ceiling/`, `round/`
-
-
-
-***
-
 #### `FLOOR` <sup><sub>[FUNCTION]</sub></sup><a name="FLOOR"></a>
 `∀ :A. QUANTIZABLE :A ⇒ (:A → INTEGER)`
 
@@ -1438,8 +1425,16 @@ Return the nearest integer to X, with ties breaking toward positive infinity.
 
 ***
 
+#### `SAFE/` <sup><sub>[FUNCTION]</sub></sup><a name="SAFE/"></a>
+`∀ :A :B. DIVIDABLE :A :B ⇒ (:A → :A → (OPTIONAL :B))`
+
+Safely divide X by Y, returning None if Y is zero.
+
+
+***
+
 #### `EXACT/` <sup><sub>[FUNCTION]</sub></sup><a name="EXACT/"></a>
-`(INTEGER → INTEGER → (OPTIONAL FRACTION))`
+`(INTEGER → INTEGER → FRACTION)`
 
 Exactly divide two integers and produce a fraction.
 
@@ -1447,7 +1442,7 @@ Exactly divide two integers and produce a fraction.
 ***
 
 #### `FLOOR/` <sup><sub>[FUNCTION]</sub></sup><a name="FLOOR/"></a>
-`(INTEGER → INTEGER → (OPTIONAL INTEGER))`
+`(INTEGER → INTEGER → INTEGER)`
 
 Divide two integers and compute the floor of the quotient.
 
@@ -1455,7 +1450,7 @@ Divide two integers and compute the floor of the quotient.
 ***
 
 #### `ROUND/` <sup><sub>[FUNCTION]</sub></sup><a name="ROUND/"></a>
-`(INTEGER → INTEGER → (OPTIONAL INTEGER))`
+`(INTEGER → INTEGER → INTEGER)`
 
 Divide two integers and round the quotient.
 
@@ -1471,7 +1466,7 @@ Return the least integer greater than or equal to X.
 ***
 
 #### `DOUBLE/` <sup><sub>[FUNCTION]</sub></sup><a name="DOUBLE/"></a>
-`(DOUBLE-FLOAT → DOUBLE-FLOAT → (OPTIONAL DOUBLE-FLOAT))`
+`(DOUBLE-FLOAT → DOUBLE-FLOAT → DOUBLE-FLOAT)`
 
 Compute the quotient of single-precision floats A and B as a single-precision float.
 
@@ -1479,7 +1474,7 @@ Compute the quotient of single-precision floats A and B as a single-precision fl
 ***
 
 #### `SINGLE/` <sup><sub>[FUNCTION]</sub></sup><a name="SINGLE/"></a>
-`(SINGLE-FLOAT → SINGLE-FLOAT → (OPTIONAL SINGLE-FLOAT))`
+`(SINGLE-FLOAT → SINGLE-FLOAT → SINGLE-FLOAT)`
 
 Compute the quotient of single-precision floats A and B as a single-precision float.
 
@@ -1487,7 +1482,7 @@ Compute the quotient of single-precision floats A and B as a single-precision fl
 ***
 
 #### `CEILING/` <sup><sub>[FUNCTION]</sub></sup><a name="CEILING/"></a>
-`(INTEGER → INTEGER → (OPTIONAL INTEGER))`
+`(INTEGER → INTEGER → INTEGER)`
 
 Divide two integers and compute the ceiling of the quotient.
 
@@ -1495,7 +1490,7 @@ Divide two integers and compute the ceiling of the quotient.
 ***
 
 #### `INEXACT/` <sup><sub>[FUNCTION]</sub></sup><a name="INEXACT/"></a>
-`(INTEGER → INTEGER → (OPTIONAL DOUBLE-FLOAT))`
+`(INTEGER → INTEGER → DOUBLE-FLOAT)`
 
 Compute the quotient of integers A and B as a double-precision float.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,7 +47,7 @@ Constructors:
 - [`FUNCTOR`](#FUNCTOR) [`(RESULT :A)`](#RESULT)
 - [`SEMIGROUP :A`](#SEMIGROUP) `=>` [`SEMIGROUP`](#SEMIGROUP) [`(RESULT :B :A)`](#RESULT)
 - [`APPLICATIVE`](#APPLICATIVE) [`(RESULT :A)`](#RESULT)
-- [`WITHDEFAULT`](#WITHDEFAULT) [`(RESULT :A)`](#RESULT)
+- [`UNWRAPPABLE`](#UNWRAPPABLE) [`(RESULT :A)`](#RESULT)
 
 </details>
 
@@ -113,6 +113,7 @@ Constructors:
 - [`NUM`](#NUM) [`FRACTION`](#FRACTION)
 - [`ORD`](#ORD) [`FRACTION`](#FRACTION)
 - [`DIVIDABLE`](#DIVIDABLE) [`INTEGER`](#INTEGER) [`FRACTION`](#FRACTION)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`FRACTION`](#FRACTION)
 
 </details>
 
@@ -143,7 +144,7 @@ Constructors:
 - [`SEMIGROUP :A`](#SEMIGROUP) `=>` [`SEMIGROUP`](#SEMIGROUP) [`(OPTIONAL :A)`](#OPTIONAL)
 - [`ALTERNATIVE`](#ALTERNATIVE) [`OPTIONAL`](#OPTIONAL)
 - [`APPLICATIVE`](#APPLICATIVE) [`OPTIONAL`](#OPTIONAL)
-- [`WITHDEFAULT`](#WITHDEFAULT) [`OPTIONAL`](#OPTIONAL)
+- [`UNWRAPPABLE`](#UNWRAPPABLE) [`OPTIONAL`](#OPTIONAL)
 
 </details>
 
@@ -213,6 +214,29 @@ Constructors:
 - `LT :: ORD`
 - `GT :: ORD`
 - `EQ :: ORD`
+
+***
+
+#### `QUANTIZATION :A` <sup><sub>[TYPE]</sub></sup><a name="QUANTIZATION"></a>
+- `(QUANTIZATION :A INTEGER :A INTEGER :A)`
+
+Represents an integer quantization of `:t`. See the `Quantizable` typeclass.
+
+The fields are defined as follows:
+
+1. A value of type `:t`.
+
+2. The greatest integer less than or equal to a particular value.
+
+3. The remainder of this as a value of type `:t`.
+
+4. The least integer greater than or equal to a particular value.
+
+5. The remainder of this as a value of type `:t`.
+
+
+Constructors:
+- `QUANTIZATION :: (:A → INTEGER → :A → INTEGER → :A → (QUANTIZATION :A))`
 
 ***
 
@@ -474,11 +498,13 @@ See also: `/`
 
 
 Methods:
-- `UNSAFE-/ :: (:A → :A → :B)`
+- `UNSAFE/ :: (:A → :A → :B)`
 
 <details>
 <summary>Instances</summary>
 
+- [`DIVIDABLE`](#DIVIDABLE) [`INTEGER`](#INTEGER) [`DOUBLE-FLOAT`](#DOUBLE-FLOAT)
+- [`DIVIDABLE`](#DIVIDABLE) [`INTEGER`](#INTEGER) [`SINGLE-FLOAT`](#SINGLE-FLOAT)
 - [`DIVIDABLE`](#DIVIDABLE) [`INTEGER`](#INTEGER) [`FRACTION`](#FRACTION)
 - [`DIVIDABLE`](#DIVIDABLE) [`DOUBLE-FLOAT`](#DOUBLE-FLOAT) [`DOUBLE-FLOAT`](#DOUBLE-FLOAT)
 - [`DIVIDABLE`](#DIVIDABLE) [`SINGLE-FLOAT`](#SINGLE-FLOAT) [`SINGLE-FLOAT`](#SINGLE-FLOAT)
@@ -543,6 +569,33 @@ Methods:
 - [`APPLICATIVE`](#APPLICATIVE) [`(RESULT :A)`](#RESULT)
 - [`APPLICATIVE`](#APPLICATIVE) [`LIST`](#LIST)
 - [`APPLICATIVE`](#APPLICATIVE) [`OPTIONAL`](#OPTIONAL)
+
+</details>
+
+
+***
+
+#### `QUANTIZABLE` <sup><sub>[CLASS]</sub></sup><a name="QUANTIZABLE"></a>
+[`ORD :A`](#ORD) [`NUM :A`](#NUM) `=>` [`QUANTIZABLE`](#QUANTIZABLE) [`:A`](#:A)
+
+The representation of a type that allows "quantizing", "snapping to integers", or "rounding." (All of these concepts are roughly equivalent.)
+
+
+Methods:
+- `QUANTIZE :: (:A → (QUANTIZATION :A))`
+
+<details>
+<summary>Instances</summary>
+
+- [`QUANTIZABLE`](#QUANTIZABLE) [`FRACTION`](#FRACTION)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`DOUBLE-FLOAT`](#DOUBLE-FLOAT)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`SINGLE-FLOAT`](#SINGLE-FLOAT)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`U64`](#U64)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`U32`](#U32)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`U8`](#U8)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`I64`](#I64)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`I32`](#I32)
+- [`QUANTIZABLE`](#QUANTIZABLE) [`INTEGER`](#INTEGER)
 
 </details>
 
@@ -651,14 +704,6 @@ The denominator of a fraction Q.
 ## File: [arith.lisp](../src/library/arith.lisp)
 
 ### Functions
-
-#### `/` <sup><sub>[FUNCTION]</sub></sup><a name="/"></a>
-`∀ :A :B. DIVIDABLE :A :B ⇒ (:A → :A → (OPTIONAL :B))`
-
-Divide X by Y, returning None if Y is zero.
-
-
-***
 
 #### `ABS` <sup><sub>[FUNCTION]</sub></sup><a name="ABS"></a>
 `∀ :A. (NUM :A) (ORD :A) ⇒ (:A → :A)`
@@ -903,6 +948,22 @@ Returns the first element of a list.
 
 ***
 
+#### `INIT` <sup><sub>[FUNCTION]</sub></sup><a name="INIT"></a>
+`∀ :A. ((LIST :A) → (LIST :A))`
+
+Returns every element except the last in a list.
+
+
+***
+
+#### `LAST` <sup><sub>[FUNCTION]</sub></sup><a name="LAST"></a>
+`∀ :A. ((LIST :A) → (OPTIONAL :A))`
+
+Returns the last element of a list.
+
+
+***
+
 #### `NULL` <sup><sub>[FUNCTION]</sub></sup><a name="NULL"></a>
 `∀ :A. ((LIST :A) → BOOLEAN)`
 
@@ -922,7 +983,7 @@ Performs a stable sort of XS.
 #### `TAIL` <sup><sub>[FUNCTION]</sub></sup><a name="TAIL"></a>
 `∀ :A. ((LIST :A) → (OPTIONAL (LIST :A)))`
 
-Returns every element but the first in a list.
+Returns every element except the first in a list.
 
 
 ***
@@ -956,6 +1017,11 @@ Returns the Ith element of XS.
 
 Returns a list containing the numbers from START to END inclusive.
 
+
+***
+
+#### `SPLIT` <sup><sub>[FUNCTION]</sub></sup><a name="SPLIT"></a>
+`(CHAR → STRING → (LIST STRING))`
 
 ***
 
@@ -1339,6 +1405,106 @@ Print a line to *STANDARD-OUTPUT* in the form "{STR}: {ITEM}"
 ***
 
 
+## File: [quantize.lisp](../src/library/quantize.lisp)
+
+### Functions
+
+#### `/` <sup><sub>[FUNCTION]</sub></sup><a name="/"></a>
+`∀ :A :B. DIVIDABLE :A :B ⇒ (:A → :A → (OPTIONAL :B))`
+
+Divide X by Y, returning None if Y is zero.
+
+This operator requires the resulting type to be known and constrained.
+
+Some monomorphic convenience variants: `exact/`, `floor/`, `ceiling/`, `round/`
+
+
+
+***
+
+#### `FLOOR` <sup><sub>[FUNCTION]</sub></sup><a name="FLOOR"></a>
+`∀ :A. QUANTIZABLE :A ⇒ (:A → INTEGER)`
+
+Return the greatest integer less than or equal to X.
+
+
+***
+
+#### `ROUND` <sup><sub>[FUNCTION]</sub></sup><a name="ROUND"></a>
+`∀ :A. QUANTIZABLE :A ⇒ (:A → INTEGER)`
+
+Return the nearest integer to X, with ties breaking toward positive infinity.
+
+
+***
+
+#### `EXACT/` <sup><sub>[FUNCTION]</sub></sup><a name="EXACT/"></a>
+`(INTEGER → INTEGER → (OPTIONAL FRACTION))`
+
+Exactly divide two integers and produce a fraction.
+
+
+***
+
+#### `FLOOR/` <sup><sub>[FUNCTION]</sub></sup><a name="FLOOR/"></a>
+`(INTEGER → INTEGER → (OPTIONAL INTEGER))`
+
+Divide two integers and compute the floor of the quotient.
+
+
+***
+
+#### `ROUND/` <sup><sub>[FUNCTION]</sub></sup><a name="ROUND/"></a>
+`(INTEGER → INTEGER → (OPTIONAL INTEGER))`
+
+Divide two integers and round the quotient.
+
+
+***
+
+#### `CEILING` <sup><sub>[FUNCTION]</sub></sup><a name="CEILING"></a>
+`∀ :A. QUANTIZABLE :A ⇒ (:A → INTEGER)`
+
+Return the least integer greater than or equal to X.
+
+
+***
+
+#### `DOUBLE/` <sup><sub>[FUNCTION]</sub></sup><a name="DOUBLE/"></a>
+`(DOUBLE-FLOAT → DOUBLE-FLOAT → (OPTIONAL DOUBLE-FLOAT))`
+
+Compute the quotient of single-precision floats A and B as a single-precision float.
+
+
+***
+
+#### `SINGLE/` <sup><sub>[FUNCTION]</sub></sup><a name="SINGLE/"></a>
+`(SINGLE-FLOAT → SINGLE-FLOAT → (OPTIONAL SINGLE-FLOAT))`
+
+Compute the quotient of single-precision floats A and B as a single-precision float.
+
+
+***
+
+#### `CEILING/` <sup><sub>[FUNCTION]</sub></sup><a name="CEILING/"></a>
+`(INTEGER → INTEGER → (OPTIONAL INTEGER))`
+
+Divide two integers and compute the ceiling of the quotient.
+
+
+***
+
+#### `INEXACT/` <sup><sub>[FUNCTION]</sub></sup><a name="INEXACT/"></a>
+`(INTEGER → INTEGER → (OPTIONAL DOUBLE-FLOAT))`
+
+Compute the quotient of integers A and B as a double-precision float.
+
+Note: This does *not* divide double-float arguments.
+
+
+***
+
+
 ## File: [cell.lisp](../src/library/cell.lisp)
 
 ### Types
@@ -1544,6 +1710,11 @@ Call the function F once for each item in V
 
 Sort a vector with predicate function F
 
+
+***
+
+#### `VECTOR-TO-LIST` <sup><sub>[FUNCTION]</sub></sup><a name="VECTOR-TO-LIST"></a>
+`∀ :A. ((VECTOR :A) → (LIST :A))`
 
 ***
 

--- a/src/library/arith.lisp
+++ b/src/library/arith.lisp
@@ -312,26 +312,26 @@
       (%Fraction z 1)))
 
   (define-instance (Dividable Single-Float Single-Float)
-    (define (unsafe/ x y)
+    (define (/ x y)
       (lisp Single-Float (x y)
         (cl:/ x y))))
 
   (define-instance (Dividable Double-Float Double-Float)
-    (define (unsafe/ x y)
+    (define (/ x y)
       (lisp Double-Float (x y)
         (cl:/ x y))))
 
   (define-instance (Dividable Integer Fraction)
-    (define (unsafe/ x y)
+    (define (/ x y)
       (%mkFraction x y)))
 
   (define-instance (Dividable Integer Single-Float)
-    (define (unsafe/ x y)
+    (define (/ x y)
       (lisp Single-Float (x y)
         (cl:coerce (cl:/ x y) 'cl:single-float))))
 
   (define-instance (Dividable Integer Double-Float)
-    (define (unsafe/ x y)
+    (define (/ x y)
       (lisp Double-Float (x y)
         (cl:coerce (cl:/ x y) 'cl:double-float))))
   )

--- a/src/library/arith.lisp
+++ b/src/library/arith.lisp
@@ -1,4 +1,8 @@
-(in-package #:coalton-library)
+;;;; arith.lisp
+;;;;
+;;;; Number types and basic arithmetic.
+
+(cl:in-package #:coalton-library)
 
 (cl:declaim (cl:inline %unsigned->signed))
 (cl:defun %unsigned->signed (bits x)
@@ -271,13 +275,6 @@
     "Compute the least common multiple of A and B."
     (lisp Integer (a b) (cl:lcm a b)))
 
-  (declare / ((Dividable :a :b) => (:a -> :a -> (Optional :b))))
-  (define (/ x y)
-    "Divide X by Y, returning None if Y is zero."
-    (if (== y (fromInt 0))
-        None
-        (Some (unsafe-/ x y))))
-
   (declare %reduce-fraction (Fraction -> Fraction))
   (define (%reduce-fraction q)
     (let ((n (numerator q))
@@ -315,18 +312,29 @@
       (%Fraction z 1)))
 
   (define-instance (Dividable Single-Float Single-Float)
-    (define (unsafe-/ x y)
+    (define (unsafe/ x y)
       (lisp Single-Float (x y)
         (cl:/ x y))))
 
   (define-instance (Dividable Double-Float Double-Float)
-    (define (unsafe-/ x y)
+    (define (unsafe/ x y)
       (lisp Double-Float (x y)
         (cl:/ x y))))
 
   (define-instance (Dividable Integer Fraction)
-    (define (unsafe-/ x y)
-      (%mkFraction x y))))
+    (define (unsafe/ x y)
+      (%mkFraction x y)))
+
+  (define-instance (Dividable Integer Single-Float)
+    (define (unsafe/ x y)
+      (lisp Single-Float (x y)
+        (cl:coerce (cl:/ x y) 'cl:single-float))))
+
+  (define-instance (Dividable Integer Double-Float)
+    (define (unsafe/ x y)
+      (lisp Double-Float (x y)
+        (cl:coerce (cl:/ x y) 'cl:double-float))))
+  )
 
 (coalton-toplevel
   (define-instance (Into Integer String)

--- a/src/library/classes.lisp
+++ b/src/library/classes.lisp
@@ -103,15 +103,12 @@ establishes that division of two `Single-Float`s can result in a `Single-Float`.
 
 Note that `Dividable` does *not* establish a default result type; you must constrain the result type yourself.
 
-See also: `/`
+The function / is partial, and will error produce a run-time error if the divisor is zero.
 "
     ;; This is a type that is more pragmatic and less mathematical in
     ;; nature. It expresses a division relationship between one input
     ;; type and one output type.
-    ;;
-    ;; UNSAFE/ does the division unsafely. This may mean that an
-    ;; error is signaled or that undefined results may occur.
-    (unsafe/ (:arg-type -> :arg-type -> :res-type)))
+    (/ (:arg-type -> :arg-type -> :res-type)))
 
   ;;
   ;; Quantizable

--- a/src/library/classes.lisp
+++ b/src/library/classes.lisp
@@ -109,9 +109,39 @@ See also: `/`
     ;; nature. It expresses a division relationship between one input
     ;; type and one output type.
     ;;
-    ;; UNSAFE-/ does the division unsafely. This may mean that an
+    ;; UNSAFE/ does the division unsafely. This may mean that an
     ;; error is signaled or that undefined results may occur.
-    (unsafe-/ (:arg-type -> :arg-type -> :res-type)))
+    (unsafe/ (:arg-type -> :arg-type -> :res-type)))
+
+  ;;
+  ;; Quantizable
+  ;;
+
+  (define-type (Quantization :t)
+    "Represents an integer quantization of `:t`. See the `Quantizable` typeclass.
+
+The fields are defined as follows:
+
+1. A value of type `:t`.
+
+2. The greatest integer less than or equal to a particular value.
+
+3. The remainder of this as a value of type `:t`.
+
+4. The least integer greater than or equal to a particular value.
+
+5. The remainder of this as a value of type `:t`.
+"
+    (Quantization :t Integer :t Integer :t))
+
+  (define-class ((Ord :t) (Num :t) => (Quantizable :t))
+    "The representation of a type that allows \"quantizing\", \"snapping to integers\", or \"rounding.\" (All of these concepts are roughly equivalent.)
+"
+    ;; Given a X of type :T, (QUANTIZE X) will return the least
+    ;; integer greater or equal to X, and the greatest integer less
+    ;; than or equal to X, along with their respective remainders
+    ;; expressed as values of type :T.
+    (quantize (:t -> (Quantization :t))))
 
   ;;
   ;; Haskell

--- a/src/library/quantize.lisp
+++ b/src/library/quantize.lisp
@@ -75,55 +75,50 @@
   )                                     ; Coalton-Toplevel
 
 (coalton-toplevel
-  (declare / ((Dividable :a :b) => (:a -> :a -> (Optional :b))))
-  (define (/ x y)
-    "Divide X by Y, returning None if Y is zero.
-
-This operator requires the resulting type to be known and constrained.
-
-Some monomorphic convenience variants: `exact/`, `floor/`, `ceiling/`, `round/`
-"
+  (declare safe/ ((Dividable :a :b) => (:a -> :a -> (Optional :b))))
+  (define (safe/ x y)
+    "Safely divide X by Y, returning None if Y is zero."
     (if (== y (fromInt 0))
         None
-        (Some (unsafe/ x y))))
+        (Some (/ x y))))
   )
 
 (coalton-toplevel
-  (declare exact/ (Integer -> Integer -> (Optional Fraction)))
+  (declare exact/ (Integer -> Integer -> Fraction))
   (define (exact/ a b)
     "Exactly divide two integers and produce a fraction."
     ;; BUG: I don't know why I *have* to specify (the Integer *) here,
     ;; but the type checker fails otherwise.
-    (the (Optional Fraction) (/ (the Integer a) (the Integer b))))
+    (the Fraction (/ (the Integer a) (the Integer b))))
 
-  (declare inexact/ (Integer -> Integer -> (Optional Double-Float)))
+  (declare inexact/ (Integer -> Integer -> Double-Float))
   (define (inexact/ a b)
     "Compute the quotient of integers A and B as a double-precision float.
 
 Note: This does *not* divide double-float arguments."
     (/ a b))
 
-  (declare floor/ (Integer -> Integer -> (Optional Integer)))
+  (declare floor/ (Integer -> Integer -> Integer))
   (define (floor/ a b)
     "Divide two integers and compute the floor of the quotient."
-    (map floor (exact/ a b)))
+    (floor (exact/ a b)))
 
-  (declare ceiling/ (Integer -> Integer -> (Optional Integer)))
+  (declare ceiling/ (Integer -> Integer -> Integer))
   (define (ceiling/ a b)
     "Divide two integers and compute the ceiling of the quotient."
-    (map ceiling (exact/ a b)))
+    (ceiling (exact/ a b)))
 
-  (declare round/ (Integer -> Integer -> (Optional Integer)))
+  (declare round/ (Integer -> Integer -> Integer))
   (define (round/ a b)
     "Divide two integers and round the quotient."
-    (map round (exact/ a b)))
+    (round (exact/ a b)))
 
-  (declare single/ (Single-Float -> Single-Float -> (Optional Single-Float)))
+  (declare single/ (Single-Float -> Single-Float -> Single-Float))
   (define (single/ a b)
     "Compute the quotient of single-precision floats A and B as a single-precision float."
     (/ a b))
 
-  (declare double/ (Double-Float -> Double-Float -> (Optional Double-Float)))
+  (declare double/ (Double-Float -> Double-Float -> Double-Float))
   (define (double/ a b)
     "Compute the quotient of single-precision floats A and B as a single-precision float."
     (/ a b))

--- a/src/library/quantize.lisp
+++ b/src/library/quantize.lisp
@@ -1,0 +1,130 @@
+;;;; quantize.lisp
+;;;;
+;;;; Non-trivial rounding operations.
+
+(cl:in-package #:coalton-library)
+
+(coalton-toplevel
+  (define-instance (Quantizable Integer)
+    (define (quantize x)
+      (Quantization x x 0 x 0))))
+
+(cl:macrolet ((define-integer-quantizations (cl:&rest int-types)
+                `(coalton-toplevel
+                   ,@(cl:loop :for ty :in int-types :collect
+                        `(define-instance (Quantizable ,ty)
+                           (define (quantize x)
+                             (let ((n (into x)))
+                               (Quantization x n (fromInt 0) n (fromInt 0)))))))))
+  (define-integer-quantizations I32 I64 U8 U32 U64))
+
+(coalton-toplevel
+  (define-instance (Quantizable Single-Float)
+    (define (quantize f)
+      (lisp (Quantization Single-Float) (f)
+        (uiop:nest
+         (cl:multiple-value-bind (fl-quo fl-rem) (cl:floor f))
+         (cl:multiple-value-bind (ce-quo ce-rem) (cl:ceiling f))
+         (Quantization f fl-quo fl-rem ce-quo ce-rem)))))
+
+  (define-instance (Quantizable Double-Float)
+    (define (quantize f)
+      (lisp (Quantization Double-Float) (f)
+        (uiop:nest
+         (cl:multiple-value-bind (fl-quo fl-rem) (cl:floor f))
+         (cl:multiple-value-bind (ce-quo ce-rem) (cl:ceiling f))
+         (Quantization f fl-quo fl-rem ce-quo ce-rem))))))
+
+(coalton-toplevel
+  (define-instance (Quantizable Fraction)
+    (define (quantize q)
+      (let ((n (numerator q))
+            (d (denominator q)))
+        (lisp (Quantization Fraction) (n d)
+          ;; Not the most efficient... just relying on CL to do the
+          ;; work.
+          (cl:flet ((to-frac (f)
+                      (%Fraction (cl:numerator f) (cl:denominator f))))
+            (cl:let ((f (cl:/ n d)))
+              (uiop:nest
+               (cl:multiple-value-bind (fl-quo fl-rem) (cl:floor f))
+               (cl:multiple-value-bind (ce-quo ce-rem) (cl:ceiling f))
+               (Quantization f
+                             fl-quo (to-frac fl-rem)
+                             ce-quo (to-frac ce-rem))))))))))
+
+(coalton-toplevel
+  (define (floor x)
+    "Return the greatest integer less than or equal to X."
+    (match (quantize x)
+      ((Quantization _ z _ _ _) z)))
+
+  (define (ceiling x)
+    "Return the least integer greater than or equal to X."
+    (match (quantize x)
+      ((Quantization _ _ _ z _) z)))
+
+  (define (round x)
+    "Return the nearest integer to X, with ties breaking toward positive infinity."
+    (match (quantize x)
+      ((Quantization _ a ar b br)
+       (match (<=> (abs ar) (abs br))
+         ((LT) a)
+         ((GT) b)
+         ((EQ) (max a b))))))
+  )                                     ; Coalton-Toplevel
+
+(coalton-toplevel
+  (declare / ((Dividable :a :b) => (:a -> :a -> (Optional :b))))
+  (define (/ x y)
+    "Divide X by Y, returning None if Y is zero.
+
+This operator requires the resulting type to be known and constrained.
+
+Some monomorphic convenience variants: `exact/`, `floor/`, `ceiling/`, `round/`
+"
+    (if (== y (fromInt 0))
+        None
+        (Some (unsafe/ x y))))
+  )
+
+(coalton-toplevel
+  (declare exact/ (Integer -> Integer -> (Optional Fraction)))
+  (define (exact/ a b)
+    "Exactly divide two integers and produce a fraction."
+    ;; BUG: I don't know why I *have* to specify (the Integer *) here,
+    ;; but the type checker fails otherwise.
+    (the (Optional Fraction) (/ (the Integer a) (the Integer b))))
+
+  (declare inexact/ (Integer -> Integer -> (Optional Double-Float)))
+  (define (inexact/ a b)
+    "Compute the quotient of integers A and B as a double-precision float.
+
+Note: This does *not* divide double-float arguments."
+    (/ a b))
+
+  (declare floor/ (Integer -> Integer -> (Optional Integer)))
+  (define (floor/ a b)
+    "Divide two integers and compute the floor of the quotient."
+    (map floor (exact/ a b)))
+
+  (declare ceiling/ (Integer -> Integer -> (Optional Integer)))
+  (define (ceiling/ a b)
+    "Divide two integers and compute the ceiling of the quotient."
+    (map ceiling (exact/ a b)))
+
+  (declare round/ (Integer -> Integer -> (Optional Integer)))
+  (define (round/ a b)
+    "Divide two integers and round the quotient."
+    (map round (exact/ a b)))
+
+  (declare single/ (Single-Float -> Single-Float -> (Optional Single-Float)))
+  (define (single/ a b)
+    "Compute the quotient of single-precision floats A and B as a single-precision float."
+    (/ a b))
+
+  (declare double/ (Double-Float -> Double-Float -> (Optional Double-Float)))
+  (define (double/ a b)
+    "Compute the quotient of single-precision floats A and B as a single-precision float."
+    (/ a b))
+  )                                     ; Coalton-Toplevel

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -491,7 +491,7 @@
    #:max
    #:min
    #:Num #:+ #:- #:* #:fromInt
-   #:Dividable #:unsafe/
+   #:Dividable #:/
    #:Quantization
    #:Quantizable #:quantize
    #:Semigroup #:<>
@@ -529,7 +529,14 @@
    #:floor
    #:ceiling
    #:round
-   #:/ #:exact/ #:inexact/ #:floor/ #:ceiling/ #:round/ #:single/ #:double/)
+   #:safe/
+   #:exact/
+   #:inexact/
+   #:floor/
+   #:ceiling/
+   #:round/
+   #:single/
+   #:double/)
   ;; Fraction
   (:export
    #:numerator

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -491,7 +491,9 @@
    #:max
    #:min
    #:Num #:+ #:- #:* #:fromInt
-   #:Dividable #:unsafe-/
+   #:Dividable #:unsafe/
+   #:Quantization
+   #:Quantizable #:quantize
    #:Semigroup #:<>
    #:Monoid #:mempty
    #:Functor #:map
@@ -505,6 +507,7 @@
   (:export
    #:undefined
    #:error)
+  ;; Arith
   (:export
    #:single-float->integer
    #:double-float->integer
@@ -520,8 +523,13 @@
    #:even
    #:odd
    #:gcd
-   #:lcm
-   #:/)
+   #:lcm)
+  ;; Quantize
+  (:export
+   #:floor
+   #:ceiling
+   #:round
+   #:/ #:exact/ #:inexact/ #:floor/ #:ceiling/ #:round/ #:single/ #:double/)
   ;; Fraction
   (:export
    #:numerator

--- a/tests/quantize-tests.lisp
+++ b/tests/quantize-tests.lisp
@@ -1,0 +1,17 @@
+(in-package #:coalton-tests)
+
+(deftest test-rounding ()
+  (is (= 0 (coalton:coalton (coalton-library:floor 0.1))))
+  (is (= 1 (coalton:coalton (coalton-library:ceiling 0.1))))
+  (is (= 0 (coalton:coalton (coalton-library:round 0.1))))
+  
+  (is (= -1 (coalton:coalton (coalton-library:floor -0.1))))
+  (is (= 0 (coalton:coalton (coalton-library:ceiling -0.1))))
+  (is (= 0 (coalton:coalton (coalton-library:round -0.1))))
+  
+  (is (= 0 (coalton:coalton (coalton-library:floor 0.0))))
+  (is (= 0 (coalton:coalton (coalton-library:ceiling 0.0))))
+  (is (= 0 (coalton:coalton (coalton-library:round 0.0))))
+  
+  (is (= 1 (coalton:coalton (coalton-library:round 0.5))))
+  (is (= 0 (coalton:coalton (coalton-library:round -0.5)))))


### PR DESCRIPTION
This commit adds some functionality to make division more convenient.

First, it removes `unsafe/` which was nice in theory but too cumbersome in practice. Now `/` may signal an error at run-time. `safe/` is provided if needed.

Second, it adds a Quantizable class for rounding number types to integers. This is used to implement floor, ceiling, and round in a generic way.

Third, some convenience functions are added for supporting integer and float division. These are common, monomorphic functions that make use of the generic machinery.

Fourth, the introduction is improved to discuss division and how to work with it.

Fifth, the reference was updated.