### PR TITLE
Fix formatting in introductory document

### DIFF
--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -490,7 +490,7 @@ Flattened let expressions support pattern matching:
 
 Flattened let expression are non recursive, and do not support let polymorhpism. Thus the following is invalid:
 
-````
+```
 (coalton
   (progn
     (let id = (fn (x) x))


### PR DESCRIPTION
Found this while double-checking some syntax - this error causes the markdown parser to consider half of the document a code block, so it gets formatted poorly.