### PR TITLE
basic complex arithmetic with Complex class

### DIFF
--- a/src/library/types.lisp
+++ b/src/library/types.lisp
@@ -91,4 +91,8 @@
     ;; This shouldn't be pattern matched against with user code.
     ;;
     ;; See arith.lisp for more info.
-    (%Fraction Integer Integer)))
+    (%Fraction Integer Integer))
+
+  (define-type (Complex :a)
+    "Represents a complex algebra of a given type."
+    (Complex :a :a)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -489,6 +489,7 @@
    #:Result #:Err #:Ok
    #:Optional #:Some #:None
    #:Fraction
+   #:Complex
    #:undefined
    )
   ;; Classes
@@ -534,7 +535,15 @@
    #:even
    #:odd
    #:gcd
-   #:lcm)
+   #:lcm
+   #:numerator
+   #:denominator
+   #:reciprocal
+   #:real-part
+   #:imag-part
+   #:conjugate
+   #:ii
+   )
   ;; Quantize
   (:export
    #:floor
@@ -548,11 +557,6 @@
    #:round/
    #:single/
    #:double/)
-  ;; Fraction
-  (:export
-   #:numerator
-   #:denominator
-   #:reciprocal)
   ;; String
   (:export
    #:concat-string


### PR DESCRIPTION
This introduces the bare minimum needed to represent complex numbers with any participating data type. Functions like `sqrt` and `exp` and `abs` aren't implemented yet.