### PR TITLE
Fix typo'd exports for hashtable-set! and hashtable-remove!

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -717,8 +717,8 @@
    #:make-hashtable
    #:make-hashtable-capacity
    #:hashtable-get
-   #:hashtable-set
-   #:hashtable-remove
+   #:hashtable-set!
+   #:hashtable-remove!
    #:hashtable-count
    #:hashtable-foreach
    #:hashtable-keys


### PR DESCRIPTION
Oops.