### PR TITLE
Replace usages of `ensure-symbol (gensym)` with `gentemp`

### DIFF
--- a/src/ast/parse-form.lisp
+++ b/src/ast/parse-form.lisp
@@ -100,7 +100,7 @@ This does not attempt to do any sort of analysis whatsoever. It is suitable for 
         :collect
         (cons
          var
-         (alexandria:ensure-symbol (gensym (concatenate 'string (symbol-name var) "-")) package))))
+         (gentemp (concatenate 'string (symbol-name var) "-") package))))
 
 (defun parse-abstraction (unparsed vars subexprs m package)
   (declare (type t unparsed)
@@ -112,7 +112,7 @@ This does not attempt to do any sort of analysis whatsoever. It is suitable for 
   (let ((nullary-fn nil)
         (var nil))
     (when (null vars)
-      (setf var (alexandria:ensure-symbol (gensym) package))
+      (setf var (gentemp "G" package))
       (setf vars (list var))
       (setf nullary-fn t))
 

--- a/src/codegen/hoister.lisp
+++ b/src/codegen/hoister.lisp
@@ -37,7 +37,7 @@
       (progn
         (setf (gethash node (hoist-point-definitions hoist-point))
               (node-variable (node-type node)
-                             (alexandria:ensure-symbol (gensym "hoisted_") package)))
+                             (gentemp "hoisted_" package)))
         (values (gethash node (hoist-point-definitions hoist-point))))))
 
 (defun hoist-point-list-p (x)

--- a/src/codegen/monomorphize.lisp
+++ b/src/codegen/monomorphize.lisp
@@ -144,9 +144,8 @@ recompilation, and also maintains a stack of uncompiled candidates."
     (return-from candidate-manager-push))
 
   (let ((new-name
-          (alexandria:ensure-symbol
-           (gensym (concatenate 'string (symbol-name (compile-candidate-name candidate)) "#"))
-           package)))
+          (gentemp (concatenate 'string (symbol-name (compile-candidate-name candidate)) "#")
+                   package)))
 
     (setf (gethash candidate (candidate-manager-map candidate-manager)) new-name))
 

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -113,7 +113,6 @@
 
       (inline-methods env)
 
-      #+this-is-broken
       (static-dict-lift hoister package env))
      (pop-final-hoist-point hoister))))
 


### PR DESCRIPTION
`*gensym-counter*` is not strictly increasing. Coalton was generating
identifiers with coliding names. This was causing runtime failures.