### PR TITLE
Reimplement global lexical variables with an explicit environment.

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -20,7 +20,6 @@
                           #+sbcl (sb-ext:*block-compile-default* :specified))
                       (funcall compile)))
   :depends-on (#:alexandria
-               #:global-vars
                #:trivia
                #:fset
                #:float-features

--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -9,8 +9,9 @@
 ;;; be generated at macroexpansion time of the ambient Common Lisp
 ;;; compiler. See the COALTON macro.
 
-(define-global-var **repr-specifiers** '(:lisp :transparent :native :enum)
-  "(repr ...) specifiers that the compiler is known to understand.")
+(alexandria:define-constant **repr-specifiers** '(:lisp :transparent :native :enum)
+  :test #'equal
+  :documentation "(repr ...) specifiers that the compiler is known to understand.")
 
 (defmacro install-operator-metadata (&rest directives)
   "Associate metadata with symbols as described by DIRECTIVES.

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -449,9 +449,6 @@
         #:coalton-impl/algorithm
         #:coalton-impl/ast
         #:coalton-impl/typechecker)
-  (:import-from #:global-vars
-                #:define-global-var
-                #:define-global-var*)
   (:local-nicknames
    (#:tc #:coalton-impl/typechecker))
   ;; settings


### PR DESCRIPTION
This has the following advantages:

* The Coalton top level environment for variable bindings is now a
distinct object that does not have to rely on the Lisp global
environment. This means that with more work we can choose not to
pollute the Lisp environment with Coalton value bindings at all. It
also leads to the possibility of rebinding the environment when
compiling to allow for first class environment manipulation, e.g.
compiling code in different environments.

* Performance of lexical variable access is not tied to whether the
underlying Lisp implementation has something like DEFGLOBAL, i.e. we
get fast lexical access even if variable references are dynamic in the
underlying Lisp implementation. For SBCL, this means that variable
references are just as fast as before. For other implementations, this
is a potentially huge increase in speed, as now a variable reference
is essentially just a memory load.

Consider the following snippet of code:

```
(coalton-toplevel
  (define a 3))

(cl:defun f () (coalton a))
```

Before, the code on SBCL for #'f looked like:
```
> (cl:disassemble #'f)

; disassembly for F
; Size: 27 bytes. Origin: #x53AD2D4C                          ; F
; 4C:       498B4510         MOV RAX, [R13+16]                ; thread.binding-stack-pointer
; 50:       488945F8         MOV [RBP-8], RAX
; 54:       488B05C5FFFFFF   MOV RAX, [RIP-59]                ; 'COALTON-GLOBAL-SYMBOLS::|(lexical) COALTON-USER::A|
; 5B:       488B5001         MOV RDX, [RAX+1]
; 5F:       488BE5           MOV RSP, RBP
; 62:       F8               CLC
; 63:       5D               POP RBP
; 64:       C3               RET
; 65:       CC10             INT3 16                          ; Invalid argument count trap

```

Now, the disassembly looks like:

```
> (cl:disassemble #'f)

; disassembly for F
; Size: 27 bytes. Origin: #x53CFEF1C                          ; F
; 1C:       498B4510         MOV RAX, [R13+16]                ; thread.binding-stack-pointer
; 20:       488945F8         MOV [RBP-8], RAX
; 24:       488B05C5FFFFFF   MOV RAX, [RIP-59]                ; '(3 . A)
; 2B:       488B50F9         MOV RDX, [RAX-7]
; 2F:       488BE5           MOV RSP, RBP
; 32:       F8               CLC
; 33:       5D               POP RBP
; 34:       C3               RET
; 35:       CC10             INT3 16                          ; Invalid argument count trap
```

You can see the new code is just as fast despite the environment being
explicit. We can also do away with the global-var asd system
dependency now.