### PR TITLE
Fix bug in cell implementation

### DIFF
--- a/library/cell.lisp
+++ b/library/cell.lisp
@@ -99,7 +99,7 @@
   (declare decrement! (Num :counter => (Cell :counter) -> :counter))
   (define (decrement! cel)
     "Subtract one from the contents of CEL, storing and returning the new value"
-    (update! (- 1) cel))
+    (update! (+ -1) cel))
 
   ;; i am very skeptical of these instances
   (define-instance (Eq :a => Eq (Cell :a))


### PR DESCRIPTION
Currently, `cell:decrement` doesn't work: the problem is an issue with the semantics of `(- 1)`, which is equivalent to `(fn (x) (- 1 x))`, not `(fn (x) (- x 1))`, which is what was intended.