### PR TITLE
Make reduce-context aware of current substitutions

### DIFF
--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -133,7 +133,7 @@
           (derive-expression-type parsed-form *global-environment* nil)
         (let* ((env (coalton-impl/typechecker::apply-substitution substs *global-environment*))
                (preds (coalton-impl/typechecker::apply-substitution substs preds))
-               (preds (coalton-impl/typechecker::reduce-context env preds))
+               (preds (coalton-impl/typechecker::reduce-context env preds substs))
                (typed-node (coalton-impl/typechecker::apply-substitution substs typed-node))
                (type (coalton-impl/typechecker::apply-substitution substs type))
                (qual-type (coalton-impl/typechecker::qualify preds type))

--- a/src/codegen/compile-expression.lisp
+++ b/src/codegen/compile-expression.lisp
@@ -110,7 +110,7 @@
                       (typed-node-seq-subnodes expr)))))
 
 (defun reduce-preds-for-codegen (preds env)
-  (reduce-context env (remove-duplicates preds :test #'equalp)))
+  (reduce-context env (remove-duplicates preds :test #'equalp) nil))
 
 (defun compile-binding-list (typed-bindings sorted-bindings subnode dynamic-extent-bindings ctx env)
   "Compiles a binding list to nested LET and LABELS based on topological sorting of the bindings."

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -157,7 +157,8 @@
          (preds (reduce-context
                  env
                  (remove-duplicates (remove-if #'static-predicate-p (scheme-predicates type))
-                                    :test #'equalp)))
+                                    :test #'equalp)
+                 nil))
 
          (dict-context (mapcar (lambda (pred) (cons pred (gensym))) preds))
 
@@ -199,7 +200,7 @@
           ((= 1 (length scc-typed-bindings))
            ;; Variables
            (let* ((b (first scc-typed-bindings))
-                  (preds (reduce-context env (scheme-predicates (typed-node-type (cdr b))))))
+                  (preds (reduce-context env (scheme-predicates (typed-node-type (cdr b))) nil)))
              (if (not (every #'static-predicate-p  preds))
                  `(,@(compile-function (car b) nil (typed-node-type (cdr b)) (typed-node-type (cdr b)) (cdr b) env))
                  `((coalton-impl::define-global-lexical ,(car b) ':|@@unbound@@|)

--- a/src/library/quantize.lisp
+++ b/src/library/quantize.lisp
@@ -87,9 +87,7 @@
   (declare exact/ (Integer -> Integer -> Fraction))
   (define (exact/ a b)
     "Exactly divide two integers and produce a fraction."
-    ;; BUG: I don't know why I *have* to specify (the Integer *) here,
-    ;; but the type checker fails otherwise.
-    (the Fraction (/ (the Integer a) (the Integer b))))
+    (/ a b))
 
   (declare inexact/ (Integer -> Integer -> Double-Float))
   (define (inexact/ a b)

--- a/src/library/vector.lisp
+++ b/src/library/vector.lisp
@@ -278,19 +278,4 @@
                     (Cons (vector-index-unsafe index v) (inner v (+ 1 index)))))))
         (inner v 0))))
 
-  (define-instance (Iso (Vector :a) (List :a)))
-
-  (coalton-toplevel
-    (declare vector-to-list ((Vector :a) -> (List :a)))
-    (define (vector-to-list v)
-      (match v
-        ((Vector v)
-         (lisp (List :a) (v) 
-           (cl:coerce v 'cl:list)))))))
-
-
-(coalton-toplevel
-  (declare v (Vector Integer))
-  (define v (into (make-list 1 2 3 4 5)))
-                
-  (define v2 (map (+ 2) v)))
+  (define-instance (Iso (Vector :a) (List :a))))

--- a/src/toplevel-define.lisp
+++ b/src/toplevel-define.lisp
@@ -121,7 +121,7 @@ Returns new environment, binding list of declared nodes, a DAG of dependencies, 
         (dolist (b typed-bindings)
           (let* ((type (coalton-impl/typechecker::fresh-inst (lookup-value-type env (car b))))
 
-                 (preds (reduce-context env (coalton-impl/typechecker::qualified-ty-predicates type))))
+                 (preds (reduce-context env (coalton-impl/typechecker::qualified-ty-predicates type) subs)))
             (when (and (not (gethash (car b) declared-types))
                        (not (coalton-impl/typechecker::typed-node-abstraction-p (cdr b)))
                        (not (null preds)))

--- a/src/typechecker/parse-class-definition.lisp
+++ b/src/typechecker/parse-class-definition.lisp
@@ -187,11 +187,13 @@
                                                     :test #'equalp)
                                         (coalton-impl/ast::error-parsing form "class type variable ~S cannot appear in method constraints" (car tyvar))))
 
-                                    (let* ((qualified-method-type (qualify
-                                                                   (reduce-context env
-                                                                    (append method-context
-                                                                            (qualified-ty-predicates fresh-method-type)))
-                                                                   (qualified-ty-type fresh-method-type)))
+                                    (let* ((qualified-method-type
+                                             (qualify
+                                              (reduce-context env
+                                                              (append method-context
+                                                                      (qualified-ty-predicates fresh-method-type))
+                                                              subs)
+                                              (qualified-ty-type fresh-method-type)))
                                            (method-type (quantify (type-variables qualified-method-type)
                                                                   qualified-method-type)))
                                       (cons method-name method-type)))))))


### PR DESCRIPTION
This fixes #69 and #273 which were caused by context reduction bugs. `reduce-context` now applies substitutions internally and will no longer signal a context reduction error in cases where the predicates should be deferred to the enclosing context. Additionally, explicit type annotations with `the` had a check for predicates which is no longer valid and has been removed.