### PR TITLE
Remove scheme and arguments from constructor-entry

### DIFF
--- a/src/codegen/compile-type-definition.lisp
+++ b/src/codegen/compile-type-definition.lisp
@@ -40,13 +40,13 @@
              :for superclass := (type-definition-name def)
              :for constructor-name :=  (constructor-entry-name constructor)
              :for fields
-               := (loop :for field :in (constructor-entry-arguments constructor)
-                        :for type := (lisp-type field env)
+               := (loop :for field :in (constructor-arguments constructor-name env)
+                        :for runtime-type := (lisp-type field env)
                         :for i :from 0
                         :for name := (alexandria:format-symbol package "_~D" i)
                         :collect (make-struct-or-class-field
                                   :name name
-                                  :type type))
+                                  :type runtime-type))
 
              :for field-names := (mapcar #'struct-or-class-field-name fields)
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -205,8 +205,6 @@
    #:constructor-entry-name             ; ACCESSOR
    #:constructor-entry-arity            ; ACCESSOR
    #:constructor-entry-constructs       ; ACCESSOR
-   #:constructor-entry-scheme           ; ACCESSOR
-   #:constructor-entry-arguments        ; ACCESSOR
    #:constructor-entry-classname        ; ACCESSOR
    #:constructor-entry-compressed-repr  ; ACCESSOR
    #:make-constructor-entry             ; CONSTRUCTOR
@@ -239,6 +237,7 @@
    #:type-definition-name               ; ACCESSOR
    #:type-definition-type               ; ACCESSOR
    #:type-definition-constructors       ; ACCESSOR
+   #:type-definition-constructor-types  ; ACCESSOR
    #:type-definition-list               ; TYPE
    #:type-definition-runtime-type       ; ACCESSOR
    #:type-definition-enum-repr          ; ACCESSOR
@@ -287,9 +286,10 @@
    #:reduce-context                     ; FUNCTION
    #:split-context                      ; FUNCTION
    #:apply-type-argument                ; FUNCTION
-   #:set-class
-   #:add-class
-   #:add-instance
+   #:set-class                          ; FUNCTION
+   #:constructor-arguments              ; FUNCTION
+   #:add-class                          ; FUNCTION
+   #:add-instance                       ; FUNCTION
    )
   (:export
    #:instance-definition                ; STRUCT

--- a/src/toplevel-define-type.lisp
+++ b/src/toplevel-define-type.lisp
@@ -28,48 +28,50 @@
                 :newtype (type-definition-newtype parsed-deftype)
                 :docstring (type-definition-docstring parsed-deftype))))
 
-        (dolist (ctor (type-definition-constructors parsed-deftype))
-          ;; Add the constructors to the constructor environment
-          (setf env
-                (set-constructor
-                 env
-                 (constructor-entry-name ctor) ctor))
+        (loop :for ctor :in (type-definition-constructors parsed-deftype)
+              :for ctor-type :in (type-definition-constructor-types parsed-deftype)
+              :for ctor-name := (constructor-entry-name ctor)
 
-          ;; Add the constructor as a value to the value environment
-          (setf env
-                (set-value-type
-                 env
-                 (constructor-entry-name ctor)
-                 (constructor-entry-scheme ctor)))
+              ;; Add the constructors to the constructor environment
+              :do
+                 (setf env
+                       (set-constructor
+                        env
+                        (constructor-entry-name ctor) ctor))
 
-          ;; Register the constructor in the name environment
-          (setf env
-                (set-name
-                 env
-                 (constructor-entry-name ctor)
-                 (make-name-entry
-                  :name (constructor-entry-name ctor)
-                  :type :constructor
-                  :docstring nil
-                  :location (or *compile-file-pathname*
-                                *load-truename*))))
+                 ;; Add the constructor as a value to the value environment
+                 (setf env
+                       (set-value-type
+                        env
+                        ctor-name
+                        ctor-type))
 
-          ;; If the constructor takes paramaters then add it to the function environment
-          (if (not (= (constructor-entry-arity ctor) 0))
-              (setf env
-                    (set-function
-                     env
-                     (constructor-entry-name ctor)
-                     (make-function-env-entry
-                      :name (constructor-entry-name ctor)
-                      :arity (constructor-entry-arity ctor))))
+                 ;; Register the constructor in the name environment
+                 (setf env
+                       (set-name
+                        env
+                        (constructor-entry-name ctor)
+                        (make-name-entry
+                         :name (constructor-entry-name ctor)
+                         :type :constructor
+                         :docstring nil
+                         :location (or *compile-file-pathname*
+                                       *load-truename*))))
 
-              ;; TODO: This does not seem right... Is this to ensure
-              ;; that redefined constructors are correctly removed
-              ;; from the environment?
-              (setf env
-                    (unset-function
-                     env
-                     (constructor-entry-name ctor)))))))
+                 ;; If the constructor takes paramaters then add it to the function environment
+                 (if (not (= (constructor-entry-arity ctor) 0))
+                     (setf env
+                           (set-function
+                            env
+                            (constructor-entry-name ctor)
+                            (make-function-env-entry
+                             :name (constructor-entry-name ctor)
+                             :arity (constructor-entry-arity ctor))))
+
+                     ;; If the constructor does not take parameters then remove it from the function environment
+                     (setf env
+                           (unset-function
+                            env
+                            (constructor-entry-name ctor)))))))
 
     (values parsed-deftypes env)))

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -253,8 +253,6 @@
   (name            (required 'name)            :type symbol                         :read-only t)
   (arity           (required 'arity)           :type alexandria:non-negative-fixnum :read-only t)
   (constructs      (required 'constructs)      :type symbol                         :read-only t)
-  (scheme          (required 'scheme)          :type ty-scheme                      :read-only t)
-  (arguments       (required 'arguments)       :type scheme-list                    :read-only t)
   (classname       (required 'classname)       :type symbol                         :read-only t)
 
   ;; If this constructor constructs a compressed-repr type then
@@ -306,8 +304,6 @@
               :name 'coalton:True
               :arity 0
               :constructs 'coalton:Boolean
-              :scheme (to-scheme (qualify nil *boolean-type*))
-              :arguments nil
               :classname 'coalton::Boolean/True
               :compressed-repr 't))
 
@@ -316,8 +312,6 @@
               :name 'coalton:False
               :arity 0
               :constructs 'coalton:Boolean
-              :scheme (to-scheme (qualify nil *boolean-type*))
-              :arguments nil
               :classname 'coalton::Boolean/False
               :compressed-repr 'nil))
 
@@ -326,8 +320,6 @@
               :name 'coalton:Cons
               :arity 2
               :constructs 'coalton:List
-              :scheme cons-scheme
-              :arguments (list var-scheme list-scheme)
               :classname nil
               :compressed-repr 'nil))
 
@@ -336,8 +328,6 @@
               :name 'coalton:Nil
               :arity 0
               :constructs 'coalton:List
-              :scheme list-scheme
-              :arguments nil
               :classname nil
               :compressed-repr 'nil))))))
 
@@ -832,6 +822,13 @@
                           (environment-function-environment env)
                           functions
                           #'make-function-environment)))
+
+(defun constructor-arguments (name env)
+  (declare (type symbol name)
+           (type environment env)
+           (values ty-list &optional))
+  (lookup-constructor env name)
+  (function-type-arguments (lookup-value-type env name)))
 
 (defun add-class (env symbol value)
   (declare (type environment env)


### PR DESCRIPTION
Both of these fields store information duplicate type information. A
constructor-entry's scheme is equivalent to it's associated value's
scheme. A constructor-entry's arguments can be computed from that
scheme.