### PR TITLE
file/char-stream i/o interface

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -133,6 +133,7 @@
                (:file "hashtable")
                (:file "monad/state")
                (:file "iterator")
+               (:file "char-io")
                (:file "file")
                (:file "system")
                (:file "prelude")))

--- a/coalton.asd
+++ b/coalton.asd
@@ -133,6 +133,7 @@
                (:file "hashtable")
                (:file "monad/state")
                (:file "iterator")
+               (:file "resource")
                (:file "char-io")
                (:file "file")
                (:file "system")

--- a/coalton.asd
+++ b/coalton.asd
@@ -133,6 +133,7 @@
                (:file "hashtable")
                (:file "monad/state")
                (:file "iterator")
+               (:file "file")
                (:file "system")
                (:file "prelude")))
 
@@ -231,4 +232,5 @@
                (:file "slice-tests")
                (:file "quantize-tests")
                (:file "hashtable-tests")
-               (:file "iterator-tests")))
+               (:file "iterator-tests")
+               (:file "file-tests")))

--- a/library/char-io.lisp
+++ b/library/char-io.lisp
@@ -1,0 +1,211 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/char-io
+    (:use
+     #:coalton
+     #:coalton-library/classes
+     #:coalton-library/builtin)
+  (:local-nicknames (#:iter #:coalton-library/iterator))
+  (:export
+
+   ;; error handling
+   #:UnknownStreamError
+   #:StreamError #:Closed #:EndOfFile #:Unknown
+
+   ;; input files
+   #:Input
+   #:close-input!
+   #:open-input?
+   #:read-char!
+   #:read-line!
+   #:iterator!
+   #:chars!
+   #:lines!
+   #:standard-input
+
+   ;; output files
+   #:Output
+   #:close-output!
+   #:open-output?
+   #:write-char!
+   #:write-string!
+   #:write-line!
+   #:newline!
+   #:standard-output))
+(cl:in-package #:coalton-library/char-io)
+
+;; errors
+
+(coalton-toplevel
+  (repr :native cl:stream-error)
+  (define-type UnknownStreamError)
+  
+  (define-type StreamError
+    Closed
+    EndOfFile
+    (Unknown UnknownStreamError)))
+
+(cl:defmacro with-converting-stream-errors (cl:&body forms)
+  `(cl:handler-case
+       (cl:progn ,@forms)
+     (cl:end-of-file () (Err EndOfFile))
+     #+sbcl (sb-int:closed-stream-error () (Err Closed))
+     (cl:stream-error (e) (Err (Unknown e)))
+     (:no-error (res cl:&rest ignored) ; `cl:read-line' returns an extra value that we don't care about, so ignore it
+       (cl:declare (cl:ignore ignored))
+       (Ok res))))
+
+;; char input streams
+
+(coalton-toplevel
+  (repr :native (cl:and cl:stream (cl:satisfies cl:input-stream-p)))
+  (define-type Input
+    "An input stream, from which characters can be read.")
+
+  (declare open-input? (Input -> Boolean))
+  (define (open-input? in)
+    "Is IN open? Returns `False' if `close-input!' has been called on IN in the past.
+
+If `False', reads from IN will fail."
+    (lisp Boolean (in)
+      (cl:open-stream-p in)))
+
+  (declare close-input! (Input -> Unit))
+  (define (close-input! in)
+    "Close IN, freeing any corresponding resources. Future reads from IN will fail.
+
+It is safe to call `close-input!' on an `Input' that is already closed."
+    (when (open-input? in)
+      (lisp :any (in)
+        (cl:close in))
+      Unit))
+
+  (declare try-close-input! (Input -> (Result StreamError Unit)))
+  (define (try-close-input! in)
+    (if (open-input? in)
+        (Ok (close-input! in))
+        (Err Closed)))
+
+  (declare read-char! (Input -> (Result StreamError Char)))
+  (define (read-char! in)
+    "Read a character from IN.
+
+Blocks if no data is available from IN."
+    (lisp (Result StreamError Char) (in)
+      (with-converting-stream-errors
+        (cl:read-char in cl:t cl:nil cl:nil))))
+
+  (declare read-line! (Input -> (Result StreamError String)))
+  (define (read-line! in)
+    "Read a line up to a newline from IN, discard the newline and return the line.
+
+Blocks if no data is available from IN."
+    (lisp (Result StreamError String) (in)
+      (with-converting-stream-errors
+          (cl:read-line in cl:t cl:nil cl:nil))))
+
+  (declare iterator! ((Input -> (Result StreamError :elt))
+                      -> Input
+                      -> (iter:Iterator (Result StreamError :elt))))
+  (define (iterator! read-elt! in)
+    "Returns an iterator over elements of IN by READ-ELT!"
+    (iter:new
+     (fn ()
+       (if (not (open-input? in))
+           None
+           (match (read-elt! in)
+             ((Ok elt) (Some (Ok elt)))
+             ((Err (EndOfFile)) None)
+             ((Err e) (Some (Err e))))))))
+
+  (declare chars! (Input -> (iter:Iterator (Result StreamError Char))))
+  (define (chars! in)
+    "Returns an iterator over the characters of IN, calling `read-char!' successively.
+
+`next!' may block if no data is available on IN."
+    (iterator! read-char! in))
+
+  (declare lines! (Input -> (iter:Iterator (Result StreamError String))))
+  (define (lines! in)
+    "Returns an iterator over the lines of IN, calling `read-line!' successively.
+
+`next!' may block if no data is available on IN."
+    (iterator! read-line! in))
+
+  (declare standard-input (Unit -> Input))
+  (define (standard-input)
+    "Returns the current standard input stream, i.e. the value of `cl:*standard-input*'."
+    (lisp Input () cl:*standard-input*)))
+
+;; output files
+
+(coalton-toplevel
+  (repr :native (cl:and cl:stream (cl:satisfies cl:output-stream-p)))
+  (define-type Output
+    "An output file, to which characters can be written.")
+
+  (declare open-output? (Output -> Boolean))
+  (define (open-output? out)
+    "Is OUT open? Returns `False' if `close-output!' has been called on OUT in the past.
+
+If `False', writes to OUT will fail."
+    (lisp Boolean (out)
+      (cl:open-stream-p out)))
+  
+  (declare close-output! (Output -> Unit))
+  (define (close-output! out)
+    "Close OUT, forcing its writes to complete and then freeing corresponding resources.
+
+Future writes to OUT will fail.
+
+It is safe to call `close-output!' on an `Output' that has already been closed."
+    (when (open-output? out)
+      (lisp :any (out)
+        (cl:close out)))
+    Unit)
+
+  (declare try-close-output! (Output -> (Result StreamError Unit)))
+  (define (try-close-output! out)
+    "Close OUT, forcing its writes to complete and then freeing corresponding resources.
+
+Returns (Err Closed) if OUT was already closed.
+
+Future writes to OUT will fail."
+    (if (open-output? out)
+        (Ok (close-output! out))
+        (Err Closed)))
+
+  (declare write-char! (Output -> Char -> (Result StreamError Unit)))
+  (define (write-char! out c)
+    "Write C to OUT."
+    (lisp (Result StreamError Unit) (out c)
+      (with-converting-stream-errors
+        (cl:write-char c out)
+        Unit)))
+
+  (declare write-string! (Output -> String -> (Result StreamError Unit)))
+  (define (write-string! out str)
+    "Write STR to OUT."
+    (lisp (Result StreamError Unit) (out str)
+      (with-converting-stream-errors
+        (cl:write-string str out)
+        Unit)))
+
+  (declare write-line! (Output -> String -> (Result StreamError Unit)))
+  (define (write-line! out str)
+    "Write STR to OUT with a trailing newline."
+    (lisp (Result StreamError Unit) (out str)
+      (with-converting-stream-errors
+        (cl:write-line str out)
+        Unit)))
+
+  (declare newline! (Output -> (Result StreamError Unit)))
+  (define (newline! out)
+    "Write a newline to OUT."
+    (lisp (Result StreamError Unit) (out)
+        (with-converting-stream-errors
+          (cl:terpri out)
+          Unit)))
+
+  (declare standard-output (Unit -> Output))
+  (define (standard-output)
+    "Returns the current standard output stream, i.e. the value of `cl:*standard-output*'."
+    (lisp Output () cl:*standard-output*)))

--- a/library/file.lisp
+++ b/library/file.lisp
@@ -1,0 +1,350 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/file
+    (:use
+     #:coalton
+     #:coalton-library/classes
+     #:coalton-library/builtin)
+  (:local-nicknames (#:iter #:coalton-library/iterator))
+  (:export
+
+   ;; encodings
+   #:Encoding #:ASCII #:UTF-8 #:UTF-16 #:LATIN-1
+   #:default-encoding
+
+   ;; input files
+   #:Input
+   #:open-input! #:input-with-encoding!
+   #:close-input!
+   #:open-input?
+   #:read-char!
+   #:read-line!
+   #:iterator!
+   #:chars!
+   #:lines!
+   #:call-with-input-file! #:with-input-file!
+   #:standard-input
+   #:call-with-standard-input! #:with-standard-input!
+
+   ;; output files
+   #:Output
+   #:open-output! #:output-with-encoding!
+   #:close-output!
+   #:open-output?
+   #:write-char!
+   #:write-string!
+   #:write-line!
+   #:newline!
+   #:call-with-output-file! #:with-output-file!
+   #:standard-output
+   #:call-with-standard-output! #:with-standard-output!
+
+   ;; formatted output
+   #:Show #:show!))
+(cl:in-package #:coalton-library/file)
+
+;; encodings
+
+(coalton-toplevel
+  (define-type Encoding
+    "A text encoding; CL calls this an \"external format\".
+
+Others are allowed; SBCL supports a wealth, listed at http://www.sbcl.org/manual/#Supported-External-Formats .
+
+To add a new external format, define a variant of `Encoding', and add a corresponding branch to `encoding-name'."
+    ASCII
+    UTF-8
+    UTF-16
+    LATIN-1)
+
+  (declare encoding-name (Encoding -> Lisp-Object))
+  (define (encoding-name enc)
+    (match enc
+      ((ASCII) (lisp Lisp-Object () :ascii))
+      ((UTF-8) (lisp Lisp-Object () :utf-8))
+      ((UTF-16) (lisp Lisp-Object () :utf-16))
+      ((LATIN-1) (lisp Lisp-Object () :latin-1))))
+
+  (define default-encoding UTF-8))
+
+;; input files
+
+(coalton-toplevel
+  (repr :native (cl:and cl:stream (cl:satisfies cl:input-stream-p)))
+  (define-type Input
+    "An input stream, from which characters can be read.")
+
+  (declare input-with-encoding! (Encoding -> String -> (Optional Input)))
+  (define (input-with-encoding! enc path)
+    "Open PATH as an input file using the encoding ENC."
+    (let ((enc-name (encoding-name enc)))
+      (lisp (Optional Input) (path enc-name)
+        (cl:handler-case
+            (cl:open path
+                     :direction :input
+                     :element-type 'cl:character
+                     :if-does-not-exist :error
+                     :external-format enc-name)
+          (cl:file-error () None)
+          (:no-error (f) (Some f))))))
+
+  (declare open-input! (String -> (Optional Input)))
+  (define (open-input! path)
+    "Open PATH as an input file using the default encoding."
+    (input-with-encoding! default-encoding path))
+
+  (declare open-input? (Input -> Boolean))
+  (define (open-input? file)
+    "Is FILE open? Returns `False' if `close-input!' has been called on FILE in the past.
+
+If `False', reads from FILE will fail."
+    (lisp Boolean (file)
+      (cl:open-stream-p file)))
+
+  (declare close-input! (Input -> Unit))
+  (define (close-input! file)
+    "Close FILE, freeing any corresponding resources. Future reads from FILE will fail.
+
+It is safe to call `close-input!' on an `Input' that is already closed."
+    (when (open-input? file)
+      (lisp :any (file)
+        (cl:close file))
+      Unit))
+
+  (declare read-char! (Input -> (Optional Char)))
+  (define (read-char! file)
+    "Read a character from FILE.
+
+Blocks if no data is available from FILE."
+    (lisp (Optional Char) (file)
+      (cl:handler-case
+          (cl:read-char file cl:t cl:nil cl:nil)
+        (cl:error () None)
+        (:no-error (c) (Some c)))))
+
+  (declare read-line! (Input -> (Optional String)))
+  (define (read-line! file)
+    "Read a line up to a newline from FILE, discard the newline and return the line.
+
+Blocks if no data is available from FILE."
+    (lisp (Optional String) (file)
+      (cl:handler-case
+          (cl:read-line file cl:t cl:nil cl:nil)
+        (cl:error () None)
+        (:no-error (l missing-newline-p)
+          (cl:declare (cl:ignore missing-newline-p))
+          (Some l)))))
+
+  (declare iterator! ((Input -> (Optional :elt))
+                      -> Input
+                      -> (iter:Iterator :elt)))
+  (define (iterator! read-elt! file)
+    "Returns an iterator over elements of FILE by READ-ELT!, closing FILE after READ-ELT! returns `None' for the first time."
+    (iter:new
+     (fn ()
+       (if (not (open-input? file))
+           None
+           (match (read-elt! file)
+             ((Some elt) (Some elt))
+             ((None) (progn (close-input! file)
+                            None)))))))
+
+  (declare chars! (Input -> (iter:Iterator Char)))
+  (define (chars! file)
+    "Returns an iterator over the characters of FILE, calling `read-char!' successively.
+
+Closes the file when done.
+
+`next!' may block if no data is available on FILE."
+    (iterator! read-char! file))
+
+  (declare lines! (Input -> (iter:Iterator String)))
+  (define (lines! file)
+    "Returns an iterator over the lines of FILE, calling `read-line!' successively.
+
+Closes the file when done.
+
+`next!' may block if no data is available on FILE."
+    (iterator! read-line! file))
+
+  (declare call-with-input-file! (Encoding -> String -> (Input -> :res) -> (Optional :res)))
+  (define (call-with-input-file! enc path thunk)
+    "Open PATH as an ENC-encoded input file, call THUNK with the file, then close the file.
+
+If opening the file fails, THUNK will not be called, and `None' is returned."
+    (match (input-with-encoding! enc path)
+      ((Some file)
+       (progn (let res = (thunk file))
+              (close-input! file)
+              (Some res)))
+      ((None) None)))
+
+  (declare standard-input (Unit -> Input))
+  (define (standard-input)
+    "Returns the current standard input stream, i.e. the value of `cl:*standard-input*'."
+    (lisp Input () cl:*standard-input*))
+
+  (declare call-with-standard-input! (Input -> (Unit -> :ret) -> :ret))
+  (define (call-with-standard-input! inp thunk)
+    "Call THUNK with INP as the standard input stream, i.e. with `cl:*standard-input*' bound to INP."
+    (lisp :ret (inp thunk)
+      (cl:let ((cl:*standard-input* inp))
+        (coalton-impl/codegen/function-entry:a1 thunk Unit)))))
+
+(cl:defmacro with-input-file! ((var path cl:&optional (enc 'default-encoding)) cl:&body body)
+  "Evaluate BODY with VAR bound to an open `Input' file reading from PATH using ENC encoding.
+
+Close the file after BODY.
+
+If opening the file fails, BODY will not be evaluated, and `None' is returned."
+  `(call-with-input-file! ,enc ,path (fn (,var) ,@body)))
+
+(cl:defmacro with-standard-input! ((stream) cl:&body body)
+  "Evaluate BODY with STREAM as the standard input stream, i.e. with `cl:*standard-input*' bound to STREAM."
+  `(call-with-standard-input! ,stream (fn () ,@body)))
+
+;; output files
+
+(cl:defmacro lisp-write! (inputs cl:&body (do-write))
+  `(lisp (Optional Unit) ,inputs
+     (cl:handler-case ,do-write
+       (cl:error () None)
+       (:no-error (cl:&rest stuff) (cl:declare (cl:ignore stuff)) (Some Unit)))))
+
+(coalton-toplevel
+  (repr :native (cl:and cl:stream (cl:satisfies cl:output-stream-p)))
+  (define-type Output
+    "An output file, to which characters can be written.")
+
+  (declare output-with-encoding! (Encoding -> String -> (Optional Output)))
+  (define (output-with-encoding! enc path)
+    "Open PATH for output using ENC as an encoding, replacing if it exists."
+    (let enc-name = (encoding-name enc))
+    (lisp (Optional Output) (enc-name path)
+      (cl:handler-case
+           (cl:open path
+                    :direction :output
+                    :element-type 'cl:character
+                    :if-exists :supersede
+                    :external-format enc-name)
+         (cl:file-error () None)
+         (:no-error (f) (Some f)))))
+
+  (declare open-output! (String -> (Optional Output)))
+  (define (open-output! path)
+    "Open PATH for output using the default encoding, replacing if it exists."
+    (output-with-encoding! default-encoding path))
+
+  (declare open-output? (Output -> Boolean))
+  (define (open-output? file)
+    "Is FILE open? Returns `False' if `close-output!' has been called on FILE in the past.
+
+If `False', writes to FILE will fail."
+    (lisp Boolean (file)
+      (cl:open-stream-p file)))
+  
+  (declare close-output! (Output -> Unit))
+  (define (close-output! file)
+    "Close FILE, forcing its writes to complete and then freeing corresponding resources.
+
+Future writes to FILE will fail.
+
+It is safe to call `close-output!' on an `Output' that has already been closed."
+    (when (open-output? file)
+      (lisp :any (file)
+        (cl:close file)))
+    Unit)
+
+  (declare write-char! (Output -> Char -> (Optional Unit)))
+  (define (write-char! file c)
+    "Write C to FILE. Returns (Some Unit) if successful, or None if the write failed."
+    (lisp-write! (file c)
+      (cl:write-char c file)))
+
+  (declare write-string! (Output -> String -> (Optional Unit)))
+  (define (write-string! file str)
+    "Write STR to FILE. Returns (Some Unit) if successful, or None if the write failed."
+    (lisp-write! (file str)
+      (cl:write-string str file)))
+
+  (declare write-line! (Output -> String -> (Optional Unit)))
+  (define (write-line! file str)
+    "Write STR to FILE with a trailing newline. Returns (Some Unit) if successful, or None if the write failed."
+    (lisp-write! (file str)
+      (cl:write-line str file)))
+
+  (declare newline! (Output -> (Optional Unit)))
+  (define (newline! file)
+    "Write a newline to FILE. Returns (Some Unit) if successful, or None if the write failed."
+    (lisp-write! (file)
+      (cl:terpri file)))
+
+  (declare call-with-output-file! (Encoding -> String -> (Output -> :res) -> (Optional :res)))
+  (define (call-with-output-file! enc path thunk)
+    "Open PATH as an ENC-encoded output file, call THUNK with the file, then close the file.
+
+If opening the file fails, THUNK will not be called, and `None' is returned."
+    (match (output-with-encoding! enc path)
+      ((Some file)
+       (progn (let res = (thunk file))
+              (close-output! file)
+              (Some res)))
+      ((None) None)))
+
+  (declare standard-output (Unit -> Output))
+  (define (standard-output)
+    "Returns the current standard output stream, i.e. the value of `cl:*standard-output*'."
+    (lisp Output () cl:*standard-output*))
+
+  (declare call-with-standard-output! (Output -> (Unit -> :res) -> :res))
+  (define (call-with-standard-output! file thunk)
+    "Call THUNK with FILE as the standard output stream, i.e. with `cl:*standard-output*' bound to FILE."
+    (lisp :res (file thunk)
+      (cl:let ((cl:*standard-output* file))
+        (coalton-impl/codegen/function-entry:a1 thunk Unit)))))
+
+(cl:defmacro with-output-file! ((var path cl:&optional (enc 'UTF-8)) cl:&body body)
+  "Evaluate BODY with VAR bound to an open `Output' file writing to PATH using ENC encoding.
+
+If a file already exists at PATH, it will be replaced.
+
+Close the file after BODY.
+
+If opening the file fails, BODY will not be evaluated, and `None' is returned."
+  `(call-with-output-file! ,enc ,path (fn (,var) ,@body)))
+
+(cl:defmacro with-standard-output! ((file) cl:&body body)
+  "Evaluate BODY with FILE as the standard output stream, i.e. with `cl:*standard-output*' bound to FILE."
+  `(call-with-standard-output! ,file (fn () ,@body)))
+
+;; formatted output
+
+(coalton-toplevel
+  (define-class (Show :showable)
+    "Types which can be printed on an `Output' stream.
+
+`show!' methods should return (Some Unit) if the write succeeds, or None if the write fails."
+    (show! (Output -> :showable -> (Optional Unit))))
+
+  (define-instance (Show Char)
+    (define show! write-char!))
+
+  (define-instance (Show String)
+    (define show! write-string!)))
+
+(cl:defmacro define-show-integer (type)
+  `(coalton-toplevel
+     (define-instance (Show ,type)
+       (define (show! file int)
+         (lisp-write! (file int)
+           (cl:format file "~d" int))))))
+
+(define-show-integer Integer)
+(define-show-integer UFix)
+(define-show-integer IFix)
+(define-show-integer U8)
+(define-show-integer I8)
+(define-show-integer U16)
+(define-show-integer I16)
+(define-show-integer U32)
+(define-show-integer I32)
+(define-show-integer U64)
+(define-show-integer I64)

--- a/library/resource.lisp
+++ b/library/resource.lisp
@@ -1,0 +1,108 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/resource
+  (:use #:coalton
+        #:coalton-library/classes
+        #:coalton-library/result)
+  (:local-nicknames (#:cell #:coalton-library/cell))
+  (:export
+
+   #:ResourceError
+   #:OpenError
+   #:RunError
+   #:CloseError
+
+   #:flatten-resource-error
+
+   #:with-resource))
+(cl:in-package #:coalton-library/resource)
+
+;; a more robust version of `ResourceError' would encode various possibilityes when the `close!' step fails:
+;; - if the `run!' step had a non-local exit, then neither a `:run-error' nor a `:result' exists
+;; - if the `run!' step succeeded but the `close!' step returned an error, in addition to a `:close-error',
+;;   there is also either a `:result' or a `:run-error'. the current definition discards the result of the
+;;   `run!' step, if any, when the `close!' step fails.
+
+(coalton-toplevel
+  (define-type (ResourceError :open :run :close)
+    "Encodes the three different occasions that an error might occur during a `with-resource' call."
+    (OpenError :open)
+    (RunError :run)
+    (CloseError :close))
+
+  (declare flatten-resource-error ((ResourceError :err :err :err) -> :err))
+  (define (flatten-resource-error err)
+    (match err
+      ((OpenError e) e)
+      ((RunError e) e)
+      ((CloseError e) e)))
+
+  (declare unwind-protect ((Unit -> :res)
+                           -> (Unit -> Unit)
+                           -> :res))
+  (define (unwind-protect protected cleanup)
+    (lisp :res (protected cleanup)
+      (cl:unwind-protect (coalton-impl/codegen:a1 protected Unit)
+        (coalton-impl/codegen:a1 cleanup Unit))))
+
+  (declare do-run-step ((cell:Cell (Optional (Result (ResourceError :open-error
+                                                                    :run-error
+                                                                    :close-error)
+                                                     :result)))
+                        -> :resource
+                        -> (:resource -> (Result :run-error :result))
+                        -> Unit))
+  (define (do-run-step result resource run!)
+    (cell:write! result
+                 (Some (match (run! resource)
+                         ((Err run-error) (Err (RunError run-error)))
+                         ((Ok result) (Ok result)))))
+    Unit)
+
+  (declare do-cleanup-step ((cell:Cell (Optional (Result (ResourceError :open-error
+                                                                        :run-error
+                                                                        :close-error)
+                                                         :result)))
+                            -> :resource
+                            -> (:resource -> (Result :close-error Unit))
+                            -> Unit))
+  (define (do-cleanup-step result resource close!)
+    (match (close! resource)
+      ((Err close-error)
+       ;; if `close!' returns an error, overwrite the result to return that error
+       (cell:write! result (Some (Err (CloseError close-error))))
+       Unit)
+      ((Ok _)
+       ;; if `close!' succeeds, there's no need to set the result
+       Unit)))
+
+  (declare with-resource ((Unit -> (Result :open-error :resource))
+                          -> (:resource -> (Result :run-error :result))
+                          -> (:resource -> (Result :close-error Unit))
+                          -> (Result (ResourceError :open-error :run-error :close-error)
+                                     :result)))
+  (define (with-resource open! run! close!)
+    "Use OPEN! to create a RESOURCE, pass it to RUN!, then CLOSE! the RESOURCE. Return the result of RUN! unless an error occurs.
+
+If OPEN! returns an (Err open-error), `with-resource' returns (Result (OpenError open-error)). Neither RUN!
+nor CLOSE! is invoked in this case, as no resource has been created.
+
+If RUN! returns and CLOSE! returns an (Err close-error), `with-resource' returns (Result (CloseError
+close-error)). Note that this clobbers the result of RUN!, even if RUN! returned an Err.
+
+If RUN! returns an (Err run-error) and CLOSE! succeeds, `with-resource' returns (Result (RunError
+run-error)). Note that, if CLOSE! fails, the error returned by RUN! will be silently discarded.
+
+If RUN! returns (Ok result) and CLOSE! succeeds, `with-resource' returns (Ok result). Note that, if CLOSE!
+fails, the result returned by RUN! will be silently discarded.
+
+If RUN! takes a non-local exit, CLOSE! will be run. The non-local exit will then continue."
+    (match (open!)
+      ((Err open-error) (Err (OpenError open-error)))
+      ((Ok resource)
+       (let result = (cell:new None))
+       (unwind-protect
+            (fn () (do-run-step result resource run!))
+         (fn () (do-cleanup-step result resource close!)))
+       ;; if execution reaches this point, we know that `run!' did not take a non-local exit (or unwinding
+       ;; would have continued after running `close!'). therefore, `result' contains `Some', whether it's an
+       ;; `Ok' from `run!', a `RunError', or a `CloseError'.
+       (unwrap (cell:read result))))))

--- a/tests/file-tests.lisp
+++ b/tests/file-tests.lisp
@@ -1,0 +1,15 @@
+(cl:in-package #:coalton-native-tests)
+
+(define-test write-then-read ()
+  (let ((path (lisp String () (cl:symbol-name (cl:gensym "coalton-test-tempfile-"))))
+        (test-data (lisp String () (cl:symbol-name (cl:gensym "coalton-test-data-")))))
+    (progn
+      (expect "Opening output file failed"
+              (file:with-output-file! (out path)
+                (expect "Write failed"
+                        (file:write-line! out test-data))))
+      (is (== test-data
+              (expect "Opening input file failed"
+                      (file:with-input-file! (in path)
+                        (expect "Read failed"
+                                (file:read-line! in)))))))))

--- a/tests/file-tests.lisp
+++ b/tests/file-tests.lisp
@@ -4,14 +4,12 @@
   (let ((path (lisp String () (cl:symbol-name (cl:gensym "coalton-test-tempfile-"))))
         (test-data (lisp String () (cl:symbol-name (cl:gensym "coalton-test-data-")))))
     (progn
-      (expect "Opening output file failed"
-              (file:with-char-output! file:default-file-options
+      (expect "Writing as output failed"
+              (file:with-char-output! (file:config file:Output)
                 (into path)
-                (fn (out) (expect "Write failed"
-                                  (char-io:write-line! out test-data)))))
+                (fn (out) (char-io:write-line! out test-data))))
       (is (== test-data
-              (expect "Opening input file failed"
-                      (file:with-char-input! file:default-file-options
+              (expect "Reading as input failed"
+                      (file:with-char-input! (file:config file:Input)
                         (into path)
-                        (fn (in) (expect "Read failed"
-                                         (char-io:read-line! in))))))))))
+                        (fn (in) (char-io:read-line! in)))))))))

--- a/tests/file-tests.lisp
+++ b/tests/file-tests.lisp
@@ -5,11 +5,13 @@
         (test-data (lisp String () (cl:symbol-name (cl:gensym "coalton-test-data-")))))
     (progn
       (expect "Opening output file failed"
-              (file:with-output-file! (out path)
-                (expect "Write failed"
-                        (file:write-line! out test-data))))
+              (file:with-char-output! file:default-file-options
+                (into path)
+                (fn (out) (expect "Write failed"
+                                  (char-io:write-line! out test-data)))))
       (is (== test-data
               (expect "Opening input file failed"
-                      (file:with-input-file! (in path)
-                        (expect "Read failed"
-                                (file:read-line! in)))))))))
+                      (file:with-char-input! file:default-file-options
+                        (into path)
+                        (fn (in) (expect "Read failed"
+                                         (char-io:read-line! in))))))))))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -28,7 +28,8 @@
    (#:vector #:coalton-library/vector)
    (#:slice #:coalton-library/slice)
    (#:hashtable #:coalton-library/hashtable)
-   (#:iter #:coalton-library/iterator)))
+   (#:iter #:coalton-library/iterator)
+   (#:file #:coalton-library/file)))
 
 (in-package #:coalton-native-tests)
 

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -29,7 +29,8 @@
    (#:slice #:coalton-library/slice)
    (#:hashtable #:coalton-library/hashtable)
    (#:iter #:coalton-library/iterator)
-   (#:file #:coalton-library/file)))
+   (#:file #:coalton-library/file)
+   (#:char-io #:coalton-library/char-io)))
 
 (in-package #:coalton-native-tests)
 


### PR DESCRIPTION
A long-awaited interface for reading from and writing to character streams in Coalton!

Features:
- `Input` and `Output` types which wrap `cl:stream`
- `Show` typeclass for printing stuff to `Output` streams, with instances for `String`, `Char` and the various integers
- The four `Encoding`s (external-formats) I cared about while developing, with utf-8 as a default
- `with-input-file!` and `with-output-file!` macros
- Iterators over the `chars!` and `lines!` of an `Input`
- Reading and locally binding (but not setting) `*standard-input*` and `*standard-output*`
- Docstrings
- One (1) test

Still to do:
- External documentation
- More tests
- Filesystem APIs, like `file-exists?` and `generate-temp-file-name`
- More `Show` instances
- Formatting functions, like printing integers as binary or hex, floats in scientific notation, etc

Open questions:
- Is there a better way to encode write errors than returning `(Optional Unit)`?
- Do we care about any other CL i/o functions, like `read-sequence`?
- What errors should we transform into returning `None` (currently: `cl:error`), and what should we leave as unhandled conditions (currently: none, afaik)?
  - Part of me wants to handle only `file-error`.
  - Another part of me wants to handle closed stream errors, which are non-standard and therefore not of type `file-error`.
    - This part is currently winning.
- Byte streams?