### PR TITLE
Fix typed-node predicate removal in binding lists

### DIFF
--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -547,14 +547,17 @@ EXPL-DECLARATIONS is a HASH-TABLE from SYMBOL to SCHEME"
                    (mapcar (lambda (b node)
                              (let* ((node-qual-type (fresh-inst (typed-node-type node)))
                                     (node-type (qualified-ty-type node-qual-type))
-                                    (node-preds (qualified-ty-predicates node-qual-type))
+                                    (node-preds (reduce-context
+                                                 env
+                                                 (qualified-ty-predicates node-qual-type)
+                                                 local-subs))
                                     (new-preds (remove-if
                                                 (lambda (p)
                                                   (member p deferred-preds :test #'equalp))
                                                 node-preds)))
+
                                (cons (car b)
-                                     (replace-node-type node (to-scheme (qualify new-preds node-type)))
-                                     )))
+                                     (replace-node-type node (to-scheme (qualify new-preds node-type))))))
                            bindings typed-bindings)
                    deferred-preds
                    output-env

--- a/tests/runtime-tests.lisp
+++ b/tests/runtime-tests.lisp
@@ -6,9 +6,25 @@
                           goal
                           (f (coalton-library:+ x inc) inc goal)))
 
-    (coalton:define x (f 0 1 5)))
+  (coalton:define x (f 0 1 5)))
 
 ;; Test that functions with typeclass constraints call themselfs recursively
 ;; This was bugged in the past #216 #147 #125
 (deftest test-recursive-predicate-calls ()
   (is (equal x 5)))
+
+
+;; Test that predicates are correctly removed when deferred
+(coalton:coalton-toplevel
+  (coalton:define (gh-295-f a)
+    (coalton:let ((g (coalton:fn (x)
+                       (coalton-library:== x (coalton-library:make-list a)))))
+      g))
+
+  (coalton:define gh-295-x (gh-295-f 1 (coalton-library:make-list 2 3 4)))
+  (coalton:define gh-295-y (gh-295-f 1 (coalton-library:make-list 1))))
+
+;; See gh #295
+(deftest test-deferred-predicate-removal ()
+  (is (equal gh-295-x nil))
+  (is (equal gh-295-y t)))


### PR DESCRIPTION
This fixes #295 which was caused by deferred predicate removal failing due to checking equalp against non-reduced node predicates.