### PR TITLE
Add matching to inline let constructs

### DIFF
--- a/src/language-macros.lisp
+++ b/src/language-macros.lisp
@@ -186,8 +186,12 @@ Coalton boolean."
                                   (cl:return-from process
                                     `(coalton::seq
                                       ,@(cl:reverse before-let)
-                                      (coalton:match  ,(cl:fourth form)
-                                        (,(cl:second form) ,(process (cl:nthcdr (cl:+ 1 (cl:length before-let)) forms))))))))
+                                      ,(cl:if (cl:symbolp (cl:second form))
+                                              `(coalton::bind ,(cl:second form) ,(cl:fourth form)
+                                                             ,(process (cl:nthcdr (cl:+ 1 (cl:length before-let)) forms)))
+                                              `(coalton:match ,(cl:fourth form)
+                                                 (,(cl:second form)
+                                                  ,(process (cl:nthcdr (cl:+ 1 (cl:length before-let)) forms)))))))))
                                (cl:t (cl:push form before-let)))))
 
                          ;; There was never a let generate a simple seq


### PR DESCRIPTION
This adds pattern matching support to coalton's inline `let` statements. I found this very useful when working with product types.

Example:
```lisp
(coalton 
  (progn
    (let t = (Tuple 1 2)) ; Normal bindings still work
    (let (Tuple a b) = t) ; Destructuring binding
    (+ a b)))
```

A few possible downsides:
- Incongruity between parenthesized `let` and inline `let`
- Only matches on a single case, so non-exhaustive for sum types:

```lisp
(coalton
  (progn
    (let l = (make-list))
    (let (Cons a b) = l)
    a)
```
results in
> Evaluation aborted on #<COMMON-LISP:SIMPLE-ERROR "Pattern match not exaustive error" {1009F4DD03}>.
