### PR TITLE
`Fixnum` and `Natnum` types

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -419,6 +419,8 @@
    #:I32
    #:I64
    #:Integer
+   #:Fixnum
+   #:Natnum
    #:Single-Float
    #:Double-Float
    #:String

--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -7,11 +7,11 @@
 (defun derive-literal-type (value)
   (declare (values ty ty-predicate-list))
   (etypecase value
-    (integer      (values tInteger      nil))
-    (single-float (values tSingle-Float nil))
-    (double-float (values tDouble-Float nil))
-    (string       (values tString       nil))
-    (character    (values tChar         nil))))
+    (integer      (values *integer-type*      nil))
+    (single-float (values *single-float-type* nil))
+    (double-float (values *double-float-type* nil))
+    (string       (values *string-type*       nil))
+    (character    (values *char-type*         nil))))
 
 (defgeneric derive-expression-type (value env substs)
   (:documentation "Derive the TYPE and generate a TYPED-NODE for expression VALUE

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -173,6 +173,24 @@
             :newtype nil
             :docstring "Unbound integer. Uses `integer`."))
 
+          ('coalton:Fixnum
+           (type-entry
+            :name 'coalton:Fixnum
+            :runtime-type 'cl:fixnum
+            :type *fixnum-type*
+            :enum-repr nil
+            :newtype nil
+            :docstring "Non-allocating tagged integer; range is platform-dependent. Uses `fixnum`."))
+
+          ('coalton:Natnum
+           (type-entry
+            :name 'coalton:Natnum
+            :runtime-type '(cl:and cl:fixnum cl:unsigned-byte)
+            :type *natnum-type*
+            :enum-repr nil
+            :newtype nil
+            :docstring "Non-allocating tagged non-negative integer; range is platform-dependent. Uses `(and fixnum unsigned-byte)`."))
+
           ('coalton:Single-Float
            (type-entry
             :name 'coalton:Single-Float

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -78,7 +78,7 @@
            (type-entry
             :name 'coalton:Boolean
             :runtime-type 'cl:boolean
-            :type tBoolean
+            :type *boolean-type*
             :enum-repr t
             :newtype nil
             :docstring "Either true or false represented by `t` and `nil` respectively."))
@@ -87,7 +87,7 @@
            (type-entry
             :name 'coalton:Char
             :runtime-type 'cl:character
-            :type tChar
+            :type *char-type*
             :enum-repr nil
             :newtype nil
             :docstring "A single character represented as a `character` type."))
@@ -96,7 +96,7 @@
            (type-entry
             :name 'coalton:U8
             :runtime-type '(cl:unsigned-byte 8)
-            :type tU8
+            :type *u8-type*
             :enum-repr nil
             :newtype nil
             :docstring "Unsigned 8-bit integer capable of storing values in `[0, 255]`. Uses `(unsigned-byte 8)`."))
@@ -105,7 +105,7 @@
            (type-entry
             :name 'coalton:U16
             :runtime-type '(cl:unsigned-byte 16)
-            :type tU16
+            :type *u16-type*
             :enum-repr nil
             :newtype nil
             :docstring "Unsigned 16-bit integer capable of storing values in `[0, 65535]`. Uses `(unsigned-byte 16)`."))
@@ -114,7 +114,7 @@
            (type-entry
             :name 'coalton:U32
             :runtime-type '(cl:unsigned-byte 32)
-            :type tU32
+            :type *u32-type*
             :enum-repr nil
             :newtype nil
             :docstring "Unsigned 32-bit integer capable of storing values in `[0, 4294967295]`. Uses `(unsigned-byte 32)`."))
@@ -123,7 +123,7 @@
            (type-entry
             :name 'coalton:U64
             :runtime-type '(cl:unsigned-byte 64)
-            :type tU64
+            :type *u64-type*
             :enum-repr nil
             :newtype nil
             :docstring "Unsigned 64-bit integer capable of storing values in `[0, 18446744073709551615]`. Uses `(unsigned-byte 64)`."))
@@ -132,7 +132,7 @@
            (type-entry
             :name 'coalton:I8
             :runtime-type '(cl:signed-byte 8)
-            :type tI8
+            :type *i8-type*
             :enum-repr nil
             :newtype nil
             :docstring "Signed 8-bit integer capable of storing values in `[-128, 127]`. Uses `(signed-byte 8)`."))
@@ -141,7 +141,7 @@
            (type-entry
             :name 'coalton:I16
             :runtime-type '(cl:signed-byte 16)
-            :type tI16
+            :type *i16-type*
             :enum-repr nil
             :newtype nil
             :docstring "Signed 16-bit integer capable of storing values in `[-32768, 32767]`. Uses `(signed-byte 16)`."))
@@ -150,7 +150,7 @@
            (type-entry
             :name 'coalton:I32
             :runtime-type '(cl:signed-byte 32)
-            :type tI32
+            :type *i32-type*
             :enum-repr nil
             :newtype nil
             :docstring "Signed 32-bit integer capable of storing values in `[-2147483648, 2147483647]`. Uses `(signed-byte 32)`."))
