### PR TITLE
Fix some monorphizer edge cases

### DIFF
--- a/library/list.lisp
+++ b/library/list.lisp
@@ -522,14 +522,14 @@
               x xs)))))
 
   (declare maximum (Ord :a => ((List :a) -> (Optional :a))))
-  (define maximum
+  (define (maximum l)
     "Returns a greatest element of a list, or None."
-    (optimumBy >))
+    (optimumBy > l))
 
   (declare minimum (Ord :a => ((List :a) -> (Optional :a))))
-  (define minimum
+  (define (minimum l)
     "Returns a least element of a list, or None."
-    (optimumBy <))
+    (optimumBy < l))
 
   (declare sum (Num :a => ((List :a) -> :a)))
   (define (sum xs)

--- a/src/codegen/ast-subsitutions.lisp
+++ b/src/codegen/ast-subsitutions.lisp
@@ -34,6 +34,12 @@
              (values node))
     node)
 
+  (:method (subs (node node-lisp))
+    (declare (type ast-substitution-list subs)
+             (ignore subs)
+             (values node))
+    node)
+
   (:method (subs (node node-variable))
     (declare (type ast-substitution-list subs)
              (values node))

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -462,6 +462,12 @@ both CL namespaces appearing in NODE"
    (node-abstraction-vars node)
    (tc:apply-substitution subs (node-abstraction-subexpr node))))
 
+(defmethod tc:apply-substitution (subs (node node-bare-abstraction))
+  (node-bare-abstraction
+   (tc:apply-substitution subs (node-type node))
+   (node-bare-abstraction-vars node)
+   (tc:apply-substitution subs (node-bare-abstraction-subexpr node))))
+
 (defmethod tc:apply-substitution (subs (node node-let))
   (node-let
    (tc:apply-substitution subs (node-type node))


### PR DESCRIPTION


- Adds some substitution methods
  - `node-bare-abstraction` is hopefully straight foward
  - I can't imagine any substitutions should be taking place in `node-lisp`
- Does _not_ fix a bug where monomorphizing fails on over-application, just changes an instance of over-application in the standard library. https://github.com/coalton-lang/coalton/issues/624
- Fixes a rare case where hoisted variable would be called before it was defined when monomorphizing (`optimizer.lisp`)
  This one I am not so sure about. I don't know if it makes sense to monomorphize _after_ optimizing direct application - perhaps that defeats the purpose - but swapping the order of those does prevent invalid codegen from being generated.



You can reproduce these bugs by monomorphizing `generate-maform-output-with-double` in https://github.com/quil-lang/quilc/pull/819 on SBCL 2.2.5