### PR TITLE
Export the `sexp-fmt` symbol from the `util` package

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -21,6 +21,7 @@
    #:literal-value                      ; TYPE
    #:maphash-values-new                 ; FUNCTION
    #:find-symbol?                       ; FUNCTION
+   #:sexp-fmt                           ; FUNCTION
    ))
 
 (uiop:define-package #:coalton-impl/algorithm


### PR DESCRIPTION
Exports the `sexp-fmt` symbol from the `util` package:

This function isn't used anywhere except in a custom format specifier in the `typechecker` package. That format specifier, which is supposed to emit a relevant warning message, causes the compiler to crash as this function isn't found.