@@ -159,7 +159,7 @@
            (type-entry
             :name 'coalton:I64
             :runtime-type '(cl:signed-byte 64)
-            :type tI64
+            :type *i64-type*
             :enum-repr nil
             :newtype nil
             :docstring "Signed 64-bit integer capable of storing values in `[-9223372036854775808, 9223372036854775807]`. Uses `(signed-byte 64)`."))
@@ -168,7 +168,7 @@
            (type-entry
             :name 'coalton:Integer
             :runtime-type 'cl:integer
-            :type tInteger
+            :type *integer-type*
             :enum-repr nil
             :newtype nil
             :docstring "Unbound integer. Uses `integer`."))
@@ -177,7 +177,7 @@
            (type-entry
             :name 'coalton:Single-Float
             :runtime-type 'cl:single-float
-            :type tSingle-Float
+            :type *single-float-type*
             :enum-repr nil
             :newtype nil
             :docstring "Single precision floating point numer. Uses `single-float`."))
@@ -186,7 +186,7 @@
            (type-entry
             :name 'coalton:Double-Float
             :runtime-type 'cl:double-float
-            :type tDouble-Float
+            :type *double-float-type*
             :enum-repr nil
             :newtype nil
             :docstring "Double precision floating point numer. Uses `double-float`."))
@@ -195,7 +195,7 @@
            (type-entry
             :name 'coalton:String
             :runtime-type 'cl:string
-            :type tString
+            :type *string-type*
             :enum-repr nil
             :newtype nil
             :docstring "String of characters represented by Common Lisp `string`."))
@@ -204,7 +204,7 @@
            (type-entry
             :name 'coalton:Lisp-Object
             :runtime-type 't
-            :type tLisp-Object
+            :type *lisp-object-type*
             :enum-repr nil
             :newtype nil
             :docstring "Opaque container for arbitrary lisp objects. At runtime this is equivalent to the type `t`."))
@@ -213,7 +213,7 @@
            (type-entry
             :name 'coalton:Arrow
             :runtime-type nil
-            :type tArrow
+            :type *arrow-type*
             :enum-repr nil
             :newtype nil
             :docstring "Type constructor for function types. `(Arrow :a :b)` is equivalent to `(:a -> :b)`."))
@@ -222,7 +222,7 @@
            (type-entry
             :name 'coalton:List
             :runtime-type 'cl:list
-            :type tList
+            :type *list-type*
             :enum-repr nil
             :newtype nil
             :docstring "Homogeneous list of objects represented as a Common Lisp `list`.")))))
