### PR TITLE
Allow `progn` at top level

### DIFF
--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -9,7 +9,8 @@
 ;;; be generated at macroexpansion time of the ambient Common Lisp
 ;;; compiler. See the COALTON macro.
 
-(define-global-var **toplevel-operators** '(coalton:coalton-toplevel))
+(define-global-var **toplevel-operators** '(coalton:coalton-toplevel
+                                            coalton-library:progn))
 (define-global-var **special-operators** `(,@**toplevel-operators**
                                            coalton:define
                                            coalton:define-type


### PR DESCRIPTION
This enables macros that define several toplevel forms.