### PR TITLE
Move arith, integral, and complex to a new math package

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -119,9 +119,11 @@
                (:file "functions")
                (:file "boolean")
                (:file "bits")
-               (:file "arith")
-               (:file "complex")
-               (:file "integral")
+               (:module "math"
+                :serial t
+                :components ((:file "arith")
+                             (:file "integral")
+                             (:file "complex")))
                (:file "char")
                (:file "string")
                (:file "tuple")

--- a/library/big-float/big-float.lisp
+++ b/library/big-float/big-float.lisp
@@ -5,7 +5,7 @@
 (coalton-library/utils:defstdlib-package #:coalton-library/big-float
   (:use #:coalton
         #:coalton-library/classes
-        #:coalton-library/arith)
+        #:coalton-library/math)
 
   (:export
    #:RoundingMode
@@ -300,7 +300,7 @@
         (mpfr->rational (sb-mpfr::mpfr-float-ref x)))))
 )                                       ; COALTON-TOPLEVEL
 
-(coalton-library/complex::%define-standard-complex-instances Big-Float)
+(coalton-library/math/complex::%define-standard-complex-instances Big-Float)
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/BIG-FLOAT")

--- a/library/math/arith.lisp
+++ b/library/math/arith.lisp
@@ -2,8 +2,8 @@
 ;;;;
 ;;;; Number types and basic arithmetic.
 
