### PR TITLE
Fix pointfree transform

### DIFF
--- a/benchmarks/package.lisp
+++ b/benchmarks/package.lisp
@@ -120,11 +120,13 @@
     (+ (fib-generic (- n 1)) (fib-generic (- n 2))))
 
   (declare fib-generic-wrapped (Integer -> Integer))
-  (define fib-generic-wrapped fib-generic)
+  (define (fib-generic-wrapped x)
+    (fib-generic x))
 
   (monomorphize)
   (declare fib-monomorphized (Integer -> Integer))
-  (define fib-monomorphized fib-generic)
+  (define (fib-monomorphized x)
+    (fib-generic x))
 
   (declare fib-generic-optional (Integer -> Optional Integer))
   (define (fib-generic-optional x)

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -150,8 +150,10 @@
            (values node))
   (declare (type node node)
            (values node))
-  (if (node-abstraction-p node)
-      (return-from pointfree node))
+
+
+  (unless (node-variable-p node)
+    (return-from pointfree node))
 
   (if (not (tc:function-type-p (node-type node)))
       (return-from pointfree node))


### PR DESCRIPTION
Side-efecting forms were being wrapped in lambdas.

Fixes #557