### PR TITLE
Additions to standard library

### DIFF
--- a/library/cell.lisp
+++ b/library/cell.lisp
@@ -97,7 +97,7 @@
 
   (declare decrement! (Num :counter => (Cell :counter) -> :counter))
   (define (decrement! cel)
-    "Add one to the contents of CEL, storing and returning the new value"
+    "Subtract one from the contents of CEL, storing and returning the new value"
     (update! (- 1) cel))
 
   ;; i am very skeptical of these instances

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -26,6 +26,7 @@
    #:next!
    #:fold!
    #:empty
+   #:last!
    #:list-iter
    #:vector-iter
    #:string-chars
@@ -119,6 +120,11 @@ STATE, using INIT as the first STATE."
   (define empty
     "Yields nothing; stops immediately"
     (%Iterator (fn () None)))
+
+  (declare last! ((Iterator :a) -> (Optional :a)))
+  (define (last! iter)
+    "Yields the last element of ITER, completely consuming it."
+    (fold! (fn (s e) (Some e)) None iter))
   
   (declare list-iter ((List :elt) -> (Iterator :elt)))
   (define (list-iter lst)


### PR DESCRIPTION
Fixes a documentation error in `cell` and adds a new function to `iterator`