### PR TITLE
Define conversions from integers to floats

### DIFF
--- a/library/math/arith.lisp
+++ b/library/math/arith.lisp
@@ -23,7 +23,6 @@
    #:negative-infinity
    #:nan
    #:nan?
-   #:integer->float
    #:negate
    #:abs
    #:sign

--- a/library/math/conversions.lisp
+++ b/library/math/conversions.lisp
@@ -8,10 +8,7 @@
    #:coalton-library/builtin
    #:coalton-library/classes
    #:coalton-library/functions
-   #:coalton-library/math/bounded)
-  (:export
-   #:integer->double-float
-   #:integer->single-float))
+   #:coalton-library/math/bounded))
 
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
@@ -142,6 +139,27 @@ cannot be represented in :TO. These fall into a few categories:
 (define-integer-conversions UFix)
 (define-integer-conversions IFix)
 (define-integer-conversions Integer)
+
+(cl:defmacro integer-into-float (integer coalton-float lisp-float)
+  `(coalton-toplevel
+     (define-instance (Into ,integer ,coalton-float)
+       (define (into x)
+         (lisp ,coalton-float (x)
+           (cl:coerce x (cl:quote ,lisp-float)))))))
+
+;; Only exact conversions
+;; Single-Float: 24 bit mantissa (not including sign)
+(integer-into-float U8 Single-Float cl:single-float)
+(integer-into-float I8 Single-Float cl:single-float)
+(integer-into-float U16 Single-Float cl:single-float)
+(integer-into-float I16 Single-Float cl:single-float)
+;; Double-Float: 53 bit mantissa (not including sign)
+(integer-into-float U8 Double-Float cl:double-float)
+(integer-into-float I8 Double-Float cl:double-float)
+(integer-into-float U16 Double-Float cl:double-float)
+(integer-into-float I16 Double-Float cl:double-float)
+(integer-into-float U32 Double-Float cl:double-float)
+(integer-into-float I32 Double-Float cl:double-float)
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/MATH/CONVERSIONS")

--- a/library/math/integral.lisp
+++ b/library/math/integral.lisp
@@ -22,6 +22,7 @@
    #:rem
    #:quotRem
    #:toInteger
+   #:integral->num
    #:lsh
    #:rsh
    #:even?
@@ -54,6 +55,11 @@
     "Integral is a number that is either even or odd where `div' and `quot'
 are floored and truncated division, respectively."
     (toInteger (:int -> Integer)))
+
+  (declare integral->num ((Integral :a) (Num :b) => :a -> :b))
+  (define (integral->num n)
+    "Converts any Integral N into any Num."
+    (fromInt (toInteger n)))
 
   (declare rsh ((Integral :n) (Bits :b) => :b -> :n -> :b))
   (define (rsh x n)


### PR DESCRIPTION
Adds some missing Into float instances. The bounds on the integers are within the float's sign*mantissa, so all the coerces should be safe and exact.

For anything else, I added `integral->num`.

I also removed some orphan exports.