### PR TITLE
Stdlib Improvements

### DIFF
--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -729,7 +729,7 @@
       (define (inst ts t)
         (match t
           ((TAp l r) (TAp (inst ts l) (inst ts r)))
-          ((TGen n)  (fromSome "Failed to find TGen type" (list:index ts n)))
+          ((TGen n)  (fromSome "Failed to find TGen type" (list:index n ts)))
           (_ t))))
 
   (define-instance (Instantiate :a => (Instantiate (List :a)))

--- a/library/arith.lisp
+++ b/library/arith.lisp
@@ -454,8 +454,15 @@ The fields are defined as follows:
     (lisp Integer (q)
       (cl:denominator q)))
 
-  (declare reciprocal (Fraction -> Fraction))
-  (define (reciprocal q)
+  (declare reciprocal ((Dividable :a :a) (Num :a) => :a -> :a))
+  (define (reciprocal x)
+    "The multiplicative of a number."
+    (/ 1 x))
+
+  (specialize reciprocal reciprocal-frac (Fraction -> Fraction))
+
+  (declare reciprocal-frac (Fraction -> Fraction))
+  (define (reciprocal-frac q)
     "The reciprocal of a fraction."
     (lisp Fraction (q)
       (cl:/ q)))

--- a/library/arith.lisp
+++ b/library/arith.lisp
@@ -456,7 +456,7 @@ The fields are defined as follows:
 
   (declare reciprocal ((Dividable :a :a) (Num :a) => :a -> :a))
   (define (reciprocal x)
-    "The multiplicative of a number."
+    "The multiplicative inverse of a number."
     (/ 1 x))
 
   (specialize reciprocal reciprocal-frac (Fraction -> Fraction))

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -200,8 +200,8 @@
           0
           l))
 
-  (declare index (List :a -> Integer -> Optional :a))
-  (define (index xs i)
+  (declare index (Integer -> List :a -> Optional :a))
+  (define (index i xs)
     "Returns the Ith element of a list."
     (match xs
       ((Nil)
@@ -209,12 +209,12 @@
       ((Cons x xs)
        (if (== 0 i)
            (Some x)
-           (index xs (- i 1))))))
+           (index (- i 1) xs)))))
 
   (declare nth (Integer -> List :t -> :t))
   (define (nth n l)
     "Like INDEX, but errors if the index is not found."
-    (fromSome "There is no NTH" (index l n)))
+    (fromSome "There is no NTH" (index n l)))
 
   (declare elemIndex (Eq :a => :a -> List :a -> Optional Integer))
   (define (elemIndex x xs)

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -164,6 +164,23 @@
              s1 s2)
             (cell:read out)))))
 
