### PR TITLE
Add `(REPR :TRANSPARENT)` and `(REPR :NATIVE)`

### DIFF
--- a/docs/coalton-lisp-interop.md
+++ b/docs/coalton-lisp-interop.md
@@ -113,6 +113,10 @@ The pragma `(repr :lisp)` helps achieve Lisp compatibility of structures regardl
 
 **HALF-HEARTED PROMISE**: For each non-nullary constructor (say `Ctor1`), a `setf`-able accessor function called `<class-name>/<ctor-name>-_<k>` will be defined for the `k`th member of that constructor. For the example above, suppose that `Ctor1` has two fields. Then the accessor functions `FOO/CTOR1-_0` and `FOO/CTOR1-_1` will be defined. (*Note*: The naming here is subject to change.)
 
+### Wrapper types with `(REPR :TRANSPARENT)`
+
+Types with a single construtor consisting of a single field can be annotated with `(REPR :TRANSPARENT)`. This guarentees the wrapper type does not exist at runtime. The constructor function will still be generated, but it will be the identity function.
+
 ## Promises of `define`
 
 Consider the following definitions:

--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -9,7 +9,7 @@
 ;;; be generated at macroexpansion time of the ambient Common Lisp
 ;;; compiler. See the COALTON macro.
 
-(define-global-var **repr-specifiers** '(:lisp)
+(define-global-var **repr-specifiers** '(:lisp :transparent)
   "(repr ...) specifiers that the compiler is known to understand.")
 
 (defmacro install-operator-metadata (&rest directives)
@@ -64,9 +64,13 @@ in FORMS that begin with that operator."
                                                    with a symbol."))))
          (establish-repr (specifier type)
            (unless (member specifier **repr-specifiers**)
-             (alexandria:simple-style-warning
-              "The compiler is not known to understand (repr ~S)."
+             (error
+              "The compiler does not understand (repr ~S)."
               specifier))
+
+           (when (listp type)
+             (setf type (car type)))
+
            (setf (gethash type (getf plist 'repr-table)) specifier))
          (walk (forms)
            (loop

--- a/src/library/cell.lisp
+++ b/src/library/cell.lisp
@@ -25,13 +25,15 @@
   (inner (cl:error "") :type cl:t))
 
 (cl:defmethod cl:print-object ((self cell-internal) stream)
-  (cl:format stream "~A" (cell-internal-inner self))
+  (cl:format stream "#.(CELL ~A)" (cell-internal-inner self))
   self)
 
 #+sbcl
 (cl:declaim (sb-ext:freeze-type cell-internal))
 
 (coalton-toplevel
+
+  (repr :transparent)
   (define-type (Cell :a)
     "Internally mutable cell"
     (%Cell Lisp-Object))

--- a/src/library/hashtable.lisp
+++ b/src/library/hashtable.lisp
@@ -25,6 +25,7 @@
   ;; Hashtable
   ;;
 
+  (repr :transparent)
   (define-type (Hashtable :key :value)
     (%Hashtable Lisp-Object))
 

--- a/src/library/iterator.lisp
+++ b/src/library/iterator.lisp
@@ -66,6 +66,7 @@
 
 ;;; fundamental operators
 (coalton-toplevel
+  (repr :transparent)
   (define-type (Iterator :elt)
     "A forward-moving pointer into an ordered sequence of :ELTs"
     (%Iterator (Unit -> (Optional :elt))))

--- a/src/library/prelude.lisp
+++ b/src/library/prelude.lisp
@@ -138,10 +138,25 @@
    #:coalton-library/iterator
    #:Iterator))
 
-(uiop:define-package #:coalton-user
+(cl:defpackage #:coalton-user
   (:use
    #:coalton
-   #:coalton-prelude))
+   #:coalton-prelude)
+  (:local-nicknames
+   (#:bits #:coalton-library/bits)
+   (#:arith #:coalton-library/arith)
+   (#:char #:coalton-library/char)
+   (#:string #:coalton-library/string)
+   (#:tuple #:coalton-library/tuple)
+   (#:optional #:coalton-library/optional)
+   (#:list #:coalton-library/list)
+   (#:result #:coalton-library/result)
+   (#:cell #:coalton-library/cell)
+   (#:vector #:coalton-library/vector)
+   (#:slice #:coalton-library/slice)
+   (#:hashtable #:coalton-library/hashtable)
+   (#:st #:coalton-library/monad/state)
+   (#:iter #:coalton-library/iterator)))
 
 (cl:in-package #:coalton-prelude)
 

--- a/src/library/slice.lisp
+++ b/src/library/slice.lisp
@@ -30,6 +30,7 @@
   ;; Slice
   ;;
 
+  (repr :transparent)
   (define-type (Slice :a)
     (%Slice Lisp-Object))
 

--- a/src/library/vector.lisp
+++ b/src/library/vector.lisp
@@ -43,6 +43,7 @@
   ;; Vector
   ;;
 
+  (repr :transparent)
   (define-type (Vector :a)
     (%Vector Lisp-Object))
 

--- a/src/typechecker/parse-type-definition.lisp
+++ b/src/typechecker/parse-type-definition.lisp
@@ -163,21 +163,9 @@ Returns TYPE-DEFINITIONS"
                     :constructor-types ctor-types
                     :docstring docstring))
 
-                  ((and enum-type
-                        (coalton-impl:coalton-release-p))
-                   (let ((parsed-ctors (mapcar #'rewrite-ctor parsed-ctors)))
-                     (make-type-definition
-                      :name tycon-name
-                      :type tcon
-                      :runtime-type `(member ,@(mapcar #'constructor-entry-compressed-repr parsed-ctors))
-                      :enum-repr t
-                      :newtype nil
-                      :constructors parsed-ctors
-                      :constructor-types ctor-types
-                      :docstring docstring)))
-
-                  ((and newtype
-                        (coalton-impl:coalton-release-p))
+                  ((or (and newtype (eql repr :transparent))
+                    (and newtype
+                            (coalton-impl:coalton-release-p)))
                    (let (;; The runtime type of a newtype is the runtime type of it's only constructor's only argument
                          (runtime-type (function-type-from
                                         (qualified-ty-type
@@ -191,6 +179,23 @@ Returns TYPE-DEFINITIONS"
                       :constructors parsed-ctors
                       :constructor-types ctor-types
                       :docstring docstring)))
+
+                  ((and (eql repr :transparent) (not newtype))
+                   (error "Type ~A cannot be repr transparent" tycon-name))
+
+                  ((and enum-type
+                        (coalton-impl:coalton-release-p))
+                   (let ((parsed-ctors (mapcar #'rewrite-ctor parsed-ctors)))
+                     (make-type-definition
+                      :name tycon-name
+                      :type tcon
+                      :runtime-type `(member ,@(mapcar #'constructor-entry-compressed-repr parsed-ctors))
+                      :enum-repr t
+                      :newtype nil
+                      :constructors parsed-ctors
+                      :constructor-types ctor-types
+                      :docstring docstring)))
+
 
                   (t
                    (make-type-definition

--- a/tests/toplevel-walker-tests.lisp
+++ b/tests/toplevel-walker-tests.lisp
@@ -40,7 +40,7 @@
        (coalton:define-type Foo Foo)))))
 
 (deftest test-repr-form-argument ()
-  (signals style-warning
+  (signals error
     (run-coalton-toplevel-walker
      ;; Not a meaningful repr choice
      '((coalton:repr :something-weird)


### PR DESCRIPTION
Fixes #395 

`(repr :transparent)` forces the newtype optimization in development mode. 

`(repr :native x)` makes a types runtime representation `x`. This is useful for interop hacks.