### PR TITLE
Fix type-variables on environment

### DIFF
--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -501,7 +501,8 @@ EXPL-DECLARATIONS is a HASH-TABLE from SYMBOL to SCHEME"
                                  expr-types
                                  :key #'type-variables)) ; vss
              (local-tvars (set-difference expr-tvars
-                                          env-tvars)) ; gs
+                                          env-tvars
+                                          :test #'equalp)) ; gs
              )
         (multiple-value-bind (deferred-preds retained-preds)
             (split-context env env-tvars expr-preds)

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -15,7 +15,11 @@
                 (immutable-map-data env))))
 
 (defmethod type-variables ((env value-environment))
-  (remove-duplicates (mapcan #'type-variables (fset:convert 'list (fset:range (immutable-map-data env)))) :test #'equalp))
+  (let ((out nil))
+    (fset:do-map (name type (immutable-map-data env))
+      (declare (ignore name))
+      (setf out (append (type-variables type) out)))
+    (remove-duplicates out :test #'equalp)))
 
 ;;;
 ;;; Type environments

--- a/src/typechecker/equality.lisp
+++ b/src/typechecker/equality.lisp
@@ -71,11 +71,6 @@
    (fresh-inst scheme1)
    (fresh-inst scheme2)))
 
-(defmethod fset:compare ((x ty-scheme) (y ty-scheme))
-  (if (type-scheme= x y)
-      :equal
-      :unequal))
-
 (defun type-predicate= (pred1 pred2)
   (and (eql (ty-predicate-class pred1)
             (ty-predicate-class pred2))

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -398,3 +398,11 @@
    '((coalton:define x (coalton:the coalton:U32 (coalton-library:+ (coalton-library:fromInt 1)
                                                                    (coalton-library:fromInt 2)))))
    '((x . coalton:U32))))
+
+(deftest test-regression ()
+  ;; Fixed in #283
+  (check-coalton-types
+   '((coalton:define (f a)
+       (coalton:let ((g (coalton:fn (x) (coalton-library:Tuple x a))))
+         (g 5))))
+   '((f . (:a -> (coalton-library:Tuple Integer :a))))))


### PR DESCRIPTION
Previously fset:domain was used to get the keys in a map. Fset:domain builds a set, which deduplicates values. Fset:compare was defined to `type-scheme=` which treated `forall. a` and `forall. b` as equal.

Fixes #249