### PR TITLE
Add `progn` form to toplevel

### DIFF
--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -83,7 +83,15 @@ in FORMS that begin with that operator."
          (handle-monomorphize (definition-name)
            (push :monomorphize (gethash definition-name (getf plist 'attr-table))))
 
+         (expand-progn (forms)
+           (loop :for form :in forms
+                 :if (eql (operator form) 'coalton:progn)
+                   :nconc (expand-progn (cdr form))
+                 :else
+                   :nconc (list form))) 
+
          (walk (forms)
+           (setf forms (expand-progn forms))
            (loop
              :until (null forms)
              :for form := (pop forms)


### PR DESCRIPTION
This adds a `progn` form to the toplevel, which is allows for writing macros that generate several toplevel forms