### PR TITLE
Prevent defaulting on invalid explicit types

### DIFF
--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -802,14 +802,13 @@ EXPL-DECLARATIONS is a HASH-TABLE from SYMBOL to SCHEME"
                                              (not (entail env expr-preds p)))
                                            (apply-substitution local-subs preds))))
 
-        ;; NOTE: This is where defaulting happens
-
-        (unless allow-deferred-predicates
-          (setf local-subs (compose-substitution-lists (default-subs env nil reduced-preds) local-subs))
-          (setf reduced-preds (apply-substitution local-subs reduced-preds)))
-
         (multiple-value-bind (deferred-preds retained-preds)
             (split-context env env-tvars local-tvars reduced-preds local-subs)
+
+          ;; NOTE: This is where defaulting happens
+
+          (unless allow-deferred-predicates
+            (setf local-subs (compose-substitution-lists (default-subs env nil reduced-preds) local-subs)))
 
           (with-type-context ("definition of ~A" (car binding))
             (when (and returns (not allow-returns))

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -86,6 +86,12 @@
      '((coalton:declare x :a)
        (coalton:define x coalton:Unit))))
 
+  ;; Missing explicit predicates cannot be defualted
+  (signals coalton-impl::coalton-type-error
+    (run-coalton-typechecker
+     '((coalton:declare x :a)
+       (coalton:define x 1))))
+
   ;; Implicitly typed functions should only infer types from the declared type signature of an explicitly typed functions
   ;; http://jeremymikkola.com/posts/2019_01_12_type_inference_for_haskell_part_12.html
   (check-coalton-types


### PR DESCRIPTION
Fixes
```
(coalton-toplevel
  (declare f (:a -> :a))
  (define (f x)
    (+ x 1)))

(coalton (f 1/2))
;; =>
;; The value
;;   1/2
;; is not of type
;;   INTEGER
;; when binding X-8196
```