### PR TITLE
add eq instance for unit

### DIFF
--- a/src/library/classes.lisp
+++ b/src/library/classes.lisp
@@ -91,6 +91,9 @@
     "Types which have equality defined."
     (== (:a -> :a -> Boolean)))
 
+  (define-instance (Eq Unit)
+    (define (== _ _) True))
+
   ;;
   ;; Ord
   ;;


### PR DESCRIPTION
I had cause to use this instance recently, and it seems like a fundamentally sane rule-abiding instance.