### PR TITLE
use `UFix` as sequence indices rather than `Integer`

### DIFF
--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -54,7 +54,7 @@
     (TVar Tyvar)
     (TCon Tycon)
     (TAp Type Type)
-    (TGen Integer))
+    (TGen UFix))
 
   (define-instance (Eq Type)
       (define (== t1 t2)

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -138,14 +138,14 @@ Behavior is undefined if the iterator is advanced after a destructive modificati
     "Yield successive elements of VEC.
 Behavior is undefined if the iterator is advanced after a destructive modification of VEC."
     (map ((flip vector:index-unsafe) vec)
-         (up-to (fromInt (vector:length vec)))))
+         (up-to (vector:length vec))))
 
   (declare string-chars (String -> Iterator Char))
   (define (string-chars str)
     "Yield successive `Char`s from STR.
 Behavior is undefined if the iterator is advanced after a destructive modification of STR."
     (map (string:ref-unchecked str)
-         (up-to (fromInt (string:length str)))))
+         (up-to (string:length str))))
 
   (declare recursive-iter ((:elt -> :elt) -> (:elt -> Boolean) -> :elt -> Iterator :elt))
   (define (recursive-iter succ done? start)
@@ -356,7 +356,7 @@ In the case one iterator terminates before the other, the other is exhausted bef
     "Add together all the elements of ITER."
     (fold! + 0 iter))
 
-  (declare count! (Iterator :elt -> Integer))
+  (declare count! (Iterator :elt -> UFix))
   (define (count! iter)
     "Return the number of elements in ITER.
 This operation could be called `length!`, but `count!` emphasizes the fact that it consumes ITER, and
@@ -434,7 +434,7 @@ Returns `False` if ITER is empty."
     "Construct a `List` containing all the elements from ITER in order."
     (list:reverse (fold! (flip Cons) Nil iter)))
 
-  (declare collect-vector-size-hint! (Integer -> Iterator :elt -> Vector :elt))
+  (declare collect-vector-size-hint! (UFix -> Iterator :elt -> Vector :elt))
   (define (collect-vector-size-hint! size iter)
     "Construct a `Vector` with initial allocation for SIZE elements, and fill it with all the elements from ITER in order.
 

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -133,7 +133,7 @@
     "Returns a list containting one element."
     (Cons x Nil))
 
-  (declare repeat (Integer -> :a -> List :a))
+  (declare repeat (UFix -> :a -> List :a))
   (define (repeat n x)
     "Returns a list with the same value repeated multiple times."
     (if (== 0 n)
@@ -151,7 +151,7 @@
     ;; like (fold (flip Cons) Nil xs)
     (%reverse xs Nil))
 
-  (declare drop (Integer -> List :a -> List :a))
+  (declare drop (UFix -> List :a -> List :a))
   (define (drop n xs)
     "Returns a list with the first N elements removed."
     (if (== n 0)
@@ -161,7 +161,7 @@
            (drop (- n 1) xs))
           ((Nil) Nil))))
 
-  (declare take (Integer -> List :a -> List :a))
+  (declare take (UFix -> List :a -> List :a))
   (define (take n xs)
     "Returns the first N elements of a list."
     (if (== n 0)
@@ -194,7 +194,7 @@
                         (fun xs ys)))))))
       (fun xs Nil)))
 
-  (declare length (List :a -> Integer))
+  (declare length (List :a -> UFix))
   (define (length l)
     "Returns the length of a list."
     (fold (fn (a b)
@@ -202,7 +202,7 @@
           0
           l))
 
-  (declare index (Integer -> List :a -> Optional :a))
+  (declare index (UFix -> List :a -> Optional :a))
   (define (index i xs)
     "Returns the Ith element of a list."
     (match xs
@@ -213,16 +213,16 @@
            (Some x)
            (index (- i 1) xs)))))
 
-  (declare nth (Integer -> List :t -> :t))
+  (declare nth (UFix -> List :t -> :t))
   (define (nth n l)
     "Like INDEX, but errors if the index is not found."
     (fromSome "There is no NTH" (index n l)))
 
-  (declare elemIndex (Eq :a => :a -> List :a -> Optional Integer))
+  (declare elemIndex (Eq :a => :a -> List :a -> Optional UFix))
   (define (elemIndex x xs)
     (findIndex (== x) xs))
 
