### PR TITLE
Refactor toplevel codewalker

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -121,6 +121,7 @@
   :serial t
   :components ((:file "package")
                (:file "utilities")
+               (:file "syntax-tests")
                (:file "free-variables-tests")
                (:file "tarjan-scc-tests")
                (:file "type-inference-tests")

--- a/coalton.asd
+++ b/coalton.asd
@@ -121,7 +121,7 @@
   :serial t
   :components ((:file "package")
                (:file "utilities")
-               (:file "syntax-tests")
+               (:file "toplevel-walker-tests")
                (:file "free-variables-tests")
                (:file "tarjan-scc-tests")
                (:file "type-inference-tests")

--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -56,8 +56,12 @@ in FORMS that begin with that operator."
     (labels
         ((operator (form)
            (handler-case
-               (car form)
-             (type-error () (error-parsing form "Non-list form at toplevel"))))
+               (prog1
+                   (car form)
+                 (assert (symbolp (car form))))
+             (type-error () (error-parsing form "Non-list form at toplevel"))
+             (simple-error () (error-parsing form "A toplevel form must begin ~
+                                                   with a symbol."))))
          (establish-repr (specifier type)
            (unless (member specifier **repr-specifiers**)
              (alexandria:simple-style-warning

--- a/tests/syntax-tests.lisp
+++ b/tests/syntax-tests.lisp
@@ -2,35 +2,35 @@
 
 (deftest test-repr-form-position ()
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-typechecker
+    (run-coalton-walker
      ;; No next form
      '((coalton:repr :lisp))))
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-typechecker
+    (run-coalton-walker
      ;; Wrong next form
      '((coalton:repr :lisp)
        (coalton:define foo "foo")))))
 
 (deftest test-repr-form-arity ()
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-typechecker
+    (run-coalton-walker
      ;; Too few arguments
      '((coalton:repr)
        (coalton:define-type Foo Foo))))
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-typechecker
+    (run-coalton-walker
      ;; Too many arguments
      '((coalton:repr :lisp :what-am-i-doing-here)
        (coalton:define-type Foo Foo)))))
 
 (deftest test-repr-form-argument ()
   (signals warning
-    (run-coalton-typechecker
+    (run-coalton-walker
      ;; Not a meaningful repr choice
      '((coalton:repr :something-weird)
        (coalton:define-type Foo Foo))))
   (finishes
-    (run-coalton-typechecker
+    (run-coalton-walker
      ;; Perfect!
      '((coalton:repr :lisp)
        (coalton:define-type Foo Foo)))))

--- a/tests/syntax-tests.lisp
+++ b/tests/syntax-tests.lisp
@@ -24,7 +24,7 @@
        (coalton:define-type Foo Foo)))))
 
 (deftest test-repr-form-argument ()
-  (signals warning
+  (signals style-warning
     (run-coalton-walker
      ;; Not a meaningful repr choice
      '((coalton:repr :something-weird)

--- a/tests/syntax-tests.lisp
+++ b/tests/syntax-tests.lisp
@@ -1,0 +1,36 @@
+(in-package #:coalton-tests)
+
+(deftest test-repr-form-position ()
+  (signals coalton-impl::coalton-parse-error
+    (run-coalton-typechecker
+     ;; No next form
+     '((coalton:repr :lisp))))
+  (signals coalton-impl::coalton-parse-error
+    (run-coalton-typechecker
+     ;; Wrong next form
+     '((coalton:repr :lisp)
+       (coalton:define foo "foo")))))
+
+(deftest test-repr-form-arity ()
+  (signals coalton-impl::coalton-parse-error
+    (run-coalton-typechecker
+     ;; Too few arguments
+     '((coalton:repr)
+       (coalton:define-type Foo Foo))))
+  (signals coalton-impl::coalton-parse-error
+    (run-coalton-typechecker
+     ;; Too many arguments
+     '((coalton:repr :lisp :what-am-i-doing-here)
+       (coalton:define-type Foo Foo)))))
+
+(deftest test-repr-form-argument ()
+  (signals warning
+    (run-coalton-typechecker
+     ;; Not a meaningful repr choice
+     '((coalton:repr :something-weird)
+       (coalton:define-type Foo Foo))))
+  (finishes
+    (run-coalton-typechecker
+     ;; Perfect!
+     '((coalton:repr :lisp)
+       (coalton:define-type Foo Foo)))))

--- a/tests/syntax-tests.lisp
+++ b/tests/syntax-tests.lisp
@@ -1,5 +1,21 @@
 (in-package #:coalton-tests)
 
+(deftest test-bad-toplevel-type ()
+  (signals coalton-impl::coalton-parse-error
+    (run-coalton-walker
+     ;; Atoms don't make sense at toplevel.
+     '(:this-is-a-stray-atom)))
+  (signals coalton-impl::coalton-parse-error
+    (run-coalton-walker
+     ;; Neither do lists with cars that are not symbols.
+     '((1729)))))
+
+(deftest test-bad-toplevel-form ()
+  (signals coalton-impl::coalton-parse-error
+    (run-coalton-walker
+     ;; Expressions representing values don't make sense there either.
+     '((coalton:Cons coalton:Nil coalton:Nil)))))
+
 (deftest test-repr-form-position ()
   (signals coalton-impl::coalton-parse-error
     (run-coalton-walker
@@ -34,3 +50,9 @@
      ;; Perfect!
      '((coalton:repr :lisp)
        (coalton:define-type Foo Foo)))))
+
+(deftest test-walker-return-value ()
+  (let ((trivial-value (run-coalton-walker '())))
+    (is (listp trivial-value))
+    (is (hash-table-p
+         (getf trivial-value 'coalton-impl::repr-table)))))

--- a/tests/toplevel-walker-tests.lisp
+++ b/tests/toplevel-walker-tests.lisp
@@ -2,57 +2,57 @@
 
 (deftest test-bad-toplevel-type ()
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Atoms don't make sense at toplevel.
      '(:this-is-a-stray-atom)))
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Neither do lists with cars that are not symbols.
      '((1729)))))
 
 (deftest test-bad-toplevel-form ()
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Expressions representing values don't make sense there either.
      '((coalton:Cons coalton:Nil coalton:Nil)))))
 
 (deftest test-repr-form-position ()
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; No next form
      '((coalton:repr :lisp))))
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Wrong next form
      '((coalton:repr :lisp)
        (coalton:define foo "foo")))))
 
 (deftest test-repr-form-arity ()
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Too few arguments
      '((coalton:repr)
        (coalton:define-type Foo Foo))))
   (signals coalton-impl::coalton-parse-error
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Too many arguments
      '((coalton:repr :lisp :what-am-i-doing-here)
        (coalton:define-type Foo Foo)))))
 
 (deftest test-repr-form-argument ()
   (signals style-warning
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Not a meaningful repr choice
      '((coalton:repr :something-weird)
        (coalton:define-type Foo Foo))))
   (finishes
-    (run-coalton-walker
+    (run-coalton-toplevel-walker
      ;; Perfect!
      '((coalton:repr :lisp)
        (coalton:define-type Foo Foo)))))
 
-(deftest test-walker-return-value ()
-  (let ((trivial-value (run-coalton-walker '())))
+(deftest test-toplevel-walker-return-value ()
+  (let ((trivial-value (run-coalton-toplevel-walker '())))
     (is (listp trivial-value))
     (is (hash-table-p
          (getf trivial-value 'coalton-impl::repr-table)))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -25,7 +25,7 @@
                    (coalton-impl::lookup-value-type env symbol)
                    (coalton-impl/typechecker::parse-and-resolve-type env type))))))
 
-(defun run-coalton-walker (toplevel)
+(defun run-coalton-toplevel-walker (toplevel)
   (coalton-impl::collect-toplevel-forms toplevel))
 
 (defun run-coalton-typechecker (toplevel)

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -25,5 +25,8 @@
                    (coalton-impl::lookup-value-type env symbol)
                    (coalton-impl/typechecker::parse-and-resolve-type env type))))))
 
+(defun run-coalton-walker (toplevel)
+  (coalton-impl::collect-toplevel-forms toplevel))
+
 (defun run-coalton-typechecker (toplevel)
   (coalton-impl::process-coalton-toplevel toplevel coalton-impl::*initial-environment*))


### PR DESCRIPTION
The entry point to the compiler, COLLECT-TOPLEVEL-FORMS, seems to have grown in interface complexity to the point that it’s difficult to keep straight. At this point, the function claims to return three values, lists five, and actually returns six!

These commits go a long way toward detangling and simplifying the code, mainly by attaching information about Coalton operators to the operator symbols themselves. It now reads pretty much top to bottom without recursing or returning from the middle. A new macro, INSTALL-OPERATOR-METADATA, makes this technique self-documenting and easily extensible with new operators or constraints. COLLECT-TOPLEVEL-FORMS now returns a single plist instead of six values, eliminating the demand on the caller to handle the results positionally (and allowing the function’s behavior to change further while keeping its interface frozen).

Also included is a new test suite to make sure the rewritten codewalker does what it promises.