### PR TITLE
use `cl:length` in `vector:length` rather than explicit `cl:fill-pointer`

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -260,4 +260,5 @@
                (:file "iterator-tests")
                (:file "addressable-tests")
                (:file "call-coalton-from-lisp")
+               (:file "vector-tests")
                (:file "recursive-let-tests")))

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -65,7 +65,7 @@
   (define (length v)
     "Returns the length of V"
     (lisp Integer (v)
-      (cl:fill-pointer v)))
+      (cl:length v)))
 
   (declare capacity (Vector :a -> Integer))
   (define (capacity v)

--- a/tests/vector-tests.lisp
+++ b/tests/vector-tests.lisp
@@ -1,0 +1,5 @@
+(cl:in-package #:coalton-native-tests)
+
+;; test that it's possible to treat a lisp `simple-vector' as a coalton `Vector'
+(define-test vector-length-on-non-adjustable ()
+  (is (== 3 (vector:length (lisp (Vector UFix) () (cl:vector 0 1 2))))))


### PR DESCRIPTION
for purposes of lisp-coalton interop, it is useful to allow the coalton `Vector` type to
include Common Lisp `simple-vector`, i.e. to not require that coalton `Vector`s have fill
pointers and be adjustable.

the `repr :native` of `Vector` already allowed this; it is `(vector t)`, not `(and (vector
t) (not simple-array))`. but `coalton-library/vector:length`, which is called by many
vector operators including `map`, read a vector's length using the less-generic
`cl:fill-pointer` rather than the more-generic `cl:length`.

`cl:length` does what you want when applied to a vector: for vectors with fill pointers,
it reads the fill pointer, and for vectors without a fill pointer, it reads the
capacity. `cl:fill-pointer`, in the second case, is a type error.

this commit redefines `coalton-library/vector:length` to call `cl:length`, so i can
meaningfully operate on simple vectors.