### PR TITLE
Add a restart around the error if SB-MPFR failed to load

### DIFF
--- a/library/big-float/big-float.lisp
+++ b/library/big-float/big-float.lisp
@@ -36,10 +36,18 @@
 (in-package #:coalton-library/big-float)
 
 #-sbcl (error "This file is hopelessly SBCL specific.")
-#-sb-mpfr (error "SB-MPFR failed to load, for some reason. ~
-                  This is probably due to the shared library ~
-                  not existing, or the system being unable ~
-                  to find it.")
+#+sbcl
+cl-user::
+(eval-when (:compile-toplevel :load-toplevel)
+  (loop :until (uiop:featurep :sb-mpfr)
+        :do (restart-case (error "SB-MPFR failed to load, for some reason. ~
+                                  This is probably due to the shared library ~
+                                  not existing, or the system being unable ~
+                                  to find it.")
+              (reload-sb-mpfr ()
+                :report "Reload the MPFR library"
+                (handler-case (sb-mpfr::load-mpfr)
+                  (simple-warning (e) (declare (ignore e))))))))
 
 ;;; Preliminary patched functionality for SB-MPFR
 ;;;


### PR DESCRIPTION
Useful for interactive use: this provides me a way to see the error, go "crap, i forgot to
install MPFR," install it, and tell coalton "okay it's there now, look again."