### PR TITLE
Change predicate defaulting behavior

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -186,6 +186,12 @@
     (* (:a -> :a -> :a))
     (fromInt (Integer -> :a)))
 
+  (define-class (DefaultInt :a)
+    "Internal class to mark implicit defaulting to integers."
+    (defaultInt (:a -> :a)))
+
+  (define-instance (Num :a => DefaultInt :a)
+    (define (defaultInt x) x))
 
   ;;
   ;; Haskell

--- a/src/ast/parse-form.lisp
+++ b/src/ast/parse-form.lisp
@@ -262,17 +262,25 @@ This does not attempt to do any sort of analysis whatsoever. It is suitable for 
        (pattern-constructor ctor (mapcar #'parse-pattern args))))))
 
 (defun parse-atom (atom)
-  ;; Convert integer literals into fromInt calls. This allows for
+  ;; Convert integer literals into defaultInt calls. This allows for
   ;; "overloaded" number literals. Other literals are left as is.
-  (let ((fromInt
+  (let ((defaultInt
+           (alexandria:ensure-symbol
+           "DEFAULTINT"
+           (find-package "COALTON-LIBRARY/CLASSES")))
+        (fromInt
           (alexandria:ensure-symbol
            "FROMINT"
            (find-package "COALTON-LIBRARY/CLASSES"))))
     (etypecase atom
-      (integer (node-application
-         atom
-         (node-variable fromInt fromInt)
-         (list (node-literal atom atom))))
+      (integer
+       (let ((num-cast
+               (node-application
+                atom (node-variable fromInt fromInt)
+                (list (node-literal atom atom)))))
+         (node-application
+          num-cast (node-variable defaultInt defaultInt)
+          (list num-cast))))
       (t (node-literal atom atom)))))
 
 (defun parse-seq (expr subnodes m package)

--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -167,7 +167,10 @@ in FORMS that begin with that operator."
 
         (let* ((env (coalton-impl/typechecker::apply-substitution substs *global-environment*))
                (preds (coalton-impl/typechecker::reduce-context env preds substs))
-               (substs (coalton-impl/typechecker::pred-defaults preds substs))
+               (substs
+                 (nth-value
+                  1 (coalton-impl/typechecker::assure-pred-defaults
+                     env preds substs :keep-default-constraint t)))
                (preds (coalton-impl/typechecker::reduce-context env preds substs))
                (typed-node (coalton-impl/typechecker::remove-static-preds
                             (coalton-impl/typechecker::apply-substitution substs typed-node)))

--- a/src/toplevel-define.lisp
+++ b/src/toplevel-define.lisp
@@ -147,6 +147,7 @@ Returns new environment, binding list of declared nodes, and a DAG of dependenci
            impl-bindings expl-bindings declared-types env nil nil
            :disable-monomorphism-restriction t
            :allow-deferred-predicates nil
+           :allow-default-predicates t
            :allow-returns nil)
         (when preds
           (coalton-bug "Preds not expected. ~A" preds))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -12,6 +12,9 @@
                 #:pattern-wildcard
                 #:pattern-literal
                 #:pattern-constructor)
+  (:local-nicknames
+   (#:arith #:coalton-library/arith)
+   (#:class #:coalton-library/classes))
   (:shadowing-import-from #:coalton
                           #:String
                           #:Integer

--- a/tests/runtime-tests.lisp
+++ b/tests/runtime-tests.lisp
@@ -116,6 +116,11 @@
         (z id))
     (z 5)))
 
+;; Test the following codegens
+(define-test test-default-codegen ()
+  (fn (x) (+ x 1))
+  ((fn (x) (/ x 1)) (the Fraction 2)))
+
 ;; Test mutli param typeclass context reduction
 (coalton-toplevel
   (declare context-reduction (Into :a Integer => :a -> Integer))

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -28,6 +28,20 @@
      (x . Integer)
      (y . String)))
 
+  ;; Check let bindings do default
+  (check-coalton-types
+   '((coalton:define x
+       (coalton:let ((y 2))
+         y)))
+   '((x . Integer)))
+
+  ;; Check type doesn't default and looks pretty
+  (check-coalton-types
+   '((coalton:define (f x)
+       (arith:/ 2 x)))
+   '((f . ((arith:Dividable :a :a)
+           (class:Num :a) => :a -> :a))))
+
   ;; Check that let bindings are polymorphic over kinds
   (check-coalton-types
    '((coalton:define x
@@ -83,6 +97,24 @@
     (run-coalton-typechecker
      '((coalton:declare x :a)
        (coalton:define x 5))))
+
+  ;; Check let bindings don't default on explicit declerations
+  (check-coalton-types
+   '((coalton:declare x coalton:Fraction)
+     (coalton:define x
+       (coalton:let ((y 2))
+         y)))
+   '((x . coalton:Fraction)))
+
+  ;; Check defaulting occurs within explicit declerations
+  (check-coalton-types
+   '((coalton:declare x coalton:Integer)
+     (coalton:define x
+       (coalton:progn
+         ;; 2 should be an Integer
+         2
+         3)))
+   '((x . Integer)))
 
   ;; Implicitly typed functions should only infer types from the declared type signature of an explicitly typed functions
   ;; http://jeremymikkola.com/posts/2019_01_12_type_inference_for_haskell_part_12.html


### PR DESCRIPTION
This is my first foray into Coalton's internals, so feedback is appreciated. Here are the changes:  

 - Prevent defaults in let bindings from conflicting with declarations.
  The following failed to type check before:
```
  (declare a (Num :a => :a -> :a))
  (define (a x)
    (let y = 2)
    (+ x y))
```
but
```
  (define (b x)
    (let y = 2)
    (+ x y))
```
still has `(type-of 'b)` = `Integer -> Integer`.

 - Constrain defaults to only integer literals with `defaultInt` instead of `fromInt`.
  `(define (c x) (+ x x))` now has `(type-of 'c)` = `Num :a => :a -> :a`
  `(define (d x) (+ x 1))` still has `(type-of 'd)` = `Integer -> Integer`.
 
 - Prevent defaulting when missing an instance.
    `(define (e x) (/ x 1))` is now valid ~but `(type-of 'e)` = ` ∀ A. (Dividable A A) (DefaultInt A) ⇒ (A → A)`~.

-  Allow defaulting of values in explicitly declared forms.
This now type checks:
```
  (declare f (:a -> :a))
  (define (f x)
    (traceObject "2" 2)
    x)
```

