### PR TITLE
Keep error context in a separate stack

### DIFF
--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -216,7 +216,7 @@ Returns (VALUES type predicate-list typed-node subs)")
     (let ((tvar (make-variable)))
       (multiple-value-bind (ty preds typed-expr new-subs returns)
           (derive-expression-type (node-match-expr value) env subs)
-        (with-type-context ("match on ~A" (node-unparsed (node-match-expr value)))
+        (with-type-context ("match on ~W" (node-unparsed (node-match-expr value)))
           (multiple-value-bind (typed-branches match-preds new-subs new-returns)
               (derive-match-branches-type
                (make-function-type ty tvar)


### PR DESCRIPTION
This fixes a bug that prevents coalton type errors from containing more than `SB-KERNEL:*MAXIMUM-ERROR-DEPTH*` context frames. It does away with managing contexts by wrapping errors and replaces it with an explicit `*type-error-context-stack*`, which means we can have a virtually unlimited stack depth. This bug was technically in coalton for a while, but my recent addition of source contexts means it's more apparent.

Example code that would fail previously, but doesn't fail (meaning it gives a correct type error) with this patch:
```lisp
(in-package :coalton)

(cl:defun ex (depth)
  (cl:if (cl:zerop depth)
    "Base"
    `(match None ((None) None) ((Some _) ,(ex (cl:1- depth)))))

(cl:eval `(coalton ,(ex 20)))
```