### PR TITLE
Fix minor typos introduced by #259

### DIFF
--- a/src/algorithm/immutable-listmap.lisp
+++ b/src/algorithm/immutable-listmap.lisp
@@ -6,7 +6,7 @@
 ;;
 
 (defstruct immutable-listmap
-  (data (fset:empty-map (fset:empty-seq)) :type fset:map) :read-only t)
+  (data (fset:empty-map (fset:empty-seq)) :type fset:map :read-only t))
 
 (defun immutable-listmap-lookup (m key &key no-error)
   "Lookup key in M"

--- a/src/ast/node.lisp
+++ b/src/ast/node.lisp
@@ -76,7 +76,7 @@
     (node-abstraction
      (:include node)
      (:constructor node-abstraction (unparsed vars subexpr name-map)))
-  (vars     (required 'vars)     :type t :read-only t)
+  (vars     (required 'vars)     :type t           :read-only t)
   (subexpr  (required 'subexpr)  :type node        :read-only t)
   (name-map (required 'name-map) :type list        :read-only t))
 

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -412,7 +412,7 @@
   (name      (required 'name)      :type symbol                               :read-only t)
   (type      (required 'type)      :type (member :value :method :constructor) :read-only t)
   (docstring (required 'docstring) :type (or null string)                     :read-only t)
-  (location  (required 'location)  :type t)                                   :read-only t)
+  (location  (required 'location)  :type t                                    :read-only t))
 
 (defmethod make-load-form ((self name-entry) &optional env)
   (make-load-form-saving-slots
@@ -448,7 +448,7 @@
   (class-environment       (required 'class-environment)       :type class-environment       :read-only t)
   (instance-environment    (required 'instance-environment)    :type instance-environment    :read-only t)
   (function-environment    (required 'function-environment)    :type function-environment    :read-only t)
-  (name-environment        (required 'name-environment)        :type name-environment)       :read-only t)
+  (name-environment        (required 'name-environment)        :type name-environment       :read-only t))
 
 (defmethod make-load-form ((self environment) &optional env)
   (make-load-form-saving-slots


### PR DESCRIPTION
This was mostly parenthesis in incorrect places causing unwanted slots on some structs.