### PR TITLE
test for substring appearance

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -278,4 +278,5 @@
                (:file "addressable-tests")
                (:file "call-coalton-from-lisp")
                (:file "vector-tests")
+               (:file "string-tests")
                (:file "recursive-let-tests")))

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -12,7 +12,9 @@
    #:strip-suffix
    #:parse-int
    #:ref
-   #:ref-unchecked))
+   #:ref-unchecked
+   #:substring-index
+   #:substring?))
 
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
@@ -89,6 +91,22 @@ does not have that suffix."
     (if (< idx (fromInt (length str)))
         (Some (ref-unchecked str idx))
         None))
+
+  (declare substring-index (String -> String -> (Optional UFix)))
+  (define (substring-index small big)
+    "If the first argument appears as a substring within the second argument, return the starting index into the second argument."
+    (lisp (Optional UFix) (small big)
+      (alexandria:if-let (idx (cl:search small big))
+        (Some idx)
+        None)))
+
+  (declare substring? (String -> String -> Boolean))
+  (define (substring? small big)
+    "Return true if the first argument appears as a substring within the second argument."
+    ;; not a call to `optional:isSome' because this file is loaded before optional.lisp
+    (match (substring-index small big)
+      ((None) False)
+      ((Some _) True)))
 
   ;;
   ;; String Instances

--- a/tests/string-tests.lisp
+++ b/tests/string-tests.lisp
@@ -1,0 +1,28 @@
+(cl:in-package #:coalton-native-tests)
+
+(define-test string-substring-finders ()
+  (let find-foo = (string:substring-index "foo"))
+  (is (== (Some 0) (find-foo "foo")))
+  (is (== (Some 0) (find-foo "foo bar")))
+  (is (== (Some 4) (find-foo "bar foo")))
+  (is (== (Some 4) (find-foo "bar foo baz")))
+  (is (== None (find-foo "")))
+  (is (== None (find-foo "bar")))
+  (is (== None (find-foo "bar baz quux")))
+
+  (let find-empty-string = (string:substring-index ""))
+  (is (== (Some 0) (find-empty-string "")))
+  (is (== (Some 0) (find-empty-string "foo")))
+
+  (let has-foo? = (string:substring? "foo"))
+  (is (has-foo? "foo"))
+  (is (has-foo? "foo bar"))
+  (is (has-foo? "bar foo"))
+  (is (has-foo? "bar foo baz"))
+  (is (not (has-foo? "")))
+  (is (not (has-foo? "bar")))
+  (is (not (has-foo? "bar baz quux")))
+
+  (let has-empty? = (string:substring? ""))
+  (is (has-empty? ""))
+  (is (has-empty? "foo")))


### PR DESCRIPTION
Define two functions, `string:substring-index` and `string:substring?`, for searching a string for the appearance of a substring.

`substring-index` is `String -> String -> (Optional UFix)`, returning the index of the start of the substring.

`substring?` is `String -> String -> Boolean`, returning true if the substring appears in the string.

Both of these functions take the "needle" substring as their first argument, and the "haystack" superstring as their second argument. I believe this to be more useful for currying; `(substring? "foo")` is a function which, given a string, tests if `"foo"` appears in that string, and `(substring-index "foo")` is a function which, given a string, returns the first index of `"foo"` in that string.