### PR TITLE
Add math/real

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -123,6 +123,7 @@
                 :serial t
                 :components ((:file "arith")
                              (:file "integral")
+                             (:file "real")
                              (:file "complex")))
                (:file "char")
                (:file "string")

--- a/library/math/real.lisp
+++ b/library/math/real.lisp
@@ -1,0 +1,255 @@
+;;;; real.lisp
+;;;;
+;;;; Numbers that exist on the real number line
+
+(coalton-library/utils::defstdlib-package #:coalton-library/math/real
+    (:use
+     #:coalton
+     #:coalton-library/math/arith
+     #:coalton-library/math/integral
+     #:coalton-library/classes
+     #:coalton-library/functions)
+  (:export
+   #:Quantizable
+   #:proper
+   #:floor
+   #:ceiling
+   #:truncate
+   #:round
+   #:Real
+   #:real-approx
+   #:Rational
+   #:to-fraction
+   #:best-approx
+   #:Quantization
+   #:quantize
+   #:round-half-up
+   #:round-half-down
+   #:safe/
+   #:exact/
+   #:inexact/
+   #:floor/
+   #:ceiling/
+   #:round/
+   #:single/
+   #:double/))
+
+#+coalton-release
+(cl:declaim #.coalton-impl:*coalton-optimize-library*)
+
+(cl:in-package #:coalton-library/math/real)
+
+(coalton-toplevel
+  (define-class (Quantizable :a)
+    "The representation of a type that allows for rounding operations
+max x such that (floor x) <= x
+min x such that (ceiling x) <= x
+And (proper x) = (Tuple (truncate x) (- x (truncate x)))
+where (truncate x) = (* (sign x) (floor (abs x))
+"
+    (proper (:a -> (Tuple Integer :a)))
+    (floor (:a -> Integer))
+    (ceiling (:a -> Integer)))
+
+  (define-class ((Quantizable :a) (Num :a) => Real :a)
+    "A real number that can be approximated with abs(real-approx x - x) < 2^-n."
+    (real-approx (UFix -> :a -> Fraction)))
+
+  (define-class ((Real :a) (Ord :a) => Rational :a)
+    "Any number that can be exactly represented by a fraction, or is not finite.
+If a rational can be converted from a fraction it must satisfy:
+
+(into (to-fraction x)) = x
+(into (best-approx x)) = x
+
+Furthermore, best-approx returns the simplest fraction, and both functions may be partial.
+"
+    (to-fraction (:a -> Fraction))
+    (best-approx (:a -> Fraction)))
+
+  (declare truncate ((Quantizable :a) => :a -> Integer))
+  (define (truncate x)
+    "Returns the integer closest/equal to X that is within 0 and X."
+    (match (proper x)
+      ((Tuple t _) t)))
+
+  (declare round ((Quantizable :a) (Num :a) => :a -> Integer))
+  (define (round x)
+    "Return the nearest integer to X, with ties breaking towards even numbers."
+    (match (proper x)
+      ((Tuple n r)
+       (match (<=> (abs (floor r)) (abs (ceiling r)))
+         ;; Negative r
+         ((GT)
+          ;; r <=> -0.5
+          (let s = (+ (* 2 r) 1))
+          (match (<=> (abs (floor s)) (abs (ceiling s)))
+            ((LT) n)
+            ((GT) (- n 1))
+            ;; r = -0.5
+            ((EQ) (if (even? n)
+                      n
+                      (- n 1)))))
+         ;; Positive r
+         ((LT)
+          ;; r <=> 0.5
+          (let s = (- (* 2 r) 1))
+          (match (<=> (abs (floor s)) (abs (ceiling s)))
+            ((LT) (+ n 1))
+            ((GT) n)
+            ;; r = 0.5
+            ((EQ) (if (even? n)
+                      n
+                      (+ n 1)))))
+         ;; Zero r
+         ((EQ) n)))))
+
+  (define (rational-approx precision x)
+    "Implemention of `real-approx' for rationals."
+    ;; See figure 3 in https://doi.org/10.1145/142675.142726
+    (let epsilon = (^ (reciprocal 2) precision))
+    (when (== epsilon 0)
+      (return (to-fraction x)))
+    (let ((approximate-rec
+            (fn (e0 p0 q0 e1 p1 q1)
+              (cond
+                ((and (/= q1 0)
+                      (< (abs (- (/ (fromInt p1) (fromInt q1)) x)) epsilon))
+                 (mkFraction p1 q1))
+                ((/= 0 e1)
+                 (let r = (floor (/ e0 e1)))
+                 (approximate-rec e1 p1 q1
+                                  (- e0 (* (fromInt r) e1))
+                                  (- p0 (* r p1))
+                                  (- q0 (* r q1))))
+                (True (mkFraction p1 q1))))))
+      (approximate-rec x 0 1 -1 1 0))))
+
+(cl:defmacro %define-integer-roundings (coalton-type)
+  `(coalton-toplevel
+     (define-instance (Quantizable ,coalton-type)
+       (define (floor x) (fromInt (toInteger x)))
+       (define (ceiling x) (fromInt (toInteger x)))
+       (define (proper x)
+         (Tuple (fromInt (toInteger x)) 0)))
+
+     (define-instance (Real ,coalton-type)
+       (define (real-approx _ x) (fromInt (toInteger x))))
+
+     (define-instance (Rational ,coalton-type)
+       (define (to-fraction x) (fromint (tointeger x)))
+       (define (best-approx x) (fromint (tointeger x))))))
+
+(cl:dolist (ty '(U8 U32 U64 UFix I8 I32 I64 IFix Integer))
+  (cl:eval `(%define-integer-roundings ,ty)))
+
+(cl:defmacro %define-native-rationals (type)
+  (cl:let
+      ((round (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-ROUND"))))
+    `(coalton-toplevel
+       (define-instance (Quantizable ,type)
+         (define (floor q)
+           (lisp Integer (q)
+             (cl:nth-value 0 (cl:floor q))))
+         (define (ceiling q)
+           (lisp Integer (q)
+             (cl:nth-value 0 (cl:ceiling q))))
+         (define (proper q)
+           (lisp (Tuple Integer ,type) (q)
+             (cl:multiple-value-bind (n r)
+                 (cl:truncate q)
+               (Tuple n r)))))
+
+       (define-instance (Real ,type)
+         (define (real-approx prec x)
+           (rational-approx prec x)))
+
+       (define-instance (Rational ,type)
+         (define (to-fraction x)
+           (lisp Fraction (x)
+             (cl:rational x)))
+         (define (best-approx x)
+           (lisp Fraction (x)
+             (cl:rationalize x))))
+
+       (specialize round ,round (,type -> Integer))
+       (declare ,round (,type -> Integer))
+       (define (,round x)
+         (lisp Integer (x)
+           (cl:nth-value 0 (cl:round x)))))))
+
+(%define-native-rationals Fraction)
+(%define-native-rationals Single-Float)
+(%define-native-rationals Double-Float)
+
+(coalton-toplevel
+  (define-type (Quantization :a)
+    "Represents an integer quantization of `:a`.
+
+The fields are defined as follows:
+
+1. A value of type `:a`.
+2. The greatest integer less than or equal to a particular value.
+3. The remainder of this as a value of type `:a`.
+4. The least integer greater than or equal to a particular value.
+5. The remainder of this as a value of type `:a`.
+"
+    (Quantization :a Integer :a Integer :a))
+
+  (declare quantize (Real :a => (:a -> (Quantization :a))))
+  (define (quantize x)
+    "Given X, (QUANTIZE X) will return the least integer greater or equal to X,
+and the greatest integer less than or equal to X, along with their respective
+remainders expressed as values of type of X."
+    (let x-floor = (floor x))
+    (let x-ceiling = (ceiling x))
+    (let x-rem-floor = (- x (fromInt x-floor)))
+    (let x-rem-ceiling = (- x (fromInt x-ceiling)))
+    (Quantization x x-floor x-rem-floor x-ceiling x-rem-ceiling))
+
+  (declare round-half-up ((Quantizable :a) (Num :a) => :a -> INteger))
+  (define (round-half-up x)
+    "Return the nearest integer to X, with ties breaking toward positive infinity."
+    (ceiling/ (floor (* 2 x)) 2))
+
+  (declare round-half-down ((Quantizable :a) (Num :a) => :a -> INteger))
+  (define (round-half-down x)
+    "Return the nearest integer to X, with ties breaking toward positive infinity."
+    (floor/ (ceiling (* 2 x)) 2))
+
+  (declare safe/ ((Num :a) (Dividable :a :b) => (:a -> :a -> (Optional :b))))
+  (define (safe/ x y)
+    "Safely divide X by Y, returning None if Y is zero."
+    (if (== y 0)
+        None
+        (Some (general/ x y))))
+
+  (declare exact/ (Integer -> Integer -> Fraction))
+  (define (exact/ a b)
+    "Exactly divide two integers and produce a fraction."
+    (general/ a b))
+
+  (declare inexact/ (Integer -> Integer -> Double-Float))
+  (define (inexact/ a b)
+    "Compute the quotient of integers as a double-precision float.
+
+Note: This does *not* divide double-float arguments."
+    (general/ a b))
+
+  (declare floor/ (Integer -> Integer -> Integer))
+  (define (floor/ a b)
+    "Divide two integers and compute the floor of the quotient."
+    (floor (exact/ a b)))
+
+  (declare ceiling/ (Integer -> Integer -> Integer))
+  (define (ceiling/ a b)
+    "Divide two integers and compute the ceiling of the quotient."
+    (ceiling (exact/ a b)))
+
+  (declare round/ (Integer -> Integer -> Integer))
+  (define (round/ a b)
+    "Divide two integers and round the quotient."
+    (round (exact/ a b))))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/MATH/REAL")

--- a/library/prelude.lisp
+++ b/library/prelude.lisp
@@ -6,6 +6,7 @@
   (:use-reexport
    #:coalton-library/math/arith
    #:coalton-library/math/integral
+   #:coalton-library/math/real
    #:coalton-library/math/complex))
 
 (uiop:define-package #:coalton-prelude
@@ -21,9 +22,6 @@
    #:negate
    #:abs
    #:expt
-   #:floor
-   #:ceiling
-   #:round
    #:1+
    #:1-)
   (:export
@@ -32,11 +30,22 @@
    #:negate
    #:abs
    #:expt
+   #:1+
+   #:1-)
+
+  (:import-from
+   #:coalton-library/math/real
    #:floor
    #:ceiling
    #:round
-   #:1+
-   #:1-)
+   #:Real
+   #:Rational)
+  (:export
+   #:floor
+   #:ceiling
+   #:round
+   #:Real
+   #:Rational)
 
   (:import-from
    #:coalton-library/math/complex

--- a/tests/quantize-tests.lisp
+++ b/tests/quantize-tests.lisp
@@ -4,14 +4,32 @@
   (is (= 0 (coalton:coalton (coalton-prelude:floor 0.1))))
   (is (= 1 (coalton:coalton (coalton-prelude:ceiling 0.1))))
   (is (= 0 (coalton:coalton (coalton-prelude:round 0.1))))
-  
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-up 0.1))))
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-down 0.1))))
+  (is (= 0 (coalton:coalton (coalton-library/math:truncate 0.1))))
+
   (is (= -1 (coalton:coalton (coalton-prelude:floor -0.1))))
   (is (= 0 (coalton:coalton (coalton-prelude:ceiling -0.1))))
   (is (= 0 (coalton:coalton (coalton-prelude:round -0.1))))
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-up -0.1))))
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-down -0.1))))
+  (is (= 0 (coalton:coalton (coalton-library/math:truncate -0.1))))
   
   (is (= 0 (coalton:coalton (coalton-prelude:floor 0.0))))
   (is (= 0 (coalton:coalton (coalton-prelude:ceiling 0.0))))
   (is (= 0 (coalton:coalton (coalton-prelude:round 0.0))))
-  
-  (is (= 1 (coalton:coalton (coalton-prelude:round 0.5))))
-  (is (= 0 (coalton:coalton (coalton-prelude:round -0.5)))))
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-up 0.0))))
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-down 0.0))))
+  (is (= 0 (coalton:coalton (coalton-library/math:truncate 0.0))))
+
+  (is (= 1 (coalton:coalton (coalton-library/math:round-half-up 0.5))))
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-down 0.5))))
+  (is (= 0 (coalton:coalton (coalton-library/math:round-half-up -0.5))))
+  (is (= -1 (coalton:coalton (coalton-library/math:round-half-down -0.5))))
+
+  (is (= (cl:round 2.5) (coalton:coalton (coalton-prelude:round 2.5))))
+  (is (= (cl:round -2.5) (coalton:coalton (coalton-prelude:round -2.5))))
+  (is (= (cl:round 1.5) (coalton:coalton (coalton-prelude:round 1.5))))
+  (is (= (cl:round -1.5) (coalton:coalton (coalton-prelude:round -1.5))))
+  (is (= (cl:round 0.5) (coalton:coalton (coalton-prelude:round 0.5))))
+  (is (= (cl:round -0.5) (coalton:coalton (coalton-prelude:round -0.5)))))


### PR DESCRIPTION
Creates another math package Real containing rounding/approximation facilities for Real-ish numbers.

- Redefine Quantization
  - Rounding only requires a `cl:truncate` operation instead of a `cl:floor` and `cl:ceiling`
- Use closest even rounding for `round` as that is what `cl:round` does.
- Add Rational and Real class with approximation methods for floats and what not
  - Remove RealFloat

Relevant: #449
Replaces: #579 
Requires: #594 