-  (declare findIndex ((:a -> Boolean) -> List :a -> Optional Integer))
+  (declare findIndex ((:a -> Boolean) -> List :a -> Optional UFix))
   (define (findIndex f xs)
     "Returns the index of the first element matching the predicate function F."
     (let ((find (fn (xs n)
@@ -235,9 +235,9 @@
                          (find xs (+ n 1))))))))
       (find xs 0)))
 
-  (declare range (Integer -> Integer -> List Integer))
+  (declare range ((Num :int) (Ord :int) => :int -> :int -> List :int))
   (define (range start end)
-    "Returns a list containing the numbers from START to END inclusive.
+    "Returns a list containing the numbers from START to END inclusive, counting by 1.
 
 
     ```
@@ -394,7 +394,7 @@
     "Builds a list of tuples with the elements of XS and YS."
     (zipWith Tuple xs ys))
 
-  (declare countBy ((:a -> Boolean) -> (List :a) -> Integer))
+  (declare countBy ((:a -> Boolean) -> (List :a) -> UFix))
   (define (countBy f things)
     "Count the number of items in THINGS that satisfy the predicate F."
     (fold (fn (sum x)
@@ -584,7 +584,7 @@ The ordering of elements of L is preserved in the ordering of elements in each l
       ((Cons x xs)
        (concatMap (fn (y) (make-list y (Cons x y))) (combs xs)))))
 
-  (declare combsOf (Integer -> List :a -> (List (List :a))))
+  (declare combsOf (UFix -> List :a -> (List (List :a))))
   (define (combsOf n l)
     "Produce a list of size-N subsets of L.
 
@@ -592,13 +592,14 @@ The ordering of elements of L is preserved in the ordering of elements in each l
 
 This function is equivalent to all size-N elements of `(COMBS L)`."
 
-    (match (Tuple n l)
-      ((Tuple 0 _)           (make-list Nil))
-      ((Tuple 1 _)           (map singleton l))
-      ((Tuple _ (Nil))       Nil)
-      ((Tuple _ (Cons x xs)) (append
+    (cond ((== 0 n) (make-list Nil))
+          ((== 1 n) (map singleton l))
+          (True (match l
+                  ((Nil) Nil)
+                  ((Cons x xs) (append
                               (map (Cons x) (combsOf (- n 1) xs)) ; combs with X
-                              (combsOf n xs)))))                  ; and without X
+                              (combsOf n xs)                      ; and without x
+                              ))))))
 
   ;;
   ;; List instances

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -37,7 +37,7 @@
   (repr :native (cl:vector cl:t))
   (define-type (Slice :a))
 
-  (declare new (Integer -> Integer -> (Vector :a) -> (Slice :a)))
+  (declare new (UFix -> UFix -> (Vector :a) -> (Slice :a)))
   (define (new start length v)
     (when (< start 0)
       (error "Start of slice cannot be less than 0."))
@@ -55,10 +55,10 @@
        :displaced-to v
        :displaced-index-offset start)))
 
-  (declare length ((Slice :a) -> Integer))
+  (declare length ((Slice :a) -> UFix))
   (define (length s)
     "Returns the length of S"
-    (lisp Integer (s)
+    (lisp UFix (s)
       (cl:array-dimension s 0)))
 
   (declare copy ((Slice :a) -> (Slice :a)))
@@ -67,21 +67,21 @@
     (lisp (Slice :a) (s)
       (alexandria:copy-array s)))
 
-  (declare set! (Integer -> :a -> (Slice :a) -> Unit))
+  (declare set! (UFix -> :a -> (Slice :a) -> Unit))
   (define (set! index item s)
     "Set the element at INDEX in S to ITEM"
     (lisp :a (index item s)
       (cl:setf (cl:aref s index) item))
     Unit)
 
-  (declare index (Integer -> (Slice :a) -> (Optional :a)))
+  (declare index (UFix -> (Slice :a) -> (Optional :a)))
   (define (index idx s)
     "Lookup the element at INDEX in S"
     (if (>= idx (length s))
         None
         (Some (index-unsafe idx s))))
 
-  (declare index-unsafe (Integer -> (Slice :a) -> :a))
+  (declare index-unsafe (UFix -> (Slice :a) -> :a))
   (define (index-unsafe idx s)
     "Lookup the element at INDEX in S without bounds checking"
     (lisp :a (idx s)
@@ -95,7 +95,7 @@
          :do (coalton-impl/codegen::A1 f elem)))
     Unit)
 
-  (declare foreach-index ((Integer -> :a -> :b) -> (Slice :a) -> Unit))
+  (declare foreach-index ((UFix -> :a -> :b) -> (Slice :a) -> Unit))
   (define (foreach-index f s)
     "Call the function F once for each item in S with its index"
     (lisp :a (f s)
@@ -119,7 +119,7 @@
   ;; Vector functions
   ;;
 
-  (declare iter-sliding (((Slice :a) -> :b) -> Integer -> (Vector :a) -> Unit))
+  (declare iter-sliding (((Slice :a) -> :b) -> UFix -> (Vector :a) -> Unit))
   (define (iter-sliding f size v)
     "Sliding iteration over a vector"
     (let ((inner
@@ -132,7 +132,7 @@
                     (inner (+ offset 1)))))))
       (inner 0)))
 
-  (declare iter-chunked (((Slice :a) -> :b) -> Integer -> (Vector :a) -> Unit))
+  (declare iter-chunked (((Slice :a) -> :b) -> UFix -> (Vector :a) -> Unit))
   (define (iter-chunked f size v)
     "Chunked iteration over a vector. Ignores elements at the end if the vector does not evenly divide by the chunk size."
     (let ((inner

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -37,13 +37,13 @@
     "Reverse a string."
     (lisp String (s) (cl:reverse s)))
 
-  (declare length (String -> Integer))
+  (declare length (String -> UFix))
   (define (length str)
     "The length of a string STR."
-    (lisp Integer (str)
+    (lisp UFix (str)
       (cl:length str)))
 
-  (declare substring (String -> Integer -> Integer -> String))
+  (declare substring (String -> UFix -> UFix -> String))
   (define (substring str start end)
     "Compute a substring of a string bounded by given indices."
     (let ((real-start (max 0 (min start end)))
@@ -88,7 +88,7 @@ does not have that suffix."
 
   (declare ref (String -> UFix -> (Optional Char)))
   (define (ref str idx)
-    (if (< idx (fromInt (length str)))
+    (if (< idx (length str))
         (Some (ref-unchecked str idx))
         None))
 

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -56,22 +56,22 @@
     "Create a new empty vector"
     (with-capacity 0))
 
-  (declare with-capacity (Integer -> Vector :a))
+  (declare with-capacity (UFix -> Vector :a))
   (define (with-capacity n)
     "Create a new vector with N elements preallocated"
     (lisp (Vector :a) (n)
       (cl:make-array n :fill-pointer 0 :adjustable cl:t)))
 
-  (declare length (Vector :a -> Integer))
+  (declare length (Vector :a -> UFix))
   (define (length v)
     "Returns the length of V"
-    (lisp Integer (v)
+    (lisp UFix (v)
       (cl:length v)))
 
-  (declare capacity (Vector :a -> Integer))
+  (declare capacity (Vector :a -> UFix))
   (define (capacity v)
     "Returns the number of elements that V can store without resizing"
-    (lisp Integer (v)
+    (lisp UFix (v)
       (cl:array-dimension v 0)))
 
   (declare empty? (Vector :a -> Boolean))
@@ -85,10 +85,10 @@
     (lisp (Vector :a) (v)
       (alexandria:copy-array v)))
 
-  (declare push! (:a -> Vector :a -> Integer))
+  (declare push! (:a -> Vector :a -> UFix))
   (define (push! item v)
     "Append ITEM to V and resize V if necessary"
-    (lisp Integer (item v)
+    (lisp UFix (item v)
       (cl:progn
 	(cl:vector-push-extend item v)
 	(cl:1- (cl:fill-pointer v)))))
@@ -106,20 +106,20 @@
     (lisp :a (v)
       (cl:vector-pop v)))
 
-  (declare index (Integer -> Vector :a -> Optional :a))
+  (declare index (UFix -> Vector :a -> Optional :a))
   (define (index index v)
     "Return the INDEXth element of V"
     (if (>= index (length v))
         None
         (Some (index-unsafe index v))))
 
-  (declare index-unsafe (Integer -> Vector :a -> :a))
+  (declare index-unsafe (UFix -> Vector :a -> :a))
   (define (index-unsafe index v)
     "Return the INDEXth element of V without checking if the element exists"
     (lisp :a (index v)
       (cl:aref v index)))
 
-  (declare set! (Integer -> :a -> Vector :a -> Unit))
+  (declare set! (UFix -> :a -> Vector :a -> Unit))
   (define (set! index item v)
     "Set the INDEXth element of V to ITEM. This function left intentionally unsafe because it does not have a return value to check."
     (lisp Void (index item v)
@@ -146,13 +146,13 @@
     "Return the last element of V without first checking if V is empty"
     (index-unsafe (- (length v) 1) v))
 
-  (declare find-elem (Eq :a => :a -> Vector :a -> Optional Integer))
+  (declare find-elem (Eq :a => :a -> Vector :a -> Optional UFix))
   (define (find-elem e v)
     "Find the index of element E in V"
     (let ((test (fn (elem)
                   (== elem e))))
 
-      (lisp (Optional Integer) (v test)
+      (lisp (Optional UFix) (v test)
         (cl:let ((pos (cl:position-if
                        (cl:lambda (x)
                          (cl:equalp True (coalton-impl/codegen::A1 test x)))
@@ -169,7 +169,7 @@
          :do (coalton-impl/codegen::A1 f elem)))
     Unit)
 
-  (declare foreach-index ((Integer -> :a -> :b) -> Vector :a -> Unit))
+  (declare foreach-index ((UFix -> :a -> :b) -> Vector :a -> Unit))
   (define (foreach-index f v)
     "Call the function F once for each item in V with its index"
     (lisp Void (f v)
@@ -201,14 +201,14 @@
     (foreach f v2)
     out)
 
-  (declare swap-remove! (Integer -> Vector :a -> Optional :a))
+  (declare swap-remove! (UFix -> Vector :a -> Optional :a))
   (define (swap-remove! idx vec)
     "Remove the element IDX from VEC and replace it with the last element in VEC. Then return the removed element."
     (if (>= idx (length vec))
         None
         (Some (swap-remove-unsafe! idx vec))))
 
-  (declare swap-remove-unsafe! (Integer -> Vector :a -> :a))
+  (declare swap-remove-unsafe! (UFix -> Vector :a -> :a))
   (define (swap-remove-unsafe! idx vec)
     "Remove the element IDX from VEC and replace it with the last element in VEC without bounds checking. Then return the removed element."
     (if (== (+ 1 idx) (length vec))

--- a/tests/float-tests.lisp
+++ b/tests/float-tests.lisp
@@ -97,7 +97,7 @@
   (declare float-checklist ((math:Dividable Integer :a) => (List :a)))
   (define float-checklist
     (coalton-prelude:zipWith
-     math:general/ (coalton-prelude:range -100 100) (coalton-prelude:range 200 1))))
+     math:general/ (coalton:the (coalton:List coalton:Integer) (coalton-prelude:range -100 100)) (coalton-prelude:range 200 1))))
 
 (coalton-toplevel
   (define (check-against-double x y)


### PR DESCRIPTION
All array types (vectors, strings, slices, etc.) require that their indices be positive
fixnums, never bignums (see the spec on `ARRAY-TOTAL-SIZE-LIMIT`,
http://www.lispworks.com/documentation/HyperSpec/Body/v_ar_tot.htm).

For consistency's sake, it seems reasonable to impose the same restriction on list
indices; I find it unlikely that anyone will be able to cons a non-circular list with
length > most-positive-fixnum, as on both 32-bit and 64-bit machines with 1-bit fixnum
tags, that many cons cells would fill the entire address space.

Lazy iterators are also unlikely to ever have non-fixnum indices, at least within a human
user's lifetime. (This might not be true on a 32-bit machine, but I maintain that 32-bit
machines aren't real.)

In light of that, this commit restricts the library sequences' length- and index-related
operators to have type `UFix` rather than `Integer`.

It also generalizes the type of `list:range` to support any type that is `Num` and `Ord`,
rather than just `Integer`; this came up when editing thih-coalton to use `UFix` to
represent `TGen` generated types (which are indexes into some list of types).