### PR TITLE
Native Complex

### DIFF
--- a/src/ast/parse-form.lisp
+++ b/src/ast/parse-form.lisp
@@ -38,9 +38,9 @@ This does not attempt to do any sort of analysis whatsoever. It is suitable for 
 
        ;; Lisp
        ((coalton:lisp &rest args)
-        (unless (= 3 (length args))
+        (unless (<= 3 (length args))
           (error-parsing expr "Invalid embedded Lisp expression."))
-        (parse-lisp expr (first args) (second args) (third args) m))
+        (parse-lisp expr (first args) (second args) (nthcdr 2 args) m))
 
        ;; Match
        ((coalton:match expr_ &rest patterns)
@@ -192,7 +192,7 @@ This does not attempt to do any sort of analysis whatsoever. It is suitable for 
        (parse-form subexpr new-m package)
        (invert-alist binding-local-names)))))
 
-(defun parse-lisp (unparsed type variables lisp-expr m)
+(defun parse-lisp (unparsed type variables lisp-exprs m)
   (declare (type immutable-map m))
   (node-lisp
    unparsed
@@ -203,7 +203,7 @@ This does not attempt to do any sort of analysis whatsoever. It is suitable for 
                    (or (immutable-map-lookup m var)
                        (error-parsing unparsed "Unknown variable ~A in lisp node~%" var))))
    ;; Do *NOT* parse LISP-EXPR!
-   lisp-expr))
+   lisp-exprs))
 
 (defun parse-application (unparsed rator rands m package)
   (declare (type immutable-map m)

--- a/src/codegen/compile-expression.lisp
+++ b/src/codegen/compile-expression.lisp
@@ -75,15 +75,15 @@
 
   (:method ((expr typed-node-lisp) ctx env)
     (let ((inner
-            (if *emit-type-annotations*
-                `(the (values ,(lisp-type expr env) &optional) ,(typed-node-lisp-form expr))
-                (typed-node-lisp-form expr))))
-      (if (typed-node-lisp-variables expr)
-          `(let ,(mapcar
-                  (lambda (vars)
-                    (list (car vars) (cdr vars)))
-                  (typed-node-lisp-variables expr))
-             ,inner)
+            `(let ,(mapcar
+                    (lambda (vars)
+                      (list (car vars) (cdr vars)))
+                    (typed-node-lisp-variables expr))
+               ,@ (typed-node-lisp-form expr))))
+
+      (if *emit-type-annotations*
+          `(the (values ,(lisp-type expr env) &optional)
+                ,inner)
           inner)))
 
   (:method ((expr typed-node-match) ctx env)


### PR DESCRIPTION
Hides the constructor for `Complex` and exposes the new `Complex` type class for making complex numbers. Uses lisp's native representation for supported types. 

* This is much easier to read w/ a split diff