### PR TITLE
Export mapErr in result package

### DIFF
--- a/library/result.lisp
+++ b/library/result.lisp
@@ -9,6 +9,7 @@
   (:export
    #:isOk
    #:isErr
+   #:mapErr
    #:flatten))
 
 #+coalton-release


### PR DESCRIPTION
Exports the pre-existing but previously private utility function `mapErr` from the `:coalon-library/result` package. I assume this was meant to be exported (it's never used elsewhere in the package).