### PR TITLE
Cleanup stdlib

### DIFF
--- a/src/library/cell.lisp
+++ b/src/library/cell.lisp
@@ -42,33 +42,27 @@
   (define (new data)
     "Create a new mutable cell"
     (lisp (Cell :a) (data)
-      (%Cell (make-cell-internal :inner data))))
+      (make-cell-internal :inner data)))
 
   (declare read ((Cell :a) -> :a))
-  (define (read c)
+  (define (read cel)
     "Read the value of a mutable cell"
-    (match c
-      ((%Cell c)
-       (lisp :a (c)
-         (cell-internal-inner c)))))
+    (lisp :a (cel)
+      (cell-internal-inner cel)))
 
   (declare swap! ((Cell :a) -> :a -> :a))
   (define (swap! cel data)
     "Replace the value of a mutable cell with a new value, then return the old value"
-    (match cel
-      ((%Cell c)
-       (lisp :a (data c)
-         (cl:let* ((old (cell-internal-inner c)))
-           (cl:setf (cell-internal-inner c) data)
-           old)))))
+    (lisp :a (data cel)
+      (cl:let* ((old (cell-internal-inner cel)))
+        (cl:setf (cell-internal-inner cel) data)
+        old)))
 
   (declare write! ((Cell :a) -> :a -> :a))
   (define (write! cel data)
     "Set the value of a mutable cell, returning the new value"
-    (match cel
-      ((%Cell c)
-       (lisp :a (data c)
-         (cl:setf (cell-internal-inner c) data)))))
+    (lisp :a (data cel)
+      (cl:setf (cell-internal-inner cel) data)))
 
   (declare update! ((:a -> :a) -> (Cell :a) -> :a))
   (define (update! f cel)
@@ -80,7 +74,7 @@
     "Apply F to the contents of CEL, swapping the result for the old value"
     (swap! cel (f (read cel))))
 
-  ;;; operators on cells of lists
+;;; operators on cells of lists
   (declare push! ((Cell (List :elt)) -> :elt -> (List :elt)))
   (define (push! cel new-elt)
     (update! (Cons new-elt) cel))
@@ -93,7 +87,7 @@
               (Some fst)))
       ((Nil) None)))
 
-  ;;; operators on cells of numbers
+;;; operators on cells of numbers
   (declare increment! ((Num :counter) => (Cell :counter) -> :counter))
   (define (increment! cel)
     "Add one to the contents of CEL, storing and returning the new value"

--- a/src/library/slice.lisp
+++ b/src/library/slice.lisp
@@ -47,39 +47,31 @@
       (when (> end (vector:length v))
         (error "Slice cannot extend beyond length of backing vector."))
 
-      (match v
-        ((vector::%Vector v)
-         (lisp (Slice :a) (v start length)
-           (%Slice (cl:make-array
-                   length
-                   :displaced-to v
-                   :displaced-index-offset start)))))))
+      (lisp (Slice :a) (v start length)
+        (cl:make-array
+         length
+         :displaced-to v
+         :displaced-index-offset start))))
 
   (declare length ((Slice :a) -> Integer))
   (define (length s)
     "Returns the length of S"
-    (match s
-      ((%Slice s)
-       (lisp Integer (s)
-         (cl:array-dimension s 0)))))
+    (lisp Integer (s)
+      (cl:array-dimension s 0)))
 
   (declare copy ((Slice :a) -> (Slice :a)))
   (define (copy s)
     "Returns a new slice containg the same elements as S"
-    (match s
-      ((%Slice s)
-       (lisp (Slice :a) (s)
-         (%Slice (alexandria:copy-array s))))))
+    (lisp (Slice :a) (s)
+      (alexandria:copy-array s)))
 
   (declare set! (Integer -> :a -> (Slice :a) -> Unit))
   (define (set! index item s)
     "Set the element at INDEX in S to ITEM"
-    (match s
-      ((%Slice s)
-       (progn
-         (lisp Lisp-Object (index item s)
-           (cl:setf (cl:aref s index) item))
-         Unit))))
+    (progn
+      (lisp Lisp-Object (index item s)
+        (cl:setf (cl:aref s index) item))
+      Unit))
 
   (declare index (Integer -> (Slice :a) -> (Optional :a)))
   (define (index idx s)
@@ -99,39 +91,33 @@
   (declare foreach ((:a -> :b) -> (Slice :a) -> Unit))
   (define (foreach f s)
     "Call the function F once for each item in S"
-    (match s
-      ((%Slice s)
-       (progn
-         (lisp Lisp-Object (f s)
-           (cl:loop :for elem :across s
-              :do (coalton-impl/codegen::A1 f elem)))
-         Unit))))
+    (progn
+      (lisp Lisp-Object (f s)
+        (cl:loop :for elem :across s
+           :do (coalton-impl/codegen::A1 f elem)))
+      Unit))
 
   (declare foreach-index ((Integer -> :a -> :b) -> (Slice :a) -> Unit))
   (define (foreach-index f s)
     "Call the function F once for each item in S with its index"
-    (match s
-      ((%Slice s)
-       (progn
-         (lisp Lisp-Object (f s)
-           (cl:loop
-              :for elem :across s
-              :for i :from 0
-              :do (coalton-impl/codegen::A2 f i elem)))
-         Unit))))
+    (progn
+      (lisp Lisp-Object (f s)
+        (cl:loop
+           :for elem :across s
+           :for i :from 0
+           :do (coalton-impl/codegen::A2 f i elem)))
+      Unit))
 
   (declare foreach2 ((:a -> :b -> :c) -> (Slice :a) -> (Slice :b) -> Unit))
   (define (foreach2 f s1 s2)
     "Iterate over S1 and S2 calling F once on each iteration"
-    (match (Tuple s1 s2)
-      ((Tuple (%Slice s1) (%Slice s2))
-       (progn
-         (lisp Lisp-Object (f s1 s2)
-           (cl:loop
-              :for e1 :across s1
-              :for e2 :across s2
-              :do (coalton-impl/codegen::A2 f e1 e2)))
-         Unit))))
+    (progn
+      (lisp Lisp-Object (f s1 s2)
+        (cl:loop
+           :for e1 :across s1
+           :for e2 :across s2
+           :do (coalton-impl/codegen::A2 f e1 e2)))
+      Unit))
 
   ;;
   ;; Vector functions

