### PR TITLE
Add Foldable and Traversable

### DIFF
--- a/src/library/classes.lisp
+++ b/src/library/classes.lisp
@@ -19,6 +19,9 @@
    #:>>
    #:MonadFail #:fail
    #:Alternative #:alt #:empty
+   #:Foldable #:fold #:foldr
+   #:Traversable #:traverse
+   #:sequence
    #:Into
    #:TryInto
    #:Iso
@@ -213,6 +216,21 @@
     "Types which are monoids on applicative functors."
     (alt ((:f :a) -> (:f :a) -> (:f :a)))
     (empty (:f :a)))
+
+  (define-class (Foldable :t)
+    "Types which can be folded into a single element.
+
+`fold` is a left tail recursive fold
+
+`foldr` is a right non tail recursive fold"
+    (fold ((:b -> :a -> :b) -> :b -> :t :a -> :b))
+    (foldr ((:a -> :b -> :b) -> :b -> :t :a -> :b)))
+
+  (define-class (Traversable :t)
+    (traverse (Applicative :f => (:a -> :f :b) -> :t :a -> :f (:t :b))))
+
+  (declare sequence ((Traversable :t) (Applicative :f) => :t (:f :b) -> :f (:t :b)))
+  (define sequence (traverse (fn (x) x)))
 
   ;;
   ;; Conversions

--- a/src/library/functions.lisp
+++ b/src/library/functions.lisp
@@ -16,8 +16,6 @@
    #:disjoin
    #:complement
    #:uncurry
-   #:traverse
-   #:sequence
    #:msum
    #:asum
    #:/=))
@@ -103,17 +101,6 @@
   ;;
   ;; Monadic operators
   ;;
-
-  (declare traverse (Applicative :m => ((:a -> (:m :b)) -> (List :a) -> (:m (List :b)))))
-  (define (traverse f xs)
-    "Map the elements of XS with F from left to right, collecting the results."
-    (let ((cons-f (fn (x ys)
-                    (liftA2 Cons (f x) ys))))
-      (fold cons-f (pure Nil) (reverse xs))))
-
-  (declare sequence (Applicative :f => ((List (:f :a)) -> (:f (List :a)))))
-  (define (sequence xs)
-    (traverse id xs))
 
   (declare msum (Monoid :a => ((List :a) -> :a)))
   (define (msum xs)


### PR DESCRIPTION
Also switches the type signature of fold from

`(:a -> :b -> :b) -> :b -> (List :a) -> :b`

to

`(:b -> :a -> :b) -> :b -> (List :a) -> :b`

The argument order now matches the order of the fold. This is also now consistent with Haskell and `iterator:fold!`.