### PR TITLE
`make-vector` and `make-hash-table` macros

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -109,7 +109,8 @@
                       (funcall compile)))
   :depends-on (#:coalton/compiler
                #:coalton/hashtable-shim
-               #:trivial-garbage)
+               #:trivial-garbage
+               #:alexandria)
   :pathname "library/"
   :serial t
   :components ((:file "utils")

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -34,7 +34,8 @@
    #:swap-remove!
    #:swap-remove-unsafe!
    #:sort!
-   #:sort-by!))
+   #:sort-by!
+   #:make))
 
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
@@ -307,6 +308,16 @@
 
   (define-instance (addr:Addressable (Vector :elt))
     (define addr:eq? addr::unsafe-internal-eq?)))
+
+(cl:defmacro make (cl:&rest elements)
+  "Construct a `Vector' containing the ELEMENTS, in the order listed."
+  (cl:let* ((length (cl:length elements))
+            (vec (cl:gensym "VEC-")))
+    `(progn
+      (let ,vec = (with-capacity ,length))
+      ,@(cl:loop :for elt :in elements
+           :collect `(push! ,elt ,vec))
+      ,vec)))
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/VECTOR")

--- a/tests/hashtable-tests.lisp
+++ b/tests/hashtable-tests.lisp
@@ -18,3 +18,48 @@
       (hashtable:remove! ht "zero")
       (is (isNone (get "zero")))
       (is (== 3 (hashtable:count ht))))))
+
+(define-test hashtable-constructor-equivalencies ()
+  (let ht-eq? = (fn (ht-a ht-b)
+                  (== (hashtable:entries ht-a)
+                      (hashtable:entries ht-b))))
+  (let ht = (hashtable:new))
+  (hashtable:set! ht "zero" 0)
+  (hashtable:set! ht "one" 1)
+  (hashtable:set! ht "two" 2)
+  (hashtable:set! ht "three" 3)
+  (is (ht-eq? ht
+              (hashtable:make ("zero" 0)
+                              ("one" 1)
+                              ("two" 2)
+                              ("three" 3))))
+  (is (ht-eq? ht
+              (let ((zero "zero")
+                    (one "one")
+                    (two "two")
+                    (three "three"))
+                (hashtable:make (zero 0)
+                                (one 1)
+                                (two 2)
+                                (three 3))))))
+
+(cl:in-package #:coalton-tests)
+
+(deftest hashtable-static-duplicate-keys ()
+  (signals coalton-library/hashtable::make-hash-table-static-duplicate-keys
+    (run-coalton-typechecker
+     '((coalton:define my-ht
+         (coalton-library/hashtable:make ("zero" 0)
+                                         ("one" 1)
+                                         ("two" 2)
+                                         ("zero" 3))))))
+  (signals coalton-library/hashtable::make-hash-table-static-duplicate-keys
+    (run-coalton-typechecker
+     '((coalton:define my-ht
+         (coalton:let ((zero "zero")
+                       (one "one")
+                       (two "two"))
+           (coalton-library/hashtable:make (zero 0)
+                                           (one 1)
+                                           (two 2)
+                                           (zero 3))))))))

--- a/tests/vector-tests.lisp
+++ b/tests/vector-tests.lisp
@@ -3,3 +3,12 @@
 ;; test that it's possible to treat a lisp `simple-vector' as a coalton `Vector'
 (define-test vector-length-on-non-adjustable ()
   (is (== 3 (vector:length (lisp (Vector UFix) () (cl:vector 0 1 2))))))
+
+(define-test vector-constructor-equivalencies ()
+  (let vec = (vector:with-capacity 10))
+  (iter:for-each! (flip vector:push! vec)
+                  (iter:up-to 10))
+  (is (== (vector:make 0 1 2 3 4 5 6 7 8 9)
+          vec))
+  (is (== (iter:collect-vector! (iter:up-to 10))
+          vec)))


### PR DESCRIPTION
re: #539 

including a little machinery for best-effort macroexpand-time detection of duplicate keys
in `make-hash-table`.

still necessary: docstrings and docs.

open for discussion: we *could* define that, if the same key appears twice in a
`make-hash-table` form, the latter value takes precedence. this seems stupid to me; i
believe statically-detectable duplicate keys in `make-hash-table` are always bugs, but i
mention it here because it's possible there's some use case i'm not thinking of. (macros
generating `make-hash-table` forms?)

note: `make-hash-table` does not do constant folding, it doesn't get a parsed ast, etc,
etc, so it can't detect all cases of duplicate keys, e.g. it misses `(let x =
a) (make-hash-table (x foo) (a bar))`. it's just a sanity check for the obvious cases.