### PR TITLE
Fix class parsing

### DIFF
--- a/src/typechecker/parse-class-definition.lisp
+++ b/src/typechecker/parse-class-definition.lisp
@@ -161,15 +161,17 @@
                                                      (alexandria:format-symbol
                                                       (symbol-package class-name)
                                                       (format nil "SUPER-~D" i)))))
-               (class (ty-class
-                       class-name
-                       class-predicate
-                       class-context
-                       class-methods
-                       class-codegen-sym
-                       superclass-dict
-                       docstring
-                       (or *compile-file-pathname* *load-truename*)))
+               (class (apply-substitution
+                       subs
+                       (ty-class
+                        class-name
+                        class-predicate
+                        class-context
+                        class-methods
+                        class-codegen-sym
+                        superclass-dict
+                        docstring
+                        (or *compile-file-pathname* *load-truename*))))
 
                ;; Create a ENV with our new class defined so that reduce-context will work
                (env (set-class env class-name class))

--- a/tests/runtime-tests.lisp
+++ b/tests/runtime-tests.lisp
@@ -53,3 +53,23 @@
             (make-list 5 4 3 2 1 0)))
     (is (== (gh-377-b 1 0 5)
             (make-list 5 4 3 2 1 0)))))
+
+
+;; Test that classes can have both methods and constants in either order
+;; See gh #400
+(coalton-toplevel
+  (define-class (Gh-400-a :a)
+    (gh-400-a-constant :a)
+    (gh-400-a-method (:a -> :a)))
+
+  (define-class (Gh-400-b :a)
+    (gh-400-b-method (:a -> :a))
+    (gh-400-b-constant :a))
+
+  (define-instance (Gh-400-a Integer)
+    (define gh-400-a-constant 5)
+    (define (gh-400-a-method x) x))
+
+  (define-instance (Gh-400-b Integer)
+    (define (gh-400-b-method x) x)
+    (define gh-400-b-constant 5)))


### PR DESCRIPTION
Unaplied substitutions were causing classes to be built incorrectly.

Fixes #400