### PR TITLE
Remove implicit `Unit` from `when` and `unless`

### DIFF
--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -158,7 +158,8 @@
             (foreach2
              (fn (e1 e2)
                (unless (== e1 e2)
-                 (cell:write! out False)))
+                 (cell:write! out False)
+                 Unit))
              s1 s2)
             (cell:read out)))))
 

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -247,7 +247,8 @@
             (foreach2
              (fn (e1 e2)
                (unless (== e1 e2)
-                 (cell:write! out False)))
+                 (cell:write! out False)
+                 Unit))
              v1 v2)
             (cell:read out)))))
 

--- a/src/language-macros.lisp
+++ b/src/language-macros.lisp
@@ -9,17 +9,13 @@
 
 (cl:defmacro when (expr cl:&rest then)
   `(if ,expr
-       (progn
-        ,@then
-        Unit)
+       (progn ,@then)
        Unit))
 
 (cl:defmacro unless (expr cl:&rest then)
   `(if ,expr
        Unit
-       (progn
-        ,@then
-        Unit)))
+       (progn ,@then)))
 
 (cl:defmacro and (cl:&rest exprs)
   "A short-circuiting AND operator."


### PR DESCRIPTION
Currently, our implementations of `coalton:when` and `coalton:unless` do not execute their code in tail position. For example:

```lisp
(coalton
  (progn
    (let c = (cell:new 0))
    (let ((lp (fn (i)
                 (when (> i 0)
                   (cell:increment! c)
                   (lp (- i 1))))))
      (lp 100000)))) 
```

Gives a stack overflow, when other languages don't.

The reason is that we implicitly add a `Unit` form to the end each `when` and `unless` clause, which
breaks the tail positioning. Removing these means that tail recursion works, but it breaks some imperative code 
which relies on that type-checking to pass. I've fixed the relevant places in the stdlib which rely on it.