### PR TITLE
Codegen functions from the environment type

### DIFF
--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -127,6 +127,12 @@ in FORMS that begin with that operator."
   `(let ((*emit-type-annotations* t))
      (process-coalton-toplevel ',toplevel-forms *global-environment*)))
 
+(defmacro coalton:coalton-codegen-ast (&body toplevel-forms)
+  "Prints the AST of the typechecked coalton code. Intended for debugging."
+  `(let ((*coalton-dump-ast* t))
+     (process-coalton-toplevel ',toplevel-forms *global-environment*)
+     (values)))
+
 (defmacro coalton:coalton (form)
   (let ((parsed-form (parse-form form (make-immutable-map) *package*)))
     (coalton-impl/typechecker::with-type-context ("COALTON")

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -138,9 +138,19 @@
            (type environment env))
   (let* ((var-names (mapcar #'car vars))
 
-         (preds (remove-duplicates
-                 (remove-if #'static-predicate-p (scheme-predicates type))
-                 :test #'equalp))
+         (inferred-type (coalton-impl/typechecker::fresh-inst
+                         (lookup-value-type env name)))
+         (inferred-type-ty (coalton-impl/typechecker::qualified-ty-type inferred-type))
+
+         (inferred-type-preds
+           (coalton-impl/typechecker::qualified-ty-predicates inferred-type))
+
+         (node-type
+           (coalton-impl/typechecker::qualified-ty-type
+            (coalton-impl/typechecker::fresh-inst type)))
+
+         (subs (coalton-impl/typechecker::match inferred-type-ty node-type))
+         (preds (coalton-impl/typechecker::apply-substitution subs inferred-type-preds))
 
          (dict-context (mapcar (lambda (pred) (cons pred (gensym))) preds))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -397,6 +397,7 @@
    #:coalton-toplevel
    #:coalton-codegen
    #:coalton-codegen-types
+   #:coalton-codegen-ast
    #:coalton
    #:declare
    #:define

--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -26,3 +26,5 @@ Enable release mode either by setting the UNIX environment variable COALTON_ENV 
 
 (when (coalton-release-p)
   (format t "~&;; COALTON starting in release mode~%"))
+
+(defvar *coalton-dump-ast* nil)

--- a/src/toplevel-define.lisp
+++ b/src/toplevel-define.lisp
@@ -128,12 +128,15 @@ Returns new environment, binding list of declared nodes, and a DAG of dependenci
                        :name (car b))))))
 
         (loop :for (name . node) :in typed-bindings :do
-          (setf env (set-name env name
-                              (make-name-entry
-                               :name name
-                               :type :value
-                               :docstring (second (find name docstrings :key #'car))
-                               :location (or *compile-file-pathname* *load-truename*)))))
+          (progn
+            (when *coalton-dump-ast*
+              (format t "~A :: ~A~%~A~%~%" name (lookup-value-type env name) node))
+            (setf env (set-name env name
+                                (make-name-entry
+                                 :name name
+                                 :type :value
+                                 :docstring (second (find name docstrings :key #'car))
+                                 :location (or *compile-file-pathname* *load-truename*))))))
 
         (values
          env

--- a/tests/runtime-tests.lisp
+++ b/tests/runtime-tests.lisp
@@ -1,30 +1,55 @@
-(in-package #:coalton-tests)
+(cl:in-package #:coalton-native-tests)
 
-(coalton:coalton-toplevel
-    (coalton:define (f x inc goal)
-      (coalton-library:if (coalton-library:== x goal)
-                          goal
-                          (f (coalton-library:+ x inc) inc goal)))
-
-  (coalton:define x (f 0 1 5)))
+(coalton-toplevel
+  (define (recursive-predicate x inc goal)
+    (if (== x goal)
+        goal
+        (recursive-predicate (+ x inc) inc goal))))
 
 ;; Test that functions with typeclass constraints call themselfs recursively
 ;; This was bugged in the past #216 #147 #125
-(deftest test-recursive-predicate-calls ()
-  (is (equal x 5)))
+(define-test test-recursive-predicate ()
+  (is (== (recursive-predicate 0 1 5) 5)))
 
-
-;; Test that predicates are correctly removed when deferred
-(coalton:coalton-toplevel
-  (coalton:define (gh-295-f a)
-    (coalton:let ((g (coalton:fn (x)
-                       (coalton-library:== x (coalton-library:make-list a)))))
-      g))
-
-  (coalton:define gh-295-x (gh-295-f 1 (coalton-library:make-list 2 3 4)))
-  (coalton:define gh-295-y (gh-295-f 1 (coalton-library:make-list 1))))
+(coalton-toplevel
+  (define (gh-295-f a)
+    (let ((g (fn (x)
+               (== x (make-list a)))))
+      g)))
 
 ;; See gh #295
-(deftest test-deferred-predicate-removal ()
-  (is (equal gh-295-x nil))
-  (is (equal gh-295-y t)))
+(define-test test-deferred-predicate-removal ()
+  (progn
+    (is (== (gh-295-f 1 (make-list 2 3 4)) False))
+    (is (== (gh-295-f 1 (make-list 1)) True))))
+
+
+;; Test that functions can be given explicit predicates in any order
+;; See gh #377
+(coalton-toplevel
+  (declare gh-377-a ((Num :a) (Ord :a) => :a -> :a -> :a -> (List :a)))
+  (define (gh-377-a step start end)
+    (let ((inner
+            (fn (current acc)
+              (if (> current end)
+                  acc
+                  (inner (+ current step)
+                         (Cons current acc))))))
+      (inner start Nil)))
+
+ (declare gh-377-b ((Ord :a) (Num :a) => :a -> :a -> :a -> (List :a)))
+  (define (gh-377-b step start end)
+    (let ((inner
+            (fn (current acc)
+              (if (> current end)
+                  acc
+                  (inner (+ current step)
+                         (Cons current acc))))))
+      (inner start Nil))))
+
+(define-test test-explicit-predicate-order ()
+  (progn
+    (is (== (gh-377-a 1 0 5)
+            (make-list 5 4 3 2 1 0)))
+    (is (== (gh-377-b 1 0 5)
+            (make-list 5 4 3 2 1 0)))))


### PR DESCRIPTION
Previously Coalton looked at the type on a typed-node. This is incorrect
because the type of a typed-node does not always match the inferred type
for the definiton that generated that typed-node.

Fixes #377