### PR TITLE
`defparameter *coalton-stage-1-complete*`, not `defvar`

### DIFF
--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -41,7 +41,9 @@ Enable release mode either by setting the UNIX environment variable COALTON_ENV 
 
 ;; Set to t when base types are defined
 (declaim (type boolean *coalton-stage-1-complete*))
-(defvar *coalton-stage-1-complete* nil)
+;; this has to be a `defparameter', not a `defvar', or else re-loading coalton in an image where it's already
+;; been compiled once will fail.
+(defparameter *coalton-stage-1-complete* nil)
 
 (defvar *coalton-optimize* '(optimize (speed 3) (safety 0)))
 


### PR DESCRIPTION
using a `defvar` here breaks recompiling/reloading the library; if the library has already
been loaded once, then `*coalton-stage-1-complete*` has already been set to `T`. prior to
this change, `*coalton-stage-1-complete*` would not be reset when reloading settings.lisp,
and compiling the early parts of the library which violate the orphan rule by defining
instances on built-in types would fail.