### PR TITLE
Friendly interface for calling Coalton function-entry objects from CL

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -258,4 +258,5 @@
                (:file "quantize-tests")
                (:file "hashtable-tests")
                (:file "iterator-tests")
-               (:file "addressable-tests")))
+               (:file "addressable-tests")
+               (:file "call-coalton-from-lisp")))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -439,6 +439,19 @@
    #:*coalton-print-unicode*
    #:*coalton-pretty-print-tyvars*))
 
+(defpackage #:coalton-impl/codegen/function-entry
+  (:use
+   #:cl
+   #:coalton-impl/util)
+  (:export
+   #:*function-constructor-functions*
+   #:*function-application-functions*
+   #:construct-function-entry
+   #:call-coalton-function
+   #:too-many-arguments-to-coalton-function
+   #:too-many-arguments-function
+   #:too-many-arguments-count
+   #:too-many-arguments-arguments))
 
 (defpackage #:coalton-impl
     (:documentation "Implementation and runtime for COALTON. This is a package private to the COALTON system and is not intended for public use.")
@@ -503,6 +516,11 @@
    #:in-package)
   (:export
    #:in-package)
+
+  (:import-from
+   #:coalton-impl/codegen/function-entry
+   #:call-coalton-function)
+  (:export #:call-coalton-function)
 
   (:export
    #:coalton-toplevel

--- a/tests/call-coalton-from-lisp.lisp
+++ b/tests/call-coalton-from-lisp.lisp
@@ -1,0 +1,15 @@
+(in-package #:coalton-tests)
+
+(deftest call-coalton-from-lisp ()
+  (let ((coalton+ (coalton:coalton (coalton:fn (a b)
+                                      ;; force this function to be of non-parametric type, so it doesn't get
+                                      ;; extra instance args injected
+                                      (coalton-prelude:+ (coalton:the coalton:UFix a)
+                                                         (coalton:the coalton:UFix b))))))
+    (is (typep coalton+ 'coalton-impl/codegen/function-entry::function-entry))
+    (is (= (coalton-impl/codegen/function-entry::function-entry-arity coalton+)
+           2))
+    (is (= 3 (coalton:call-coalton-function coalton+ 1 2)))
+    (is (= 3 (apply #'coalton:call-coalton-function coalton+ '(1 2))))
+    (signals coalton-impl/codegen/function-entry:too-many-arguments-to-coalton-function
+      (apply #'coalton:call-coalton-function coalton+ (loop :for i :below 100 :collect i)))))


### PR DESCRIPTION
Define a CL function `call-coalton-function`, exported from the `COALTON` package, with an interface like `cl:funcall`, but for applying `function-entry` objects from CL code. That function checks its argument count against `function-arity-limit` and, if necessary, signals an error of class `too-many-arguments-to-coalton-function`. For efficiency's sake, a compiler macro on `call-coalton-function` moves the argument count checking and application-function lookup to compile-time, with the compiler macro expanding into a direct call to the appropriate entry in `*function-application-arguments*`.

Probably wise to do:
[ ] Rewrite any parts of the library that directly use `A1...A9` to instead use `call-coalton-function`.
[ ] Un-export `A1...A9` and tell people to use `call-coalton-function` instead.
[ ] Add a section to the Coalton-Lisp interop docs describing `call-coalton-function`.