+  (define-instance (Foldable Slice)
+    (define (fold f init s)
+      (lisp :a (f init s)
+        (cl:reduce
+         (cl:lambda (b a)
+           (coalton-impl/codegen::A2 f b a))
+         s
+         :initial-value init)))
+    (define (foldr f init s)
+      (lisp :a (f init s)
+        (cl:reduce
+         (cl:lambda (a b)
+           (coalton-impl/codegen::A2 f a b))
+         s
+         :initial-value init
+         :from-end cl:t))))
+
   (define-instance (Into (Slice :a) (Vector :a))
     (define (into s)
       (let v = (vector:with-capacity (length s)))

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -33,9 +33,8 @@
   ;; Slice
   ;;
 
-  (repr :transparent)
-  (define-type (Slice :a)
-    (%Slice Lisp-Object))
+  (repr :native (cl:vector cl:t))
+  (define-type (Slice :a))
 
   (declare new (Integer -> Integer -> (Vector :a) -> (Slice :a)))
   (define (new start length v)
@@ -84,10 +83,8 @@
   (declare index-unsafe (Integer -> (Slice :a) -> :a))
   (define (index-unsafe idx s)
     "Lookup the element at INDEX in S without bounds checking"
-    (match s
-      ((%Slice s)
-       (lisp :a (idx s)
-         (cl:aref s idx)))))
+    (lisp :a (idx s)
+      (cl:aref s idx)))
 
   (declare foreach ((:a -> :b) -> (Slice :a) -> Unit))
   (define (foreach f s)

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -151,54 +151,54 @@
     (let ((test (fn (elem)
                   (== elem e))))
 
-        (lisp (Optional Integer) (v test)
-          (cl:let ((pos (cl:position-if
-                         #'(cl:lambda (x)
-                             (cl:equalp True (coalton-impl/codegen::A1 test x)))
-                         v)))
-            (cl:if pos
-                   (Some pos)
-                   None)))))
+      (lisp (Optional Integer) (v test)
+        (cl:let ((pos (cl:position-if
+                       #'(cl:lambda (x)
+                           (cl:equalp True (coalton-impl/codegen::A1 test x)))
+                       v)))
+          (cl:if pos
+                 (Some pos)
+                 None)))))
 
   (declare foreach ((:a -> :b) -> Vector :a -> Unit))
   (define (foreach f v)
     "Call the function F once for each item in V"
     (lisp Void (f v)
-        (cl:loop :for elem :across v
-           :do (coalton-impl/codegen::A1 f elem)))
+      (cl:loop :for elem :across v
+         :do (coalton-impl/codegen::A1 f elem)))
     Unit)
 
   (declare foreach-index ((Integer -> :a -> :b) -> Vector :a -> Unit))
   (define (foreach-index f v)
     "Call the function F once for each item in V with its index"
     (lisp Void (f v)
-        (cl:loop
-           :for elem :across v
-           :for i :from 0
-           :do (coalton-impl/codegen::A2 f i elem)))
+      (cl:loop
+         :for elem :across v
+         :for i :from 0
+         :do (coalton-impl/codegen::A2 f i elem)))
     Unit)
 
   (declare foreach2 ((:a -> :b -> :c) -> Vector :a -> Vector :b -> Unit))
   (define (foreach2 f v1 v2)
     "Like vector-foreach but twice as good"
     (lisp Void (f v1 v2)
-        (cl:loop
-           :for e1 :across v1
-           :for e2 :across v2
-           :do (coalton-impl/codegen::A2 f e1 e2)))
+      (cl:loop
+         :for e1 :across v1
+         :for e2 :across v2
+         :do (coalton-impl/codegen::A2 f e1 e2)))
     Unit)
 
   (declare append (Vector :a -> Vector :a -> Vector :a))
   (define (append v1 v2)
     "Create a new VECTOR containing the elements of v1 followed by the elements of v2"
-      (let out = (with-capacity (+ (length v1) (length v2))))
-      (let f =
-        (fn (item)
-          (push! item out)))
+    (let out = (with-capacity (+ (length v1) (length v2))))
+    (let f =
+      (fn (item)
+        (push! item out)))
 
-      (foreach f v1)
-      (foreach f v2)
-      out)
+    (foreach f v1)
+    (foreach f v2)
+    out)
 
   (declare swap-remove! (Integer -> Vector :a -> Optional :a))
   (define (swap-remove! idx vec)
@@ -261,6 +261,23 @@
          (push! (f item) out))
        v)
       out))
+
+  (define-instance (Foldable Vector)
+    (define (fold f init vec)
+      (lisp :a (f init vec)
+          (cl:reduce
+           (cl:lambda (b a)
+             (coalton-impl/codegen::A2 f b a))
+           vec
+           :initial-value init)))
+    (define (foldr f init vec)
+      (lisp :a (f init vec)
+          (cl:reduce
+           (cl:lambda (a b)
+             (coalton-impl/codegen::A2 f a b))
+           vec
+           :initial-value init
+           :from-end cl:t)))) 
 
   (define-instance (Into (List :a) (Vector :a))
     (define (into lst)

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -46,9 +46,8 @@
   ;; Vector
   ;;
 
-  (repr :transparent)
-  (define-type (Vector :a)
-    (%Vector Lisp-Object))
+  (repr :native (cl:vector cl:t))
+  (define-type (Vector :a))
 
   (declare new (Unit -> Vector :a))
   (define (new _)
@@ -82,7 +81,7 @@
   (define (copy v)
     "Return a new vector containing the same elements as V"
     (lisp (Vector :a) (v)
-      (%Vector (alexandria:copy-array v))))
+      (alexandria:copy-array v)))
 
   (declare push! (:a -> Vector :a -> Integer))
   (define (push! item v)
@@ -153,7 +152,7 @@
 
       (lisp (Optional Integer) (v test)
         (cl:let ((pos (cl:position-if
-                       #'(cl:lambda (x)
+                       (cl:lambda (x)
                            (cl:equalp True (coalton-impl/codegen::A1 test x)))
                        v)))
           (cl:if pos


### PR DESCRIPTION
* generalize reciprocal to `:a -> :a` (fixes #507)
* reverse argument order of `list:index` to match `vector:index` (fixes
  #503)
* add `Foldable` instanes for `Vector` and `Slice`