### PR TITLE
Call graph based monomorphization

### DIFF
--- a/benchmarks/package.lisp
+++ b/benchmarks/package.lisp
@@ -10,9 +10,9 @@
    #:fib
    #:fib-fixnum
    #:fib-generic-wrapped
-   #:fib-monomorphised
+   #:fib-monomorphized
    #:fib-generic-optional
-   #:fib-monomorphised-optional))
+   #:fib-monomorphized-optional))
 
 (cl:in-package #:coalton-benchmarks)
 
@@ -54,11 +54,11 @@
   (report trivial-benchmark::*current-timer*))
 
 
-(define-benchmark recursive-fib-monomorphised ()
+(define-benchmark recursive-fib-monomorphized ()
   (declare (optimize speed))
   (loop :repeat 1000
         :do (with-benchmark-sampling
-              (coalton-benchmarks/native:fib-monomorphised 20)))
+              (coalton-benchmarks/native:fib-monomorphized 20)))
   (report trivial-benchmark::*current-timer*))
 
 ;;
@@ -75,11 +75,11 @@
   (report trivial-benchmark::*current-timer*))
 
 #+ignore
-(define-benchmark recursive-fib-monomorphised-optional ()
+(define-benchmark recursive-fib-monomorphized-optional ()
   (declare (optimize speed))
   (loop :repeat 1000
         :do (with-benchmark-sampling
-              (coalton-benchmarks/native:fib-monomorphised-optional 10)))
+              (coalton-benchmarks/native:fib-monomorphized-optional 10)))
   (report trivial-benchmark::*current-timer*))
 
 (defun lisp-fib (n)
@@ -122,16 +122,16 @@
   (declare fib-generic-wrapped (Integer -> Integer))
   (define fib-generic-wrapped fib-generic)
 
-  (monomorphise)
-  (declare fib-monomorphised (Integer -> Integer))
-  (define fib-monomorphised fib-generic)
+  (monomorphize)
+  (declare fib-monomorphized (Integer -> Integer))
+  (define fib-monomorphized fib-generic)
 
   (declare fib-generic-optional (Integer -> Optional Integer))
   (define (fib-generic-optional x)
     (fib-generic (Some x)))
 
-  (monomorphise)
-  (declare fib-monomorphised-optional (Integer -> Optional Integer))
-  (define (fib-monomorphised-optional x) 
+  (monomorphize)
+  (declare fib-monomorphized-optional (Integer -> Optional Integer))
+  (define (fib-monomorphized-optional x) 
     (fib-generic (Some x))))
 

--- a/coalton.asd
+++ b/coalton.asd
@@ -83,7 +83,7 @@
                              (:file "codegen-expression")
                              (:file "codegen-type-definition")
                              (:file "codegen-class")
-                             (:file "monomorphise")
+                             (:file "monomorphize")
                              (:file "optimizer")
                              (:file "program")
                              (:file "package")))

--- a/coalton.asd
+++ b/coalton.asd
@@ -91,6 +91,7 @@
                (:file "toplevel-declare")
                (:file "toplevel-define")
                (:file "toplevel-define-instance")
+               (:file "toplevel-specializations")
                (:file "unlock-package" :if-feature :sb-package-locks)
                (:file "coalton")
                (:file "debug")

--- a/coalton.asd
+++ b/coalton.asd
@@ -29,7 +29,6 @@
   :pathname "src/"
   :serial t
   :components ((:file "package")
-               (:file "unlock-package" :if-feature :sb-package-locks)
                (:file "settings")
                (:file "utilities")
                (:file "global-lexical")
@@ -70,6 +69,7 @@
                (:module "codegen"
                 :serial t
                 :components ((:file "ast")
+                             (:file "ast-subsitutions")
                              (:file "resolve-instance")
                              (:file "typecheck-node")
                              (:file "hoister")
@@ -83,12 +83,15 @@
                              (:file "codegen-expression")
                              (:file "codegen-type-definition")
                              (:file "codegen-class")
+                             (:file "monomorphise")
+                             (:file "optimizer")
                              (:file "program")
                              (:file "package")))
                (:file "toplevel-define-type")
                (:file "toplevel-declare")
                (:file "toplevel-define")
                (:file "toplevel-define-instance")
+               (:file "unlock-package" :if-feature :sb-package-locks)
                (:file "coalton")
                (:file "debug")
                (:file "faux-macros")

--- a/src/ast/pattern.lisp
+++ b/src/ast/pattern.lisp
@@ -22,6 +22,9 @@
      (:constructor pattern-var (id)))
   (id (required 'id) :type symbol :read-only t))
 
+(defmethod make-load-form ((self pattern-var) &optional env)
+  (make-load-form-saving-slots self :environment env))
+
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type pattern-var))
 
@@ -29,6 +32,9 @@
     (pattern-wildcard
      (:include pattern)
      (:constructor pattern-wildcard)))
+
+(defmethod make-load-form ((self pattern-wildcard) &optional env)
+  (make-load-form-saving-slots self :environment env))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type pattern-wildcard))
@@ -39,6 +45,9 @@
      (:constructor pattern-literal (value)))
   (value (required 'value) :type literal-value :read-only t))
 
+(defmethod make-load-form ((self pattern-literal) &optional env)
+  (make-load-form-saving-slots self :environment env))
+
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type pattern-literal))
 
