### PR TITLE
Collect results of TRAVERSE in the right order

### DIFF
--- a/src/library/functions.lisp
+++ b/src/library/functions.lisp
@@ -45,10 +45,10 @@
 
   (declare traverse (Applicative :m => ((:a -> (:m :b)) -> (List :a) -> (:m (List :b)))))
   (define (traverse f xs)
-    "Map the elements of XS with F then collect the results."
+    "Map the elements of XS with F from left to right, collecting the results."
     (let ((cons-f (fn (x ys)
                     (liftA2 Cons (f x) ys))))
-      (fold cons-f (pure Nil) xs)))
+      (fold cons-f (pure Nil) (reverse xs))))
 
   (declare sequence (Applicative :f => ((List (:f :a)) -> (:f (List :a)))))
   (define (sequence xs)


### PR DESCRIPTION
Left fold applies its arguments in the reverse of the order that it receives them, so the list argument needs to be given in reverse.

Before, `(sequence (make-list (Ok 1) (Ok 2)))` yielded `(Ok (2 1))`; now it yields `(Ok (1 2))`.