### PR TITLE
Respect `*print-escape*`, print package names in instance codegen syms

### DIFF
--- a/src/ast/pattern.lisp
+++ b/src/ast/pattern.lisp
@@ -109,12 +109,16 @@
            (ignore colon-p at-sign-p)
            (values pattern))
   (etypecase pattern
-    (pattern-var (format stream "~A" (string (pattern-var-id pattern))))
-    (pattern-wildcard (format stream "_"))
-    (pattern-literal (format stream "~A" (pattern-literal-value pattern)))
-    (pattern-constructor (format stream "(~A~{ ~A~})"
-                                 (pattern-constructor-name pattern)
-                                 (pattern-constructor-patterns pattern))))
+    (pattern-var (write (pattern-var-id pattern) :stream stream))
+    (pattern-wildcard (write-char #\_ stream))
+    (pattern-literal (write (pattern-literal-value pattern) :stream stream))
+    (pattern-constructor
+     (write-char #\( stream)
+     (write (pattern-constructor-name pattern) :stream stream)
+     (loop :for pat :in (pattern-constructor-patterns pattern)
+           :do (write-char #\space stream)
+               (write pat :stream stream))
+     (write-char #\) stream)))
   pattern)
 
 (set-pprint-dispatch 'pattern 'pprint-pattern)

--- a/src/toplevel-define-instance.lisp
+++ b/src/toplevel-define-instance.lisp
@@ -28,7 +28,8 @@
                         package "INSTANCE/~A"
                         (with-output-to-string (s)
                           (with-pprint-variable-context ()
-                            (pprint-predicate s predicate)))))
+                            (let* ((*print-escape* t))
+                              (pprint-predicate s predicate))))))
 
                      (method-names (mapcar
                                     #'car
@@ -41,7 +42,7 @@
                                :do (setf (gethash method-name table)
                                          (alexandria:format-symbol
                                           package
-                                          "~A-~A"
+                                          "~A-~S"
                                           instance-codegen-sym
                                           method-name)))
                          table))

--- a/src/typechecker/kinds.lisp
+++ b/src/typechecker/kinds.lisp
@@ -239,6 +239,9 @@
 ;;; Pretty printing
 ;;;
 
+(defvar *coalton-print-unicode* t
+  "Whether to print coalton info using unicode symbols")
+
 (defun pprint-kind (stream kind &optional colon-p at-sign-p)
   (declare (type stream stream)
            (type kind kind)
@@ -247,25 +250,29 @@
            (values kind))
   (etypecase kind
     (kstar
-     (format stream "*"))
+     (write-char #\* stream))
     (kfun
      (let ((from (kfun-from kind))
            (to (kfun-to kind)))
        (when (kfun-p from)
-         (format stream "("))
+         (write-char #\( stream))
        (pprint-kind stream from)
        (when (kfun-p from)
-         (format stream ")"))
+         (write-char #\) stream))
 
-       (format stream " -> ")
+       (write-string (if *coalton-print-unicode*
+                         " → "
+                         " -> ")
+                     stream)
 
        (when (kfun-p to)
-         (format stream "("))
+         (write-char #\( stream))
        (pprint-kind stream to)
        (when (kfun-p to)
-         (format stream ")"))))
+         (write-char #\) stream))))
     (kvar
-     (format stream "#K~A" (kyvar-id (kvar-kyvar kind)))))
+     (write-string "#K" stream)
+     (write (kyvar-id (kvar-kyvar kind)) :stream stream)))
   kind)
 
 (set-pprint-dispatch 'kind 'pprint-kind)

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -139,9 +139,10 @@
            (ignore colon-p)
            (ignore at-sign-p)
            (values ty-predicate &optional))
-  (format stream "~S ~{~A~^ ~}"
-          (ty-predicate-class predicate)
-          (ty-predicate-types predicate))
+  (write (ty-predicate-class predicate) :stream stream)
+  (loop :for ty :in (ty-predicate-types predicate)
+        :do (write-char #\space stream)
+            (write ty :stream stream))
   predicate)
 
 (set-pprint-dispatch 'ty-predicate 'pprint-predicate)
@@ -152,25 +153,27 @@
            (ignore at-sign-p))
   (cond
     ((= 0 (length (qualified-ty-predicates qualified-ty)))
-     (format stream "~A" (qualified-ty-type qualified-ty)))
+     (write (qualified-ty-type qualified-ty) :stream stream))
 
     ((= 1 (length (qualified-ty-predicates qualified-ty)))
-     (format stream "~A" (first (qualified-ty-predicates qualified-ty)))
+     (write (first (qualified-ty-predicates qualified-ty))
+            :stream stream)
      (write-string (if *coalton-print-unicode*
                           " ⇒ "
                           " => ")
                    stream)
-     (format stream "~A" (qualified-ty-type qualified-ty)))
+     (write (qualified-ty-type qualified-ty)
+            :stream stream))
     (t
      (dolist (pred (qualified-ty-predicates qualified-ty))
        (write-string "(" stream)
-       (format stream "~A" pred)
+       (write pred :stream stream)
        (write-string ") " stream))
      (write-string (if *coalton-print-unicode*
                           "⇒ "
                           "=> ")
                    stream)
-     (format stream "~A" (qualified-ty-type qualified-ty))))
+     (write (qualified-ty-type qualified-ty) :stream stream)))
   nil)
 
 (set-pprint-dispatch 'qualified-ty 'pprint-qualified-ty)

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -104,17 +104,21 @@
            (values ty-scheme))
   (cond
     ((null (ty-scheme-kinds scheme))
-     (format stream "~A" (ty-scheme-type scheme)))
+     (write (ty-scheme-type scheme) :stream stream))
     (t
      (with-pprint-variable-scope ()
        (let* ((types (mapcar (lambda (k) (next-pprint-variable-as-tvar k))
                              (ty-scheme-kinds scheme)))
               (new-type (instantiate types (ty-scheme-type scheme))))
-         (format stream "~A~{ ~A~}. ~A"
-                 (if *coalton-print-unicode*
-                     "∀"
-                     "FORALL")
-                 types new-type)))
+         (write-string (if *coalton-print-unicode*
+                           "∀"
+                           "FORALL")
+                       stream)
+         (loop :for ty :in types
+               :do (write-char #\space stream)
+                   (write ty :stream stream))
+         (write-string ". " stream)
+         (write new-type :stream stream)))
      ))
   scheme)
 