-(coalton-library/utils::defstdlib-package #:coalton-library/arith
-  (:use
+(coalton-library/utils::defstdlib-package #:coalton-library/math/arith
+    (:use
      #:coalton
      #:coalton-library/builtin
      #:coalton-library/classes
@@ -64,7 +64,7 @@
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
 
-(in-package #:coalton-library/arith)
+(in-package #:coalton-library/math/arith)
 
 (coalton-toplevel
   ;;
@@ -138,12 +138,12 @@ The fields are defined as follows:
 
 (cl:defmacro %define-overflow-handler (name bits)
   `(cl:defun ,name (value)
-    (cl:typecase value
-      ((cl:signed-byte ,bits) value)
-      (cl:otherwise
-       (cl:cerror "Continue, wrapping around."
-                  ,(cl:format cl:nil "Signed value overflowed ~D bits." bits))
-       (%unsigned->signed ,bits (cl:mod value ,(cl:expt 2 bits)))))))
+     (cl:typecase value
+       ((cl:signed-byte ,bits) value)
+       (cl:otherwise
+        (cl:cerror "Continue, wrapping around."
+                   ,(cl:format cl:nil "Signed value overflowed ~D bits." bits))
+        (%unsigned->signed ,bits (cl:mod value ,(cl:expt 2 bits)))))))
 
 (cl:eval-when (:compile-toplevel :load-toplevel)
   (cl:defparameter +fixnum-bits+
@@ -325,10 +325,10 @@ The fields are defined as follows:
        (define (into x) (fromInt x)))
 
      ,@(cl:loop :for super :in supers :collecting
-        `(define-instance (Into ,coalton-type ,super)
-           (define (into x)
-             (lisp ,super (x)
-               x))))
+          `(define-instance (Into ,coalton-type ,super)
+             (define (into x)
+               (lisp ,super (x)
+                 x))))
 
      (define-instance (Into ,coalton-type Single-Float)
        (define (into x)
@@ -630,7 +630,7 @@ The fields are defined as follows:
        (define ee
          (lisp ,coalton-type ()
            (cl:exp (cl:coerce 1 ',underlying-type))))
-         
+
        (define pi
          (lisp ,coalton-type ()
            (cl:coerce cl:pi ',underlying-type))))
@@ -687,27 +687,13 @@ The fields are defined as follows:
 (%define-integer-expt-instance Ifix) 
 (%define-integer-expt-instance Ufix) 
 
-(coalton-toplevel
-  (define-instance (Into Integer String)
-    (define (into z)
-      (lisp String (z)
-        (cl:format cl:nil "~D" z))))
-
-  (define-instance (TryInto String Integer)
-    (define (tryInto s)
-      (lisp (Result String Integer) (s)
-        (cl:let ((z (cl:ignore-errors (cl:parse-integer s))))
-          (cl:if (cl:null z)
-                 (Err "String doesn't have integer syntax.")
-                 (Ok z)))))))
-
 ;;;; `Bits' instances
 ;;; signed
 
 (cl:defmacro define-signed-bit-instance (type handle-overflow)
   (cl:flet ((lisp-binop (op)
               `(lisp ,type (left right)
-                     (,op left right))))
+                 (,op left right))))
     `(coalton-toplevel
        (define-instance (bits:Bits ,type)
          (define (bits:and left right)
@@ -749,19 +735,19 @@ The fields are defined as follows:
 (cl:defmacro define-unsigned-bit-instance (type width)
   (cl:flet ((define-binop (coalton-name lisp-name)
               `(define (,coalton-name left right)
-                   (lisp ,type (left right)
-                         (,lisp-name left right)))))
+                 (lisp ,type (left right)
+                   (,lisp-name left right)))))
     `(coalton-toplevel
-      (define-instance (bits:Bits ,type)
-        ,(define-binop 'bits:and 'cl:logand)
-        ,(define-binop 'bits:or 'cl:logior)
-        ,(define-binop 'bits:xor 'cl:logxor)
-        (define (bits:not bits)
-            (lisp ,type (bits) (unsigned-lognot bits ,width)))
-        (define (bits:shift amount bits)
-            (lisp ,type (amount bits)
-                  (cl:logand (cl:ash bits amount)
-                             (cl:1- (cl:ash 1 ,width)))))))))
+       (define-instance (bits:Bits ,type)
+         ,(define-binop 'bits:and 'cl:logand)
+         ,(define-binop 'bits:or 'cl:logior)
+         ,(define-binop 'bits:xor 'cl:logxor)
+         (define (bits:not bits)
+           (lisp ,type (bits) (unsigned-lognot bits ,width)))
+         (define (bits:shift amount bits)
+           (lisp ,type (amount bits)
+             (cl:logand (cl:ash bits amount)
+                        (cl:1- (cl:ash 1 ,width)))))))))
 
 (define-unsigned-bit-instance U8 8)
 (define-unsigned-bit-instance U16 16)
@@ -920,4 +906,4 @@ Note: This does *not* divide double-float arguments."
     (/= x 0)))
 
 #+sb-package-locks
-(sb-ext:lock-package "COALTON-LIBRARY/ARITH")
+(sb-ext:lock-package "COALTON-LIBRARY/MATH/ARITH")

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -1,14 +1,14 @@
-;;;; Complex
+;;;; complex.lisp
 ;;;;
 ;;;; Complex numbers
 
-(coalton-library/utils:defstdlib-package #:coalton-library/complex
+(coalton-library/utils:defstdlib-package #:coalton-library/math/complex
     (:use #:coalton
           #:coalton-library/classes
-          #:coalton-library/arith
-          #:coalton-library/utils)
+          #:coalton-library/utils
+          #:coalton-library/math/arith)
   (:local-nicknames
-   (#:arith #:coalton-library/arith))
+   (#:arith #:coalton-library/math/arith))
   (:export
    #:complex
    #:real-part
@@ -20,7 +20,7 @@
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
 
-(in-package #:coalton-library/complex)
+(in-package #:coalton-library/math/complex)
 
 (coalton-toplevel
   (repr :native (cl:or cl:number complex))
@@ -219,3 +219,6 @@
 
   (%define-builtin-complex-float-instances Single-Float)
   (%define-builtin-complex-float-instances Double-Float))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/MATH/COMPLEX")

--- a/library/math/integral.lisp
+++ b/library/math/integral.lisp
@@ -2,12 +2,12 @@
 ;;;;
 ;;;; Integral domains and operations on integers
 
-(coalton-library/utils::defstdlib-package #:coalton-library/integral
+(coalton-library/utils::defstdlib-package #:coalton-library/math/integral
     (:use
      #:coalton
      #:coalton-library/classes
      #:coalton-library/builtin
-     #:coalton-library/arith)
+     #:coalton-library/math/arith)
   (:import-from
    #:coalton-library/bits
    #:Bits)
@@ -33,7 +33,7 @@
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
 
-(in-package #:coalton-library/integral)
+(in-package #:coalton-library/math/integral)
 
 (coalton-toplevel
   (define-class (Num :a => Remainder :a)
@@ -264,4 +264,4 @@ are floored and truncated division, respectively."
 (%define-native-expt Double-Float)
 
 #+sb-package-locks
-(sb-ext:lock-package "COALTON-LIBRARY/INTEGRAL")
+(sb-ext:lock-package "COALTON-LIBRARY/MATH/INTEGRAL")

--- a/library/prelude.lisp
+++ b/library/prelude.lisp
@@ -1,3 +1,13 @@
+;;;; prelude.lisp
+;;;;
+;;;; Collections of packages
+
+(uiop:define-package #:coalton-library/math
+  (:use-reexport
+   #:coalton-library/math/arith
+   #:coalton-library/math/integral
+   #:coalton-library/math/complex))
+
 (uiop:define-package #:coalton-prelude
   (:use-reexport
    #:coalton-library/classes
@@ -5,7 +15,7 @@
    #:coalton-library/functions)
 
   (:import-from
-   #:coalton-library/arith
+   #:coalton-library/math/arith
    #:Dividable #:/
    #:Fraction
    #:negate
@@ -29,7 +39,7 @@
    #:1-)
 
   (:import-from
-   #:coalton-library/complex
+   #:coalton-library/math/complex
    #:Complex
    #:real-part
    #:imag-part)
@@ -39,7 +49,7 @@
    #:imag-part)
 
   (:import-from
-   #:coalton-library/integral
+   #:coalton-library/math/integral
    #:Integral
    #:^
    #:^^
@@ -176,9 +186,7 @@
    #:coalton-prelude)
   (:local-nicknames
    (#:bits #:coalton-library/bits)
-   (#:arith #:coalton-library/arith)
-   (#:complex #:coalton-library/complex)
-   (#:integral #:coalton-library/integral)
+   (#:math #:coalton-library/math)
    (#:char #:coalton-library/char)
    (#:string #:coalton-library/string)
    (#:tuple #:coalton-library/tuple)
@@ -197,3 +205,6 @@
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-PRELUDE")
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/MATH")

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -122,7 +122,20 @@ does not have that suffix."
       (lisp String (lst)
         (cl:coerce lst 'cl:string))))
 
-  (define-instance (Iso (List Char) String)))
+  (define-instance (Iso (List Char) String))
+
+  (define-instance (Into Integer String)
+    (define (into z)
+      (lisp String (z)
+        (cl:format cl:nil "~D" z))))
+
+  (define-instance (TryInto String Integer)
+    (define (tryInto s)
+      (lisp (Result String Integer) (s)
+        (cl:let ((z (cl:ignore-errors (cl:parse-integer s))))
+          (cl:if (cl:null z)
+                 (Err (concat "Cannot parse string as integer: " s))
+                 (Ok z)))))))
 
 (define-sxhash-hasher String)
 

--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -176,10 +176,10 @@ Returns (VALUES deferred-preds retained-preds defaultable-preds)"
   ;; Lookup class symbols if they exist. This allows defaulting to
   ;; work before the standard library is fully loaded
   (append (find-symbol? "NUM" "COALTON-LIBRARY/CLASSES")
-          (find-symbol? "QUANTIZABLE" "COALTON-LIBRARY/ARITH")
-          (find-symbol? "COMPLEX" "COALTON-LIBRARY/COMPLEX")
-          (find-symbol? "REMAINDER" "COALTON-LIBRARY/INTEGRAL")
-          (find-symbol? "INTEGRAL" "COALTON-LIBRARY/INTEGRAL")))
+          (find-symbol? "QUANTIZABLE" "COALTON-LIBRARY/MATH")
+          (find-symbol? "COMPLEX" "COALTON-LIBRARY/MATH")
+          (find-symbol? "REMAINDER" "COALTON-LIBRARY/MATH")
+          (find-symbol? "INTEGRAL" "COALTON-LIBRARY/MATH")))
 
 (defun default-preds (env tvars preds)
   (declare (type environment env)


### PR DESCRIPTION
Rationale:
- `arith.lisp` is getting quite large (I will be breaking it up further in a later PR).
-  Keeps mathematical code into one folder yet separate files
- Internally allows for managing some concept of dependencies, but gives a nice external interface as well

I'm open to naming the package whatever (e.g. `coalton-library/math`, `coalton-library/num`, `coalton-library/arith`). I went with numeric since things like `Functor` and `Semigroup` seem mathematical as well, but it has stuff beyond simple arithmetic.

I believe I remember hearing @eliaslfox  thinking about something like this, so let me know if I am in line with your plans.