### PR TITLE
 Use jump tables to eliminate under- and over-application overhead. 

### DIFF
--- a/src/codegen/codegen-class.lisp
+++ b/src/codegen/codegen-class.lisp
@@ -11,7 +11,6 @@
    #:lisp-type)
   (:import-from
    #:coalton-impl/codegen/function-entry
-   #:apply-function-entry
    #:construct-function-entry)
   (:local-nicknames
    (#:tc #:coalton-impl/typechecker))

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -41,7 +41,7 @@
     (let* ((arity (length (node-application-rands node)))
 
            (function-applicator
-             (gethash arity *function-application-functions*)))
+             (aref *function-application-functions* arity)))
 
       `(,function-applicator
         ,(codegen-expression (node-application-rator node) current-function env)
@@ -67,7 +67,7 @@
            (arity (length var-names))
 
            (function-constructor
-             (gethash arity *function-constructor-functions*))
+             (aref *function-constructor-functions* arity))
 
            (type-decs
              (when coalton-impl:*emit-type-annotations*
@@ -197,7 +197,7 @@
               (find name (node-variables (node-bind-body expr) :variable-namespace-only t)))
          (let* ((arity (length (node-abstraction-vars (node-bind-expr expr))))
 
-                (function-constructor (gethash arity *function-constructor-functions*)))
+                (function-constructor (aref *function-constructor-functions* arity)))
            `(let ((,name))
               (declare (ignorable ,name))
               (labels ((,name
@@ -251,7 +251,7 @@
                     (append
                      (loop :for (name . node) :in scc-bindings
                            :for arity := (length (node-abstraction-vars node))
-                           :for function-constructor := (gethash arity *function-constructor-functions*)
+                           :for function-constructor := (aref *function-constructor-functions* arity)
                            :if (find name binding-names-vars :test #'equalp)
                              :collect `(setf
                                         ,name

--- a/src/codegen/function-entry.lisp
+++ b/src/codegen/function-entry.lisp
@@ -5,10 +5,7 @@
   (:export
    #:*function-constructor-functions*
    #:*function-application-functions*
-   #:construct-function-entry
-   #:apply-function-entry
-   #:f1 #:f2 #:f3 #:f4 #:f5 #:f6 #:f7 #:f8 #:f9
-   #:a1 #:a2 #:a3 #:a4 #:a5 #:a6 #:a7 #:a8 #:a9))
+   #:construct-function-entry))
 
 (in-package #:coalton-impl/codegen/function-entry)
 
@@ -103,11 +100,3 @@ NOTE: There is no FUNCTION-ENTRY for arity 1 and the function will be returned"
          (unless function-constructor
            (error "Unable to construct function of arity ~A" arity))
          `(,function-constructor ,function)))
-
-(defun apply-function-entry (function &rest args)
-"Apply a function (OR FUNCTION-ENTRY FUNCTION) constructed by coalton"
-(let* ((arity (length args))
-       (function-application (aref *function-application-functions* arity)))
-  (unless function-application
-    (error "Unable to apply function of arity ~A" arity))
-  `(,function-application ,function ,@args)))

--- a/src/codegen/function-entry.lisp
+++ b/src/codegen/function-entry.lisp
@@ -14,14 +14,12 @@
 
 (defconstant function-arity-limit 50)
 
-;; We need to evaluate this early so the macro below can inline calls
-(eval-when (:load-toplevel)
-  (defstruct function-entry
+(defstruct function-entry
     (arity    (required 'arity)    :type fixnum   :read-only t)
     (function (required 'function) :type function :read-only t)
     (curried  (required 'curried)  :type function :read-only t))
-  #+sbcl
-  (declaim (sb-ext:freeze-type function-entry)))
+#+sbcl
+(declaim (sb-ext:freeze-type function-entry))
 
 (defvar *function-constructor-functions* (make-array function-arity-limit))
 (defvar *function-application-functions* (make-array function-arity-limit))

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -8,8 +8,7 @@
    #:lisp-type)
   (:import-from
    #:coalton-impl/codegen/function-entry
-   #:construct-function-entry
-   #:apply-function-entry)
+   #:construct-function-entry)
   (:import-from
    #:coalton-impl/codegen/compile-expression
    #:compile-toplevel)


### PR DESCRIPTION
Before this change, if we partially apply a function entry object
`f` (representing a first class Coalton function use) of arity `N` with
`M` (< `N`) arguments, this partial application is done by calling a
nested Lisp lambda repeatedly. This means we currently end up having
to do `M` function calls and `M` closure environment allocations to
unpeel each layer of nesting. The resulting closure, `f_p`, when
supplied with the remaining `M - N` arguments, still has to partially
apply away the arguments one-by-one. The only time the saturation
optimization kicks in at the moment is when the original function
entry object `f` is supplied all of its arguments, and is never used
for the intermediate partially applied functions. The same applies for
an over-saturated function call: Closures are applied and created one
by one for each argument.

This change avoids the unpeeling altogether by modifying the
`FUNCTION-ENTRY` structure to contain entry points for each possible
argument count (in esssence a jump table), ditching the direct use of
Lisp lambdas. We now no longer allocate any more extra closures than
are ever explicitly created by functional partial applications, and
partially evaluated functions are now also eligible to be
saturated. Unlike the old way, there is no asymmetry with respect to
the optimizations applicable to partially evaluated functions and
functions defined elsehow.

To achieve this, we create a function entry object on every under- or
over- application, instead of specially-handled nested Lisp
closures. Because the jump table used for currying is stored as a
load-time constant with `LOAD-TIME-VALUE`, the overhead for creating a
function entry object consists of consing the structure and setting
the fields, which is a constant time overhead similar to that of
allocating a closure environment. Hence, this is pretty much a strict
improvement over the old way of doing things, while being much more
efficient for a larger number of arguments. Overapplication is also
more efficient because we saturate the function all at once with the
arity information stored in the function entry object before doing the
normal application dispatch via the jump table.

`FUNCTION-ARITY-LIMIT` was lowered a tiny bit to make SBCL not barf on
the large block compilation.

Fixes https://github.com/coalton-lang/coalton/issues/631, https://github.com/coalton-lang/coalton/issues/632.