--- a/src/typechecker/substitutions.lisp
+++ b/src/typechecker/substitutions.lisp
@@ -75,9 +75,10 @@
 (defun pprint-substution (stream sub &optional colon-p at-sign-p)
   (declare (ignore colon-p)
            (ignore at-sign-p))
-  (format stream "#T~a" (tyvar-id (substitution-from sub)))
-  (format stream " +-> ")
-  (format stream "~a" (substitution-to sub))
+  (write-string "#T" stream)
+  (write (tyvar-id (substitution-from sub)) :stream stream)
+  (write-string " +-> " stream)
+  (write (substitution-to sub) :stream stream)
   nil)
 
 (set-pprint-dispatch 'substitution 'pprint-substution)

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -346,9 +346,6 @@
 ;;; Pretty printing
 ;;;
 
-(defvar *coalton-print-unicode* t
-  "Whether to print coalton info using unicode symbols")
-
 (defvar *coalton-pretty-print-tyvars* nil
   "Whether to print all tyvars using type variable syntax
 
@@ -365,9 +362,11 @@ This requires a valid PPRINT-VARIABLE-CONTEXT")
      (if *coalton-pretty-print-tyvars*
          ;; Print the tvar using the current printing context. Requires use of PPRINT-VARIABLE-CONTEXT
          (pprint-ty stream (pprint-tvar ty))
-         (format stream "#T~A" (tyvar-id (tvar-tyvar ty)))))
+         (progn
+           (write-string "#T" stream)
+           (write (tyvar-id (tvar-tyvar ty)) :stream stream))))
     (tcon
-     (format stream "~A" (tycon-name (tcon-tycon ty))))
+     (write (tycon-name (tcon-tycon ty)) :stream stream))
     (tapp
      (cond
        ((function-type-p ty) ;; Print function types
@@ -413,7 +412,8 @@ This requires a valid PPRINT-VARIABLE-CONTEXT")
              (pprint-ty stream (tapp-to ty))
              (write-string ")" stream)))))))
     (tgen
-     (format stream "#GEN~A" (tgen-id ty))))
+     (write-string "#GEN" stream)
+     (write (tgen-id ty) :stream stream)))
   ty)
 
 (set-pprint-dispatch 'ty 'pprint-ty)


### PR DESCRIPTION
EDIT: This PR rewrites all the various `pprint-*` functions on Coalton internal data structures to recurse using `write` instead of `format _ "~A"`. This way, printing those objects respects the printer control variables like `*print-escape*`. Now, if you format a `ty` with `~S`, you'll see package names, whereas if you format one with `~A`, you'll get the same output as before.

The impetus for this change was my detecting a codegen bug where instance codegen syms included the name but not the package of the types to which they applied, so `(Into foo:Foo bar:Foo)` and `(Into bar:Foo foo:Foo)` got the same codegen symbol. Now, instance codegen symbols are generated with `*print-escape*` bound to `t`, so the package names are included, and there is no conflict.

OLD MESSAGE: Prior to this commit, `pprint-predicate` (called when generating codegen symbols for
instance definitions) printed type names with `~A` rather than `~S`, i.e. it discarded the
package component and printed only the `symbol-name`. This caused a bug where I had two
types with the same name by `string=` defined in different packages, and I wanted to
define instances for `(Into foo:Foo bar:Foo)` and `(Into bar:Foo foo:Foo)`; these
instances generated the same codegen symbols.

With this change, packages are encoded in instance names, so it's now possible for `(Into
foo:Foo bar:Foo)` and `(Into bar:Foo foo:Foo)` to coexist.