### PR TITLE
reduce `function-arity-limit` to control compile-time heap usage

### DIFF
--- a/src/codegen/function-entry.lisp
+++ b/src/codegen/function-entry.lisp
@@ -1,6 +1,6 @@
 (in-package #:coalton-impl/codegen/function-entry)
 
-(defconstant function-arity-limit 45)
+(defconstant function-arity-limit 32)
 
 ;;; A FUNCTION-ENTRY represents a partially applicable function.
 (defstruct function-entry


### PR DESCRIPTION
an undocumented "not-user-facing" change in SBCL 2.2.6 increases heap usage for top-level
evaluation. that broke our CI builds, as the old large value of `function-arity-limit`
caused a heap overflow when compiling src/codegen/function-entry.lisp. this commit lowers
`function-arity-limit` to 32, which hopefully will fit in SBCL's default heap limit on the
CI runner.