@@ -48,6 +57,9 @@
      (:constructor pattern-constructor (name patterns)))
   (name      (required 'name) :type symbol       :read-only t)
   (patterns  (required 'type) :type pattern-list :read-only t))
+
+(defmethod make-load-form ((self pattern-constructor) &optional env)
+  (make-load-form-saving-slots self :environment env))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type pattern-constructor))

--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -40,7 +40,7 @@ either (INDICATOR VALUE) or just INDICATOR; the short form means (INDICATOR T)."
  (coalton:repr              :toplevel
                             (:must-precede-one-of (coalton:define-type)))
 
- (coalton:monomorphise      :toplevel
+ (coalton:monomorphize      :toplevel
                             (:must-precede-one-of (coalton:declare
                                                    coalton:define)))
  (coalton:specialize :toplevel))
@@ -79,8 +79,8 @@ in FORMS that begin with that operator."
 
            (setf (gethash type (getf plist 'repr-table)) (cons specifier arg)))
 
-         (handle-monomorphise (definition-name)
-           (push :monomorphise (gethash definition-name (getf plist 'attr-table))))
+         (handle-monomorphize (definition-name)
+           (push :monomorphize (gethash definition-name (getf plist 'attr-table))))
 
          (walk (forms)
            (loop
@@ -114,13 +114,13 @@ in FORMS that begin with that operator."
 
                     (establish-repr (cadr form) (cadr next-form) (caddr form)))
 
-                   (coalton:monomorphise
+                   (coalton:monomorphize
                     (unless (= (length form) 1)
                       (error-parsing form "Wrong number of arguments"))
 
                     (if (listp (cadr next-form))
-                        (handle-monomorphise (first (cadr next-form)))
-                        (handle-monomorphise (cadr next-form))))))))
+                        (handle-monomorphize (first (cadr next-form)))
+                        (handle-monomorphize (cadr next-form))))))))
       ;; Populate PLIST...
       (walk forms)
       ;; ...and return it, with its values reversed to reflect the order that

--- a/src/codegen/ast-subsitutions.lisp
+++ b/src/codegen/ast-subsitutions.lisp
@@ -1,0 +1,135 @@
+(defpackage #:coalton-impl/codegen/ast-substitutions
+  (:use
+   #:cl
+   #:coalton-impl/util
+   #:coalton-impl/codegen/ast)
+  (:export
+   #:ast-substitution                   ; STRUCT
+   #:ast-substitution-from              ; ACCESSOR
+   #:ast-substitution-to                ; ACCESSOR
+   #:ast-substitution-list              ; TYPE
+   ))
+
+(in-package #:coalton-impl/codegen/ast-substitutions)
+
+(defstruct (ast-substitution (:constructor ast-substitution (from to)))
+  (from (required 'from) :type symbol :read-only t)
+  (to   (required 'to)   :type node   :read-only t))
+
+(defun ast-substitution-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'ast-substitution-p x)))
+
+(deftype ast-substitution-list ()
+  '(satisfies ast-substitution-list-p))
+
+(defgeneric apply-ast-substitution (subs node)
+  (:method (subs (list list))
+    (loop :for node :in list
+          :collect (apply-ast-substitution subs node)))
+
+  (:method (subs (node node-literal))
+    (declare (type ast-substitution-list subs)
+             (ignore subs)
+             (values node))
+    node)
+
+  (:method (subs (node node-variable))
+    (declare (type ast-substitution-list subs)
+             (values node))
+    (let ((res (find (node-variable-value node) subs :key #'ast-substitution-from)))
+      (if res
+          (ast-substitution-to res)
+          node)))
+
+  (:method (subs (node node-application))
+    (declare (type ast-substitution-list subs)
+             (values node))
+    (node-application
+     (node-type node)
+     (apply-ast-substitution subs (node-application-rator node))
+     (apply-ast-substitution subs (node-application-rands node))))
+
+  (:method (subs (node node-direct-application))
+    (declare (type ast-substitution-list subs)
+             (values node))
+
+    (when (find (node-direct-application-rator node) subs :key #'ast-substitution-from)
+      (coalton-bug
+       "Failure to apply ast substitution on variable ~A to node-direct-application"
+       (node-direct-application-rator node)))
+
+    (node-direct-application
+     (node-type node)
+     (node-direct-application-rator-type node)
+     (node-direct-application-rator node)
+     (apply-ast-substitution subs (node-direct-application-rands node))))
+
+  (:method (subs (node node-abstraction))
+    (declare (type ast-substitution-list subs)
+             (values node))
+
+    (node-abstraction
+     (node-type node)
+     (node-abstraction-vars node)
+     (apply-ast-substitution subs (node-abstraction-subexpr node))))
+
+  (:method (subs (node node-bare-abstraction))
+    (declare (type ast-substitution-list subs)
+             (values node))
+    (node-bare-abstraction
+     (node-type node)
+     (node-bare-abstraction-vars node)
+     (apply-ast-substitution subs (node-bare-abstraction-subexpr node))))
+
+  (:method (subs (node node-let))
+    (declare (type ast-substitution-list subs)
+             (values node))
+
+    (node-let
+     (node-type node)
+     (loop :for (name . node) :in (node-let-bindings node)
+           :do (when (find name subs :key #'ast-substitution-from)
+                 (coalton-bug
+                  "Failure to apply ast substitution on variable ~A to node-let"
+                  name))
+           :collect (cons name (apply-ast-substitution subs node)))
+     (apply-ast-substitution subs (node-let-subexpr node))))
+
+  (:method (subs (node match-branch))
+    (declare (type ast-substitution-list subs)
+             (values match-branch))
+    (match-branch
+     (match-branch-pattern node)
+     (match-branch-bindings node)
+     (apply-ast-substitution subs (match-branch-body node))))
+
+  (:method (subs (node node-match))
+    (declare (type ast-substitution-list subs)
+             (values node))
+    (node-match
+     (node-type node)
+     (apply-ast-substitution subs (node-match-expr node))
+     (apply-ast-substitution subs (node-match-branches node))))
+
+  (:method (subs (node node-seq))
+    (declare (type ast-substitution-list subs)
+             (values node))
+    (node-seq
+     (node-type node)
+     (apply-ast-substitution subs (node-seq-nodes node))))
+
+  (:method (subs (node node-return))
+    (declare (type ast-substitution-list subs)
+             (values node))
+    (node-return
+     (node-type node)
+     (apply-ast-substitution subs (node-return-expr node))))
+
+  (:method (subs (node node-field))
+    (declare (type ast-substitution-list subs)
+             (values node))
+    (node-field
+     (node-type node)
+     (node-field-name node)
+     (apply-ast-substitution subs (node-field-dict node)))))

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -75,7 +75,7 @@
 ;;;
 
 (defstruct (node (:constructor nil))
-  (type (required 'type) :type (or null tc:ty) :read-only t))
+  (type (required 'type) :type tc:ty :read-only t))
 
 (defun node-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -171,7 +171,13 @@
 
   (:method ((expr node-return) current-function env)
     (assert (not (null current-function)))
-    `(return-from ,current-function ,(codegen-expression (node-return-expr expr) current-function env))))
+    `(return-from ,current-function ,(codegen-expression (node-return-expr expr) current-function env)))
+
+  (:method ((expr node-field) current-function env)
+    (declare (type tc:environment env)
+             (type (or null symbol) current-function))
+    `(,(node-field-name expr)
+      ,(codegen-expression (node-field-dict expr) current-function env))))
 
 (defun codegen-let (node sccs current-function local-vars env)
   (declare (type node-let node)

--- a/src/codegen/compile-expression.lisp
+++ b/src/codegen/compile-expression.lisp
@@ -66,6 +66,20 @@
                    (mapcar #'car (tc:typed-node-abstraction-vars expr)))
                   subnode)))
 
+              ;; Nodes that are not abstractions but are compiled to bare abstractions must be wrapped
+              ((and bare-abstraction (tc:function-type-p inferred-type))
+               (let* ((ty-args (tc:function-type-arguments inferred-type-ty))
+                      (args (alexandria:make-gensym-list (length ty-args))))
+                 (node-bare-abstraction
+                  inferred-type-ty
+                  args
+                  (node-application
+                   (tc:function-return-type inferred-type-ty)
+                   (compile-expression expr full-ctx env)
+                   (loop :for arg :in args
+                         :for ty :in (tc:function-type-arguments inferred-type-ty)
+                         :collect (node-variable ty arg))))))
+
               (ctx
                (let ((inner (compile-expression expr full-ctx env)))
                  (funcall node-abstraction_

--- a/src/codegen/function-entry.lisp
+++ b/src/codegen/function-entry.lisp
@@ -82,13 +82,11 @@
                                     (alexandria:format-symbol *package* "A~D" i))
                               funs)))
       `(progn
-         (declaim (inline ,@funs))
-         (locally (declaim (notinline ,@funs))
-           #+sbcl
-           (declaim (sb-ext:start-block ,@funs))
-           ,@(reverse body)
-           #+sbcl
-           (declaim (sb-ext:end-block)))))))
+         #+sbcl
+         (declaim (sb-ext:start-block ,@funs))
+         ,@(reverse body)
+         #+sbcl
+         (declaim (sb-ext:end-block))))))
 
 (define-function-macros)
 

--- a/src/codegen/function-entry.lisp
+++ b/src/codegen/function-entry.lisp
@@ -82,11 +82,13 @@
                                     (alexandria:format-symbol *package* "A~D" i))
                               funs)))
       `(progn
-         #+sbcl
-         (declaim (sb-ext:start-block ,@funs))
-         ,@(reverse body)
-         #+sbcl
-         (declaim (sb-ext:end-block))))))
+         (declaim (inline ,@funs))
+         (locally (declaim (notinline ,@funs))
+           #+sbcl
+           (declaim (sb-ext:start-block ,@funs))
+           ,@(reverse body)
+           #+sbcl
+           (declaim (sb-ext:end-block)))))))
 
 (define-function-macros)
 

--- a/src/codegen/monomorphise.lisp
+++ b/src/codegen/monomorphise.lisp
@@ -1,9 +1,9 @@
-;;;; src/codegen/monomorphise.lisp
+;;;; src/codegen/monomorphize.lisp
 ;;;;
 ;;;; Recompile specialized versions of type class generic functions across a call graph.
 ;;;;
 
-(defpackage #:coalton-impl/codegen/monomorphise
+(defpackage #:coalton-impl/codegen/monomorphize
   (:use
    #:cl
    #:coalton-impl/util
@@ -28,9 +28,9 @@
   (:local-nicknames
    (#:tc #:coalton-impl/typechecker))
   (:export
-   #:monomorphise))
+   #:monomorphize))
 
-(in-package #:coalton-impl/codegen/monomorphise)
+(in-package #:coalton-impl/codegen/monomorphize)
 
 (deftype argument ()
   `(or (member @@unpropagated) node))
@@ -299,7 +299,7 @@ constant values could be."
       (cons :direct-application #'apply-candidate))
      nil)))
 
-(defun monomorphise (name manager package resolve-table optimize-node env)
+(defun monomorphize (name manager package resolve-table optimize-node env)
   (declare (type symbol name)
            (type candidate-manager manager)
            (type package package)

--- a/src/codegen/monomorphise.lisp
+++ b/src/codegen/monomorphise.lisp
@@ -1,0 +1,320 @@
+;;;; src/codegen/monomorphise.lisp
+;;;;
+;;;; Recompile specialized versions of type class generic functions across a call graph.
+;;;;
+
+(defpackage #:coalton-impl/codegen/monomorphise
+  (:use
+   #:cl
+   #:coalton-impl/util
+   #:coalton-impl/codegen/ast)
+  (:import-from
+   #:coalton-impl/codegen/transformations
+   #:traverse
+   #:traverse-bindings)
+  (:import-from
+   #:coalton-impl/codegen/ast-substitutions
+   #:ast-substitution
+   #:apply-ast-substitution)
+  (:import-from
+   #:coalton-impl/codegen/typecheck-node
+   #:typecheck-node)
+  (:import-from
+   #:coalton-impl/codegen/hoister
+   #:make-hoister
+   #:pop-final-hoist-point)
+  (:local-nicknames
+   (#:tc #:coalton-impl/typechecker))
+  (:export
+   #:monomorphise))
+
+(in-package #:coalton-impl/codegen/monomorphise)
+
+(deftype argument ()
+  `(or (member @@unpropagated) node))
+
+(defun argument-p (x)
+  (typep x 'argument))
+
+(defun argument-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'argument-p x)))
+
+(deftype argument-list ()
+  '(satisfies argument-list-p))
+
+(defstruct compile-candidate
+  (name      (required 'name) :type symbol        :read-only t)
+  (args      (required 'args) :type argument-list :read-only t))
+
+(defun compile-candidate-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'compile-candidate-p x)))
+
+(deftype compile-candidate-list ()
+  '(satisfies compile-candidate-list-p))
+
+(defun propagatable-p (x)
+  (not (eq x '@@unpropagated)))
+
+(defun node-can-be-propidated (node env)
+  "Returns true if a given node should be const propidated to a callee.
+Currently only typeclass dictionaries will be propidated, although
+constant values could be."
+  (cond
+    ((and
+      (node-variable-p node)
+      (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t))
+     t)
+
+    ((and
+      (node-direct-application-p node)
+      (tc:lookup-instance-by-codegen-sym env (node-direct-application-rator node) :no-error t))
+     t) 
+
+    ((and
+      (node-application-p node)
+      (node-variable-p (node-application-rator node))
+      (tc:lookup-instance-by-codegen-sym env (node-variable-value (node-application-rator node)) :no-error t))
+     t)
+
+    (t
+     nil)))
+
+(defstruct (candidate-manager (:constructor candidate-manager))
+  (map   (make-hash-table :test #'equalp) :type hash-table            :read-only t)
+  (stack nil                              :type compile-candidate-list            ))
+
+(defun candidate-manager-get (candidate-manager candidate)
+  "Returns name the given to a recompiled compile-candidate"
+  (declare (type candidate-manager candidate-manager)
+           (type compile-candidate candidate)
+           (values symbol))
+  (let ((name (gethash candidate (candidate-manager-map candidate-manager))))
+    name))
+
+(defun candidate-manager-push (candidate-manager candidate package)
+  "Push a new candidate to be compiled"
+  (declare (type candidate-manager candidate-manager)
+           (type compile-candidate candidate)
+           (values))
+
+  (when (candidate-manager-get candidate-manager candidate)
+    (return-from candidate-manager-push))
+
+  (let ((new-name
+          (alexandria:ensure-symbol
+           (gensym (concatenate 'string (symbol-name (compile-candidate-name candidate)) "-"))
+           package)))
+
+    (setf (gethash candidate (candidate-manager-map candidate-manager)) new-name))
+
+  (push candidate (candidate-manager-stack candidate-manager))
+
+  nil)
+
+(defun candidate-manager-pop (candidate-manager)
+  "Returns a candidate that has been queued for compilation"
+  (declare (type candidate-manager candidate-manager)
+           (values (or null compile-candidate)))
+  (pop (candidate-manager-stack candidate-manager)))
+
+(defun valid-candidate-p (name args bound-variables env)
+  "Returns the candidate for a given function and arguments. Returns nil if a given application cannot be a candidate."
+  (declare (type symbol name)
+           (type node-list args)
+           (type symbol-list bound-variables)
+           (values (or compile-candidate null) &optional))
+
+  ;; Only functions with known code are valid candidates
+  (unless (tc:lookup-code env name :no-error t)
+    (return-from valid-candidate-p))
+
+  (let ((new-args (loop :for node :in args
+                    :if (and (node-can-be-propidated node env) (node-free-p node bound-variables))
+                      :collect node
+                    :else
+                      :collect '@@unpropagated)))
+
+    ;; Candidates must have at least one propagatable argument
+    (unless (some #'propagatable-p new-args)
+      (return-from valid-candidate-p))
+
+    ;; Fully propigating arguments could change the ordering of side effects
+    ;; Exit early to avoid this
+    (when (every #'propagatable-p new-args)
+      (return-from valid-candidate-p))
+
+    (make-compile-candidate
+     :name name
+     :args new-args)))
+
+(defun compile-candidate (candidate node env)
+  (declare (type compile-candidate candidate)
+           (type node-abstraction node)
+           (type tc:environment env))
+
+  (let* ((subs nil)
+
+         (new-type (node-type node))
+
+         (arg-tys nil)
+
+         (new-vars (loop :for var :in (node-abstraction-vars node)
+                         :for arg :in (compile-candidate-args candidate)
+
+                         :if (eq arg '@@unpropagated)
+                           :collect (progn
+                                      (push (tc:function-type-from new-type) arg-tys)
+                                      var)
+                         :else
+                           :do (push (ast-substitution var arg) subs)
+
+                         :do (setf new-type (tc:function-type-to new-type))))
+
+
+         (new-node
+           (node-abstraction
+            (tc:make-function-type*
+             (reverse arg-tys)
+             new-type)
+            new-vars
+            (apply-ast-substitution subs (node-abstraction-subexpr node)))))
+
+    (typecheck-node new-node env)
+    new-node))
+
+(defun resolve-var (node resolve-table)
+  (declare (type node node)
+           (type hash-table resolve-table)
+           (values node))
+
+  (unless (node-variable-p node)
+    (return-from resolve-var node))
+
+  (let ((resolved (gethash (node-variable-value node) resolve-table)))
+    (if resolved
+        resolved
+        node)))
+
+(defun candidate-selection (node candidate-manager resolve-table package env)
+  (declare (type node node)
+           (type candidate-manager candidate-manager)
+           (type hash-table resolve-table)
+           (type package package)
+           (type tc:environment env))
+  (labels ((validate-candidate (node &key bound-variables &allow-other-keys)
+             (let ((name (node-rator-name node))
+                   (rands (node-rands node)))
+
+               (unless name
+                 (return-from validate-candidate))
+
+               (let ((candidate
+                       (valid-candidate-p
+                        name
+                        (loop :for rand :in rands
+                              :collect (resolve-var rand resolve-table))
+                        bound-variables
+                        env)))
+
+                 (unless candidate
+                   (return-from validate-candidate))
+
+                 (candidate-manager-push candidate-manager candidate package)
+
+                 nil))))
+
+    (traverse
+     node
+     (list
+      (cons :direct-application #'validate-candidate)
+      (cons :application #'validate-candidate))
+     nil))
+  (values))
+
+
+(defun rewrite-callsites (node candidate-manager resolve-table env)
+  (declare (type node node)
+           (type candidate-manager candidate-manager)
+           (type hash-table resolve-table)
+           (type tc:environment env)
+           (values node &optional))
+
+  (labels ((apply-candidate (node &key bound-variables &allow-other-keys)
+             (let ((name (node-rator-name node))
+                   (rands (node-rands node)))
+
+               (unless name
+                 (return-from apply-candidate))
+
+               (let ((candidate (valid-candidate-p
+                                 name
+                                 (loop :for rand :in rands
+                                       :collect (resolve-var rand resolve-table))
+                                 bound-variables
+                                 env)))
+
+                 (unless candidate
+                   (return-from apply-candidate))
+
+                 (let* ((function-name (candidate-manager-get candidate-manager candidate))
+
+                        (new-type (node-rator-type node))
+
+                        (arg-tys nil) 
+
+                        (args (loop
+                                :for arg :in (node-rands node)
+                                :for candidate-arg :in (compile-candidate-args candidate)
+
+                                :when (eq candidate-arg '@@unpropagated)
+                                  :collect (progn
+                                             (push (node-type arg) arg-tys)
+                                             arg)
+
+                                :do (setf new-type (tc:function-type-to new-type)))))
+
+                   (node-application
+                    (node-type node)
+                    (node-variable
+                     (tc:make-function-type*
+                      (reverse arg-tys)
+                      new-type)
+                     function-name)
+                    args))))))
+
+    (traverse
+     node
+     (list
+      (cons :application #'apply-candidate)
+      (cons :direct-application #'apply-candidate))
+     nil)))
+
+(defun monomorphise (name manager package resolve-table optimize-node env)
+  (declare (type symbol name)
+           (type candidate-manager manager)
+           (type package package)
+           (type hash-table resolve-table)
+           (type tc:environment env)
+           (values binding-list &optional))
+
+  (let* ((initial-code (tc:lookup-code env name))
+
+         (binding-group nil))
+
+    (candidate-selection initial-code manager resolve-table package env)
+    (push (cons name (rewrite-callsites initial-code manager resolve-table env)) binding-group)
+
+    (loop :for candidate := (candidate-manager-pop manager)
+          :while candidate
+          :for name := (compile-candidate-name candidate)
+          :for code := (tc:lookup-code env name)
+          :for new-code := (compile-candidate candidate code env)
+          :for new-code_ := (rewrite-callsites new-code manager resolve-table env)
+          :for new-code__ := (funcall optimize-node new-code_)
+          :do (candidate-selection new-code__ manager resolve-table package env)
+          :do (push (cons (candidate-manager-get manager candidate) (rewrite-callsites new-code__ manager resolve-table env))
+                    binding-group))
+
+    binding-group))

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -1,0 +1,433 @@
+(defpackage #:coalton-impl/codegen/optimizer
+  (:use
+   #:cl
+   #:coalton-impl/util
+   #:coalton-impl/codegen/ast)
+  (:import-from
+   #:coalton-impl/codegen/typecheck-node
+   #:typecheck-node)
+  (:import-from
+   #:coalton-impl/codegen/resolve-instance
+   #:pred-type
+   #:resolve-static-dict)
+  (:import-from
+   #:coalton-impl/codegen/hoister
+   #:hoister
+   #:hoist-definition
+   #:make-hoister
+   #:pop-hoist-point
+   #:push-hoist-point
+   #:pop-final-hoist-point)
+  (:import-from
+   #:coalton-impl/codegen/monomorphise
+   #:monomorphise
+   #:candidate-manager)
+  (:import-from
+   #:coalton-impl/codegen/transformations
+   #:traverse-bindings
+   #:update-function-env
+   #:make-function-table)
+  (:local-nicknames
+   (#:tc #:coalton-impl/typechecker))
+  (:export
+   #:optimize-bindings))
+
+(in-package #:coalton-impl/codegen/optimizer)
+
+(defun optimize-bindings (bindings package attr-table env)
+  (declare (type binding-list bindings)
+           (type package package)
+           (type hash-table attr-table)
+           (type tc:environment env)
+           (values binding-list tc:environment))
+
+  (let ((bindings (optimize-bindings-initial bindings package env)))
+
+    (loop :for (name . node) :in bindings
+          :do (setf env (tc:set-code env name node)))
+
+    (let* ((manager (candidate-manager))
+
+           (resolve-table (alexandria:alist-hash-table bindings))
+
+           ;; Passing this as a parameter breaks a cyclic dependency between the optimizer
+           ;; and the monomorphiser
+           (optimize-node
+             (lambda (node)
+               ;; minor hack because OPTIMIZE-BINDINGS-INITIAL operates on binding groups
+               ;; and we need it to run on a single node
+               (cdr
+                (first
+                 (optimize-bindings-initial (list (cons 'unused-name node)) package env)))))
+
+           (bindings
+             (loop :for (name . node) :in bindings
+                   :for attrs := (gethash name attr-table)
+
+                   :for monomorphise := (find :monomorphise attrs)
+
+                   :if monomorphise
+                     :append (optimize-bindings-initial
+                              (monomorphise
+                               name
+                               manager
+                               package
+                               resolve-table
+                               optimize-node
+                               env)
+                              package env)
+                   :else
+                     :collect (cons name node))))
+
+      (loop :for (name . node) :in bindings
+            :do (typecheck-node node env))
+
+      (setf env (update-function-env bindings env))
+
+      (let ((bindings (direct-application bindings (make-function-table env))))
+
+        (loop :for (name . node) :in bindings
+              :do (typecheck-node node env)
+              :do (setf env (tc:set-code env name node)))
+
+        (values
+         bindings
+         env)))))
+
+(defun optimize-bindings-initial (bindings package env)
+  (declare (type binding-list bindings)
+           (type package package)
+           (type tc:environment env)
+           (values binding-list))
+  (let ((hoister (make-hoister)))
+    (append
+     (alexandria-2:line-up-first
+      (loop :for (name . node) :in bindings
+            :collect (cons name (pointfree node)))
+
+      canonicalize
+
+      (resolve-static-superclass env)
+
+      (inline-methods env)
+
+      (static-dict-lift hoister package env))
+     (pop-final-hoist-point hoister))))
+
+(defun pointfree (node)
+  (declare (type node node)
+           (values node))
+  (declare (type node node)
+           (values node))
+  (if (node-abstraction-p node)
+      (return-from pointfree node))
+
+  (if (not (tc:function-type-p (node-type node)))
+      (return-from pointfree node))
+
+  (let* ((arguments (tc:function-type-arguments (node-type node)))
+         (argument-names (loop :for argument :in arguments
+                               :collect (gensym))))
+
+         (node-abstraction
+           (node-type node)
+           argument-names
+           (node-application
+            (tc:function-return-type (node-type node))
+            node
+            (loop :for ty :in arguments
+                  :for name :in argument-names
+                  :collect (node-variable ty name))))))
+
+(defun canonicalize (bindings)
+  (declare (type binding-list bindings)
+           (values binding-list &optional))
+  (labels ((rewrite-application (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (let ((rator (node-application-rator node))
+                   (rands (node-application-rands node)))
+               (when (node-application-p rator)
+                 (node-application
+                  (node-type node)
+                  (node-application-rator rator)
+                  (append
+                   (node-application-rands rator)
+                   rands))))))
+    (traverse-bindings
+     bindings
+     (list
+      (cons :application #'rewrite-application)))))
+
+(defun direct-application (bindings table)
+  (declare (type binding-list bindings)
+           (type hash-table table)
+           (values binding-list &optional))
+  (labels ((rewrite-direct-application (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (when (node-variable-p (node-application-rator node))
+               (let ((name (node-variable-value (node-application-rator node))))
+                 (when (and (gethash name table)
+                            (equalp (gethash name table)
+                                    (length (node-application-rands node))))
+                   (return-from rewrite-direct-application
+                     (node-direct-application
+                      (node-type node)
+                      (node-type (node-application-rator node))
+                      name
+                      (node-application-rands node)))))))
+
+           (add-local-funs (node &rest rest)
+             (declare (ignore rest))
+             (loop :for (name . node) :in (node-let-bindings node)
+                   :when (node-abstraction-p node) :do
+                     (setf (gethash name table) (length (node-abstraction-vars node))))))
+
+    (traverse-bindings
+     bindings
+     (list
+      (cons :application #'rewrite-direct-application)
+      (cons :before-let #'add-local-funs)))))
+
+(defun inline-methods (bindings env)
+  (declare (type binding-list bindings)
+           (type tc:environment env)
+           (values binding-list &optional))
+  (labels ((inline-method (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (let ((rator (node-application-rator node))
+                   (rands (node-application-rands node)))
+               (when (node-variable-p rator)
+                 (let (dict rands_)
+                   (cond
+                     ((node-variable-p (first rands))
+                      (setf dict (node-variable-value (first rands)))
+                      (setf rands_ (cdr rands)))
+
+                     ((and (node-application-p (first rands))
+                           (node-variable-p (node-application-rator (first rands))))
+                      (setf dict (node-variable-value (node-application-rator (first rands))))
+                      (setf rands_ (append (node-application-rands (first rands)) (cdr rands))))
+
+                     (t
+                      (return-from inline-method nil)))
+
+                   (let* ((method-name (node-variable-value rator))
+                          (inline-method-name (tc:lookup-method-inline env method-name dict :no-error t)))
+
+                     (when inline-method-name
+                       (if (null rands_)
+                           (node-variable
+                            (node-type node)
+                            inline-method-name)
+
+                           (node-application
+                            (node-type node)
+                            (node-variable
+                             (tc:make-function-type*
+                              (mapcar #'node-type rands_)
+                              (node-type node))
+                             inline-method-name)
+                            rands_))))))))
+
+           (inline-direct-method (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (let ((rands (node-direct-application-rands node)))
+               (let (dict rands_)
+                 (cond
+                   ((node-variable-p (first rands))
+                    (setf dict (node-variable-value (first rands)))
+                    (setf rands_ (cdr rands)))
+
+                   ((and (node-application-p (first rands))
+                         (node-variable-p (node-application-rator (first rands))))
+                    (setf dict (node-variable-value (node-application-rator (first rands))))
+                    (setf rands_ (append (node-application-rands (first rands)) (cdr rands))))
+
+                   (t
+                    (return-from inline-direct-method nil)))
+
+                 (let* ((method-name (node-direct-application-rator node))
+                        (inline-method-name (tc:lookup-method-inline env method-name dict :no-error t)))
+                   (when inline-method-name
+                     (if (null rands_)
+                         (node-variable
+                          (node-type node)
+                          inline-method-name)
+
+                         (node-application
+                          (node-type node)
+                          (node-variable
+                           (tc:make-function-type*
+                            (mapcar #'node-type rands_)
+                            (node-type node))
+                           inline-method-name)
+                          rands_)))))))) 
+
+    (traverse-bindings
+     bindings
+     (list
+      (cons :application #'inline-method)
+      (cons :direct-application #'inline-direct-method)))))
+
+(defun static-dict-lift (bindings hoister package env)
+  (declare (type binding-list bindings)
+           (type hoister hoister)
+           (type package package)
+           (type tc:environment env)
+           (values binding-list &optional))
+  (labels ((lift-static-dict (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (unless (and
+                      ;; The function is a variable
+                      (node-variable-p (node-application-rator node))
+
+                      ;; The function constructs a typeclass dictionary
+                      (tc:lookup-instance-by-codegen-sym
+                       env
+                       (node-variable-value (node-application-rator node))
+                       :no-error t))
+               (return-from lift-static-dict nil))
+
+             (hoist-definition node package hoister))
+
+           (handle-push-hoist-point (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (push-hoist-point (node-abstraction-vars node) hoister)
+             nil)
+
+           (handle-push-bare-hoist-point (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (push-hoist-point (node-bare-abstraction-vars node) hoister)
+             nil)
+
+           (handle-pop-hoist-point (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             ;; If definitions were hoisted to this lambda
+             ;; then add them to the ast
+             (let ((hoisted (pop-hoist-point hoister)))
+               (if hoisted
+                   (node-abstraction
+                    (node-type node)
+                    (node-abstraction-vars node)
+                    (node-let
+                     (node-type (node-abstraction-subexpr node))
+                     hoisted
+                     (node-abstraction-subexpr node)))
+
+                   node)))
+
+           (handle-pop-bare-hoist-point (node &rest rest)
+             (declare (ignore rest)
+                      (dynamic-extent rest))
+             (let ((hoisted (pop-hoist-point hoister)))
+               (if hoisted
+                   (node-bare-abstraction
+                    (node-type node)
+                    (node-bare-abstraction-vars node)
+                    (node-let
+                     (node-type (node-bare-abstraction-subexpr node))
+                     hoisted
+                     (node-bare-abstraction-subexpr node)))
+
+                   node))))
+
+    (traverse-bindings
+     bindings
+     (list
+      (cons :application #'lift-static-dict)
+      (cons :before-abstraction #'handle-push-hoist-point)
+      (cons :abstraction #'handle-pop-hoist-point)
+      (cons :before-bare-abstraction #'handle-push-bare-hoist-point)
+      (cons :bare-abstraction #'handle-pop-bare-hoist-point)))))
+
+(defun resolve-compount-superclass (node env)
+  (declare (type (or node-application node-direct-application node-variable) node)
+           (type tc:environment env))
+
+  (when (node-variable-p node)
+    (let* ((instance (tc:lookup-instance-by-codegen-sym env (node-variable-value node))))
+      (return-from resolve-compount-superclass (tc:fresh-pred (tc:ty-class-instance-predicate instance)))))
+
+  (let ((rator (node-rator-name node)))
+    (unless rator
+      (coalton-bug "Expected rator to be a symbol."))
+
+    (let* (;; Lookup the instance
+           (instance (tc:lookup-instance-by-codegen-sym env rator))
+
+           ;; Generate a fresh predicate to avoid type variable colisions
+           (pred (tc:fresh-pred (tc:ty-class-instance-predicate instance)))
+
+           ;; Generate subs to match the class's superclasses to PRED
+           (subs (tc:predicate-match (tc:ty-class-instance-predicate instance) pred))
+
+           ;; Find the superclasses of PRED
+           (constraints (tc:apply-substitution subs (tc:ty-class-instance-constraints instance)))
+
+           (args
+             (loop :for arg :in (node-rands node)
+                   :collect (resolve-compount-superclass arg env))))
+
+      (unless (= (length constraints)
+                 (length args))
+        (coalton-bug "Expected the number of arguments (~D) to match the number of constraints (~D)."
+                     (length args)
+                     (length constraints)))
+
+      ;; Match the instances constraints against the dictionary's arguments
+      (loop :for arg :in args
+            :for constraint :in constraints
+            :do (setf subs (tc:predicate-match constraint arg subs)))
+
+      (tc:apply-substitution subs pred))))
+
+(defun resolve-static-superclass (bindings env)
+  (declare (type binding-list bindings)
+           (type tc:environment env)
+           (values binding-list &optional))
+  (labels ((handle-static-superclass (node &key bound-variables &allow-other-keys)
+             (declare (type symbol-list bound-variables))
+
+             (unless (or (node-variable-p (node-field-dict node))
+                         (node-application-p (node-field-dict node))
+                         (node-direct-application-p (node-field-dict node)))
+               (return-from handle-static-superclass))
+
+             (unless (node-free-p (node-field-dict node) bound-variables)
+               (return-from handle-static-superclass))
+
+             (let* ( ;; Resolve the predicate
+                    (pred (resolve-compount-superclass (node-field-dict node) env))
+
+                    ;; Lookup the predicate's class
+                    (class (tc:lookup-class env (tc:ty-predicate-class pred)))
+
+                    ;; Find the class's superclasses
+                    (superclass-dict (tc:ty-class-superclass-dict class))
+
+                    ;; Map the accessor to a named superclass
+                    (superclass-name (gethash (node-field-name node) (tc:ty-class-superclass-map class)))
+
+                    ;; Find the predicate of the accessed superclass
+                    (superclass-pred (car (find superclass-name superclass-dict :key #'cdr)))
+
+                    ;; Match the class's predicate against the instance
+                    (subs (tc:predicate-match (tc:ty-class-predicate class) pred))
+
+                    (superclass-pred (tc:apply-substitution subs superclass-pred)))
+
+               ;; Re-resolve the dictionary
+               (resolve-static-dict superclass-pred nil env))))
+
+    (traverse-bindings
+     bindings
+     (list
+      (cons :field #'handle-static-superclass)))))

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -113,6 +113,7 @@
 
       (inline-methods env)
 
+      #+this-is-broken
       (static-dict-lift hoister package env))
      (pop-final-hoist-point hoister))))
 

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -19,8 +19,8 @@
    #:push-hoist-point
    #:pop-final-hoist-point)
   (:import-from
-   #:coalton-impl/codegen/monomorphise
-   #:monomorphise
+   #:coalton-impl/codegen/monomorphize
+   #:monomorphize
    #:candidate-manager)
   (:import-from
    #:coalton-impl/codegen/transformations
@@ -51,7 +51,7 @@
            (resolve-table (alexandria:alist-hash-table bindings))
 
            ;; Passing this as a parameter breaks a cyclic dependency between the optimizer
-           ;; and the monomorphiser
+           ;; and the monomorphizer
            (optimize-node
              (lambda (node env)
                ;; minor hack because OPTIMIZE-BINDINGS-INITIAL operates on binding groups
@@ -64,11 +64,11 @@
              (loop :for (name . node) :in bindings
                    :for attrs := (gethash name attr-table)
 
-                   :for monomorphise := (find :monomorphise attrs)
+                   :for monomorphize := (find :monomorphise attrs)
 
-                   :if monomorphise
+                   :if monomorphize
                      :append (optimize-bindings-initial
-                              (monomorphise
+                              (monomorphize
                                name
                                manager
                                package

--- a/src/codegen/resolve-instance.lisp
+++ b/src/codegen/resolve-instance.lisp
@@ -9,6 +9,7 @@
    #:pred-context                       ; TYPE
    #:pred-type                          ; FUNCTION
    #:resolve-dict                       ; FUNCTION
+   #:resolve-static-dict                ; FUNCTION
    ))
 
 (cl:in-package #:coalton-impl/codegen/resolve-instance)
@@ -76,8 +77,7 @@
            (node-variable
             (tc:make-function-type* arg-types (pred-type pred env))
             (tc:ty-class-instance-codegen-sym instance))
-           subdicts
-           :pure t)))))
+           subdicts)))))
 
 
 (defun superclass-accessors (pred ctx-pred env)
@@ -98,6 +98,7 @@
                         superclass-accessor)))
                 (lookup-pred pred superclass-pred ctx-pred superclass-accessor-symbol env)))
             (tc:ty-class-superclass-dict ctx-class))))
+
     superclass-ret))
 
 (defun lookup-pred (pred ctx-pred sub-pred method-accessor env)
@@ -136,6 +137,7 @@
 
     (let ((superclass-ret (superclass-accessors pred ctx-pred env)))
 
+
       (when superclass-ret
         (cons node superclass-ret)))))
 
@@ -150,10 +152,10 @@
 (defun build-call (args)
   (if (= 1 (length args))
       (car args)
-      (node-application
+      (node-field
        (tc:function-type-to (node-type (car args)))
-       (car args)
-       (list (build-call (cdr args))))))
+       (node-variable-value (car args))
+       (build-call (cdr args)))))
 
 (defun resolve-context-super (pred context env)
   "Search for PRED in all CONTEXT preds and return a node"

--- a/src/debug.lisp
+++ b/src/debug.lisp
@@ -23,3 +23,8 @@
 (defun coalton:kind-of (symbol)
   "Lookup the kind of type SYMBOL in the global environment"
   (coalton-impl/typechecker::kind-of (coalton-impl/typechecker::type-entry-type (coalton-impl::lookup-type *global-environment* symbol))))
+
+(defun coalton:lookup-code (name)
+  "Lookup the compiled code of a given definition"
+  (declare (type symbol name))
+  (coalton-impl/typechecker::lookup-code *global-environment* name))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -164,6 +164,8 @@
    #:function-type-arguments            ; FUNCTION
    #:function-return-type               ; FUNCTION
    #:function-type-arity                ; FUNCTION
+   #:unify                              ; FUNCTION
+   #:apply-substitution                 ; FUNCTION
    ) 
   (:export
    #:*boolean-type*
@@ -191,6 +193,7 @@
    #:ty-scheme                          ; STRUCT
    #:qualified-ty                       ; STRUCT
    #:scheme-predicates                  ; FUNCTION
+   #:fresh-pred                         ; FUNCTION
    #:apply-substitution                 ; FUNCTION
    #:predicate-match                    ; FUNCTION
    #:make-function-type                 ; FUNCTION
@@ -267,6 +270,7 @@
    #:set-constructor                    ; FUNCTION
    #:set-name                           ; FUNCTION
    #:set-method-inline                  ; FUNCTION
+   #:set-code                           ; FUNCTION
    #:lookup-value-type                  ; FUNCTION
    #:lookup-type                        ; FUNCTION
    #:lookup-class                       ; FUNCTION
@@ -274,8 +278,10 @@
    #:lookup-function                    ; FUNCTION
    #:lookup-class-instances             ; FUNCTION
    #:lookup-class-instance              ; FUNCTION
+   #:lookup-instance-by-codegen-sym     ; FUNCTION
    #:lookup-name                        ; FUNCTION
    #:lookup-method-inline               ; FUNCTION
+   #:lookup-code                        ; FUNCTION
    #:type-entry                         ; STRUCT
    #:type-entry-name                    ; ACCESSOR
    #:type-entry-runtime-type            ; ACCESSOR
@@ -301,6 +307,10 @@
    #:name-entry-type                    ; ACCESSOR
    #:name-entry-docstring               ; ACCESSOR
    #:make-name-entry                    ; CONSTRUCTOR
+   #:code-entry                         ; STRUCT
+   #:code-entry-name                    ; ACCESSOR
+   #:code-entry-code                    ; ACCESSOR
+   #:make-code-entry                    ; CONSTRUCTOR
    )
   (:export
    #:derive-expression-type             ; FUNCTION
@@ -352,6 +362,7 @@
    #:ty-class-unqualified-methods       ; ACCESSOR
    #:ty-class-codegen-sym               ; ACCESSOR
    #:ty-class-superclass-dict           ; ACCESSOR
+   #:ty-class-superclass-map            ; ACCESSOR
    #:ty-class-list                      ; TYPE
    #:ty-class-instance                  ; STRUCT
    #:ty-class-instance-predicate        ; ACCESSOR
@@ -392,6 +403,7 @@
    #:translation-unit-definitions       ; ACCESSOR
    #:translation-unit-instances         ; ACCESSOR
    #:translation-unit-classes           ; ACCESSOR
+   #:translation-unit-attr-table        ; ACCESSOR
    #:translation-unit-package           ; ACCESSOR
    )
   ;; Pretty printers
@@ -475,6 +487,7 @@
    #:define-class
    #:define-instance
    #:repr
+   #:monomorphise
    #:unable-to-codegen)
   ;; Early Types
   (:export
@@ -541,7 +554,8 @@
    #:print-value-db
    #:print-type-db
    #:print-class-db
-   #:print-instance-db)
+   #:print-instance-db
+   #:lookup-code)
   (:export
    #:type-of
    #:kind-of)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -282,6 +282,9 @@
    #:lookup-name                        ; FUNCTION
    #:lookup-method-inline               ; FUNCTION
    #:lookup-code                        ; FUNCTION
+   #:add-specialization                 ; FUNCTION
+   #:lookup-specialization              ; FUNCTION
+   #:lookup-specialization-by-type      ; FUNCTION
    #:type-entry                         ; STRUCT
    #:type-entry-name                    ; ACCESSOR
    #:type-entry-runtime-type            ; ACCESSOR
@@ -311,6 +314,12 @@
    #:code-entry-name                    ; ACCESSOR
    #:code-entry-code                    ; ACCESSOR
    #:make-code-entry                    ; CONSTRUCTOR
+   #:specialization-entry               ; STRUCT
+   #:specialization-entry-from          ; ACCESSOR
+   #:specialization-entry-to            ; ACCESSOR
+   #:specialization-entry-to-ty         ; ACCESSOR
+   #:make-specialization-entry          ; CONSTRUCTOR
+   #:specialization-entry-list          ; TYPE
    )
   (:export
    #:derive-expression-type             ; FUNCTION
@@ -417,7 +426,7 @@
    #:*coalton-pretty-print-tyvars*))
 
 
-(uiop:define-package #:coalton-impl
+(defpackage #:coalton-impl
     (:documentation "Implementation and runtime for COALTON. This is a package private to the COALTON system and is not intended for public use.")
   (:use #:cl
         #:coalton-impl/util
@@ -427,6 +436,8 @@
   (:import-from #:global-vars
                 #:define-global-var
                 #:define-global-var*)
+  (:local-nicknames
+   (#:tc #:coalton-impl/typechecker))
   ;; settings
   (:export
    #:coalton-release-p)
@@ -488,6 +499,7 @@
    #:define-instance
    #:repr
    #:monomorphise
+   #:specialize
    #:unable-to-codegen)
   ;; Early Types
   (:export

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -498,7 +498,7 @@
    #:define-class
    #:define-instance
    #:repr
-   #:monomorphise
+   #:monomorphize
    #:specialize
    #:unable-to-codegen)
   ;; Early Types

--- a/src/toplevel-specializations.lisp
+++ b/src/toplevel-specializations.lisp
@@ -1,0 +1,93 @@
+(in-package #:coalton-impl)
+
+(defun process-toplevel-specializations (specializations env)
+  (declare (type list specializations)
+           (type tc:environment env)
+           (values tc:specialization-entry-list tc:environment))
+
+  (let ((out-specializations nil))
+
+    (loop :for elem :in specializations
+          :do (multiple-value-bind (specialization new-env)
+                  (process-specialization elem env)
+                (push specialization out-specializations)
+                (setf env new-env)))
+
+    (values
+     out-specializations
+     env)))
+
+(defun process-specialization (elem env)
+  (declare (type list elem)
+           (type tc:environment env)
+           (values tc:specialization-entry tc:environment &optional))
+  (unless (= (length elem) 4)
+    (error-parsing elem "Malformed specialization"))
+
+  (let* ((from (second elem))
+
+         (to (third elem))
+
+         (type (fourth elem)))
+
+    (unless (and (symbolp from) (symbolp to))
+      (error-parsing elem "Malformed specialization"))
+
+    (let* ((from-ty (tc:lookup-value-type env from :no-error t))
+
+           (to-ty (tc:lookup-value-type env to :no-error t))
+
+           (from-name (tc:lookup-name env from))
+
+           (to-name (tc:lookup-name env to))
+
+           (type (tc:fresh-inst (tc:parse-and-resolve-type env type))))
+
+      (unless from-ty
+        (error-parsing elem "Unable to specialize unknown function ~A" from))
+
+      (unless to-ty
+        (error-parsing elem "Unable to specialize unknown function ~A" to))
+
+      (unless (eq :value (tc:name-entry-type from-name))
+        (error-parsing elem "Unable to specialize ~A because it is a ~A" from (tc:name-entry-type from-name)))
+
+      (unless (eq :value (tc:name-entry-type to-name))
+        (error-parsing elem "Unable to specialize ~A to ~A because it is a ~A" from to (tc:name-entry-type to-name)))
+
+      (let* ((from-ty (tc:fresh-inst from-ty))
+
+             (to-ty (tc:fresh-inst to-ty)))
+
+        (with-pprint-variable-context ()
+          (when (null (tc:qualified-ty-predicates from-ty))
+            (error-parsing elem "Unable to specialize function ~A~%of type ~A. ~%Only functions with type class constraints may be specialized." from from-ty)))
+
+        (unless (null (tc:qualified-ty-predicates to-ty))
+          (error-parsing elem "Unable to make ~A a specialization target for ~A. ~%Only functions without type class constraints may be specialization targets." to from))
+
+        (with-pprint-variable-context ()
+          (unless (null (tc:qualified-ty-predicates type))
+            (error-parsing elem "Unable to specialize ~A to type ~A with type class constraints." from type)))
+
+        (with-pprint-variable-context ()
+          (unless (tc:type= (tc:qualified-ty-type to-ty) (tc:qualified-ty-type type))
+            (error-parsing elem "Function ~A of type ~A~%does not match declared type ~A" to to-ty type)))
+
+        (when (tc:type= (tc:qualified-ty-type from-ty) (tc:qualified-ty-type to-ty))
+          (error-parsing elem "Function ~A does not have a more specefic type than ~A" to from))
+
+        (handler-case 
+            (tc:match (tc:qualified-ty-type from-ty) (tc:qualified-ty-type to-ty))
+          (tc:coalton-type-error (e)
+            (declare (ignore e))
+            (with-pprint-variable-context ()
+              (error-parsing elem "Function ~A of type ~A is not a valid specialization ~%for ~A of type ~A" to to-ty from from-ty))))
+
+        (let ((entry (tc:make-specialization-entry
+                      :from from
+                      :to to
+                      :to-ty (tc:qualified-ty-type to-ty))))
+          (values
+           entry 
+           (tc:add-specialization env entry)))))))

--- a/src/typechecker/kinds.lisp
+++ b/src/typechecker/kinds.lisp
@@ -194,7 +194,7 @@
      (kind-variables (kfun-from kind))
      (kind-variables (kfun-to kind)))))
 
-(defun kind-monomorphise-subs (kvars ksubs)
+(defun kind-monomorphize-subs (kvars ksubs)
   (declare (type kyvar-list kvars)
            (values ksubstitution-list &optional))
   (compose-ksubstution-lists

--- a/src/typechecker/parse-class-definition.lisp
+++ b/src/typechecker/parse-class-definition.lisp
@@ -252,14 +252,14 @@
                               :for tyvar := (second (find var class-tyvars :key #'car :test #'equalp))
                               :collect (apply-ksubstitution ksubs tyvar)))))
 
-      (setf ksubs (kind-monomorphise-subs (kind-variables predicate) ksubs))
+      (setf ksubs (kind-monomorphize-subs (kind-variables predicate) ksubs))
       (setf predicate (apply-ksubstitution ksubs predicate))
 
       (let* ((superclasses (apply-ksubstitution ksubs superclasses))
 
              (unqualifed-methods
                (loop :for (name . type) :in unqualifed-methods
-                     :for ksubs := (kind-monomorphise-subs (kind-variables type) ksubs)
+                     :for ksubs := (kind-monomorphize-subs (kind-variables type) ksubs)
                      :collect (cons name (apply-ksubstitution ksubs type))))
 
              (superclass-dict

--- a/src/typechecker/parse-type-definition.lisp
+++ b/src/typechecker/parse-type-definition.lisp
@@ -126,7 +126,7 @@
            :for (ctors . local-tyvars) :in type-constructors
 
            :for type_ := (apply-ksubstitution ksubs type)
-           :for ksubs_ := (kind-monomorphise-subs (kind-variables type_) ksubs)
+           :for ksubs_ := (kind-monomorphize-subs (kind-variables type_) ksubs)
            :for type__ := (apply-ksubstitution ksubs_ type)
 
            :for tyvar-types

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -45,7 +45,7 @@
       
       (let* ((kvars (kind-variables (apply-ksubstitution ksubs type)))
 
-             (ksubs (kind-monomorphise-subs kvars ksubs))
+             (ksubs (kind-monomorphize-subs kvars ksubs))
 
              (type (apply-ksubstitution ksubs type)))
 

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -71,6 +71,15 @@
   "Get freshly instantiated predicates of scheme TY-SCHEME"
   (qualified-ty-predicates (fresh-inst ty-scheme)))
 
+(defun fresh-pred (pred)
+  "Returns PRED with fresh type variables"
+  (declare (type ty-predicate pred)
+           (values ty-predicate))
+  (let* ((var (make-variable))
+         (qual-ty (qualified-ty (list pred) var))
+         (scheme (quantify (type-variables (list pred var)) qual-ty)))
+    (car (qualified-ty-predicates (fresh-inst scheme)))))
+
 ;;;
 ;;; Methods
 ;;;

--- a/src/typechecker/translation-unit.lisp
+++ b/src/typechecker/translation-unit.lisp
@@ -6,7 +6,8 @@
   (instances   nil                 :type instance-definition-list :read-only t)
   (classes     nil                 :type ty-class-list            :read-only t)
   (attr-table  (make-hash-table)   :type hash-table               :read-only t)
-  (package     (required 'package) :type package                  :read-only t))
+  (package     (required 'package) :type package                  :read-only t)
+  (specializations nil             :type specialization-entry-list :read-only t))
 
 ;; FUNCTION ENV
 
@@ -69,6 +70,11 @@
                       :collect (if function-entry
                                    `(set-function env ',name ,function-entry)
                                    `(unset-function env ',name)))))
+
+(defun generate-specialization-diff (specializations env)
+  (declare (type specialization-entry-list specializations))
+  (loop :for elem :in specializations
+        :collect `(add-specialization env ',(lookup-specialization env (specialization-entry-from elem) (specialization-entry-to elem)))))
 
 (defun generate-diff (translation-unit env env_name)
   `(eval-when (:load-toplevel)

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -339,7 +339,7 @@ This requires a valid PPRINT-VARIABLE-CONTEXT")
          (pprint-ty stream (pprint-tvar ty))
          (format stream "#T~A" (tyvar-id (tvar-tyvar ty)))))
     (tcon
-     (format stream "~S" (tycon-name (tcon-tycon ty))))
+     (format stream "~A" (tycon-name (tcon-tycon ty))))
     (tapp
      (cond
        ((function-type-p ty) ;; Print function types


### PR DESCRIPTION
Current benchmarks computing the 20th fibonacci number on `Integer`:

```
Benchmarking COALTON-BENCHMARKS::RECURSIVE-FIB-MONOMORPHISED...
-                SAMPLES  TOTAL     MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION
REAL-TIME        1000     0.079599  0.000076  0.000261  0.000079  0.00008   0.00001
RUN-TIME         1000     0.079365  0.000076  0.000239  0.000079  0.000079  0.000009
USER-RUN-TIME    1000     0.078538  0.000075  0.000191  0.000078  0.000079  0.000008
SYSTEM-RUN-TIME  1000     0.001038  0         0.000026  0.000001  0.000001  0.000001
PAGE-FAULTS      1000     0         0         0         0         0         0.0
GC-RUN-TIME      1000     0         0         0         0         0         0.0
BYTES-CONSED     1000     16384     0         16384     0         16.384    517.84845
EVAL-CALLS       1000     0         0         0         0         0         0.0
done.
Benchmarking COALTON-BENCHMARKS::RECURSIVE-FIB-LISP...
-                SAMPLES  TOTAL     MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION
REAL-TIME        1000     0.069646  0.000066  0.000212  0.000067  0.00007   0.000014
RUN-TIME         1000     0.06955   0.000065  0.000197  0.000067  0.00007   0.000013
USER-RUN-TIME    1000     0.068565  0.000065  0.000197  0.000066  0.000069  0.000013
SYSTEM-RUN-TIME  1000     0.001048  0         0.000018  0.000001  0.000001  0.000001
PAGE-FAULTS      1000     0         0         0         0         0         0.0
GC-RUN-TIME      1000     0         0         0         0         0         0.0
BYTES-CONSED     1000     0         0         0         0         0         0.0
EVAL-CALLS       1000     0         0         0         0         0         0.0
done.
Benchmarking COALTON-BENCHMARKS::RECURSIVE-FIB-GENERIC...
-                SAMPLES  TOTAL     MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION
REAL-TIME        1000     0.398747  0.000383  0.000737  0.000393  0.000399  0.000027
RUN-TIME         1000     0.398435  0.000382  0.000731  0.000393  0.000398  0.000026
USER-RUN-TIME    1000     0.397163  0.000382  0.000703  0.000392  0.000397  0.000025
SYSTEM-RUN-TIME  1000     0.001323  0         0.000037  0.000001  0.000001  0.000002
PAGE-FAULTS      1000     0         0         0         0         0         0.0
GC-RUN-TIME      1000     0         0         0         0         0         0.0
BYTES-CONSED     1000     0         0         0         0         0         0.0
EVAL-CALLS       1000     0         0         0         0         0         0.0
done.
Benchmarking COALTON-BENCHMARKS::RECURSIVE-FIB...
-                SAMPLES  TOTAL     MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION
REAL-TIME        1000     0.081648  0.000077  0.000245  0.000077  0.000082  0.000019
RUN-TIME         1000     0.081557  0.000076  0.000247  0.000077  0.000082  0.000018
USER-RUN-TIME    1000     0.08045   0.000076  0.000241  0.000076  0.00008   0.000017
SYSTEM-RUN-TIME  1000     0.001112  0         0.000033  0.000001  0.000001  0.000002
PAGE-FAULTS      1000     0         0         0         0         0         0.0
GC-RUN-TIME      1000     0         0         0         0         0         0.0
BYTES-CONSED     1000     0         0         0         0         0         0.0
EVAL-CALLS       1000     0         0         0         0         0         0.0
done.
```
Current benchmarks computing the 10th fibonacci number on `Optional Integer`:

```
Benchmarking COALTON-BENCHMARKS::RECURSIVE-FIB-MONOMORPHISED-OPTIONAL...
-                SAMPLES  TOTAL     MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION
REAL-TIME        1000     0.022006  0.000015  0.000161  0.000018  0.000022  0.000007
RUN-TIME         1000     0.021876  0.000015  0.000136  0.000018  0.000022  0.000007
USER-RUN-TIME    1000     0.01747   0.000014  0.000124  0.000017  0.000017  0.000004
SYSTEM-RUN-TIME  1000     0.004438  0.000001  0.000025  0.000001  0.000004  0.000004
PAGE-FAULTS      1000     0         0         0         0         0         0.0
GC-RUN-TIME      1000     0         0         0         0         0         0.0
BYTES-CONSED     1000     40735200  32736     65472     32768     40735.2   8219.482
EVAL-CALLS       1000     0         0         0         0         0         0.0
done.
Benchmarking COALTON-BENCHMARKS::RECURSIVE-FIB-GENERIC-OPTIONAL...
-                SAMPLES  TOTAL     MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION
REAL-TIME        1000     0.026454  0.000021  0.000042  0.000026  0.000026  0.000002
RUN-TIME         1000     0.026425  0.000021  0.000042  0.000026  0.000026  0.000002
USER-RUN-TIME    1000     0.018423  0.000016  0.000033  0.000018  0.000018  0.000001
SYSTEM-RUN-TIME  1000     0.00795   0.000005  0.000019  0.000008  0.000008  0.000001
PAGE-FAULTS      1000     0         0         0         0         0         0.0
GC-RUN-TIME      1000     0         0         0         0         0         0.0
BYTES-CONSED     1000     40670032  32736     49152     32768     40670.03  8185.2974
EVAL-CALLS       1000     0         0         0         0         0         0.0
done.
```

Next steps:

- [x] Rerun type class resolution after applying substitutions. This will allow inlining more complex dictionaries.
- [x] Make method inlining compatible with dictionary hoisting.