@@ -268,7 +268,7 @@
 (defun make-default-constructor-environment ()
   "Create a TYPE-ENVIRONMENT containing early constructors"
   (let* ((tvar (make-variable))
-         (list-scheme (quantify (list tvar) (qualify nil (%make-tapp tList tvar))))
+         (list-scheme (quantify (list tvar) (qualify nil (%make-tapp *list-type* tvar))))
          (var-scheme (quantify (list tvar) (qualify nil tvar))))
     (make-constructor-environment
      :data (fset:map
@@ -278,7 +278,7 @@
               :name 'coalton:True
               :arity 0
               :constructs 'coalton:Boolean
-              :scheme (to-scheme (qualify nil tBoolean))
+              :scheme (to-scheme (qualify nil *boolean-type*))
               :arguments nil
               :classname 'coalton::Boolean/True
               :compressed-repr 't))
@@ -288,7 +288,7 @@
               :name 'coalton:False
               :arity 0
               :constructs 'coalton:Boolean
-              :scheme (to-scheme (qualify nil tBoolean))
+              :scheme (to-scheme (qualify nil *boolean-type*))
               :arguments nil
               :classname 'coalton::Boolean/False
               :compressed-repr 'nil))

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -176,6 +176,8 @@
 (defvar *i32-type*     (%make-tcon (%make-tycon :name 'coalton:I32         :kind kstar)))
 (defvar *i64-type*     (%make-tcon (%make-tycon :name 'coalton:I64         :kind kstar)))
 (defvar *integer-type* (%make-tcon (%make-tycon :name 'coalton:Integer     :kind kstar)))
+(defvar *fixnum-type*  (%make-tcon (%make-tycon :name 'coalton:Fixnum      :kind kstar)))
+(defvar *natnum-type*  (%make-tcon (%make-tycon :name 'coalton:Natnum      :kind kstar)))
 (defvar *single-float-type*
   (%make-tcon (%make-tycon :name 'coalton:Single-Float :kind kstar)))
 (defvar *double-float-type*

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -165,28 +165,28 @@
 ;;; Early types
 ;;;
 
-(defvar tBoolean (%make-tcon (%make-tycon :name 'coalton:Boolean     :kind kstar)))
-(defvar tChar    (%make-tcon (%make-tycon :name 'coalton:Char        :kind kstar)))
-(defvar tU8      (%make-tcon (%make-tycon :name 'coalton:U8          :kind kstar)))
-(defvar tU16     (%make-tcon (%make-tycon :name 'coalton:U16         :kind kstar)))
-(defvar tU32     (%make-tcon (%make-tycon :name 'coalton:U32         :kind kstar)))
-(defvar tU64     (%make-tcon (%make-tycon :name 'coalton:U64         :kind kstar)))
-(defvar tI8      (%make-tcon (%make-tycon :name 'coalton:I8          :kind kstar)))
-(defvar tI16     (%make-tcon (%make-tycon :name 'coalton:I16         :kind kstar)))
-(defvar tI32     (%make-tcon (%make-tycon :name 'coalton:I32         :kind kstar)))
-(defvar tI64     (%make-tcon (%make-tycon :name 'coalton:I64         :kind kstar)))
-(defvar tInteger (%make-tcon (%make-tycon :name 'coalton:Integer     :kind kstar)))
-(defvar tSingle-Float
+(defvar *boolean-type* (%make-tcon (%make-tycon :name 'coalton:Boolean     :kind kstar)))
+(defvar *char-type*    (%make-tcon (%make-tycon :name 'coalton:Char        :kind kstar)))
+(defvar *u8-type*      (%make-tcon (%make-tycon :name 'coalton:U8          :kind kstar)))
+(defvar *u16-type*     (%make-tcon (%make-tycon :name 'coalton:U16         :kind kstar)))
+(defvar *u32-type*     (%make-tcon (%make-tycon :name 'coalton:U32         :kind kstar)))
+(defvar *u64-type*     (%make-tcon (%make-tycon :name 'coalton:U64         :kind kstar)))
+(defvar *i8-type*      (%make-tcon (%make-tycon :name 'coalton:I8          :kind kstar)))
+(defvar *i16-type*     (%make-tcon (%make-tycon :name 'coalton:I16         :kind kstar)))
+(defvar *i32-type*     (%make-tcon (%make-tycon :name 'coalton:I32         :kind kstar)))
+(defvar *i64-type*     (%make-tcon (%make-tycon :name 'coalton:I64         :kind kstar)))
+(defvar *integer-type* (%make-tcon (%make-tycon :name 'coalton:Integer     :kind kstar)))
+(defvar *single-float-type*
   (%make-tcon (%make-tycon :name 'coalton:Single-Float :kind kstar)))
-(defvar tDouble-Float
+(defvar *double-float-type*
   (%make-tcon (%make-tycon :name 'coalton:Double-Float :kind kstar)))
-(defvar tString  (%make-tcon (%make-tycon :name 'coalton:String      :kind kstar)))
-(defvar tLisp-Object
+(defvar *string-type*  (%make-tcon (%make-tycon :name 'coalton:String      :kind kstar)))
+(defvar *lisp-object-type*
   (%make-tcon (%make-tycon :name 'coalton:Lisp-Object :kind kstar)))
 
-(defvar tArrow (%make-tcon (%make-tycon :name 'coalton:-> :kind (kfun kstar (kfun kstar kstar)))))
+(defvar *arrow-type* (%make-tcon (%make-tycon :name 'coalton:-> :kind (kfun kstar (kfun kstar kstar)))))
 
-(defvar tList (%make-tcon (%make-tycon :name 'coalton:List :kind (kfun kstar kstar))))
+(defvar *list-type* (%make-tcon (%make-tycon :name 'coalton:List :kind (kfun kstar kstar))))
 
 
 (defun apply-type-argument (tcon arg)
@@ -214,7 +214,7 @@
     (error "Unable to construct function with type ~A of kind ~A" from (kind-of from)))
   (unless (kstar-p (kind-of to))
     (error "Unable to construct function with type ~A of kind ~A" to (kind-of to)))
-  (%make-tapp (%make-tapp tArrow from) to))
+  (%make-tapp (%make-tapp *arrow-type* from) to))
 
 (defun make-function-type* (args to)
   (declare (type ty-list args)
@@ -230,7 +230,7 @@
     (declare (type ty ty))
     (and (tapp-p ty)
          (tapp-p (tapp-from ty))
-         (equalp tArrow (tapp-from (tapp-from ty))))))
+         (equalp *arrow-type* (tapp-from (tapp-from ty))))))
 
 (defun function-type-from (ty)
   (declare (type tapp ty))


### PR DESCRIPTION
I'm open to discussion as to the name of `Natnum`, which corresponds to the CL type `(and fixnum unsigned-byte)`.

I was going to write a few updates on my hash-table PR (I have an idea about how to make it portable, at the cost of performing relatively poorly on non-SBCL platforms, but that's a different thread), when I was struck by the fact that Coalton didn't have a way to express the correct type of arguments to `sb-ext:mix`. This PR adds that type, `Natnum`, and defines `Fixnum` while I was at it since I'm sure I'll want it eventually.

I'd also like to raise: I'm not sure it's advisable to have `I64` and `U64` in the standard library. In my mind, these types imply to users a more efficient representation than `Integer`, which is not the case. At the very least, I think documentation should explicate that 64-bit integers may be heap-allocated when passed across full-call boundaries or stored in containers.