### PR TITLE
Enable direct application in coalton macro

### DIFF
--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -185,17 +185,22 @@ in FORMS that begin with that operator."
 
           (cond
             ((null preds)
-             (setf *global-environment* env)
-             (values
-              (coalton-impl/codegen::codegen-expression
-               (coalton-impl/codegen::optimize-node
-                (coalton-impl/codegen::compile-expression
-                 typed-node
+             (let ((node
+                     (coalton-impl/codegen::optimize-node
+                      (coalton-impl/codegen::compile-expression
+                       typed-node
+                       nil
+                       *global-environment*)
+                      *global-environment*)))
+
+               (setf *global-environment* env)
+               (values
+                (coalton-impl/codegen::codegen-expression
+                 (coalton-impl/codegen::direct-application
+                  node
+                  (coalton-impl/codegen::make-function-table *global-environment*))
                  nil
-                 *global-environment*)
-                *global-environment*)
-               nil
-               *global-environment*)))
+                 *global-environment*))))
 
             (t
              (coalton-impl/typechecker::with-pprint-variable-context ()

--- a/src/codegen/package.lisp
+++ b/src/codegen/package.lisp
@@ -6,10 +6,18 @@
    #:codegen-expression)
 
   (:import-from
-   #:coalton-impl/codegen/optimizer
-   #:optimize-node)
+   #:coalton-impl/codegen/transformations
+   #:make-function-table)
   (:export
-   #:optimize-node)
+   #:make-function-table)
+
+  (:import-from
+   #:coalton-impl/codegen/optimizer
+   #:optimize-node
+   #:direct-application)
+  (:export
+   #:optimize-node
+   #:direct-application)
 
   (:import-from
    #:coalton-impl/codegen/compile-expression


### PR DESCRIPTION
This also fixes #679, because recursive construction required that the
constructor was a direct application.