### PR TITLE
Improve support for parsing higher kinded types

### DIFF
--- a/src/ast/parse-error.lisp
+++ b/src/ast/parse-error.lisp
@@ -8,8 +8,8 @@
    (reason-args :initarg :reason-args
                 :reader coalton-parse-error-reason-args))
   (:report (lambda (c s)
-             (let ((*print-pretty* nil))
-               (format s "Failed to parse ~S~%    ~?"
+             (let ((*print-circle* nil))
+               (format s "Failed to parse ~S~%~?"
                        (coalton-parse-error-form c)
                        (coalton-parse-error-reason-control c)
                        (coalton-parse-error-reason-args c))))))
@@ -44,6 +44,18 @@
          :form form
          :reason-control reason-control
          :reason-args reason-args))
+
+(define-condition coalton-unknown-instance (coalton-parse-error)
+  ((instance :initarg :instance
+             :reader coalton-unknown-instance-instance))
+  (:report (lambda (c s)
+             (let ((*print-circle* nil))
+               (format s "Missing definition for ~A"
+                       (coalton-unknown-instance-instance c))))))
+
+(defun error-unknown-instance (instance)
+  (error 'coalton-unknown-instance
+         :instance instance))
 
 (define-condition coalton-inherited-symbol (error)
   ((symbol :initarg :symbol

--- a/src/codegen/codegen-class.lisp
+++ b/src/codegen/codegen-class.lisp
@@ -57,14 +57,20 @@
                         (tc:ty-class-unqualified-methods class))))
 
 (defun make-method-fun (m package class)
-  (let* ((arity (coalton-impl/typechecker::function-type-arity
-                 (coalton-impl/typechecker::qualified-ty-type
-                  (coalton-impl/typechecker::fresh-inst (cdr m)))))
+  (let* ((qual-ty (tc:fresh-inst (cdr m)))
+
+         (method-contraint-args
+           (length (tc:qualified-ty-predicates qual-ty)))
+
+         (arity (+ (tc:function-type-arity
+                    (tc:qualified-ty-type qual-ty))
+                   method-contraint-args))
          (params
            (loop :for i :from 0 :below arity
                  :collect (alexandria:format-symbol package "_~A" i)))
          (class-codegen-sym (tc:ty-class-codegen-sym class))
          (method-accessor (alexandria:format-symbol (symbol-package class-codegen-sym) "~A-~A" class-codegen-sym (car m))))
+
     ;; TODO: add type annotations
     `((declaim (inline ,(car m)))
       (defun ,(car m) (dict ,@params)

--- a/src/codegen/resolve-instance.lisp
+++ b/src/codegen/resolve-instance.lisp
@@ -23,7 +23,7 @@
 (defun pred-type (pred env)
   "Returns a type represention of PRED"
   (declare (type tc:ty-predicate pred)
-           (values tc:ty &optional))
+           (values tc:ty tc::ksubstitution-list &optional))
   (let* ((class-entry (tc:lookup-class env (tc:ty-predicate-class pred)))
          (pred-kind tc:kstar))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -108,6 +108,7 @@
    #:parse-form                         ; FUNCTION
    #:error-parsing                      ; FUNCTION
    #:error-inherited-symbol             ; FUNCTION
+   #:error-unknown-instance             ; FUNCTION
    #:coalton-parse-error                ; CONDITION
    #:coalton-parse-error-form           ; READER
    #:coalton-parse-error-reason-control ; READER

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -161,6 +161,7 @@
    #:function-type-arigy                ; FUNCTION
    #:function-type-arguments            ; FUNCTION
    #:function-return-type               ; FUNCTION
+   #:function-type-arity                ; FUNCTION
    ) 
   (:export
    #:kstar                              ; VARIABLE

--- a/src/toplevel-define-instance.lisp
+++ b/src/toplevel-define-instance.lisp
@@ -3,11 +3,12 @@
 ;;; Handling of toplevel COALTON:DEFINE-INSTANCE.
 
 (defun process-toplevel-instance-definitions (definstance-forms package env)
-  (declare (values instance-definition-list))
+  (declare  (values instance-definition-list))
+
   (mapcar
-   (lambda (form)
-     (parse-instance-definition form package env))
-   definstance-forms))
+     (lambda (form)
+       (parse-instance-definition form package env))
+     definstance-forms))
 
 (defun predeclare-toplevel-instance-definitions (definstance-forms package env)
   "Predeclare all instance definitions in the environment so values can be typechecked"
@@ -15,28 +16,26 @@
            (type package package)
            (type environment env)
            (values environment))
-  (let ((parsed-instances
-          (mapcar (lambda (form)
-                    (unless (and (listp form)
-                                 (<= 2 (length form))
-                                 (eql 'coalton:define-instance (first form)))
-                      (error "Malformed DEFINE-INSTANCE form ~A" form))
-                    (multiple-value-list (coalton-impl/typechecker::parse-class-signature env (cadr form) nil nil)))
-                  definstance-forms)))
-    (dolist (parsed-instance parsed-instances)
-      (let* ((class-name (coalton-impl/typechecker::ty-predicate-class
-                          (second parsed-instance)))
-             (instance-codegen-sym (alexandria:format-symbol
-                                    package "INSTANCE/~A"
-                                    (with-output-to-string (s)
-                                      (with-pprint-variable-context ()
-                                        (pprint-predicate s (second parsed-instance))))))
-             (method-names (mapcar
+
+    (loop :for form :in definstance-forms
+          :do (multiple-value-bind (predicate context methods)
+                  (coalton-impl/typechecker::parse-instance-decleration form env)
+                (declare (ignore methods))
+                (let* ((class-name (ty-predicate-class predicate))
+
+                       (instance-codegen-sym
+                         (alexandria:format-symbol
+                          package "INSTANCE/~A"
+                          (with-output-to-string (s)
+                            (with-pprint-variable-context ()
+                              (pprint-predicate s predicate)))))
+
+                       (method-names (mapcar
                             #'car
                             (coalton-impl/typechecker::ty-class-unqualified-methods
                              (coalton-impl/typechecker::lookup-class env class-name))))
 
-             (method-codegen-syms
+                       (method-codegen-syms
                (let ((table (make-hash-table)))
                  (loop :for method-name :in method-names
                        :do (setf (gethash method-name table)
@@ -46,18 +45,19 @@
                                   instance-codegen-sym
                                   method-name)))
                  table))
-             
-             (instance (coalton-impl/typechecker::ty-class-instance
-                        (first parsed-instance)
-                        (second parsed-instance)
-                        instance-codegen-sym
-                        method-codegen-syms)))
 
+                       (instance
+                         (ty-class-instance
+                          :constraints context
+                          :predicate predicate
+                          :codegen-sym instance-codegen-sym
+                          :method-codegen-syms method-codegen-syms)))
 
-        (loop :for key :being :the :hash-keys :of method-codegen-syms
+              (loop :for key :being :the :hash-keys :of method-codegen-syms
               :for value :being :the :hash-values :of method-codegen-syms
               :for codegen-sym := (coalton-impl/typechecker::ty-class-instance-codegen-sym instance)
               :do (setf env (coalton-impl/typechecker::set-method-inline env key codegen-sym value)))
 
-        (setf env (coalton-impl/typechecker::add-instance env class-name instance))))
-    env))
+                  (setf env (add-instance env class-name instance)))))
+
+  env)

--- a/src/toplevel-define.lisp
+++ b/src/toplevel-define.lisp
@@ -10,10 +10,10 @@
            (type package package)
            (type environment env)
            (values symbol node (or null string) &optional))
-  (assert (and (eql (first form) 'coalton:define)
+  (unless (and (eql (first form) 'coalton:define)
                (or (<= 3 (length form))   ; Without docstring
                     )) ; With docstring
-          () "Malformed DEFINE form ~A" form)
+    (error-parsing form "malformed DEFINE form"))
 
   ;; Defines either define a value or a function. Values and functions
   ;; in Coalton occupy the namespace, but the intent of the user can

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -327,10 +327,10 @@
 
 (defstruct
     (ty-class
-     (:constructor ty-class (name predicate superclasses unqualified-methods codegen-sym superclass-dict docstring location)))
+     (:constructor ty-class))
   (name                (required 'name)                :type symbol              :read-only t)
   (predicate           (required 'predicate)           :type ty-predicate        :read-only t)
-  (superclasses        (requried 'superclasses)        :type ty-predicate-list   :read-only t)
+  (superclasses        (required 'superclasses)        :type ty-predicate-list   :read-only t)
   ;; Methods of the class containing the same tyvars in PREDICATE for
   ;; use in pretty printing
   (unqualified-methods (required 'unqualified-methods) :type scheme-binding-list :read-only t)
@@ -361,20 +361,21 @@
 (defmethod apply-substitution (subst-list (class ty-class))
   (declare (type substitution-list subst-list)
            (values ty-class &optional))
-  (ty-class (ty-class-name class)
-            (apply-substitution subst-list (ty-class-predicate class))
-            (apply-substitution subst-list (ty-class-superclasses class))
-            (mapcar (lambda (entry)
-                      (cons (car entry)
-                            (apply-substitution subst-list (cdr entry))))
-                    (ty-class-unqualified-methods class))
-            (ty-class-codegen-sym class)
-            (mapcar (lambda (entry)
-                      (cons (apply-substitution subst-list (car entry))
-                            (cdr entry)))
-                    (ty-class-superclass-dict class))
-            (ty-class-docstring class)
-            (ty-class-location class)))
+  (ty-class
+   :name (ty-class-name class)
+   :predicate (apply-substitution subst-list (ty-class-predicate class))
+   :superclasses (apply-substitution subst-list (ty-class-superclasses class))
+   :unqualified-methods (mapcar (lambda (entry)
+                                  (cons (car entry)
+                                        (apply-substitution subst-list (cdr entry))))
+                                (ty-class-unqualified-methods class))
+   :codegen-sym (ty-class-codegen-sym class)
+   :superclass-dict (mapcar (lambda (entry)
+                              (cons (apply-substitution subst-list (car entry))
+                                    (cdr entry)))
+                            (ty-class-superclass-dict class))
+   :docstring (ty-class-docstring class)
+   :location (ty-class-location class)))
 
 (defstruct (class-environment (:include immutable-map)))
 
@@ -387,7 +388,7 @@
 
 (defstruct
     (ty-class-instance
-     (:constructor ty-class-instance (constraints predicate codegen-sym method-codegen-syms)))
+     (:constructor ty-class-instance))
   (constraints         (required 'constraints)         :type ty-predicate-list :read-only t)
   (predicate           (required 'predicate)           :type ty-predicate      :read-only t)
   (codegen-sym         (required 'codegen-sym)         :type symbol            :read-only t)
@@ -416,10 +417,10 @@
   (declare (type substitution-list subst-list)
            (values ty-class-instance &optional))
   (ty-class-instance
-   (apply-substitution subst-list (ty-class-instance-constraints instance))
-   (apply-substitution subst-list (ty-class-instance-predicate instance))
-   (ty-class-instance-codegen-sym instance)
-   (ty-class-instance-method-codegen-syms instance)))
+   :constraints (apply-substitution subst-list (ty-class-instance-constraints instance))
+   :predicate (apply-substitution subst-list (ty-class-instance-predicate instance))
+   :codegen-sym (ty-class-instance-codegen-sym instance)
+   :method-codegen-syms (ty-class-instance-method-codegen-syms instance)))
 
 (defstruct (instance-environment (:include immutable-listmap)))
 

--- a/src/typechecker/kinds.lisp
+++ b/src/typechecker/kinds.lisp
@@ -35,8 +35,173 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type kfun))
 
+
+(defstruct (kyvar (:constructor %make-kyvar))
+  (id (required 'id) :type fixnum :read-only t))
+
+(defmethod make-load-form ((self kyvar) &optional env)
+  (make-load-form-saving-slots
+   self
+   :slot-names '(id)
+   :environment env))
+
+#+(and sbcl coalton-release)
+(declaim (sb-ext:freeze-type kyvar))
+
+(defun kyvar-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'kyvar-p x)))
+
+(deftype kyvar-list ()
+  '(satisfies kyvar-list-p))
+
+#+(and sbcl coalton-release)
+(declaim (sb-ext:freeze-type kyvar-list))
+
+(defstruct (kvar (:include kind)
+                 (:constructor %make-kvar (kyvar)))
+  (kyvar (required 'kyvar) :type kyvar :read-only t))
+
+(defmethod make-load-form ((self kvar) &optional env)
+  (make-load-form-saving-slots
+   self
+   :slot-names '(kyvar)
+   :environment env))
+
+#+(and sbcl coalton-release)
+(declaim (sb-ext:freeze-type kvar))
+
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type kind))
+
+(defvar *next-kvar-id* 0)
+
+#+sbcl
+(declaim (sb-ext:always-bound *next-kvar-id*))
+
+(declaim (inline make-kvariable))
+(defun make-kvariable ()
+  (prog1 (%make-kvar (%make-kyvar :id *next-kvar-id*))
+    (incf *next-kvar-id*)))
+
+(defstruct (ksubstitution (:constructor %make-ksubstitution (from to)))
+  (from (required 'from) :type kyvar :read-only t)
+  (to   (required 'to)   :type kind  :read-only t))
+
+#+(and sbcl coalton-release)
+(declaim (sb-ext:freeze-type ksubstitution))
+
+(defun ksubstitution-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'ksubstitution-p x)))
+
+(deftype ksubstitution-list ()
+  '(satisfies ksubstitution-list-p))
+
+(defun compose-ksubstution-lists (s1 s2)
+  (declare (type ksubstitution-list s1 s2)
+           (values ksubstitution-list))
+  (append
+   (mapcar
+    (lambda (s)
+      (%make-ksubstitution
+       (ksubstitution-from s)
+       (apply-ksubstitution s1 (ksubstitution-to s))))
+    s2)
+   s1))
+
+
+(defgeneric apply-ksubstitution (subs kind)
+  (:method (subs (kind kstar))
+    (declare (type ksubstitution-list subs)
+             (ignore subs)
+             (values kind))
+    kind)
+
+  (:method (subs (kind kfun))
+    (declare (type ksubstitution-list subs)
+             (values kind))
+    (kfun
+     (apply-ksubstitution subs (kfun-from kind))
+     (apply-ksubstitution subs (kfun-to kind))))
+
+  (:method (subs (kind kvar))
+    (declare (type ksubstitution-list subs)
+             (values kind))
+    (let ((elem (find (kvar-kyvar kind) subs :key #'ksubstitution-from :test #'equalp)))
+      (if elem
+          (ksubstitution-to elem)
+          kind)))
+
+  (:method (subs (kind list))
+    (mapcar
+     (lambda (kind)
+       (apply-ksubstitution subs kind))
+     kind)))
+
+(defun kunify (kind1 kind2 subs)
+  (declare (type kind kind1 kind2)
+           (type ksubstitution-list subs)
+           (values ksubstitution-list &optional))
+  (let ((new-subs (kmgu (apply-ksubstitution subs kind1)
+                       (apply-ksubstitution subs kind2))))
+    (compose-ksubstution-lists new-subs subs)))
+
+(defgeneric kmgu (kind1 kind2)
+  (:method ((kind1 kstar) (kind2 kstar))
+    (declare (values ksubstitution-list))
+    nil)
+
+  (:method ((kind1 kvar) (kind2 kind))
+    (declare (values ksubstitution-list))
+    (list
+     (%make-ksubstitution
+      (kvar-kyvar kind1)
+      kind2)))
+
+  (:method ((kind1 kind) (kind2 kvar))
+    (declare (values ksubstitution-list))
+    (list
+     (%make-ksubstitution
+      (kvar-kyvar kind2)
+      kind1)))
+
+  (:method ((kind1 kfun) (kind2 kfun))
+    (declare (values ksubstitution-list))
+    (append
+     (kmgu (kfun-from kind1) (kfun-from kind2))
+     (kmgu (kfun-to kind1) (kfun-to kind2))))
+
+  (:method (kind1 kind2)
+    (error 'kunify-error
+           :kind1 kind1
+           :kind2 kind2)))
+
+(defun kind-return-type (kind)
+  (if (kfun-p kind)
+      (kind-return-type (kfun-to kind))
+      kind))
+
+(defgeneric kind-variables (kind)
+  (:method ((kind kstar))
+    nil)
+
+  (:method ((kind kvar))
+    (list (kvar-kyvar kind)))
+
+  (:method ((kind kfun))
+    (append
+     (kind-variables (kfun-from kind))
+     (kind-variables (kfun-to kind)))))
+
+(defun kind-monomorphise-subs (kvars ksubs)
+  (declare (type kyvar-list kvars)
+           (values ksubstitution-list &optional))
+  (compose-ksubstution-lists
+   (loop :for kvar :in kvars
+         :collect (%make-ksubstitution kvar kstar))
+   ksubs))
+
 
 (defun simple-kind-p (kind)
   "Whether KIND is a simple kind (either * or a function from many * to *)"
@@ -64,6 +229,11 @@
     (loop :for i :below arity
           :do (setf kind (kFun kStar kind)))
     kind))
+
+(defun make-kind-function* (from to)
+  (if (null from)
+      to
+      (kfun (car from) (make-kind-function* (cdr from) to))))
 
 ;;;
 ;;; Pretty printing
@@ -93,7 +263,9 @@
          (format stream "("))
        (pprint-kind stream to)
        (when (kfun-p to)
-         (format stream ")")))))
+         (format stream ")"))))
+    (kvar
+     (format stream "#K~A" (kyvar-id (kvar-kyvar kind)))))
   kind)
 
 (set-pprint-dispatch 'kind 'pprint-kind)

--- a/src/typechecker/parse-instance-definition.lisp
+++ b/src/typechecker/parse-instance-definition.lisp
@@ -154,7 +154,8 @@
                                        (setf subs
                                              (compose-substitution-lists (predicate-match node-pred context-pred) subs)))
  
-                              (setf (gethash method-name method-bindings) (remove-static-preds (apply-substitution subs (cdr binding)))))))))
+                              (setf (gethash method-name method-bindings)
+                                    (remove-static-preds (apply-substitution subs (cdr binding)))))))))
 
             ;; Check for missing method definitions
             (loop :for (name . type) :in (ty-class-unqualified-methods class-entry)

--- a/src/typechecker/parse-type-definition.lisp
+++ b/src/typechecker/parse-type-definition.lisp
@@ -30,6 +30,152 @@
   '(satisfies type-definition-list-p))
 
 
+(defun parse-type-definition (partial-type self-type type-vars ksubs env)
+  (declare (type partial-define-type partial-type)
+           (type ty self-type)
+           (type list type-vars)
+           (type ksubstitution-list ksubs)
+           (type environment env)
+           (values list list ksubstitution-list))
+
+  (let* ((name (partial-define-type-name partial-type))
+
+         (tyvar-names (partial-define-type-tyvar-names partial-type))
+
+         (unparsed-ctors (partial-define-type-constructors partial-type))
+
+         (local-type-vars
+           (loop :for tyvar-name :in tyvar-names
+                 :collect (list tyvar-name (make-variable (make-kvariable)))))
+
+         (tyvars
+           (append
+            type-vars
+            local-type-vars))
+
+         (constructors
+           (loop :for ctor :in unparsed-ctors
+                 :for name := (first ctor)
+                 :for fields := (rest ctor)
+                 :collect (cons
+                           name
+                           (loop :for field :in fields
+                                 :collect (multiple-value-bind (type new-ksubs)
+                                              (parse-type-expr env field tyvars ksubs)
+                                            (setf ksubs new-ksubs)
+                                            (setf ksubs (kunify (kind-of type) kstar ksubs))
+                                            type))))))
+
+    ;; Unify the kind of the type with the kind:
+    ;; kind(tvar1) -> kind(tvar2) ... -> *
+    (setf ksubs (kunify
+                 (kind-of self-type)
+                 (make-kind-function*
+                  (loop :for (name type) :in local-type-vars
+                        :collect (kind-of type))
+                  kstar)
+                 ksubs))
+
+    (values
+     constructors
+     local-type-vars
+     ksubs)))
+
+(defun parse-type-impls (partial-types env)
+  "Parse the PARTIAL-TYPES in a single scc"
+  (declare (type partial-define-type-list partial-types)
+           (type environment env))
+
+  (let* ((type-names (mapcar #'partial-define-type-name partial-types))
+
+         (type-vars
+           (loop :for type-name :in type-names
+                 :collect (list type-name
+                                (%make-tcon
+                                 (%make-tycon
+                                  :name type-name
+                                  :kind (make-kvariable))))))
+
+         (ksubs nil)
+
+         (type-constructors
+           (loop :for partial-type :in partial-types
+                 :for self-type := (second (find (partial-define-type-name partial-type) type-vars :key #'first))
+                 :collect (multiple-value-bind (constructors local-tyvars new-ksubs)
+                              (parse-type-definition partial-type self-type type-vars ksubs env)
+                            (setf ksubs new-ksubs)
+                            (cons constructors local-tyvars)))))
+
+    (values
+     (loop :for partial-type :in partial-types
+           :for (name type) :in type-vars
+           :for (ctors . local-tyvars) :in type-constructors
+
+           :for type_ := (apply-ksubstitution ksubs type)
+           :for ksubs_ := (kind-monomorphise-subs (kind-variables type_) ksubs)
+           :for type__ := (apply-ksubstitution ksubs_ type)
+
+           :for tyvar-types
+             := (loop :for (name tyvar) :in local-tyvars
+                      :collect (apply-ksubstitution ksubs_ tyvar))
+
+           :for applied-type
+             := (apply-type-argument-list
+                 type__
+                 tyvar-types)
+
+           ;; Declare the current type in the env. This decleration is incomplete, and is discarded away after parsing
+           :do (setf
+                env
+                (set-type
+                 env
+                 name 
+                 (type-entry
+                  :name name
+                  :runtime-type name
+                  :type type__
+                  :enum-repr nil
+                  :newtype nil
+                  :docstring nil)))
+
+           :collect (list
+                     name
+                     type__
+                     (loop :for (ctor-name . args) :in ctors
+                           :for arity := (length args)
+                           :for classname := (alexandria:format-symbol
+                                              (symbol-package name)
+                                              "~A/~A" name ctor-name)
+                           :for args_ := (apply-ksubstitution ksubs_ args)
+                           :for type := (make-function-type* args_ applied-type)
+                           :for scheme := (quantify-using-tvar-order (mapcar #'tvar-tyvar tyvar-types) (qualify nil type))
+                           :collect
+                           (cons
+                            scheme
+                            (make-constructor-entry
+                             :name ctor-name
+                             :arity arity
+                             :constructs name
+                             :classname classname
+                             :compressed-repr nil)))))
+     env)))
+
+(defstruct (partial-define-type (:constructor partial-define-type))
+  (name         (required 'name)         :type symbol           :read-only t)
+  (tyvar-names  (required 'tyvar-names)  :type symbol-list      :read-only t)
+  (constructors (required 'constructors) :type list             :read-only t)
+  (docstring    (required 'docstring)    :type (or null string) :read-only t))
+
+#+(and sbcl coalton-release)
+(declaim (sb-ext:freeze-type partial-define-type))
+
+(defun partial-define-type-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'partial-define-type-p x)))
+
+(deftype partial-define-type-list ()
+  '(satisfies partial-define-type-list-p))
+
 (defun parse-type-definitions (forms repr-table env)
   "Parse the type defintion FORM in the ENVironment
 
@@ -39,15 +185,15 @@ Returns TYPE-DEFINITIONS"
            (values type-definition-list))
 
   ;; Pull out and verify DEFINE-TYPE and type
-  (let ((parsed-tcons nil))
-    ;; First, go through and parse out all tycons so we can build an
-    ;; environment
+  (let ((type-definitions nil) ; list (name tvars constructors docstring)
+        (type-dependencies)    ; list (name dependencies*)
+        )
     (dolist (form forms)
       (assert (and (eql 'coalton:define-type (first form))
                    (<= 2 (length form))
                    (or (listp (second form))
                        (symbolp (second form))))
-              () "Malformed DEFINE-TYPE form ~A" form)
+          () "Malformed DEFINE-TYPE form ~A" form)
       (destructuring-bind (def-type type &rest ctors) form
         (declare (ignore def-type))
         ;; Pull bare symbols into a list for easier parsing
@@ -57,84 +203,99 @@ Returns TYPE-DEFINITIONS"
         (destructuring-bind (tycon-name &rest tyvar-names) type
           (assert (and (symbolp tycon-name)
                        (every #'symbolp tyvar-names))
-                  () "Malformed DEFINE-TYPE type ~A" type)
-          (assert (every (lambda (var)
-                           (equalp (symbol-package var)
-                                   keyword-package))
-                         tyvar-names)
-                  () "Type variables must be in the KEYWORD package. In type ~A" form)
+              () "Malformed DEFINE-TYPE type ~A" type)
 
           ;; Push this tycon onto the list
-          (let ((tycon-type
-                  (%make-tcon (%make-tycon :name tycon-name
-                                           :kind (tvar-count-to-kind (length tyvar-names)))))
-
-                (type-vars
-                  (loop :for i :below (length tyvar-names)
-                        :collect (make-variable)))
-
-                ;; If the first ctor is a string then it is the docstring and we should skip it.
+          (let (;; If the first ctor is a string then it is the docstring and we should skip it.
                 (constructors
-                  (if (stringp (car ctors))
-                      (cdr ctors)
-                      ctors))
+                  (mapcar #'alexandria:ensure-list
+                          (if (stringp (car ctors))
+                              (cdr ctors)
+                              ctors)))
 
                 ;; Pull out the docstring if it exists
                 (docstring
                   (when (stringp (car ctors))
                     (car ctors))))
 
-            ;; Save this for later
-            (push (list tycon-name
-                        tycon-type
-                        constructors
-                        type-vars
-                        tyvar-names
-                        docstring)
-                  parsed-tcons)))))
-
-
-    ;; Push the *incomplete* type definitions onto the
-    ;; environment to allow types to depend on concurrently
-    ;; defined types.
-    ;;
-    ;; NOTE: This does not modify the ENV of the caller and gets
-    ;;       thrown away when this function returns
-    (loop :for (tycon-name tcon ctors type-vars tyvar-names docstring) :in parsed-tcons :do
-      (setf env
-            (set-type env
-                      tycon-name
-                      (type-entry
-                       :name tycon-name
-                       :runtime-type tycon-name
-                       :type tcon
-                       :enum-repr nil
-                       :newtype nil
-                       :docstring nil))))
-
-    ;; Then, re-parse all of the type definitions and ctors using the environment
-    (loop :for (tycon-name tcon ctors type-vars tyvar-names docstring) :in parsed-tcons
-          :collect
-          (let* ((type-vars-alist nil)
-                 (applied-tycon (apply-type-argument-list tcon type-vars)))
-
             (with-parsing-context ("definition of type ~A" tycon-name)
-              ;; Populate the type variable table for use in parsing types
-              (setf type-vars-alist
-                    (loop :for name :in tyvar-names
-                          :for tvar :in type-vars
-                          :collect (cons name
-                                         (cons tvar
-                                               (kind-arity (kind-of tvar))))))
+              ;; Check for invalid type variables
+              (unless (every (lambda (var)
+                               (equalp (symbol-package var)
+                                       keyword-package))
+                             tyvar-names)
+                (error-parsing form "type variables must all be in the KEYWORD package."))
+
+              ;; Check for duplicate constructors
+              (labels ((check-for-duplicate-constructors (ctors)
+                         (if (find (car (car ctors)) (rest ctors) :key #'car :test #'equalp)
+                             (error-parsing form "duplicate constructor ~A" (car (car ctors)))
+                             (when (rest ctors)
+                               (check-for-duplicate-constructors (rest ctors))))))
+                (check-for-duplicate-constructors constructors))
+
+              ;; Check for duplicate type variables
+              (labels ((check-for-duplicate-type-variables (tyvar-names)
+                         (if (find (car tyvar-names) (rest tyvar-names) :test #'equalp)
+                             (error-parsing form "duplicate type variable ~S" (car tyvar-names))
+                             (when (rest tyvar-names) 
+                               (check-for-duplicate-type-variables (rest tyvar-names))))))
+                (check-for-duplicate-type-variables tyvar-names))
+
+              ;; Check for type variables appearing in constructors but not in the type
+              (loop :for (ctor-name . fields) :in constructors
+                    :do (loop :for field :in fields
+                              :for field-tyvars := (collect-type-vars field)
+                              :do (loop :for field-tyvar :in field-tyvars
+                                        :do (unless (find field-tyvar tyvar-names :test #'equalp)
+                                              (error-parsing
+                                               form
+                                               "type variable ~S appears in constructor ~A but not in type"
+                                               field-tyvar
+                                               ctor-name))))))
+
+            (push
+             (partial-define-type
+              :name tycon-name
+              :tyvar-names tyvar-names
+              :constructors constructors
+              :docstring docstring)
+             type-definitions)
+
+            (push
+             (cons
+              tycon-name
+              (remove-duplicates
+               (loop :for (name . args) :in constructors
+                     :append (collect-types args))
+               :test #'equalp))
+             type-dependencies)))))
+
+
+    (let* ((translation-unit-types (mapcar #'car type-dependencies))
+
+           (type-dependencies
+             (loop :for (name . deps) :in type-dependencies
+                   :collect (cons name (intersection deps translation-unit-types))))
+
+           (parsed-tcons
+             (loop :for scc :in (reverse (tarjan-scc type-dependencies))
+                   :for partial-types
+                     := (loop :for type-name :in scc
+                              :collect (find type-name type-definitions :test #'equalp :key #'partial-define-type-name))
+                   :append (multiple-value-bind (data new-env)
+                               (parse-type-impls partial-types env)
+                             (setf env new-env)
+                             data))))
+
+      (loop :for (tycon-name tcon ctor-data docstring) :in parsed-tcons
+            :collect
+            (with-parsing-context ("definition of type ~A" tycon-name)
+              
               ;; Parse out the ctors
-              (let* ((ctor-data
-                       (loop :for ctor in ctors
-                             :collect
-                             (multiple-value-list (parse-type-ctor ctor applied-tycon type-vars-alist tycon-name env))))
+              (let* ((parsed-ctors (mapcar #'cdr ctor-data))
 
-                     (parsed-ctors (mapcar #'first ctor-data))
-
-                     (ctor-types (mapcar #'second ctor-data))
+                     (ctor-types (mapcar #'car ctor-data))
 
                      ;; If every constructor entry has an arity of 0
                      ;; then this type can be compiled as an enum
@@ -179,7 +340,7 @@ Returns TYPE-DEFINITIONS"
                     :docstring docstring))
 
                   ((or (and newtype (eql repr :transparent))
-                    (and newtype
+                       (and newtype
                             (coalton-impl:coalton-release-p)))
                    (let (;; The runtime type of a newtype is the runtime type of it's only constructor's only argument
                          (runtime-type (function-type-from
@@ -232,59 +393,15 @@ Returns TYPE-DEFINITIONS"
    :classname (constructor-entry-classname ctor)
    :compressed-repr (constructor-entry-classname ctor)))
 
-(defun parse-type-ctor (form applied-tycon type-vars constructs env)
-  (declare (type t form)
-           (type ty applied-tycon)
-           (type list type-vars)
-           (type environment env)
-           (type symbol constructs)
-           (values constructor-entry ty-scheme))
-  ;; Make sure we have a list we can destructure
-  (setf form (alexandria:ensure-list form))
-  (destructuring-bind (ctor-name &rest tyarg-names) form
-
-    (with-parsing-context ("constructor definition of ~A" ctor-name)
-      ;; Lookup all type arguments either within the given TYPE-VARS or
-      ;; as a type in the environment
-      (let* ((tyvars (mapcar (lambda (v) (tvar-tyvar (cadr v))) type-vars))
-             (tyargs (mapcar (lambda (arg)
-                               (qualified-ty-type (fresh-inst (parse-and-resolve-type env arg type-vars tyvars))))
-                             tyarg-names)))
-
-        (unless (subsetp (type-variables tyargs) tyvars :test #'equalp)
-          (error "Constructor ~A cannot use type variables that are not in scope."
-                 form))
-
-        ;; Build up the constructor function
-        (labels ((build-function (args)
-                   (if (car args)
-                       (make-function-type (car args)
-                                           (build-function (cdr args)))
-                       applied-tycon))
-                 ;; This is a version of quantify allowing us to
-                 ;; preserve the order of tyvars instead of building it
-                 ;; from the type.
-                 (quantify-using-tvar-order (tyvars type)
-                   (let* ((vars (remove-if
-                                 (lambda (x) (not (find x (type-variables type) :test #'equalp)))
-                                 tyvars))
-                          (kinds (mapcar #'kind-of vars))
-                          (subst (loop :for var :in vars
-                                       :for id :from 0
-                                       :collect (%make-substitution var (%make-tgen id)))))
-                     (%make-ty-scheme kinds (apply-substitution subst type)))))
-          (values
-           (make-constructor-entry
-            :name ctor-name
-            :arity (length tyarg-names)
-            :constructs constructs
-            :classname (alexandria:format-symbol
-                        (symbol-package constructs)
-                        "~A/~A" constructs ctor-name)
-            :compressed-repr nil)
-           (quantify-using-tvar-order
-            tyvars
-            (qualify nil (build-function tyargs)))))))))
+(defun quantify-using-tvar-order (tyvars type)
+  (let* ((vars (remove-if
+                (lambda (x) (not (find x (type-variables type) :test #'equalp)))
+                tyvars))
+         (kinds (mapcar #'kind-of vars))
+         (subst (loop :for var :in vars
+                      :for id :from 0
+                      :collect (%make-substitution var (%make-tgen id)))))
+    (%make-ty-scheme kinds (apply-substitution subst type))))
 
 (defun tvar-count-to-kind (tvar-count)
   "Create a KIND from the number of type variables"

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -72,8 +72,18 @@
   (ty-predicate (ty-predicate-class type)
                       (apply-substitution subst-list (ty-predicate-types type))))
 
+(defmethod apply-ksubstitution (subs (type ty-predicate))
+  (declare (type ksubstitution-list subs))
+  (ty-predicate
+   (ty-predicate-class type)
+   (apply-ksubstitution subs (ty-predicate-types type))))
+
 (defmethod type-variables ((type ty-predicate))
   (type-variables (ty-predicate-types type)))
+
+(defmethod kind-variables ((type ty-predicate))
+  (declare (values kyvar-list))
+  (mapcan #'kind-variables (ty-predicate-types type)))
 
 (defmethod instantiate (types (type ty-predicate))
   (ty-predicate (ty-predicate-class type)
@@ -85,11 +95,23 @@
   (qualified-ty (apply-substitution subst-list (qualified-ty-predicates type))
                       (apply-substitution subst-list (qualified-ty-type type))))
 
+(defmethod apply-ksubstitution (subs (type qualified-ty))
+  (declare (type ksubstitution-list subs))
+  (qualified-ty
+   (apply-ksubstitution subs (qualified-ty-predicates type))
+   (apply-ksubstitution subs (qualified-ty-type type))))
+
 (defmethod type-variables ((type qualified-ty))
   (remove-duplicates
    (append (type-variables (qualified-ty-predicates type))
            (type-variables (qualified-ty-type type)))
    :test #'equalp))
+
+(defmethod kind-variables ((type qualified-ty))
+  (declare (values kyvar-list))
+  (append
+   (kind-variables (qualified-ty-type type))
+   (mapcan #'kind-variables (qualified-ty-predicates type))))
 
 (defmethod instantiate (types (type qualified-ty))
   (qualified-ty (instantiate types (qualified-ty-predicates type))

--- a/src/typechecker/type-errors.lisp
+++ b/src/typechecker/type-errors.lisp
@@ -326,6 +326,21 @@
                type
                name)))))
 
+(define-condition kunify-error (coalton-type-error)
+  ((kind1 :initarg :kind1
+          :reader kunify-errror-kind1
+          :type kind)
+   (kind2 :initarg :kind2
+          :reader kunify-error-kind2
+          :type kind))
+  (:report
+   (lambda (c s)
+     (let ((*print-circle* nil) ; Prevent printing using reader macros
+           )
+       (format s "Unable to unify kinds ~A and ~A"
+               (kunify-errror-kind1 c)
+               (kunify-error-kind2 c))))))
+
 (define-condition duplicate-definition (coalton-type-error)
   ((name :initarg :name
          :reader duplicate-definition-name))

--- a/tests/runtime-tests.lisp
+++ b/tests/runtime-tests.lisp
@@ -73,3 +73,16 @@
   (define-instance (Gh-400-b Integer)
     (define (gh-400-b-method x) x)
     (define gh-400-b-constant 5)))
+
+;; Test that classes can have method constraints
+(coalton-toplevel
+  (define-class (Gh-430 :a)
+    (gh-430-m (Num :b => :a -> :b -> :b -> :b)))
+
+  (define-instance (Gh-430 String)
+    (define (gh-430-m a b c)
+      (+ b c))))
+
+(define-test test-method-constraints ()
+  (is (== 5 (gh-430-m "str" 2 3)))
+  (is (== 2 (gh-430-m "hello" 1 1))))

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -125,6 +125,12 @@
        (B (A :a))))
    '())
 
+  ;; Check higher kinded type variables
+  (check-coalton-types
+   '((coalton:define-type (Fix :f)
+       (In (:f (Fix :f)))))
+   '((In . (:f (Fix :f) -> Fix :f))))
+
   ;; Check that constructors are properly typed
   (signals coalton-impl::coalton-type-error
     (run-coalton-typechecker
@@ -349,7 +355,8 @@
         (example-method ((TestClassA :a) => (:a -> :b))))
        (coalton:define-class ((TestClassB :a) => (TestClassA :a))))))
 
-  (not-signals coalton-impl::cyclic-class-definitions-error
+  ;; NOTE: This is allowed in Haskell 98
+  (signals coalton-impl::cyclic-class-definitions-error
     (run-coalton-typechecker
      '((coalton:define-class (TestClassA :a)
         (example-method ((TestClassA :b) => (:a -> :b))))))))


### PR DESCRIPTION
Mirror type variables in the kind system. Kinds now support kind variables, kind substitutions, and kind unification. Top level `define-type` forms are split by scc, each scc is then kind checked sequentially. This process mirrors the type checking of binding groups in `derive-type.lisp`.

Kind variables remaining after kind checking are currently monomorphized to `kstar`.

Also improves the type parser to allow eliding more parens.

* `(Eq :a => (Optional :a) -> (Optional :a) -> (Optional :a))` -> 
   `(Eq :a => Optional :a -> Optional :a -> Optional :a)`
* `(Eq :a => (Ord :a))` -> `(Eq :a => Ord :a)`

Fixes #396
Fixes #290

Don't merge waiting on #411 