### PR TITLE
Portable `Big-Float`

### DIFF
--- a/benchmarks/big-float.lisp
+++ b/benchmarks/big-float.lisp
@@ -1,0 +1,101 @@
+;;;; big-float.lisp
+;;;;
+;;;; Benchmarks for arbitrary precision floats
+
+(cl:in-package #:coalton-benchmarks)
+
+(cl:defvar *big-float-bench-precision*
+  #-coalton-portable-bigfloat 10000
+  #+coalton-portable-bigfloat 100)
+(cl:defvar *big-float-bench-iterations*
+  #-coalton-portable-bigfloat 1000
+  #+coalton-portable-bigfloat 10)
+
+(define-benchmark big-trig ()
+  "Benchmark at N precision big-float trigonometric functions."
+  (declare (optimize speed))
+  (loop :repeat  *big-float-bench-iterations*
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native::big-trig
+               *big-float-bench-precision*
+               (* (- (random 2)) (random 100.0d0)))))
+  (report trivial-benchmark::*current-timer*))
+
+(define-benchmark big-inv-trig ()
+  "Benchmark at N precision big-float inverse trigonometric functions."
+  (declare (optimize speed))
+  (loop :repeat *big-float-bench-iterations*
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native::big-inv-trig
+               *big-float-bench-precision*
+               (* (- (random 2)) (random 1.0d0)))))
+  (report trivial-benchmark::*current-timer*))
+
+(define-benchmark big-ln-exp ()
+  "Benchmark at N precision big-float ln and exp."
+  (declare (optimize speed))
+  (loop :repeat *big-float-bench-iterations*
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native::big-ln-exp
+               *big-float-bench-precision*
+               (* (- (random 2)) (random 100.0d0)))))
+  (report trivial-benchmark::*current-timer*))
+
+(define-benchmark big-sqrt ()
+  "Benchmark at N precision big-float square roots."
+  (declare (optimize speed))
+  (loop :repeat *big-float-bench-iterations*
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native::big-sqrt
+               *big-float-bench-precision*
+               (random 100.0d0))))
+  (report trivial-benchmark::*current-timer*))
+
+(define-benchmark big-mult-constants ()
+  "Benchmark at N precision big-float multiplication of pi and euler's number."
+  (declare (optimize speed))
+  (loop :repeat *big-float-bench-iterations*
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native::big-sqrt
+               *big-float-bench-precision*
+               (* (- (random 2)) (random 100.0d0)))))
+  (report trivial-benchmark::*current-timer*))
+
+(cl:in-package #:coalton-benchmarks/native)
+
+(cl:declaim (cl:optimize (cl:speed 3) (cl:safety 1)))
+
+(coalton-toplevel
+  (declare big-trig (UFix -> Double-Float -> Big-Float))
+  (define (big-trig n x)
+    (with-precision n
+      (fn ()
+        (let x = (into x))
+        (tan (sin (cos x))))))
+
+  (declare big-inv-trig (UFix -> Double-Float -> Big-Float))
+  (define (big-inv-trig n x)
+    (with-precision n
+      (fn ()
+        (let x = (into x))
+        (atan (+ (asin x) (acos x))))))
+
+  (declare big-ln-exp (UFix -> Double-Float -> Big-Float))
+  (define (big-ln-exp n x)
+    (with-precision n
+      (fn ()
+        (let x = (into x))
+        (ln (exp x)))))
+
+  (declare big-sqrt (UFix -> Double-Float -> Big-Float))
+  (define (big-sqrt n x)
+    (with-precision n
+      (fn ()
+        (let x = (into x))
+        (sqrt x))))
+
+  (define (big-mult-constants n x)
+    (with-precision n
+      (fn ()
+        (let x = (into x))
+        (* x (* pi ee))))))

--- a/benchmarks/fibonacci.lisp
+++ b/benchmarks/fibonacci.lisp
@@ -1,0 +1,110 @@
+;;;; fibonacci.lisp
+;;;;
+;;;; Benchmarks for different methods of generating fibonacci numbers
+
+(cl:in-package #:coalton-benchmarks)
+
+(define-benchmark recursive-fib ()
+  (declare (optimize speed))
+  (loop :repeat 1000
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native:fib 20)))
+  (report trivial-benchmark::*current-timer*))
+
+(define-benchmark recursive-fib-generic ()
+  (declare (optimize speed))
+  (loop :repeat 1000
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native:fib-generic-wrapped 20)))
+  (report trivial-benchmark::*current-timer*))
+
+(define-benchmark recursive-fib-lisp ()
+  (declare (optimize speed))
+  (loop :repeat 1000
+        :do (with-benchmark-sampling
+              (lisp-fib 20)))
+  (report trivial-benchmark::*current-timer*))
+
+
+(define-benchmark recursive-fib-monomorphized ()
+  (declare (optimize speed))
+  (loop :repeat 1000
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native:fib-monomorphized 20)))
+  (report trivial-benchmark::*current-timer*))
+
+;;
+;; Benchmarks on optional are disabled by default because they compute the 10th
+;; instead of the 20th fibonacci number. Computing the 20th was exausting the heap.
+;;
+
+#+ignore
+(define-benchmark recursive-fib-generic-optional ()
+  (declare (optimize speed))
+  (loop :repeat 1000
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native:fib-generic-optional 10)))
+  (report trivial-benchmark::*current-timer*))
+
+#+ignore
+(define-benchmark recursive-fib-monomorphized-optional ()
+  (declare (optimize speed))
+  (loop :repeat 1000
+        :do (with-benchmark-sampling
+              (coalton-benchmarks/native:fib-monomorphized-optional 10)))
+  (report trivial-benchmark::*current-timer*))
+
+(defun lisp-fib (n)
+  (declare (type integer n)
+           (values integer)
+           (optimize (speed 3) (safety 0)))
+  (when (= n 0)
+    (return-from lisp-fib 0))
+
+  (when (= n 1)
+    (return-from lisp-fib 1))
+
+  (+ (lisp-fib (- n 1)) (lisp-fib (- n 2))))
+
+(cl:in-package #:coalton-benchmarks/native)
+
+(cl:declaim (cl:optimize (cl:speed 3) (cl:safety 0)))
+
+(coalton-toplevel
+  (declare fib (Integer -> Integer))
+  (define (fib n)
+    (when (== n 0)
+      (return 0))
+
+    (when (== n 1)
+      (return 1))
+
+    (+ (fib (- n 1)) (fib (- n 2))))
+
+  (declare fib-generic (Num :a => :a -> :a))
+  (define (fib-generic n)
+    (when (== n 0)
+      (return 0))
+
+    (when (== n 1)
+      (return 1))
+
+    (+ (fib-generic (- n 1)) (fib-generic (- n 2))))
+
+  (declare fib-generic-wrapped (Integer -> Integer))
+  (define (fib-generic-wrapped x)
+    (fib-generic x))
+
+  (monomorphize)
+  (declare fib-monomorphized (Integer -> Integer))
+  (define (fib-monomorphized x)
+    (fib-generic x))
+
+  (declare fib-generic-optional (Integer -> Optional Integer))
+  (define (fib-generic-optional x)
+    (fib-generic (Some x)))
+
+  (monomorphize)
+  (declare fib-monomorphized-optional (Integer -> Optional Integer))
+  (define (fib-monomorphized-optional x)
+    (fib-generic (Some x))))

--- a/benchmarks/package.lisp
+++ b/benchmarks/package.lisp
@@ -1,3 +1,7 @@
+;;;; package.lisp
+;;;;
+;;;; Benchmarks packages and common functions
+
 (benchmark:define-benchmark-package #:coalton-benchmarks
   (:export #:run-benchmarks
            #:run-benchmarks-ci))
@@ -5,7 +9,9 @@
 (cl:defpackage #:coalton-benchmarks/native
   (:use
    #:coalton
-   #:coalton-prelude)
+   #:coalton-prelude
+   #:coalton-library/big-float
+   #:coalton-library/math)
   (:export
    #:fib
    #:fib-fixnum
@@ -31,109 +37,3 @@
        out)
       (format out "~%"))
     (values)))
-
-(define-benchmark recursive-fib ()
-  (declare (optimize speed))
-  (loop :repeat 1000
-        :do (with-benchmark-sampling
-              (coalton-benchmarks/native:fib 20)))
-  (report trivial-benchmark::*current-timer*))
-
-(define-benchmark recursive-fib-generic ()
-  (declare (optimize speed))
-  (loop :repeat 1000
-        :do (with-benchmark-sampling
-              (coalton-benchmarks/native:fib-generic-wrapped 20)))
-  (report trivial-benchmark::*current-timer*))
-
-(define-benchmark recursive-fib-lisp ()
-  (declare (optimize speed))
-  (loop :repeat 1000
-        :do (with-benchmark-sampling
-              (lisp-fib 20)))
-  (report trivial-benchmark::*current-timer*))
-
-
-(define-benchmark recursive-fib-monomorphized ()
-  (declare (optimize speed))
-  (loop :repeat 1000
-        :do (with-benchmark-sampling
-              (coalton-benchmarks/native:fib-monomorphized 20)))
-  (report trivial-benchmark::*current-timer*))
-
-;;
-;; Benchmarks on optional are disabled by default because they compute the 10th
-;; instead of the 20th fibonacci number. Computing the 20th was exausting the heap.
-;;
-
-#+ignore
-(define-benchmark recursive-fib-generic-optional ()
-  (declare (optimize speed))
-  (loop :repeat 1000
-        :do (with-benchmark-sampling
-              (coalton-benchmarks/native:fib-generic-optional 10)))
-  (report trivial-benchmark::*current-timer*))
-
-#+ignore
-(define-benchmark recursive-fib-monomorphized-optional ()
-  (declare (optimize speed))
-  (loop :repeat 1000
-        :do (with-benchmark-sampling
-              (coalton-benchmarks/native:fib-monomorphized-optional 10)))
-  (report trivial-benchmark::*current-timer*))
-
-(defun lisp-fib (n)
-  (declare (type integer n)
-           (values integer)
-           (optimize (speed 3) (safety 0)))
-  (when (= n 0)
-    (return-from lisp-fib 0))
-
-  (when (= n 1)
-    (return-from lisp-fib 1))
-
-  (+ (lisp-fib (- n 1)) (lisp-fib (- n 2))))
- 
-(cl:in-package #:coalton-benchmarks/native)
-
-(cl:declaim (cl:optimize (cl:speed 3) (cl:safety 0)))
-
-(coalton-toplevel
-  (declare fib (Integer -> Integer))
-  (define (fib n)
-    (when (== n 0)
-      (return 0))
-
-    (when (== n 1)
-      (return 1))
-
-    (+ (fib (- n 1)) (fib (- n 2))))
-
-  (declare fib-generic (Num :a => :a -> :a))
-  (define (fib-generic n)
-    (when (== n 0)
-      (return 0))
-
-    (when (== n 1)
-      (return 1))
-
-    (+ (fib-generic (- n 1)) (fib-generic (- n 2))))
-
-  (declare fib-generic-wrapped (Integer -> Integer))
-  (define (fib-generic-wrapped x)
-    (fib-generic x))
-
-  (monomorphize)
-  (declare fib-monomorphized (Integer -> Integer))
-  (define (fib-monomorphized x)
-    (fib-generic x))
-
-  (declare fib-generic-optional (Integer -> Optional Integer))
-  (define (fib-generic-optional x)
-    (fib-generic (Some x)))
-
-  (monomorphize)
-  (declare fib-monomorphized-optional (Integer -> Optional Integer))
-  (define (fib-monomorphized-optional x) 
-    (fib-generic (Some x))))
-

--- a/library/big-float/README.md
+++ b/library/big-float/README.md
@@ -1,6 +1,15 @@
 # Coalton `Big-Float`
 
-`Big-Float` is an arbitrary precision floating point number.
+`Big-Float` is an arbitrary precision floating point number. The numeric results
+will  *not* be consistent across implementations.
 
-This depends on the MPFR library being installed, and visible within
-your dynamic linker path.
+By default SBCL will use the `sb-mpfr` library.
+
+This depends on the MPFR library being installed, and visible within your
+dynamic linker path. Otherwise, you will get an error while compiling.
+
+Before coalton is compiled set the environment
+variable`COALTON_PORTABLE_BIGFLOAT=1` or add the feature
+`:coalton-portable-bigfloat` to proceed anyways.
+All other implementations will use a `Big-Float` written in Coalton. This comes
+at a significant slow down and increased memory usage.

--- a/library/big-float/impl-default.lisp
+++ b/library/big-float/impl-default.lisp
@@ -1,0 +1,830 @@
+;;;; big-float.lisp
+;;;;
+;;;; Arbitrary precision floats using pure Coalton.
+
+#+coalton-release
+(cl:declaim #.coalton-impl:*coalton-optimize-library*)
+
+(in-package #:coalton-library/big-float)
+
+(coalton-toplevel
+  ;; Rounding modes
+  (repr :enum)
+  (define-type RoundingMode
+    RoundNearAway
+    RoundEven
+    RoundToZero
+    RoundUp
+    RoundDown
+    RoundFromZero
+    RoundFaithful
+    RoundDisable))
+
+(cl:defvar *bf-precision* 53)
+(cl:defvar *bf-rounding-mode* RoundDown)
+
+(coalton-toplevel
+
+  (define rndna
+    "RouND to Nearest Away."
+    RoundNearAway)
+  (define rndn
+    "RouND to Nearest, with the even rounding rule."
+    RoundEven)
+  (define rndz
+    "RouND toward Zero."
+    RoundToZero)
+  (define rndu
+    "RouND Up, toward positive infinity."
+    RoundUp)
+  (define rndd
+    "RouND Down, toward negative infinity."
+    RoundDown)
+  (define rnda
+    "RouND Away from zero."
+    RoundFromZero)
+  (define rndf
+    "Faithful rounding (experimental)."
+    RoundFaithful)
+
+  (define (round-from-zero x)
+    "Rounds to an integer away from zero."
+    (* (sign x) (ceiling (abs x))))
+
+  (define (dyadic-round-half-away-zero x)
+    "Rounds a dyadic to the nearest integer with ties going away from zero."
+    (* (sign x) (floor (+ (abs x) (Dyadic 1 -1)))))
+
+  (define (fraction-round-half-away-zero x)
+    "Rounds a fraction to the nearest integer with ties going away from zero."
+    (* (sign x) (floor (+ (abs x) -1/2))))
+
+  (declare set-precision! (UFix -> Unit))
+  (define (set-precision! prec-bits)
+    "Set the precision of Big-Float arithmetic to PREC-BITS bits."
+    (unless (> prec-bits 0)
+      (error "Precision must be positive."))
+    (lisp Unit (prec-bits)
+      (cl:setf *bf-precision* prec-bits)
+      Unit))
+
+  (declare set-rounding-mode! (RoundingMode -> Unit))
+  (define (set-rounding-mode! r)
+    "Set the global rounding mode for Big-Float operations."
+    (lisp Unit (r)
+      (cl:setf *bf-rounding-mode* r)
+      Unit))
+
+  (declare get-precision (Unit -> UFix))
+  (define (get-precision _)
+    "Get the current global precision of Big-Float arithmetic"
+    (lisp UFix () *bf-precision*))
+
+  (declare get-rounding-mode (Unit -> RoundingMode))
+  (define (get-rounding-mode _)
+    "Get the current rounding-mode of Big-Float arithmetic."
+    (lisp RoundingMode ()
+      *bf-rounding-mode*))
+
+  (declare with-precision-rounding
+           (UFix -> RoundingMode -> (Unit -> :a) -> :a))
+  (define (with-precision-rounding prec-bits rnd f)
+    "Call F with a temporary Big-Float PREC-BITS precision and RND rounding-mode."
+    (lisp :a (f prec-bits rnd)
+      (cl:let ((*bf-precision* prec-bits)
+               (*bf-rounding-mode* rnd))
+        (coalton-impl/codegen::A1 f Unit))))
+
+  (declare with-precision (UFix -> (Unit -> :a) -> :a))
+  (define (with-precision prec-bits f)
+    "Call F with a temporary Big-Float precision PREC-BITS."
+    (with-precision-rounding prec-bits (get-rounding-mode) f))
+
+  (declare with-rounding (RoundingMode -> (Unit -> :a) -> :a))
+  (define (with-rounding rnd f)
+    "Call F with a temporary Big-Float rounding-mode RND."
+    (with-precision-rounding (get-precision) rnd f))
+
+  (declare polylog-prec (UFix -> UFix))
+  (define (polylog-prec n)
+    "Raises (ilog 2 (get-precision)) to a power N or return 1 if prec is 1."
+    (let x = (get-precision))
+    (max 1
+         (- (lisp UFix (x n) (cl:expt (cl:integer-length x) n)) 1)))
+
+  (declare bit-length (Integer -> Integer))
+  (define (bit-length n)
+    (lisp Integer (n)
+      (cl:integer-length n)))
+
+  (declare ilog2-abs (Integer -> Integer))
+  (define (ilog2-abs x)
+    (- (bit-length (abs x)) 1))
+
+  (define-type Big-Float
+    (BFValue Dyadic)
+    BFNegZero
+    (BFConst (Unit -> Big-Float))
+    BFInf
+    BFNegInf
+    BFNaN)
+
+  ;; Can compare non-normalized big-floats or big-floats of different precisions.
+  (define-instance (Eq Big-Float)
+    (define (== a b)
+      (match (Tuple a b)
+        ((Tuple (BFValue x) (BFValue y))
+         (== x y))
+        ((Tuple (BFConst f) b)
+         (== (f) b))
+        ((Tuple a (BFConst f))
+         (== a (f)))
+        ((Tuple (BFNegZero) a) (== 0 a))
+        ((Tuple a (BFNegZero)) (== a 0))
+        ((Tuple (BFInf) (BFInf)) True)
+        ((Tuple (BFNegInf) (BFNegInf)) True)
+        (_ False))))
+
+  (define-instance (Ord Big-Float)
+    (define (<=> a b)
+      (match (Tuple a b)
+        ((Tuple (BFValue x) (BFValue y))
+         (<=> x y))
+        ((Tuple (BFConst f) _)
+         (<=> (f) b))
+        ((Tuple _ (BFConst f))
+         (<=> a (f)))
+        ((Tuple (BFNegZero) _) (<=> 0 a))
+        ((Tuple _ (BFNegZero)) (<=> a 0))
+        ((Tuple (BFInf) (BFInf)) EQ)
+        ((Tuple (BFNegInf) (BFNegInf)) EQ)
+        ((Tuple (BFInf) (BFNegInf)) GT)
+        ((Tuple (BFNegInf) (BFInf)) LT)
+        ((Tuple (BFNaN) (BFNaN)) EQ)
+        ;; When sorting, NaNs will go to the left
+        ((Tuple (BFNaN) _) LT)
+        ((Tuple _ (BFNaN)) GT)
+        ((Tuple (BFInf) _) GT)
+        ((Tuple (BFNegInf) _) LT)
+        ((Tuple _ (BFInf)) LT)
+        ((Tuple _ (BFNegInf)) GT))))
+
+  (define (normalize a)
+    "Normalizes a Big-Float using current rounding and precision."
+    (let k = (get-precision))
+    (match (Tuple a (get-rounding-mode))
+      ;; normalize cannot use fromInt
+      ((Tuple (BFValue (Dyadic 0 _)) _) (BFValue (Dyadic 0 0)))
+      ((Tuple x (RoundDisable)) x)
+      ((Tuple (BFValue (Dyadic m e)) rnd-mode)
+       (let j =  (ilog2-abs m))
+       (let delta = (- (toInteger k) j))
+       (let rounder =
+         (match rnd-mode
+           ((RoundDown) floor)
+           ((RoundToZero) truncate)
+           ((RoundUp) ceiling)
+           ((RoundEven) round)
+           ((RoundNearAway) dyadic-round-half-away-zero)
+           ((RoundFromZero) round-from-zero)
+           ;; TODO: Implement round faithful.
+           ((RoundFaithful) round)
+           (_ (error "Current rounding mode not implemented"))))
+       (if (>= delta 0)
+           (BFValue (Dyadic (lsh m delta) (- e delta)))
+           (BFValue
+            (match (Dyadic (rounder (Dyadic m delta)) (- e delta))
+              ((Dyadic 0 n)
+               (Dyadic (sign m) (- n 1)))
+              (d d)))))
+      (_ a)))
+
+  (specialize negate bf-negate (Big-Float -> Big-Float))
+  (define (bf-negate x)
+    "Negates a Big-Float"
+    (match x
+      ((BFValue (Dyadic n k))
+       (if (== n 0)
+           BFNegZero
+           (BFValue (Dyadic (negate n) k))))
+      ((BFConst f) (negate (f)))
+      ((BFNegZero) 0)
+      ((BFInf) BFNegInf)
+      ((BFNegInf) BFInf)
+      ((BFNaN) BFNaN)))
+
+  (define-instance (Num Big-Float)
+    (define (+ a b)
+      (match (Tuple a b)
+        ((Tuple (BFValue x) (BFValue y))
+         (normalize (BFValue (+ x y))))
+        ((Tuple (BFConst f) b)
+         (+ (f) b))
+        ((Tuple a (BFConst f))
+         (+ a (f)))
+        ((Tuple (BFNegZero) (BFNegZero)) BFNegZero)
+        ((Tuple (BFNegZero) a) a)
+        ((Tuple a (BFNegZero)) a)
+        ((Tuple (BFInf) (BFInf)) BFInf)
+        ((Tuple (BFNegInf) (BFNegInf)) BFNegInf)
+        (_ BFNaN)))
+    (define (- a b)
+      (+ a (bf-negate b)))
+    (define (* a b)
+      (match (Tuple a b)
+        ((Tuple (BFValue (Dyadic 0 _)) (BFValue b))
+         (if (< b 0)
+             BFNegZero
+             0))
+        ((Tuple (BFValue a) (BFValue (Dyadic 0 _)))
+         (if (< a 0)
+             BFNegZero
+             0))
+        ((Tuple (BFValue a) (BFValue b))
+         (normalize (BFValue (* a b))))
+        ((Tuple (BFConst f) b)
+         (* (f) b))
+        ((Tuple a (BFConst f))
+         (* a (f)))
+        ((Tuple (BFNegZero) (BFNegZero)) 0)
+        ((Tuple (BFNegZero) a)
+         (if (>= a 0) BFNegZero 0))
+        ((Tuple a (BFNegZero))
+         (if (>= a 0) BFNegZero 0))
+        ((Tuple (BFInf) (BFInf)) BFInf)
+        ((Tuple (BFNegInf) (BFNegInf)) BFInf)
+        ((Tuple (BFInf) a)
+         (cond
+           ((nan? a) BFNaN)
+           ((< a 0) BFNegInf)
+           ((> a 0) BFInf)
+           ((== a 0) BFNaN)))
+        ((Tuple a (BFInf)) (* BFInf a))
+        (_ BFNaN)))
+    (define (fromInt x) (normalize (BFValue (fromInt x)))))
+
+  (define-instance (Reciprocable Big-Float)
+    (define (reciprocal x)
+      (match x
+        ((BFValue (Dyadic 0 _)) BFInf)
+        ((BFNegZero) BFNegInf)
+        ((BFValue (Dyadic m k))
+         (let p = (+ 1 (toInteger (get-precision))))
+         (normalize
+          (BFValue (Dyadic (div (lsh 1 (- p k)) m) (negate p)))))
+        ((BFInf) 0)
+        ((BFNegInf) BFNegZero)
+        ((BFConst f) (reciprocal (f)))
+        ((BFNaN) BFNaN)))
+    (define (/ a b)
+      (when (== b 0)
+        (return (* a (reciprocal b))))
+      (match (Tuple a b)
+        ((Tuple (BFValue (Dyadic m1 k1)) (BFValue (Dyadic m2 k2)))
+         (let p = (+ 1 (toInteger (get-precision))))
+         (normalize
+          (BFValue
+           (Dyadic
+            (div (lsh m1 (+ p (- k1 k2))) m2) (negate p)))))
+        (_ (* a (reciprocal b))))))
+
+  (define-instance (Dividable Integer Big-Float)
+    (define (general/ a b)
+      (let p = (+ 1 (toInteger (get-precision))))
+      (if (== b 0)
+          (* (fromInt a) (reciprocal (fromInt b)))
+          (normalize (BFValue (Dyadic (div (lsh a p) b) (negate p)))))))
+
+  (define-instance (Into Single-Float Big-Float)
+    (define (into a)
+      (cond
+        ((== a infinity) BFInf)
+        ((== a negative-infinity) BFNegInf)
+        ((nan? a) BFNaN)
+        (True
+         (normalize
+          (lisp Big-Float (a)
+            (cl:multiple-value-bind (n k s)
+                (cl:integer-decode-float a)
+              (cl:if (cl:and (cl:= n 0) (cl:= s 0))
+                     BFNegZero
+                     (BFValue (Dyadic (cl:* s n) k))))))))))
+
+  (define-instance (Into Double-Float Big-Float)
+    (define (into a)
+      (cond
+        ((== a infinity) BFInf)
+        ((== a negative-infinity) BFNegInf)
+        ((nan? a) BFNaN)
+        (True
+         (normalize
+          (lisp Big-Float (a)
+            (cl:multiple-value-bind (n k s)
+                (cl:integer-decode-float a)
+              (cl:if (cl:and (cl:= n 0) (cl:= s 0))
+                     BFNegZero
+                     (BFValue (Dyadic (cl:* s n) k))))))))))
+
+  (define-instance (Into Integer Big-Float)
+    (define (into a)
+      (fromInt a)))
+
+  (define-instance (Into Fraction Big-Float)
+    (define (into a)
+      (general/ (numerator a) (denominator a))))
+
+  (define-instance (Real Big-Float)
+    (define (real-approx _ x) (to-fraction x)))
+
+  (define-instance (Rational Big-Float)
+    (define (to-fraction x)
+      (match x
+        ((BFValue d)
+         (to-fraction d))
+        ((BFConst f)
+         (best-approx (f)))
+        ((BFNegZero) 0)
+        ((BFInf) (error "Cannot rationalize Inf"))
+        ((BFNegInf) (error "Cannot rationalize -Inf"))
+        ((BFNaN) (error "Cannot rationalize NaN"))))
+    (define (best-approx x)
+      (coalton-library/math/real::rational-approx (get-precision) x)))
+
+  (define-instance (Quantizable Big-Float)
+    (define (proper x)
+      (match x
+        ((BFValue d)
+         (match (proper d)
+           ((Tuple n d)
+            (Tuple n (BFValue d)))))
+        ((BFConst f)
+         (proper (f)))
+        ((BFNegZero) (Tuple 0 BFNegZero))
+        ((BFInf) (Tuple 0 BFInf))
+        ((BFNegInf) (Tuple 0 BFNegInf))
+        ((BFNaN) (Tuple 0 BFNaN))))
+    (define (floor x)
+      (match x
+        ((BFValue d) (floor d))
+        ((BFConst f) (floor (f)))
+        ((BFNegZero) 0)
+        ((BFInf) (error "Cannot floor Inf"))
+        ((BFNegInf) (error "Cannot floor -Inf"))
+        ((BFNaN) (error "Cannot floor NaN"))))
+    (define (ceiling x)
+      (match x
+        ((BFValue d) (ceiling d))
+        ((BFConst f) (ceiling (f)))
+        ((BFNegZero) 0)
+        ((BFInf) (error "Cannot ceiling Inf"))
+        ((BFNegInf) (error "Cannot ceiling -Inf"))
+        ((BFNaN) (error "Cannot ceiling NaN")))))
+
+  (define-instance (Transfinite Big-Float)
+    (define nan BFNaN)
+    (define (nan? x)
+      (match x
+        ((BFNan) True)
+        (_ False)))
+    (define infinity BFInf)
+    (define (infinite? x)
+      (match x
+        ((BFInf) True)
+        ((BFNegInf) True)
+        (_ False))))
+
+  (specialize negative-infinity bf-neg-inf Big-Float)
+  (define bf-neg-inf BFNegInf)
+
+  (define (scale x n)
+    "Scales a Big-Float X=a*2^k to a*2^(+ k n)."
+    (match x
+      ((BFValue d) (BFValue (dyadic:scale d n)))
+      ((BFConst f) (scale (f) n))
+      ((BFNegZero) BFNegZero)
+      ((BFInf) BFInf)
+      ((BFNegInf) BFNegInf)
+      ((BFNaN) BFNaN)))
+
+  (define (reciprocal-sqrt a)
+    "Non-normalized reciprocal of the sqrt of a"
+    (let prec = (get-precision))
+    (match a
+      ((BFValue (Dyadic m j))
+       (cond
+         ((< m 0) BFNaN)
+         ((== m 0) BFInf)
+         ((== a 1) 1)
+         (True
+          (let l = (bit-length m))
+          (let ((newton-rec
+                  (fn (x)
+                    (let y = (dyadic:scale (* x (- 3 (* (Dyadic m j) (* x x)))) -1))
+                    (let z = (dyadic:shift prec y))
+                    (if (== z x)
+                        z
+                        (newton-rec z)))))
+            (BFValue (newton-rec (Dyadic 1 (negate (div (+ j l) 2)))))))))
+      ((BFConst f) (reciprocal-sqrt (f)))
+      ((BFNegZero) BFNegInf)
+      ((BFInf) 0)
+      (_ BFNaN))))
+
+(coalton-library/math/complex::%define-standard-complex-instances Big-Float)
+
+(coalton-toplevel
+  ;; SeriesSplit/SeriesResult could be extended to any ring (e.g. polynomials)
+  (define-type SeriesSplit
+    "An nth element of series (SeriesSplit a(n) p(n) b(n) q(n)).
+See `binary-split` step 1."
+    (SeriesSplit Integer Integer Integer Integer))
+
+  (define-type SeriesResult
+    "An intermediary result of binary splitting series (SeriesResult P Q B T).
+See `binary-split` step 2."
+    (SeriesResult Integer Integer Integer Integer))
+
+  (define-instance (Semigroup SeriesResult)
+    (define (<> a b)
+      "Combine binary split results. See `binary-split` step 3."
+      (match (Tuple a b)
+        ((Tuple (SeriesResult ap aq ab at)
+                (SeriesResult bp bq bb bt))
+         (SeriesResult (* ap bp) (* aq bq) (* ab bb)
+                       (+ (* (* bb bq) at) (* (* ab ap) bt)))))))
+
+  (declare make-result (SeriesSplit -> SeriesResult))
+  (define (make-result b)
+    "Calculations the current intermediary result for a given element of the series.
+See `binary-split`."
+    (match b
+      ((SeriesSplit a p q b)
+       (SeriesResult p q b (* a p)))))
+
+  (declare eval-result ((Dividable Integer :a) => SeriesResult -> :a))
+  (define (eval-result r)
+    "Evaluates the final result of a SeriesResult. See `binary-split` step 4."
+    (match r
+      ((SeriesResult _ q b t)
+       (general/ t (* b q)))))
+
+  (declare recip-result ((Dividable Integer :a) => SeriesResult -> :a))
+  (define (recip-result r)
+    "Evaluates the reciprocal of `make-result`."
+    (match r
+      ((SeriesResult _ q b t)
+       (general/ (* b q) t))))
+
+  (declare binary-split ((UFix -> SeriesSplit) -> UFix -> UFix -> SeriesResult))
+  (define (binary-split s n1 n2)
+    "Implements a binary splitting algorithm described by. In short,
+ 1) Given a series S(n) = Σ^n_i=0 a(i)p(0)...p(i)/b(i)q(0)...q(i)
+ 2) Split P(n1,n2)=p(n1)...p(n2−1), Q(n1,n2)=q(n1)...q(n2−1), B(n1,n2)=b(n1)...b(n2−1), and T=BQS
+ 3) Recombined as P(a,c)=P(a,b)P(b,c),Q(a,c)=Q(a,b)Q(b,c),B(a,c)=B(a,b)B(b,c)
+                 T(a,c)=B(b,c)Q(b,c)T(a,b)+B(a,b)P(a,b)T(b,c)
+ 4) With S(n) = T(0,n)/(B(0,n)Q(0,n))
+
+Source: https://www.ginac.de/CLN/binsplit.pdf
+"
+    (let n = (- n2 n1))
+    (cond
+      ((<= n 0) (make-result (s n1)))
+      ((== n 1)
+       (<> (make-result (s n1))
+           (make-result (s (+ 1 n1)))))
+      ((== n 2)
+       (<> (make-result (s n1))
+           (<> (make-result (s (+ 1 n1)))
+               (make-result (s (+ 2 n1))))))
+      ((== n 3)
+       (<> (<> (make-result (s n1))
+               (make-result (s (+ 1 n1))))
+           (<> (make-result (s (+ 2 n1)))
+               (make-result (s (+ 3 n1))))))
+      ((== n 4)
+       (<> (<>
+            (<> (make-result (s n1))
+                (make-result (s (+ 1 n1))))
+            (<> (make-result (s (+ 2 n1)))
+                (make-result (s (+ 3 n1)))))
+           (make-result (s (+ 4 n1)))))
+      ((== n 5)
+       (<> (<>
+            (<> (make-result (s n1))
+                (make-result (s (+ 1 n1))))
+            (<> (make-result (s (+ 2 n1)))
+                (make-result (s (+ 3 n1)))))
+           (<> (make-result (s (+ 4 n1)))
+               (make-result (s (+ 5 n1))))))
+      (True
+       (let nm = (div n 2))
+       (let n3 = (+ n1 nm))
+       (<> (binary-split s n1 n3)
+           (binary-split s (+ n3 1) n2)))))
+
+  (declare eval-series (SeriesSplit -> (UFix -> SeriesSplit) -> (UFix -> SeriesResult)))
+  (define (eval-series x f n)
+    (<> (make-result x)
+        (binary-split f 1 n)))
+
+  (declare make-results ((Dividable Integer :a) => Ufix -> SeriesSplit -> (Integer -> SeriesSplit) -> :a))
+  (define (make-results n start f)
+    "For a binary-split series, given an initial SeriesSPlit X and a function that
+returns the nth SeriesSplit, return the series evaluated to the Nth element."
+    (eval-result
+     (eval-series start (fn (m) (f (toInteger m))) n)))
+
+  (declare make-recip-results ((Dividable Integer :a) => Ufix -> SeriesSplit -> (Integer -> SeriesSplit) -> :a))
+  (define (make-recip-results n start f)
+    "Reciprocal of `make-result`."
+    (recip-result
+     (eval-series start (fn (m) (f (toInteger m))) n)))
+
+  ;; XXX: We can pre-compute some values here
+  (define (bf-pi _)
+    "Return the value of pi to the currently set precision."
+    ;; Chudnovsky algorithm
+    (progn
+      (let a = (* 12 13591409))
+      (let b = (* 12 545140134))
+      (let c = 640320)
+      (let c3 = (^ c 3))
+      ;; d = c^3/24
+      (let j = (div c3 24))
+      ;; C^3/2 / 12pi
+      ;;  = Σ_n (6n)!(545140134n + 13591409)/((3q)!(n!)^3(-262537412640768000)^n
+      ;; a(n)=A+nB, b(n)=1, p(0)=1, q(0)=1,
+      ;; p(n)=−(6n−5)(2n−1)(6n−1), q(n)=1
+      (reciprocal
+       (*
+        (make-results
+         (polylog-prec 2) (SeriesSplit a 1 1 1)
+         (fn (n)
+           (let 2n = (* 2 n))
+           (let 6n = (* 3 2n))
+           (let n2 = (* n n))
+           (SeriesSplit
+            (+ a (* b n))
+            (negate (* (* (- 6n 5) (- 2n 1)) (- 6n 1)))
+            (* j (* n2 n)) 1)))
+        (reciprocal-sqrt (BFValue (dyadic:simplify-integer c3)))))))
+
+  (declare bf-ln2 (Unit -> Big-Float))
+  (define (bf-ln2)
+    "Return the value of (ln 2) to the currently set precision."
+    ;; 2/3 Σ_n 1/(9^n(2n+1))
+    ;; a(n)=2, b(n)=(6n + 3), p(n)=1, q(0)=1, q(n)=9
+    (make-results
+     (polylog-prec 4) (SeriesSplit 2 1 1 3)
+     (fn (n)
+       (SeriesSplit 2 1 9 (+ (* 6 n) 3)))))
+
+  (define-instance (Trigonometric Big-Float)
+    (define (sin x)
+      (let prec = (polylog-prec 4))
+      ;; sin(x) = Σ_n ((-1)^n x^(1 + 2 n))/((1 + 2 n)!)
+      ;; a(n)=1, b(n)=1, p(0)=u ,q(0)=v
+      ;; p(n)= −u^2, q(n)=(2n)(2n+1)v^2
+      (match x
+        ((BFValue (Dyadic m k))
+         (if (< k 0)
+             (make-results
+              prec (SeriesSplit 1 m (rsh 1 k) 1)
+              (fn (n)
+                (let 2n = (* 2 n))
+                (SeriesSplit 1 (negate (* m m)) (rsh (* 2n (+ 2n 1)) (* 2 k)) 1)))
+             (progn
+               (let u = (lsh m k))
+               (make-results
+                prec (SeriesSplit 1 u 1 1)
+                (fn (n)
+                  (let 2n = (* 2 n))
+                  (SeriesSplit 1 (negate (* u u)) (* 2n (+ 2n 1)) 1))))))
+        ((BFConst f) (sin (f)))
+        ((BFNegZero) BFNegZero)
+        (_ BFNaN)))
+    (define (cos x)
+      (let prec = (polylog-prec 4))
+      (match x
+        ((BFValue (Dyadic m k))
+         ;; cos(x) = Σ_n ((-1)^n x^(2 n))/((2 n)!)
+         ;; a(n)=1, b(n)=1, p(0)=1 ,q(0)=v
+         ;; p(n)= −u^2, q(n)=(2n)(2n+1)v^2
+         (if (< k 0)
+             (make-results
+              prec (SeriesSplit 1 1 1 1)
+              (fn (n)
+                (let 2n = (* 2 n))
+                (SeriesSplit 1 (negate (* m m)) (rsh (* 2n (- 2n 1)) (* 2 k)) 1)))
+             (progn
+               (let u = (lsh m k))
+               (make-results
+                prec (SeriesSplit 1 1 1 1)
+                (fn (n)
+                  (let 2n = (* 2 n))
+                  (SeriesSplit 1 (negate (* u u)) (* 2n (- 2n 1)) 1))))))
+        ((BFConst f) (cos (f)))
+        ((BFNegZero) 1)
+        (_ BFNaN)))
+    (define (tan x)
+      (match x
+        ((BFValue d)
+         (/ (sin (BFValue d)) (cos (BFValue d))))
+        ((BFConst f) (tan (f)))
+        ((BFNegZero) BFNegZero)
+        (_ BFNaN)))
+    (define (atan x)
+      (let prec = (get-precision))
+      ;; atan(x) =  Σ_n ((-1)^n x^(1 + 2 n))/(1 + 2 n) for abs(x)<1
+      ;; a(n)=1, b(n)=2n+1, q(n)=v^2, p(0)=u,p(n)=−u^2
+      (let compute-atan =
+        (fn (u v)
+          (make-results
+           (polylog-prec 4)
+           (SeriesSplit 1 u v 1)
+           (fn (n)
+             (SeriesSplit
+              1 (negate (* u u)) (* v v) (+ (* 2 n) 1))))))
+      (normalize
+       (with-rounding RoundDisable
+         (fn ()
+           (match x
+             ((BFValue (Dyadic m k))
+              (cond
+                ((< (abs x) 1)
+                 (let f = (to-fraction (Dyadic m k)))
+                 (compute-atan (numerator f) (denominator f)))
+                ((< x -1)
+                 (- (scale (negate (bf-pi)) -1)
+                    (atan (reciprocal x))))
+                ((> x 1)
+                 (let f = (to-fraction (Dyadic m k)))
+                 (- (scale (bf-pi) -1)
+                    (atan (reciprocal x))))
+                ((== x 1)
+                 (scale (bf-pi) -2))
+                ((== x -1)
+                 (scale (negate (bf-pi)) -2))))
+             ((BFConst f) (atan (f)))
+             ((BFNegZero) BFNegZero)
+             ((BFInf) (scale (bf-pi) -1))
+             ((BFNegInf) (scale (negate (bf-pi)) -1))
+             (_ BFNaN))))))
+    (define (asin x)
+      (atan (* x (reciprocal-sqrt (- 1 (* x x))))))
+    (define (acos x)
+      (- (scale (bf-pi) -1) (asin x))))
+
+  (define-instance (Exponentiable Big-Float)
+    (define (exp x)
+      (let prec = (get-precision))
+      (match x
+        ((BFValue (Dyadic m k))
+         ;; e^x = Σ_n x^n/(n!)
+         ;; a(n)=1, b(n)=1, p(0)=q(0)=1, p(n)=u, q(n)=nv
+         (if (< k 0)
+             (make-results
+              (polylog-prec 4) (SeriesSplit 1 1 1 1)
+              (fn (n)
+                (SeriesSplit 1 m (rsh n k) 1)))
+             (make-results
+              (polylog-prec 4) (SeriesSplit 1 1 1 1)
+              (fn (n)
+                (SeriesSplit 1 (lsh m k) n 1)))))
+        ((BFConst f) (exp (f)))
+        ((BFNegZero) 1)
+        ((BFInf) BFInf)
+        ((BFNegInf) 0)
+        (_ BFNaN)))
+    (define (ln x)
+      (let prec = (polylog-prec 4))
+      (match x
+        ((BFValue (Dyadic m k))
+         ;; ln(x) = - Σ_n ((-1)^n (-1 + x)^n)/n for abs(-1 + x)<1
+         ;; a(n)=1, b(n)=n+1, q(n)=v, p(0)=u, p(n)=−u
+         (cond
+           ((< x 0) BFNaN)
+           ((== x 0) BFNegInf)
+           ((== x 1) 0)
+           ((< x 2)
+            (let f = (- (to-fraction x) 1))
+            (let u = (numerator f))
+            (let v = (denominator f))
+            (make-results
+             prec (SeriesSplit 1 u v 1)
+             (fn (n)
+               (SeriesSplit 1 (negate u) v (+ n 1)))))
+           ((== x 2) (bf-ln2))
+           (True
+            (let (Dyadic m k) = (Dyadic m k))
+            (let j = (if (< m 1)
+                         1
+                         (bit-length m)))
+            (let y = (BFValue (Dyadic m (negate j))))
+            (when (> y 2)
+              (error "Preventing infinite loop in ln."))
+            (let l =  (+ j (toInteger k)))
+            ;; ln (u/v + 1) + l * ln 2
+            (normalize
+             (with-rounding RoundDisable
+               (fn ()
+                 (+ (ln y)
+                    (* (if (< l 0)
+                           (general/ 1 (negate l))
+                           (fromInt l))
+                       (bf-ln2)))))))))
+        ((BFConst f) (ln (f)))
+        ((BFNegZero) BFNegInf)
+        ((BFInf) BFInf)
+        (_ BFNaN)))
+    (define (pow x y)
+      (match (Tuple x y)
+        ((Tuple (BFValue x) (BFValue y))
+         (cond
+           ((and (== x 0) (== y 0)) BFNaN)
+           ((== x 0) 0)
+           ((or (== x 1) (== y 0)) 1)
+           ((< y 0)
+            (let fl-x = (floor y))
+            (if (== (fromInt fl-x) y)
+                (reciprocal (BFValue (^ x (negate fl-x))))
+                BFNaN))
+           (True
+            (let fl-x = (floor y))
+            (if (== (fromInt fl-x) y)
+                (normalize (BFValue (^ x fl-x)))
+                (exp (* (BFValue y) (ln (BFValue x))))))))
+        ((Tuple (BFConst f) y) (pow (f) y))
+        ((Tuple x (BFConst f)) (pow x (f)))
+        (_ (exp (* y (ln x))))))
+    (define (log b x)
+      (/ (ln x) (ln b))))
+
+  (define-instance (Radical Big-Float)
+    (define (sqrt x)
+      (reciprocal (reciprocal-sqrt x)))
+    (define (nth-root n x)
+      (pow x (general/ 1 n))))
+
+  (define-instance (Polar Big-Float)
+    (define (phase z)
+      (let prec = (get-precision))
+      (let x = (real-part z))
+      (let y = (imag-part z))
+      (match (Tuple (<=> x 0) (<=> y 0))
+        ((Tuple (GT) _)    (atan (/ y x)))
+        ((Tuple (LT) (LT)) (- (atan (/ y x)) pi))
+        ((Tuple (LT) _)    (+ (atan (/ y x)) pi))
+        ((Tuple (EQ) (GT)) (/ pi 2))
+        ((Tuple (EQ) (LT)) (/ pi -2))
+        ((Tuple (EQ) (EQ)) 0)))
+    (define (polar z)
+      (Tuple (magnitude z) (phase z))))
+
+  (declare bf-ee (Unit -> Big-Float))
+  (define (bf-ee)
+    "Return the value of ee = exp(1) to the currently set precision."
+    (exp 1))
+
+  (define-instance (Elementary Big-Float)
+    (define pi (BFConst bf-pi))
+    (define ee (BFConst bf-ee)))
+
+  (define (big-float->string x)
+    "Returns a Big-Float in scientific notation."
+    (match x
+      ((BFValue (Dyadic 0 _)) "0.0e+0")
+      ((BFValue d)
+       (let y = (to-fraction d))
+       (let prec = (ilog 10 (lsh 2 (get-precision))))
+       (let z = (round (* y (^ 10 prec))))
+       (let powr = (ilog 10 (max 1 (abs z))))
+       (lisp String (z powr prec)
+         (cl:multiple-value-bind (t r) (cl:truncate z (cl:expt 10 powr))
+           (cl:format
+            nil (cl:concatenate
+                 'cl:string "~d.~" ; Integer part and sign
+                 (cl:princ-to-string powr) ; Left pad of zeros
+                 ",'0de~@d") ; Decimal part and exponent.
+            t (cl:abs r) (cl:- powr prec)))))
+      ((BFConst f) (big-float->string (f)))
+      ((BFNegZero) "-0.0e+0")
+      ((BFInf) "Inf")
+      ((BFNegInf) "-Inf")
+      ((BFNaN) "NaN"))))
+
+(cl:defmethod cl:print-object ((obj big-float/bfvalue) out)
+  (cl:format out (big-float->string obj)))
+(cl:defmethod cl:print-object ((obj big-float/bfnegzero) out)
+  (cl:format out (big-float->string obj)))
+(cl:defmethod cl:print-object ((obj big-float/bfconst) out)
+  (cl:format out (big-float->string obj)))
+(cl:defmethod cl:print-object ((obj big-float/bfinf) out)
+  (cl:format out (big-float->string obj)))
+(cl:defmethod cl:print-object ((obj big-float/bfneginf) out)
+  (cl:format out (big-float->string obj)))
+(cl:defmethod cl:print-object ((obj big-float/bfnan) out)
+  (cl:format out (big-float->string obj)))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/BIG-FLOAT")

--- a/library/big-float/impl-sbcl.lisp
+++ b/library/big-float/impl-sbcl.lisp
@@ -2,35 +2,6 @@
 ;;;;
 ;;;; Arbitrary precision floats using SBCL's MPFR library.
 
-(coalton-library/utils:defstdlib-package #:coalton-library/big-float
-  (:use #:coalton
-        #:coalton-library/classes
-        #:coalton-library/functions
-        #:coalton-library/math)
-
-  (:export
-   #:RoundingMode
-   #:rndna
-   #:rndn
-   #:rndz
-   #:rndu
-   #:rndd
-   #:rnda
-   #:rndf
-   #:set-rounding-mode!
-   #:get-rounding-mode
-   #:with-rounding
-
-   #:set-precision!
-   #:get-precision
-   #:with-precision
-
-   #:Big-Float
-   #:with-precision-rounding
-
-   #:bf-pi
-   #:bf-e))
-
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
 
@@ -40,7 +11,9 @@
 #-sb-mpfr (error "SB-MPFR failed to load, for some reason. ~
                   This is probably due to the shared library ~
                   not existing, or the system being unable ~
-                  to find it.")
+                  to find it. ~
+                  Set COALTON_PORTABLE_BIGFLOAT=1 or ~
+                  add the feature :coalton-portable-bigfloat.")
 
 ;;; Preliminary patched functionality for SB-MPFR
 ;;;

--- a/library/big-float/package.lisp
+++ b/library/big-float/package.lisp
@@ -1,0 +1,36 @@
+;;;; package.lisp
+;;;;
+;;;; Big float package for various implementations
+
+(coalton-library/utils:defstdlib-package #:coalton-library/big-float
+  (:use #:coalton
+        #:coalton-library/classes
+        #:coalton-library/functions
+        #:coalton-library/math
+        #:coalton-library/math/integral)
+  (:import-from #:coalton-library/math/dyadic #:Dyadic)
+  (:local-nicknames
+   (#:dyadic #:coalton-library/math/dyadic)
+   (#:bits #:coalton-library/bits))
+  (:export
+   #:RoundingMode
+   #:rndna
+   #:rndn
+   #:rndz
+   #:rndu
+   #:rndd
+   #:rnda
+   #:rndf
+   #:set-rounding-mode!
+   #:get-rounding-mode
+   #:with-rounding
+
+   #:set-precision!
+   #:get-precision
+   #:with-precision
+
+   #:Big-Float
+   #:with-precision-rounding
+
+   #:bf-pi
+   #:bf-ee))

--- a/library/math/arith.lisp
+++ b/library/math/arith.lisp
@@ -138,7 +138,7 @@ The function general/ is partial, and will error produce a run-time error if the
         (negate x)
         x))
 
-  (declare sign ((Ord :a) (Num :a) => :a -> :a))
+  (declare sign ((Ord :a) (Num :a) (Num :b) => :a -> :b))
   (define (sign x)
     "The sign of X."
     (if (< x 0)

--- a/library/math/dyadic.lisp
+++ b/library/math/dyadic.lisp
@@ -1,0 +1,166 @@
+;;; dyadic.lisp
+;;;
+;;; Dyadic rationals meant for implementing big floats
+;;; It is not exported into the math package as it is a niche numeric type
+
+(coalton-library/utils::defstdlib-package #:coalton-library/math/dyadic
+    (:use
+     #:coalton
+     #:coalton-library/builtin
+     #:coalton-library/classes
+     #:coalton-library/math/arith
+     #:coalton-library/math/integral
+     #:coalton-library/math/real)
+  (:local-nicknames
+   (#:bits #:coalton-library/bits))
+  (:export
+   #:Dyadic
+   #:integer
+   #:simplify
+   #:simplify-integer
+   #:scale
+   #:shift))
+
+#+coalton-release
+(cl:declaim #.coalton-impl:*coalton-optimize-library*)
+
+(in-package #:coalton-library/math/dyadic)
+
+(coalton-toplevel
+  (define-type Dyadic
+    "`(Dyadic n k)` represents the rational n*2^k."
+    (Dyadic Integer Integer))
+
+  (declare exact-ilog (Integer -> Integer -> (Optional Integer)))
+  (define (exact-ilog b x)
+    "Computes the logarithm with base B of X only if the result is an integer."
+    (if (== 0 (mod b x))
+        (Some (ilog b x))
+        None))
+
+  (declare dyadic-compare ((Integer -> Integer -> :a)
+                           -> Dyadic -> Dyadic -> :a))
+  (define (dyadic-compare f a b)
+    "Return the result of a comparision function F on two dyadics A and B."
+    (match (Tuple a b)
+      ((Tuple (Dyadic n k)
+              (Dyadic m j))
+       (match (<=> j k)
+         ((GT) (f n (lsh m (- j k))))
+         ((LT) (f (lsh n (- k j)) m))
+         (_ (f n m))))))
+
+  (define-instance (Eq Dyadic)
+    (define (== a b)
+      (dyadic-compare == a b)))
+
+  (define-instance (Ord Dyadic)
+    (define (<=> a b)
+      (dyadic-compare <=> a b)))
+
+  (declare dyadic-group ((Integer -> Integer -> Integer)
+                         -> Dyadic -> Dyadic -> Dyadic))
+  (define (dyadic-group f a b)
+    "Apply an operation F on A and B with matching exponents"
+    (match (Tuple a b)
+      ((Tuple (Dyadic n k)
+              (Dyadic m j))
+       (if (< k j)
+           (Dyadic (f n (lsh m (- j k))) k)
+           (Dyadic (f (lsh n (- k j)) m) j)))))
+
+  (define-instance (Num Dyadic)
+    (define (+ a b)
+      (dyadic-group + a b))
+    (define (- a b)
+      (dyadic-group - a b))
+    (define (* a b)
+      (match (Tuple a b)
+        ((Tuple (Dyadic n k)
+                (Dyadic m j))
+         (Dyadic (* n m) (+ j k)))))
+    (define (fromInt x) (Dyadic x 0)))
+
+  (define (simplify-integer n)
+    "Finds the simplest dyadic given an integer"
+    (if (== n 0)
+        (Dyadic 0 0)
+        (match (divMod n 2)
+          ((Tuple d m)
+           (if (== m 0)
+               (* (Dyadic 1 1)
+                  (simplify-integer d))
+               (Dyadic n 0))))))
+
+  (define (simplify d)
+    "Simplifies a Dyadic by maximizing the absolute value of the exponent."
+    (match d
+      ((Dyadic m k)
+       (* (Dyadic 1 k) (simplify-integer m)))))
+
+  (define-instance (Into Dyadic Fraction)
+    (define (into a)
+      (match a
+        ((Dyadic n k)
+         (cond
+           ((== k 0) (fromInt n))
+           ((> k 0) (fromInt (* n (lsh 1 k))))
+           (True
+            (exact/ n (rsh 1 k))))))))
+
+  (define-instance (Quantizable Dyadic)
+    (define (proper x)
+      (match x
+        ((Dyadic n k)
+         (if (>= k 0)
+             (Tuple (* n (lsh 1 k)) 0)
+             (match (quotRem n (rsh 1 k))
+               ((Tuple q r)
+                (Tuple q (Dyadic r k))))))))
+    (define (floor x)
+      (match x
+        ((Dyadic n k)
+         (lsh n k))))
+    (define (ceiling x)
+      (negate (floor (negate x)))))
+
+  (specialize round dyadic-round (Dyadic -> Integer))
+  (define (dyadic-round x)
+    "Rounds a dyadic to the nearest integer with ties going to even numbers."
+    (let (Tuple n r) = (proper x))
+    (let m = (if (< r 0)
+                 (- n 1)
+                 (+ n 1)))
+    (match (<=> (- (abs r) (Dyadic 1 -1)) 0)
+      ((LT) n)
+      ((GT) m)
+      ((EQ) (if (even? n) n m))))
+
+  (define-instance (Real Dyadic)
+    (define (real-approx a x)
+      (real-approx a (the Fraction (into x)))))
+
+  (define-instance (Rational Dyadic)
+    (define (to-fraction x) (into x))
+    (define (best-approx x) (into x)))
+
+  (define-instance (Into Integer Dyadic)
+    (define into fromInt))
+
+  (define (scale x j)
+    "Scales the exponent of a dyadic X by J."
+    (match x
+      ((Dyadic n k) (Dyadic n (+ k j)))))
+
+  (declare shift (UFix -> Dyadic -> Dyadic))
+  (define (shift k a)
+    "Shift dyadic A to its floor with K+1 bits of precision."
+    (let (Dyadic m e) = a)
+    (let j = (ilog 2 (abs m)))
+    (let delta = (- j (toInteger k)))
+    (if (<= delta 0)
+        a
+        (Dyadic (rsh m delta) (+ delta e)))))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/MATH/DYADIC")

--- a/library/math/integral.lisp
+++ b/library/math/integral.lisp
@@ -9,8 +9,9 @@
      #:coalton-library/builtin
      #:coalton-library/math/arith)
   (:import-from
-   #:coalton-library/bits
-   #:Bits)
+   #:coalton-library/bits #:Bits)
+  (:local-nicknames
+   (#:bits #:coalton-library/bits))
   (:export
    #:Remainder
    #:Integral
@@ -21,6 +22,8 @@
    #:rem
    #:quotRem
    #:toInteger
+   #:lsh
+   #:rsh
    #:even?
    #:odd?
    #:^
@@ -51,6 +54,16 @@
     "Integral is a number that is either even or odd where `div' and `quot'
 are floored and truncated division, respectively."
     (toInteger (:int -> Integer)))
+
+  (declare rsh ((Integral :n) (Bits :b) => :b -> :n -> :b))
+  (define (rsh x n)
+    "Right shift X by N"
+    (bits:shift (negate (toInteger n)) x))
+
+  (declare lsh ((Integral :n) (Bits :b) => :b -> :n -> :b))
+  (define (lsh x n)
+    "Left shift X by N"
+    (bits:shift (toInteger n) x))
 
   (declare even? (Integral :a => :a -> Boolean))
   (define (even? n)

--- a/tests/float-tests.lisp
+++ b/tests/float-tests.lisp
@@ -2,6 +2,7 @@
 
 (coalton-toplevel
   (define-class (LooseCompare :a)
+    "Loosely compares floats"
     (~ (:a -> :a -> Boolean)))
 
   (define-instance (LooseCompare Single-Float)
@@ -16,12 +17,13 @@
           True
           (or (== a b) (< (abs (- a b)) 1d-6)))))
 
-  #+sbcl
   (define-instance (LooseCompare big-float:Big-Float)
     (define (~ a b)
       (if (and (math:nan? a) (math:nan? b))
           True
-          (or (== a b) (< (abs (- a b)) (into 1d-6))))))
+          (or (< (abs (- a b))
+                 (^ (math:reciprocal 2) (math:div (big-float:get-precision) 2)))
+              (== a b) ))))
 
   (define-instance ((LooseCompare :a) (Complex :a) => LooseCompare (Complex :a))
     (define (~ a b)
@@ -34,8 +36,8 @@
 
   (declare test-list-single (List Single-Float))
   (define test-list-single
-    (make-list math:infinity math:nan 0.0 1 math:pi math:ee (negate math:pi)
-               (math:sqrt 2) (/ math:pi (math:sqrt 3)) (math:general/ 1 2) 10 100))
+    (make-list math:infinity 0.0 1 math:pi math:ee (negate math:pi)
+               (math:sqrt 2) (/ math:pi (math:sqrt 3)) (math:general/ 1 2) 10))
 
   (declare test-list-double (List Double-Float))
   (define test-list-double
@@ -74,8 +76,7 @@
     (is (test-identity
          l
          (fn (x) (math:log x (math:pow x x)))
-         (fn (x) (/ (math:ln (math:exp (* x (math:ln x)))) (math:ln x)))
-         ))
+         (fn (x) (/ (math:ln (math:exp (* x (math:ln x)))) (math:ln x)))))
 
     ;; Nans and Infinities
     (is (test-identity
@@ -83,11 +84,64 @@
          (fn (x) (negate (/ x 0)))
          (fn (x) (/ (negate x) 0))))))
 
-(define-test test-float ()
+(define-test float-identities ()
   (test-identities test-list-single)
   (test-identities test-list-double)
   (test-identities test-list-complex-single)
   (test-identities test-list-complex-double)
-  #+sbcl (test-identities
-          (the (List big-float:Big-Float)
-               (map into test-list-single))))
+  (test-identities
+   (the (List big-float:Big-Float)
+        (map into test-list-single))))
+
+(coalton-toplevel
+  (declare float-checklist ((math:Dividable Integer :a) => (List :a)))
+  (define float-checklist
+    (coalton-prelude:zipWith
+     math:general/ (coalton-prelude:range -100 100) (coalton-prelude:range 200 1))))
+
+(coalton-toplevel
+  (define (check-against-double x y)
+    "Checks to see if a double-float within a tolerable error of a big-float thunk."
+    (is (<= (abs (- (math:to-fraction (the Double-Float x))
+                    (big-float:with-precision-rounding 53 big-float:rndn
+                      (fn () (math:to-fraction (the big-float:Big-Float (y)))))))
+            ;; 2^-48 is the worst a double-float will compare to a coerced fraction.
+            (math:^^ 2 -48)))))
+
+(cl:defmacro double-check (f)
+  "Syntatic sugar for defining big-float  checks against double-floats"
+  `(map (fn (x) (check-against-double (,f (fst x)) (fn () (,f (snd x)))))
+        (zipWith Tuple float-checklist float-checklist)))
+
+(define-test float-double-to-big ()
+  (double-check (fn (x) x))
+
+  (double-check (fn (x) (math:sqrt (abs x))))
+  (double-check (fn (x) (math:ln (abs (+ 1 x)))))
+  (double-check (fn (x) (math:exp (negate x))))
+
+  (double-check (fn (x) (math:sin x)))
+  (double-check (fn (x) (math:cos x)))
+  (double-check (fn (x) (math:atan x)))
+  (double-check
+   (fn (x) (math:asin (* (math:sign x)
+                         (min (math:reciprocal (abs x)) (abs x))))))
+  (double-check
+   (fn (x) (math:acos (* (math:sign x)
+                         (min (math:reciprocal (abs x)) (abs x)))))))
+
+(coalton-toplevel
+  (define (test-constant a b)
+    "Checks a big-float against an integer representing the actual first 64 digits."
+    (is (<= (abs (- (math:to-fraction
+                     (the big-float:Big-Float
+                          (big-float:with-precision-rounding 208 big-float:rndn a)))
+                    (/ b (^ 10 63)))) (^^ 2 -207)))))
+
+(define-test float-constants ()
+  (test-constant
+   big-float:bf-ee 2718281828459045235360287471352662497757247093699959574966967627)
+  (test-constant
+   big-float:bf-pi 3141592653589793238462643383279502884197169399375105820974944592)
+  (test-constant
+   (fn () (math:ln 2)) 693147180559945309417232121458176568075500134360255254120680009))


### PR DESCRIPTION
Here is a first attempt at making a portable `Big-Float` implementation.  See the readme for usage details.

I went with a binary splitting algorithm for evaluating power series so I could implement all of the transcendental functions using one algorithm. This can leave a lot to be desired in terms of performance, but hopefully this lays the ground work so we can start implementing faster methods.

For regular arithmetic, I think it actually should be fairly performant.

I also wanted to avoid lookup tables for now just to keep things feeling a bit more lean. Although, I think having pre-computed values for ln2 or pi would make sense at some point in the future.

Couple of slightly tangential notes:
- #666 changed the type of the sign function, making it difficult to extract the sign of an element as an integer. I changed the sign function to a more flexible type signature.
- Moved fibonnaci benchmarks to their own file
- Implements #667