--- a/src/library/vector.lisp
+++ b/src/library/vector.lisp
@@ -56,23 +56,19 @@
   (define (with-capacity n)
     "Create a new vector with N elements preallocated"
     (lisp (Vector :a) (n)
-      (%Vector (cl:make-array n :fill-pointer 0 :adjustable cl:t))))
+      (cl:make-array n :fill-pointer 0 :adjustable cl:t)))
 
   (declare length ((Vector :a) -> Integer))
   (define (length v)
     "Returns the length of V"
-    (match v
-      ((%Vector v)
-       (lisp Integer (v)
-         (cl:fill-pointer v)))))
+    (lisp Integer (v)
+      (cl:fill-pointer v)))
 
   (declare capacity ((Vector :a) -> Integer))
   (define (capacity v)
     "Returns the number of elements that V can store without resizing"
-    (match v
-      ((%Vector v)
-       (lisp Integer (v)
-         (cl:array-dimension v 0)))))
+    (lisp Integer (v)
+      (cl:array-dimension v 0)))
 
   (declare empty? ((Vector :a) -> Boolean))
   (define (empty? v)
@@ -82,20 +78,16 @@
   (declare copy ((Vector :a) -> (Vector :a)))
   (define (copy v)
     "Return a new vector containing the same elements as V"
-    (match v
-      ((%Vector v)
-       (lisp (Vector :a) (v)
-         (%Vector (alexandria:copy-array v))))))
+    (lisp (Vector :a) (v)
+      (%Vector (alexandria:copy-array v))))
 
   (declare push! (:a -> (Vector :a) -> Integer))
   (define (push! item v)
     "Append ITEM to V and resize V if necessary"
-    (match v
-      ((%Vector v)
-       (lisp Integer (item v)
-         (cl:progn
-	   (cl:vector-push-extend item v)
-	   (cl:1- (cl:fill-pointer v)))))))
+    (lisp Integer (item v)
+      (cl:progn
+	(cl:vector-push-extend item v)
+	(cl:1- (cl:fill-pointer v)))))
 
   (declare pop! ((Vector :a) -> (Optional :a)))
   (define (pop! v)
@@ -107,10 +99,8 @@
   (declare pop-unsafe! ((Vector :a) -> :a))
   (define (pop-unsafe! v)
     "Remove and return the first item of V without checking if the vector is empty"
-    (match v
-      ((%Vector v)
-       (lisp :a (v)
-         (cl:vector-pop v)))))
+    (lisp :a (v)
+      (cl:vector-pop v)))
 
   (declare index (Integer -> (Vector :a) -> (Optional :a)))
   (define (index index v)
@@ -122,20 +112,16 @@
   (declare index-unsafe (Integer -> (Vector :a) -> :a))
   (define (index-unsafe index v)
     "Return the INDEXth element of V without checking if the element exists"
-    (match v
-      ((%Vector v)
-       (lisp :a (index v)
-         (cl:aref v index)))))
+    (lisp :a (index v)
+      (cl:aref v index)))
 
   (declare set! (Integer -> :a -> (Vector :a) -> Unit))
   (define (set! index item v)
     "Set the INDEXth element of V to ITEM. This function left intentionally unsafe because it does not have a return value to check."
-    (match v
-      ((%Vector v)
-       (lisp Unit (index item v)
-         (cl:progn
-           (cl:setf (cl:aref v index) item)
-           Unit)))))
+    (lisp Unit (index item v)
+      (cl:progn
+        (cl:setf (cl:aref v index) item)
+        Unit)))
 
   (declare head ((Vector :a) -> (Optional :a)))
   (define (head v)
@@ -160,57 +146,49 @@
   (declare find-elem (Eq :a => (:a -> (Vector :a) -> (Optional Integer))))
   (define (find-elem e v)
     "Find the index of element E in V"
-    (match v
-      ((%Vector v)
-       (let ((test (fn (elem)
-                     (== elem e))))
+    (let ((test (fn (elem)
+                  (== elem e))))
 
-         (progn
-           (lisp (Optional Integer) (v test)
-             (cl:let ((pos (cl:position-if
-                            #'(cl:lambda (x)
-                                (cl:equalp True (coalton-impl/codegen::A1 test x)))
-                            v)))
-               (cl:if pos
-                      (Some pos)
-                      None))))))))
+      (progn
+        (lisp (Optional Integer) (v test)
+          (cl:let ((pos (cl:position-if
+                         #'(cl:lambda (x)
+                             (cl:equalp True (coalton-impl/codegen::A1 test x)))
+                         v)))
+            (cl:if pos
+                   (Some pos)
+                   None))))))
 
   (declare foreach ((:a -> :b) -> (Vector :a) -> Unit))
   (define (foreach f v)
     "Call the function F once for each item in V"
-    (match v
-      ((%Vector v)
-       (lisp Unit (f v)
-         (cl:progn
-           (cl:loop :for elem :across v
-              :do (coalton-impl/codegen::A1 f elem))
-           Unit)))))
+    (lisp Unit (f v)
+      (cl:progn
+        (cl:loop :for elem :across v
+           :do (coalton-impl/codegen::A1 f elem))
+        Unit)))
 
   (declare foreach-index ((Integer -> :a -> :b) -> (Vector :a) -> Unit))
   (define (foreach-index f v)
     "Call the function F once for each item in V with its index"
-    (match v
-      ((%Vector v)
-       (lisp Unit (f v)
-         (cl:progn
-           (cl:loop
-              :for elem :across v
-              :for i :from 0
-              :do (coalton-impl/codegen::A2 f i elem))
-           Unit)))))
+    (lisp Unit (f v)
+      (cl:progn
+        (cl:loop
+           :for elem :across v
+           :for i :from 0
+           :do (coalton-impl/codegen::A2 f i elem))
+        Unit)))
 
   (declare foreach2 ((:a -> :b -> :c) -> (Vector :a) -> (Vector :b) -> Unit))
   (define (foreach2 f v1 v2)
     "Like vector-foreach but twice as good"
-    (match (Tuple v1 v2)
-      ((Tuple (%Vector v1) (%Vector v2))
-       (lisp Unit (f v1 v2)
-         (cl:progn
-           (cl:loop
-              :for e1 :across v1
-              :for e2 :across v2
-              :do (coalton-impl/codegen::A2 f e1 e2))
-           Unit)))))
+    (lisp Unit (f v1 v2)
+      (cl:progn
+        (cl:loop
+           :for e1 :across v1
+           :for e2 :across v2
+           :do (coalton-impl/codegen::A2 f e1 e2))
+        Unit)))
 
   (declare append ((Vector :a) -> (Vector :a) -> (Vector :a)))
   (define (append v1 v2)


### PR DESCRIPTION
Some functions can be simplified now that their data structures are
marked `(repr :transparent)`.