### PR TITLE
Add context clues to unification and print relevant source code

### DIFF
--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -4,12 +4,14 @@
 ;;; Type unification
 ;;;
 
-(defun unify (substs type1 type2)
+(defun unify (substs type1 type2 &optional desc1 desc2)
   "Unify TYPE1 and TYPE2 under given substitutions, returning an updated substitution list"
-  (with-type-context ("unification of types ~A and ~A" (apply-substitution substs type1) (apply-substitution substs type2))
-    (let ((new-substs (mgu (apply-substitution substs type1)
-                           (apply-substitution substs type2))))
-      (compose-substitution-lists new-substs substs))))
+  (let ((desc1 (if desc1 (format nil " (type of ~A)" desc1) ""))
+        (desc2 (if desc2 (format nil " (type of ~A)" desc2) "")))
+    (with-type-context ("unification of types ~A~A and ~A~A" (apply-substitution substs type1) desc1 (apply-substitution substs type2) desc2)
+      (let ((new-substs (mgu (apply-substitution substs type1)
+                             (apply-substitution substs type2))))
+        (compose-substitution-lists new-substs substs)))))
 
 (defgeneric mgu (type1 type2)
   (:documentation "Returns a SUBSTITUTION-LIST of the most general substitutions required to unify TYPE1 and TYPE2.")


### PR DESCRIPTION
This adds a few changes to the type checking machinery to provide context for type errors. More specifically, it adds the unparsed source code as a type context, and adds hits to unification errors to the origins of the types being unified. There's definitely some things that could be improved, but these were a few less invasive changes that I've found to improve debug-ability.