### PR TITLE
add LET*, add docs around variable binding

### DIFF
--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -142,6 +142,60 @@ Note that since these are macros (indicated by their variadic arguments), they
 cannot be used as higher-order functions. Consider either currying or the
 `compose` function if you're thinking in that direction.
 
+
+### Variable Binding with `let` and `let*`
+
+The operators `let` and `let*` is used to bind local variables and functions.
+
+**Note**: These operators are **different** than their Common Lisp counterparts!
+
+In Coalton, `let` is close to "letrec" or "let rec" in other languages. What that means is that `let` introduces a collection of *possibly mutually dependent* variables, and as such, they can appear in any order.
+
+```lisp
+(coalton-toplevel
+  (define (quadratic a b c)
+    (let ((discr (- (* b b) (* 2 (* d c))))
+          (d (* 2 a)))
+      (Tuple (/ (+ (negate b) (sqrt discr)) d)
+             (/ (- (negate b) (sqrt discr)) d)))))
+```
+
+Note that in this definition, `discr` (introduced first) depends on `d` (introduced second).
+
+Variables can also be recursive! So the following code fragment defining a local factorial function is valid.
+
+```lisp
+(let ((f (fn (x)
+           (if (== 0 x)
+               1
+               (* x (f (- x 1)))))))
+ ;; ...
+ )
+```
+
+*Beware*, since recursion of definitions is valid, the following will give unexpected results.
+
+```lisp
+;; bad, invalid
+(coalton-toplevel
+  (define (f xs)
+    (let ((xs (map sqrt xs)))
+      (append xs xs))))
+```
+
+Here, the `let` which is attempting to re-bind `xs` is *actually* referring to itself! To remedy this, either rename the variable, or use `let*`.
+
+```lisp
+;; good
+(coalton-toplevel
+  (define (f xs)
+    (let* ((xs (map sqrt xs)))
+      (append xs xs))))
+```
+
+As can be seen, `let*` is closer to Common Lisp's `let`.
+
+
 ## Data Types
 
 Coalton allows the definition of parametric algebraic data types.

--- a/src/library/macros.lisp
+++ b/src/library/macros.lisp
@@ -5,19 +5,31 @@
      ((True) ,then)
      ((False) ,else)))
 
-(cl:defmacro when (expr cl:&rest then)
+(cl:defmacro when (expr cl:&body then)
   `(if ,expr
        (progn
         ,@then
         Unit)
        Unit))
 
-(cl:defmacro unless (expr cl:&rest then)
+(cl:defmacro unless (expr cl:&body then)
   `(if ,expr
        Unit
        (progn
         ,@then
         Unit)))
+
+(cl:defmacro let* (bindings cl:&rest body)
+  "Parallel, non-recursive binding. This is similar to COMMON-LISP:LET."
+  (cl:loop
+    :for (var val) :in bindings
+    :for gen := (cl:gensym (cl:symbol-name var))
+    :collect `(,gen ,val) :into outer
+    :collect `(,var ,gen) :into inner
+    :finally (cl:return
+               `(let ,outer
+                  (let ,inner
+                    ,@body)))))
 
 (cl:defmacro and (cl:&rest exprs)
   "A short-circuiting AND operator."

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -460,6 +460,7 @@
     ;; Macros
   (:export
    #:if
+   #:let*
    #:unless
    #:when
    #:and


### PR DESCRIPTION
This adds `let*`, which is a "more traditional" `let`-like construct that people are used to.

Also documents this `let` v `let*` business.