### PR TITLE
draft interface for `Cycle` functor

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -138,6 +138,7 @@
                (:file "hashtable")
                (:file "monad/state")
                (:file "iterator")
+               (:file "cycle")
                (:file "system")
                (:file "prelude")))
 

--- a/library/cycle.lisp
+++ b/library/cycle.lisp
@@ -1,0 +1,71 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/cycle
+  (:use
+   #:coalton
+   #:coalton-library/classes
+   #:coalton-library/builtin)
+  (:export
+   #:Cycle
+   #:make-uninit
+   #:initialize
+   #:acyclic
+   #:make-cycle))
+(cl:in-package #:coalton-library/cycle)
+
+(cl:defstruct (%cycle (:constructor %make-cycle))
+  (initp cl:nil :type cl:boolean)
+  inner)
+#+(and sbcl coalton-release)
+(declaim (sb-ext:freeze-type %cycle))
+
+(coalton-toplevel
+  (repr :native %cycle)
+  (define-type (Cycle :t)
+    "Wrapper type for cyclical data.
+
+A circular list may be encoded as (Cycle (List :elt)).")
+
+  (declare cycle-init? ((Cycle :t) -> Boolean))
+  (define (cycle-init? cyc)
+    (lisp Boolean (cyc)
+      (%cycle-initp cyc)))
+
+  (declare cycle-inner ((Cycle :t) -> (Optional :t)))
+  (define (cycle-inner cyc)
+    (if (cycle-init? cyc)
+        (Some (lisp :t (cyc)
+                (%cycle-inner cyc)))
+        None))
+
+  (declare make-uninit (Unit -> (Cycle :t)))
+  (define (make-uninit)
+    (lisp (Cycle :t) ()
+      (%make-cycle)))
+
+  (declare initialize ((Cycle :t) -> :t -> (Cycle :t)))
+  (define (initialize cyc inner)
+    (lisp :any (inner cyc)
+      (cl:setf (%cycle-inner cyc) inner
+               (%cycle-initp cyc) cl:t))
+    cyc)
+  
+  (declare acyclic (:t -> (Cycle :t)))
+  (define (acyclic data)
+    (lisp (Cycle :t) (data)
+      (%make-cycle :initp cl:t
+                   :inner data)))
+
+  (declare make-cycle (((Cycle :t) -> :t) -> (Cycle :t)))
+  (define (make-cycle ctor)
+    (let cyc = (make-uninit))
+    (let data = (ctor cyc))
+    (initialize cyc data))
+
+  (define-instance (Functor Cycle)
+    (define (map f cyc)
+      (match (cycle-inner cyc)
+        ((None) (make-uninit))
+        ((Some inner) (acyclic (f inner))))))
+
+  (define-instance (Unwrappable Cycle)
+    (define (unwrap-or-else err cyc)
+      (unwrap-or-else err (cycle-inner cyc)))))

--- a/library/cycle.lisp
+++ b/library/cycle.lisp
@@ -15,7 +15,7 @@
   (initp cl:nil :type cl:boolean)
   inner)
 #+(and sbcl coalton-release)
-(declaim (sb-ext:freeze-type %cycle))
+(cl:declaim (sb-ext:freeze-type %cycle))
 
 (coalton-toplevel
   (repr :native %cycle)


### PR DESCRIPTION
Re #619: 

Here's a different way we could support cyclical data structures, inspired by Rust's [Arc::new_cyclic](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.new_cyclic). The short version is, define a functor `Cycle` which encodes circular data, so that a circular list is of type `(Cycle (List :elt))`. This is, IMO, ergonomically much worse than #620, since it requires added type annotations and `map` calls and whatnot. It might also perform worse, since `(Cycle :elt)` has to always allocate. On the other hand, this version doesn't require an optimization regression preventing the implicit `repr :transparent` of newtypes on release mode, and this version doesn't require adding `*print-circle*` support to our `print-object` methods, or introduce the potential to mistakenly try to map a function over a circular list.

Open questions:
- What operations do we need to define to make working with `Cycle` possible?
- Is it possible to define a map operation for `(Cycle (List :elt))` that produces a new circular list rather than looping infinitely?

I still personally prefer #620, but it seemed worth prototyping an alternative for the purposes of discussion.