### PR TITLE
Make map tail-recursive

### DIFF
--- a/library/list.lisp
+++ b/library/list.lisp
@@ -634,9 +634,7 @@ This function is equivalent to all size-N elements of `(COMBS L)`."
 
   (define-instance (Functor List)
     (define (map f l)
-      (match l
-        ((Cons x xs) (Cons (f x) (map f xs)))
-        ((Nil) Nil))))
+      (reverse (fold (fn (a x) (Cons (f x) a)) Nil l))))
 
   (define-instance (Applicative List)
     (define (pure x) (Cons x Nil))


### PR DESCRIPTION
Currently, for some reason, `list:map` is not a tail recursive operation, though it definitely seems like it should be. The proposed change does allocate more than the original does, but there's no way to prevent this unless we were to add something like `nreverse`.