### PR TITLE
Remove all renamed constructors

### DIFF
--- a/src/ast/node.lisp
+++ b/src/ast/node.lisp
@@ -17,41 +17,27 @@
 (deftype binding-list ()
   `(satisfies binding-list-p))
 
-;;;;;;;;;;;;;;;;;;;;;;;;; The types of nodes ;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defstruct
-    (node-literal
-     (:include node)
-     (:constructor node-literal (unparsed value)))
+(defstruct (node-literal (:include node))
   "A literal value. These include things like integers and strings."
   (value (required 'value) :type literal-value :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-literal))
 
-(defstruct
-    (node-variable
-     (:include node)
-     (:constructor node-variable (unparsed name)))
+(defstruct (node-variable (:include node))
   (name (required 'name) :type symbol :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-variable))
 
-(defstruct
-    (node-application
-     (:include node)
-     (:constructor node-application (unparsed rator rands)))
+(defstruct (node-application (:include node))
   (rator (required 'rator) :type node      :read-only t)
   (rands (required 'rands) :type node-list :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-application))
 
-(defstruct
-    (node-abstraction
-     (:include node)
-     (:constructor node-abstraction (unparsed vars subexpr name-map)))
+(defstruct (node-abstraction (:include node))
   (vars     (required 'vars)     :type t           :read-only t)
   (subexpr  (required 'subexpr)  :type node        :read-only t)
   (name-map (required 'name-map) :type list        :read-only t))
@@ -59,10 +45,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-abstraction))
 
-(defstruct
-    (node-let
-     (:include node)
-     (:constructor node-let (unparsed bindings declared-types subexpr name-map)))
+(defstruct (node-let (:include node))
   (bindings       (required 'bindings)      :type binding-list :read-only t)
   (declared-types (required 'declare-types) :type list         :read-only t)
   (subexpr        (required 'subexpr)       :type node         :read-only t)
@@ -71,10 +54,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-let))
 
-(defstruct
-    (node-lisp
-     (:include node)
-     (:constructor node-lisp (unparsed type variables form)))
+(defstruct (node-lisp (:include node))
   (type      (required 'type)      :type t :read-only t)
   (variables (required 'variables) :type t :read-only t)
   (form      (required 'form)      :type t :read-only t))
@@ -91,48 +71,33 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type match-branch))
 
-(defstruct
-    (node-match
-     (:include node)
-     (:constructor node-match (unparsed expr branches)))
+(defstruct (node-match (:include node))
   (expr     (required 'expr)     :type node :read-only t)
   (branches (required 'branches) :type list :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-match))
 
-(defstruct
-    (node-seq
-     (:include node)
-     (:constructor node-seq (unparsed subnodes)))
-     (subnodes (required 'subnodes) :type node-list :read-only t))
+(defstruct (node-seq (:include node))
+  (subnodes (required 'subnodes) :type node-list :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-seq))
 
-(defstruct
-    (node-the
-     (:include node)
-     (:constructor node-the (unparsed type subnode)))
+(defstruct (node-the (:include node))
   (type    (required 'type)       :type t    :read-only t)
   (subnode (required 'subnode)    :type node :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-the))
 
-(defstruct
-    (node-return
-     (:include node)
-     (:constructor node-return (unparsed expr)))
+(defstruct (node-return (:include node))
   (expr (required 'expr) :type node :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type node-return))
 
-(defstruct
-    (node-bind
-     (:include node)
-     (:constructor node-bind (unparsed name expr body)))
+(defstruct (node-bind (:include node))
   (name (required 'name) :type symbol :read-only t)
   (expr (required 'expr) :type node   :read-only t)
   (body (required 'body) :type node   :read-only t))

--- a/src/ast/pattern.lisp
+++ b/src/ast/pattern.lisp
@@ -13,10 +13,7 @@
 (deftype pattern-list ()
   '(satisfies pattern-list-p))
 
-(defstruct
-    (pattern-var
-     (:include pattern)
-     (:constructor pattern-var (id)))
+(defstruct (pattern-var (:include pattern))
   (id (required 'id) :type symbol :read-only t))
 
 (defmethod make-load-form ((self pattern-var) &optional env)
@@ -25,10 +22,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type pattern-var))
 
-(defstruct
-    (pattern-wildcard
-     (:include pattern)
-     (:constructor pattern-wildcard)))
+(defstruct (pattern-wildcard (:include pattern)))
 
 (defmethod make-load-form ((self pattern-wildcard) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -36,10 +30,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type pattern-wildcard))
 
-(defstruct
-    (pattern-literal
-     (:include pattern)
-     (:constructor pattern-literal (value)))
+(defstruct (pattern-literal (:include pattern))
   (value (required 'value) :type literal-value :read-only t))
 
 (defmethod make-load-form ((self pattern-literal) &optional env)
@@ -48,10 +39,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type pattern-literal))
 
-(defstruct
-    (pattern-constructor
-     (:include pattern)
-     (:constructor pattern-constructor (name patterns)))
+(defstruct (pattern-constructor (:include pattern))
   (name      (required 'name) :type symbol       :read-only t)
   (patterns  (required 'type) :type pattern-list :read-only t))
 
@@ -77,17 +65,17 @@
     (pattern-wildcard pattern)
 
     (pattern-constructor
-     (pattern-constructor
-      (pattern-constructor-name pattern)
-      (mapcar
-       (lambda (pattern)
-         (rewrite-pattern-vars pattern m))
-       (pattern-constructor-patterns pattern))))
+     (make-pattern-constructor
+      :name (pattern-constructor-name pattern)
+      :patterns (mapcar
+                 (lambda (pattern)
+                   (rewrite-pattern-vars pattern m))
+                 (pattern-constructor-patterns pattern))))
 
     (pattern-var
-     (pattern-var
-      (or (immutable-map-lookup m (pattern-var-id pattern))
-          (coalton-impl::coalton-bug "Invalid state reached in rewrite-pattern-vars"))))))
+     (make-pattern-var
+      :id (or (immutable-map-lookup m (pattern-var-id pattern))
+              (coalton-impl::coalton-bug "Invalid state reached in rewrite-pattern-vars"))))))
 
 
 (defun pattern-variables (pattern)

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -16,54 +16,69 @@
    #:node-list                          ; TYPE
    #:binding-list                       ; TYPE
    #:node-literal                       ; STRUCT
+   #:make-node-literal                  ; CONSTRUCTOR
    #:node-literal-value                 ; ACCESSOR
    #:node-variable                      ; STRUCT
+   #:make-node-variable                 ; CONSTRUCTOR
    #:node-variable-p                    ; FUNCTION
    #:node-variable-value                ; ACCESSOR
    #:node-application                   ; STRUCT
+   #:make-node-application              ; CONSTRUCTOR
    #:node-application-p                 ; FUNCTION
    #:node-application-rator             ; ACCESSOR
    #:node-application-rands             ; ACCESSOR
    #:node-direct-application            ; STRUCT
+   #:make-node-direct-application       ; CONSTRUCTOR
    #:node-direct-application-rator-type ; ACCESSOR
    #:node-direct-application-rator      ; ACCESSOR
    #:node-direct-application-rands      ; ACCESSOR
    #:node-direct-application-p          ; FUNCTION
    #:node-abstraction                   ; STRUCT
+   #:make-node-abstraction              ; CONSTRUCTOR
    #:node-abstraction-vars              ; ACCESSOR
    #:node-abstraction-subexpr           ; ACCESSOR
    #:node-abstraction-p                 ; FUNCTION
    #:node-bare-abstraction              ; STRUCT
+   #:make-node-bare-abstraction         ; CONSTRUCTOR
    #:node-bare-abstraction-vars         ; ACCESSOR
    #:node-bare-abstraction-subexpr      ; ACCESSOR
    #:node-let                           ; STRUCT
+   #:make-node-let                      ; CONSTRUCTOR
    #:node-let-p                         ; FUNCTION
    #:node-let-bindings                  ; ACCESSOR
    #:node-let-subexpr                   ; ACCESSOR
    #:node-lisp                          ; STRUCT
+   #:make-node-lisp                     ; CONSTRUCTOR
    #:node-lisp-vars                     ; ACCESOR
    #:node-lisp-form                     ; ACCESOR
    #:match-branch                       ; STRUCT
+   #:make-match-branch                  ; CONSTRUCTOR
    #:match-branch-pattern               ; ACCESSOR
    #:match-branch-bindings              ; ACCESSOR
    #:match-branch-body                  ; ACCESSOR
    #:branch-list                        ; TYPE
    #:node-match                         ; STRUCT
+   #:make-node-match                    ; CONSTRUCTOR
    #:node-match-expr                    ; ACCESSOR
    #:node-match-branches                ; ACCESSOR
    #:node-seq                           ; STRUCT
+   #:make-node-seq                      ; CONSTRUCTOR
    #:node-seq-nodes                     ; ACCESSOR
    #:node-return                        ; STRUCT
+   #:make-node-return                   ; CONSTRUCTOR
    #:node-return-expr                   ; ACCESSOR
    #:node-field                         ; STRUCT
+   #:make-node-field                    ; CONSTRUCTOR
    #:node-field-name                    ; ACCESSOR
    #:node-field-dict                    ; ACCESSOR
    #:node-field-p                       ; FUNCTION
    #:node-dynamic-extent                ; STRUCT
+   #:make-node-dynamic-extent           ; CONSTRUCTOR
    #:node-dynamic-extent-name           ; ACCESSOR
    #:node-dynamic-extent-node           ; ACCESSOR
    #:node-dynamic-extent-body           ; ACCESSOR
    #:node-bind                          ; STRUCT
+   #:make-node-bind                     ; CONSTRUCTOR
    #:node-bind-name                     ; ACCESSOR
    #:node-bind-expr                     ; ACCESSOR
    #:node-bind-body                     ; ACCESOR
@@ -99,27 +114,21 @@
 (deftype binding-list ()
   '(satisfies binding-list-p))
 
-(defstruct (node-literal
-            (:include node)
-            (:constructor node-literal (type value)))
+(defstruct (node-literal (:include node))
   "Literal values like 1 or \"hello\""
   (value (required 'value) :type literal-value :read-only t))
 
 (defmethod make-load-form ((self node-literal) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-variable
-            (:include node)
-            (:constructor node-variable (type value)))
+(defstruct (node-variable (:include node))
   "Variables like x or y"
   (value (required 'value) :type symbol :read-only t))
 
 (defmethod make-load-form ((self node-variable) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-application
-            (:include node)
-            (:constructor node-application (type rator rands)))
+(defstruct (node-application (:include node))
   "Function application (f x)"
   (rator (required 'rator) :type node      :read-only t)
   (rands (required 'rands) :type node-list :read-only t))
@@ -127,9 +136,7 @@
 (defmethod make-load-form ((self node-application) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-direct-application
-            (:include node)
-            (:constructor node-direct-application (type rator-type rator rands)))
+(defstruct (node-direct-application (:include node))
   "Fully saturated function application of a known function"
   (rator-type (required 'rator-type) :type tc:ty     :read-only t)
   (rator      (required 'rator)      :type symbol    :read-only t)
@@ -138,9 +145,7 @@
 (defmethod make-load-form ((self node-direct-application) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-abstraction
-            (:include node)
-            (:constructor node-abstraction (type vars subexpr)))
+(defstruct (node-abstraction (:include node))
   "Lambda literals (fn (x) x)"
   (vars    (required 'vars)    :type symbol-list        :read-only t)
   (subexpr (required 'subexpr) :type node               :read-only t))
@@ -148,9 +153,7 @@
 (defmethod make-load-form ((self node-abstraction) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-bare-abstraction
-            (:include node)
-            (:constructor node-bare-abstraction (type vars subexpr)))
+(defstruct (node-bare-abstraction (:include node))
   "Lambda literals which do not need be wrapped in function-entries.
 This is used to speedup method calls. This can be done because
 although method calls are to an unknown function, they should always
@@ -161,19 +164,15 @@ be a fully saturated call."
 (defmethod make-load-form ((self node-bare-abstraction) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-let
-            (:include node)
-            (:constructor node-let (type bindings subexpr)))
+(defstruct (node-let (:include node))
   "Introduction of local mutually-recursive bindings (let ((x 2)) (+ x x))"
-  (bindings (requried 'bindings) :type binding-list :read-only t)
+  (bindings (required 'bindings) :type binding-list :read-only t)
   (subexpr  (required 'subexpr)  :type node         :read-only t))
 
 (defmethod make-load-form ((self node-let) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-lisp
-            (:include node)
-            (:constructor node-lisp (type vars form)))
+(defstruct (node-lisp (:include node))
   "An embedded lisp form"
   (vars (required 'vars) :type list :read-only t)
   (form (required 'form) :type t    :read-only t))
@@ -181,8 +180,7 @@ be a fully saturated call."
 (defmethod make-load-form ((self node-lisp) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (match-branch
-            (:constructor match-branch (pattern bindings body)))
+(defstruct match-branch
   "A branch of a match statement"
   (pattern  (required 'pattern)  :type pattern            :read-only t)
   (bindings (required 'bindings) :type tc:ty-binding-list :read-only t)
@@ -198,9 +196,7 @@ be a fully saturated call."
 (deftype branch-list ()
   '(satisfies branch-list-p))
 
-(defstruct (node-match
-            (:include node)
-            (:constructor node-match (type expr branches)))
+(defstruct (node-match (:include node))
   "A pattern matching construct. Uses MATCH-BRANCH to represent branches"
   (expr (required 'expr) :type node :read-only t)
   (branches (required 'branches) :type branch-list :read-only t))
@@ -208,27 +204,21 @@ be a fully saturated call."
 (defmethod make-load-form ((self node-match) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-seq
-            (:include node)
-            (:constructor node-seq (type nodes)))
+(defstruct (node-seq (:include node))
   "A series of statements to be executed sequentially"
   (nodes (required 'nodes) :type node-list :read-only t))
 
 (defmethod make-load-form ((self node-seq) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-return
-            (:include node)
-            (:constructor node-return (type expr)))
+(defstruct (node-return (:include node))
   "A return statement, used for early returns in functions"
   (expr (required 'expr) :type node :read-only t))
 
 (defmethod make-load-form ((self node-return) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-field
-            (:include node)
-            (:constructor node-field (type name dict)))
+(defstruct (node-field (:include node))
   "Accessing a superclass on a typeclass dictionary"
   (name (required 'field) :type symbol :read-only t)
   (dict (required 'dict)  :type node   :read-only t))
@@ -236,9 +226,7 @@ be a fully saturated call."
 (defmethod make-load-form ((self node-field) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-dynamic-extent
-            (:include node)
-            (:constructor node-dynamic-extent (type name node body)))
+(defstruct (node-dynamic-extent (:include node))
   "A single stack allocated binding"
   (name (required 'name) :type symbol :read-only t)
   (node (required 'node) :type node   :read-only t)
@@ -247,9 +235,7 @@ be a fully saturated call."
 (defmethod make-load-form ((self node-dynamic-extent) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defstruct (node-bind
-            (:include node)
-            (:constructor node-bind (type name expr body)))
+(defstruct (node-bind (:include node))
   "A single non-recursive binding"
   (name (required 'name) :type symbol :read-only t)
   (expr (required 'expr) :type node   :read-only t)
@@ -428,104 +414,104 @@ both CL namespaces appearing in NODE"
      (node-variables-g (node-bind-body node) :variable-namespace-only variable-namespace-only))))
 
 (defmethod tc:apply-substitution (subs (node node-literal))
-    (node-literal
-     (tc:apply-substitution subs (node-type node))
-     (node-literal-value node)))
+  (make-node-literal
+   :type (tc:apply-substitution subs (node-type node))
+   :value (node-literal-value node)))
 
 (defmethod tc:apply-substitution (subs (node node-variable))
-  (node-variable
-   (tc:apply-substitution subs (node-type node))
-   (node-variable-value node)))
+  (make-node-variable
+   :type (tc:apply-substitution subs (node-type node))
+   :value (node-variable-value node)))
 
 (defmethod tc:apply-substitution (subs (node node-application))
-  (node-application
-   (tc:apply-substitution subs (node-type node))
-   (tc:apply-substitution subs (node-application-rator node))
-   (mapcar
-    (lambda (node)
-      (tc:apply-substitution subs node))
-    (node-application-rands node))))
+  (make-node-application
+   :type (tc:apply-substitution subs (node-type node))
+   :rator (tc:apply-substitution subs (node-application-rator node))
+   :rands (mapcar
+           (lambda (node)
+             (tc:apply-substitution subs node))
+           (node-application-rands node))))
 
 (defmethod tc:apply-substitution (subs (node node-direct-application))
-  (node-direct-application
-   (tc:apply-substitution subs (node-type node))
-   (tc:apply-substitution subs (node-direct-application-rator-type node))
-   (node-direct-application-rator node)
-   (mapcar
-    (lambda (node)
-      (tc:apply-substitution subs node))
-    (node-direct-application-rands node))))
+  (make-node-direct-application
+   :type (tc:apply-substitution subs (node-type node))
+   :rator-type (tc:apply-substitution subs (node-direct-application-rator-type node))
+   :rator (node-direct-application-rator node)
+   :rands (mapcar
+           (lambda (node)
+             (tc:apply-substitution subs node))
+           (node-direct-application-rands node))))
 
 (defmethod tc:apply-substitution (subs (node node-abstraction))
-  (node-abstraction
-   (tc:apply-substitution subs (node-type node))
-   (node-abstraction-vars node)
-   (tc:apply-substitution subs (node-abstraction-subexpr node))))
+  (make-node-abstraction
+   :type (tc:apply-substitution subs (node-type node))
+   :vars (node-abstraction-vars node)
+   :subexpr (tc:apply-substitution subs (node-abstraction-subexpr node))))
 
 (defmethod tc:apply-substitution (subs (node node-bare-abstraction))
-  (node-bare-abstraction
-   (tc:apply-substitution subs (node-type node))
-   (node-bare-abstraction-vars node)
-   (tc:apply-substitution subs (node-bare-abstraction-subexpr node))))
+  (make-node-bare-abstraction
+   :type (tc:apply-substitution subs (node-type node))
+   :vars (node-bare-abstraction-vars node)
+   :subexpr (tc:apply-substitution subs (node-bare-abstraction-subexpr node))))
 
 (defmethod tc:apply-substitution (subs (node node-let))
-  (node-let
-   (tc:apply-substitution subs (node-type node))
-   (loop :for (name . node) :in (node-let-bindings node)
-         :collect (cons name (tc:apply-substitution subs node)))
-   (tc:apply-substitution subs (node-let-subexpr node))))
+  (make-node-let
+   :type (tc:apply-substitution subs (node-type node))
+   :bindings (loop :for (name . node) :in (node-let-bindings node)
+                   :collect (cons name (tc:apply-substitution subs node)))
+   :subexpr (tc:apply-substitution subs (node-let-subexpr node))))
 
 (defmethod tc:apply-substitution (subs (node node-lisp))
-  (node-lisp
-   (tc:apply-substitution subs (node-type node))
-   (node-lisp-vars node)
-   (node-lisp-form node)))
+  (make-node-lisp
+   :type (tc:apply-substitution subs (node-type node))
+   :vars (node-lisp-vars node)
+   :form (node-lisp-form node)))
 
 (defmethod tc:apply-substitution (subs (node match-branch))
-  (match-branch
-   (match-branch-pattern node)
-   (loop :for (name . ty) :in (match-branch-bindings node)
-         :collect (cons name (tc:apply-substitution subs ty)))
-   (tc:apply-substitution subs (match-branch-body node))))
+  (make-match-branch
+   :pattern (match-branch-pattern node)
+   :bindings (loop :for (name . ty) :in (match-branch-bindings node)
+                   :collect (cons name (tc:apply-substitution subs ty)))
+   :body (tc:apply-substitution subs (match-branch-body node))))
 
 (defmethod tc:apply-substitution (subs (node node-match))
-  (node-match
-   (tc:apply-substitution subs (node-type node))
-   (tc:apply-substitution subs (node-match-expr node))
-   (mapcar
-    (lambda (node)
-      (tc:apply-substitution subs node))
-    (node-match-branches node))))
+  (make-node-match
+   :type (tc:apply-substitution subs (node-type node))
+   :expr (tc:apply-substitution subs (node-match-expr node))
+   :branches (mapcar
+              (lambda (node)
+                (tc:apply-substitution subs node))
+              (node-match-branches node))))
 
 (defmethod tc:apply-substitution (subs (node node-seq))
-  (node-seq
-   (tc:apply-substitution subs (node-type node))
-   (mapcar
-    (lambda (node)
-      (tc:apply-substitution subs node))
-    (node-seq-nodes node))))
+  (make-node-seq
+   :type (tc:apply-substitution subs (node-type node))
+   :nodes (mapcar
+           (lambda (node)
+             (tc:apply-substitution subs node))
+           (node-seq-nodes node))))
 
 (defmethod tc:apply-substitution (subs (node node-return))
-  (node-return
-   (tc:apply-substitution subs (node-type node))
-   (tc:apply-substitution subs (node-return-expr node))))
+  (make-node-return
+   :type (tc:apply-substitution subs (node-type node))
+   :expr (tc:apply-substitution subs (node-return-expr node))))
 
 (defmethod tc:apply-substitution (subs (node node-field))
-  (node-field
-   (tc:apply-substitution subs (node-type node))
-   (node-field-name node)
-   (tc:apply-substitution subs (node-field-dict node))))
+  (make-node-field
+   :type (tc:apply-substitution subs (node-type node))
+   :name (node-field-name node)
+   :dict (tc:apply-substitution subs (node-field-dict node))))
 
 (defmethod tc:apply-substitution (subs (node node-dynamic-extent))
-  (node-dynamic-extent
-   (tc:apply-substitution subs (node-type node))
-   (node-dynamic-extent-name node)
-   (tc:apply-substitution subs (node-dynamic-extent-node node))
-   (tc:apply-substitution subs (node-dynamic-extent-body node))))
+  (make-node-dynamic-extent
+   :type (tc:apply-substitution subs (node-type node))
+   :name (node-dynamic-extent-name node)
+   :node (tc:apply-substitution subs (node-dynamic-extent-node node))
+   :body (tc:apply-substitution subs (node-dynamic-extent-body node))))
 
 (defmethod tc:apply-substitution (subs (node node-bind))
-  (node-bind
-   (tc:apply-substitution subs (node-type node))
-   (node-bind-name node)
-   (tc:apply-substitution subs (node-bind-expr node))
-   (tc:apply-substitution subs (node-bind-body node))))
+  (make-node-bind
+   :type (tc:apply-substitution subs (node-type node))
+   :name (node-bind-name node)
+   :expr (tc:apply-substitution subs (node-bind-expr node))
+   :body (tc:apply-substitution subs (node-bind-body node))))

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -141,9 +141,9 @@
     (when (and (equalp (node-type (node-match-expr expr)) tc:*boolean-type*)
                (= 2 (length (node-match-branches expr)))
                (equalp (match-branch-pattern (first (node-match-branches expr)))
-                       (ast:pattern-constructor 'coalton:True nil))
+                       (ast:make-pattern-constructor :name 'coalton:True :patterns nil))
                (equalp (match-branch-pattern (second (node-match-branches expr)))
-                       (ast:pattern-constructor 'coalton:False nil)))
+                       (ast:make-pattern-constructor :name 'coalton:False :patterns nil)))
       (return-from codegen-expression
         `(if ,(codegen-expression (node-match-expr expr) current-function env)
              ,(codegen-expression (match-branch-body (first (node-match-branches expr))) current-function env)

--- a/src/codegen/compile-instance.lisp
+++ b/src/codegen/compile-instance.lisp
@@ -80,35 +80,35 @@
 
          ;; Initial node
          (var-node
-           (node-variable
-            (tc:make-function-type*
-             (append
-              superclass-ty
-              method-ty)
-             (pred-type (tc:instance-definition-predicate instance) env))
-            (tc:ty-class-codegen-sym class)))
+           (make-node-variable
+            :type (tc:make-function-type*
+                   (append
+                    superclass-ty
+                    method-ty)
+                   (pred-type (tc:instance-definition-predicate instance) env))
+            :value (tc:ty-class-codegen-sym class)))
 
          ;; If the instance has methods then apply them
          (app-node
            (if unqualified-method-definitions
-               (node-application
-                (pred-type (tc:instance-definition-predicate instance) env)
-                var-node
-                (append
-                 (loop :for pred :in superclass-preds
-                       :collect (resolve-dict pred ctx env))
-                 unqualified-method-definitions))
+               (make-node-application
+                :type (pred-type (tc:instance-definition-predicate instance) env)
+                :rator var-node
+                :rands (append
+                        (loop :for pred :in superclass-preds
+                              :collect (resolve-dict pred ctx env))
+                        unqualified-method-definitions))
                var-node))
 
          ;; If the instances has context then wrap it in a function
          (dict-node
            (if ctx
-               (node-abstraction
-                (tc:make-function-type*
-                 ctx-ty
-                 (pred-type (tc:instance-definition-predicate instance) env))
-                (mapcar #'cdr ctx)
-                app-node)
+               (make-node-abstraction
+                :type (tc:make-function-type*
+                       ctx-ty
+                       (pred-type (tc:instance-definition-predicate instance) env))
+                :vars (mapcar #'cdr ctx)
+                :subexpr app-node)
                app-node))
 
          (bindings

--- a/src/codegen/hoister.lisp
+++ b/src/codegen/hoister.lisp
@@ -4,17 +4,18 @@
    #:coalton-impl/util
    #:coalton-impl/codegen/ast)
   (:export
-   #:hoister
-   #:make-hoister
-   #:push-hoist-point
-   #:pop-hoist-point
-   #:pop-final-hoist-point
-   #:hoist-definition))
+   #:hoister                            ; STRUCT
+   #:make-hoister                       ; CONSTRUCTOR
+   #:push-hoist-point                   ; FUNCTION
+   #:pop-hoist-point                    ; FUNCTION
+   #:pop-final-hoist-point              ; FUNCTION
+   #:hoist-definition                   ; FUNCTION
+   ))
 
 (in-package #:coalton-impl/codegen/hoister)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (defstruct (hoist-point (:constructor make-hoist-point (bound-variables)))
+  (defstruct hoist-point
     (bound-variables (required 'bound-variables)                :type symbol-list :read-only nil)
     (definitions     (make-hash-table :test #'equalp)           :type hash-table  :read-only t)))
 
@@ -37,8 +38,9 @@
       (values (gethash node (hoist-point-definitions hoist-point)))
       (progn
         (setf (gethash node (hoist-point-definitions hoist-point))
-              (node-variable (node-type node)
-                             (gentemp "hoisted_" package)))
+              (make-node-variable
+               :type (node-type node)
+               :value (gentemp "hoisted_" package)))
         (values (gethash node (hoist-point-definitions hoist-point))))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -49,9 +51,9 @@
 (deftype hoist-point-list ()
   `(satisfies hoist-point-list-p))
 
-(defstruct (hoister (:constructor make-hoister ()))
-  (hoist-points    nil                    :type hoist-point-list :read-only nil)
-  (top-hoist-point (make-hoist-point nil) :type hoist-point      :read-only t))
+(defstruct hoister
+  (hoist-points    nil                                     :type hoist-point-list :read-only nil)
+  (top-hoist-point (make-hoist-point :bound-variables nil) :type hoist-point      :read-only t))
 
 (defun definitions-to-bindings (definitions)
   (declare (type hash-table definitions))
@@ -62,7 +64,7 @@
 (defun push-hoist-point (bound-variables hoister)
   (declare (type symbol-list bound-variables)
            (type hoister hoister))
-  (push (make-hoist-point bound-variables) (hoister-hoist-points hoister)))
+  (push (make-hoist-point :bound-variables bound-variables) (hoister-hoist-points hoister)))
 
 (defun pop-hoist-point (hoister)
   (declare (type hoister hoister))

--- a/src/codegen/monomorphize.lisp
+++ b/src/codegen/monomorphize.lisp
@@ -49,6 +49,7 @@
   (:import-from
    #:coalton-impl/codegen/ast-substitutions
    #:ast-substitution
+   #:make-ast-substitution
    #:ast-substitution-from
    #:ast-substitution-to
    #:apply-ast-substitution)
@@ -62,6 +63,7 @@
   (:local-nicknames
    (#:tc #:coalton-impl/typechecker))
   (:export
+   #:make-candidate-manager
    #:monomorphize))
 
 (in-package #:coalton-impl/codegen/monomorphize)
@@ -120,7 +122,7 @@ constant values could be."
     (t
      nil)))
 
-(defstruct (candidate-manager (:constructor candidate-manager))
+(defstruct candidate-manager
   "A CANDIDATE-MANAGER is used to deduplicate COMPILE-CANDIDATE
 recompilation, and also maintains a stack of uncompiled candidates."
   (map   (make-hash-table :test #'equalp) :type hash-table            :read-only t)
@@ -222,7 +224,7 @@ their known values."
                          :else
                            :do (progn
                                  (setf subs (tc:unify subs (tc:function-type-from new-type) (node-type arg)))
-                                 (push (ast-substitution var arg) ast-subs))
+                                 (push (make-ast-substitution :from var :to arg) ast-subs))
 
                          :do (setf new-type (tc:function-type-to new-type))))
 
@@ -250,17 +252,17 @@ their known values."
                               subs
                               (apply-ast-substitution
                                ast-subs
-                               (node-abstraction
-                                (node-type (node-abstraction-subexpr node))
-                                args
-                                (node-application
-                                 (tc:make-function-type*
-                                  (subseq (tc:function-type-arguments (node-type (node-abstraction-subexpr node))) (length args))
-                                  (tc:function-return-type (node-type (node-abstraction-subexpr node))))
-                                 (node-abstraction-subexpr node)
-                                 (loop :for ty :in arg-tys
-                                       :for arg :in args
-                                       :collect (node-variable ty arg))))))))
+                               (make-node-abstraction
+                                :type (node-type (node-abstraction-subexpr node))
+                                :vars args
+                                :subexpr (make-node-application
+                                          :type (tc:make-function-type*
+                                                 (subseq (tc:function-type-arguments (node-type (node-abstraction-subexpr node))) (length args))
+                                                 (tc:function-return-type (node-type (node-abstraction-subexpr node))))
+                                          :rator (node-abstraction-subexpr node)
+                                          :rands (loop :for ty :in arg-tys
+                                                       :for arg :in args
+                                                       :collect (make-node-variable :type ty :value arg))))))))
                   node))
 
                ;; Function is under applied
@@ -275,21 +277,21 @@ their known values."
                        (ret-ty (tc:function-return-type node-ty)))
                   (tc:apply-substitution
                    subs
-                   (node-abstraction
-                    (tc:make-function-type* arg-tys ret-ty)
-                    remaining-args
-                    (apply-ast-substitution ast-subs (node-abstraction-subexpr node))))))
+                   (make-node-abstraction
+                    :type (tc:make-function-type* arg-tys ret-ty)
+                    :vars remaining-args
+                    :subexpr (apply-ast-substitution ast-subs (node-abstraction-subexpr node))))))
 
                ;; Function is applied
                (t
                 (tc:apply-substitution
                  subs
-                 (node-abstraction
-                  (tc:make-function-type*
-                   (reverse arg-tys)
-                   new-type)
-                  (append new-vars retained-args)
-                  (apply-ast-substitution ast-subs (node-abstraction-subexpr node)))))))))
+                 (make-node-abstraction
+                  :type (tc:make-function-type*
+                         (reverse arg-tys)
+                         new-type)
+                  :vars (append new-vars retained-args)
+                  :subexpr (apply-ast-substitution ast-subs (node-abstraction-subexpr node)))))))))
 
     (typecheck-node new-node env)
 
@@ -390,17 +392,17 @@ propigate dictionaries that have been moved by the hoister."
                                 :do (setf new-type (tc:function-type-to new-type)))))
 
                    (if (null args)
-                       (node-variable
-                        new-type
-                        function-name)
-                       (node-application
-                        (node-type node)
-                        (node-variable
-                         (tc:make-function-type*
-                          (reverse arg-tys)
-                          new-type)
-                         function-name)
-                        args)))))))
+                       (make-node-variable
+                        :type new-type
+                        :value function-name)
+                       (make-node-application
+                        :type (node-type node)
+                        :rator (make-node-variable
+                                :type (tc:make-function-type*
+                                       (reverse arg-tys)
+                                       new-type)
+                                :value function-name)
+                        :rands args)))))))
 
     (traverse
      node

--- a/src/codegen/resolve-instance.lisp
+++ b/src/codegen/resolve-instance.lisp
@@ -29,13 +29,13 @@
          (pred-kind tc:kstar))
 
     (loop :for type :in (reverse (tc:ty-predicate-types pred)) :do
-      (setf pred-kind (tc:kfun (tc:kind-of type) pred-kind)))
+      (setf pred-kind (tc:make-kfun :from (tc:kind-of type) :to pred-kind)))
 
     (tc:apply-type-argument-list
-     (tc:%make-tcon
-      (tc:%make-tycon
-       :name (tc:ty-class-codegen-sym class-entry)
-       :kind pred-kind))
+     (tc:make-tcon
+      :tycon (tc:make-tycon
+             :name (tc:ty-class-codegen-sym class-entry)
+             :kind pred-kind))
      (tc:ty-predicate-types pred))))
 
 (defun resolve-static-dict (pred context env)
@@ -67,17 +67,17 @@
 
       (if (null subdicts)
           ;; If the instance has no superclasses return a variable
-          (node-variable
-           (pred-type pred env)
-           (tc:ty-class-instance-codegen-sym instance))
+          (make-node-variable
+           :type (pred-type pred env)
+           :value (tc:ty-class-instance-codegen-sym instance))
 
           ;; Otherwise create a new dict at runtime
-          (node-application
-           (pred-type pred env) 
-           (node-variable
-            (tc:make-function-type* arg-types (pred-type pred env))
-            (tc:ty-class-instance-codegen-sym instance))
-           subdicts)))))
+          (make-node-application
+           :type (pred-type pred env) 
+           :rator (make-node-variable
+                   :type (tc:make-function-type* arg-types (pred-type pred env))
+                   :value (tc:ty-class-instance-codegen-sym instance))
+           :rands subdicts)))))
 
 
 (defun superclass-accessors (pred ctx-pred env)
@@ -111,27 +111,27 @@
            (values list &optional))
 
   (when (equalp pred ctx-pred)
-    (return-from lookup-pred (list (node-variable
-                                    (tc:make-function-type
-                                     (pred-type sub-pred env)
-                                     (pred-type pred env))
-                                    method-accessor))))
+    (return-from lookup-pred (list (make-node-variable
+                                    :type (tc:make-function-type
+                                           (pred-type sub-pred env)
+                                           (pred-type pred env))
+                                    :value method-accessor))))
 
   (let ((superclass-ret (superclass-accessors pred ctx-pred env)))
 
     (when superclass-ret
       (cons
-       (node-variable
-        (tc:make-function-type
-         (pred-type sub-pred env)
-         (pred-type ctx-pred env))
-        method-accessor)
+       (make-node-variable
+        :type (tc:make-function-type
+               (pred-type sub-pred env)
+               (pred-type ctx-pred env))
+        :value method-accessor)
        superclass-ret))))
 
 (defun lookup-pred-base (pred ctx-pred ctx-name env)
-  (let ((node (node-variable
-               (pred-type ctx-pred env)
-               ctx-name)))
+  (let ((node (make-node-variable
+               :type (pred-type ctx-pred env)
+               :value ctx-name)))
     (when (equalp pred ctx-pred)
       (return-from lookup-pred-base (list node)))
 
@@ -152,10 +152,10 @@
 (defun build-call (args)
   (if (= 1 (length args))
       (car args)
-      (node-field
-       (tc:function-type-to (node-type (car args)))
-       (node-variable-value (car args))
-       (build-call (cdr args)))))
+      (make-node-field
+       :type (tc:function-type-to (node-type (car args)))
+       :name (node-variable-value (car args))
+       :dict (build-call (cdr args)))))
 
 (defun resolve-context-super (pred context env)
   "Search for PRED in all CONTEXT preds and return a node"

--- a/src/global-lexical.lisp
+++ b/src/global-lexical.lisp
@@ -3,13 +3,12 @@
 ;;;; Global environments:
 
 ;;; The global environment contains top level bindings.
-(defstruct (global-environment
-            (:constructor make-empty-global-environment ()))
+(defstruct global-environment
   ;; A map from variable names to their top level bindings.
   (bindings (make-hash-table :test #'eq) :type hash-table))
 
 
-(defvar *top-level-environment* (make-empty-global-environment)
+(defvar *top-level-environment* (make-global-environment)
   "The current global top level environment.")
 
 (declaim (type global-environment *top-level-environment*))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -107,6 +107,7 @@
    #:pattern-literal                    ; STRUCT
    #:pattern-literal-value              ; ACCESSOR
    #:pattern-constructor                ; STRUCT
+   #:make-pattern-constructor           ; CONSTRUCTOR
    #:pattern-constructor-name           ; ACCESSOR
    #:pattern-constructor-patterns       ; ACCESSOR
    #:pattern-variables                  ; FUNCTION
@@ -141,22 +142,22 @@
    #:tyvar-kind                         ; ACCESSOR
    #:tyvar-list                         ; TYPE
    #:tvar                               ; STRUCT
-   #:%make-tvar                         ; CONSTRUCTOR
+   #:make-tvar                          ; CONSTRUCTOR
    #:make-variable                      ; FUNCTION
    #:tvar-tyvar                         ; ACCESSOR
    #:tycon                              ; STRUCT
-   #:%make-tycon                        ; CONSTRUCTOR
+   #:make-tycon                         ; CONSTRUCTOR
    #:tycon-name                         ; ACCESSOR
    #:tycon-kind                         ; ACCESSOR
    #:tcon                               ; STRUCT
-   #:%make-tcon                         ; CONSTRUCTOR
+   #:make-tcon                          ; CONSTRUCTOR
    #:tcon-tycon                         ; ACCESSOR
    #:tapp                               ; STRUCT
-   #:%make-tapp                         ; CONSTRUCTOR
+   #:make-tapp                          ; CONSTRUCTOR
    #:tapp-from                          ; ACCESSOR
    #:tapp-to                            ; ACCESSOR
    #:tgen                               ; STRUCT
-   #:%make-tgen                         ; CONSTRUCTOR
+   #:make-tgen                          ; CONSTRUCTOR
    #:tgen-id                            ; ACCESSOR
    #:kind-of                            ; FUNCTION
    #:apply-type-argument                ; FUNCTION
@@ -203,8 +204,8 @@
    #:apply-substitution                 ; FUNCTION
    #:predicate-match                    ; FUNCTION
    #:make-function-type                 ; FUNCTION
-   #:make-kind-of-arity                 ; FUNCTION
-   #:kfun                               ; FUNCTION
+   #:kfun                               ; STRUCT
+   #:make-kfun                          ; CONSTRUCTOR
    #:fresh-inst                         ; FUNCTION
    #:qualified-ty-predicates            ; ACCESSOR
    #:qualified-ty-type                  ; ACCESSOR
@@ -213,14 +214,6 @@
    #:qualify                            ; FUNCTION
    #:to-scheme                          ; FUNCTION
    #:replace-node-type                  ; FUNCTION
-   #:pattern-var-id                     ; ACCESSOR
-   #:pattern-wildcard                   ; STRUCT
-   #:pattern-literal                    ; STRUCT
-   #:pattern-constructor                ; STRUCT
-   #:pattern-var                        ; STRUCT
-   #:pattern-literal-value              ; ACCESSOR
-   #:pattern-constructor-name           ; ACCESSOR
-   #:pattern-constructor-patterns       ; ACCESSOR
    )
   (:export
    #:typed-node                           ; STRUCT
@@ -297,6 +290,7 @@
    #:lookup-specialization              ; FUNCTION
    #:lookup-specialization-by-type      ; FUNCTION
    #:type-entry                         ; STRUCT
+   #:make-type-entry                    ; CONSTRUCTOR
    #:type-entry-name                    ; ACCESSOR
    #:type-entry-runtime-type            ; ACCESSOR
    #:type-entry-type                    ; ACCESSOR
@@ -389,6 +383,7 @@
    #:ty-class-superclass-map            ; ACCESSOR
    #:ty-class-list                      ; TYPE
    #:ty-class-instance                  ; STRUCT
+   #:make-ty-class-instance             ; CONSTRUCTOR
    #:ty-class-instance-predicate        ; ACCESSOR
    #:ty-class-instance-constraints      ; ACCESSOR
    #:ty-class-instance-codegen-sym      ; ACCESSOR

--- a/src/toplevel-define-instance.lisp
+++ b/src/toplevel-define-instance.lisp
@@ -48,7 +48,7 @@
                          table))
 
                      (instance
-                       (ty-class-instance
+                       (make-ty-class-instance
                         :constraints context
                         :predicate predicate
                         :codegen-sym instance-codegen-sym

--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -105,7 +105,7 @@ Returns (VALUES deferred-preds retained-preds defaultable-preds)"
       (let ((retained_ (default-preds env (append environment-vars local-vars) retained)))
         (values deferred (set-difference retained retained_ :test #'equalp) retained_)))))
 
-(defstruct (ambiguity (:constructor ambiguity (var preds)))
+(defstruct ambiguity
   (var   (required 'var)   :type tyvar             :read-only t)
   (preds (required 'preds) :type ty-predicate-list :read-only t))
 
@@ -127,7 +127,7 @@ Returns (VALUES deferred-preds retained-preds defaultable-preds)"
                         (lambda (pred)
                           (find v (type-variables pred) :test #'equalp))
                         preds)
-        :collect (ambiguity v preds_)))
+        :collect (make-ambiguity :var v :preds preds_)))
 
 (defun candidates (env ambig)
   (declare (type environment env)
@@ -161,7 +161,7 @@ Returns (VALUES deferred-preds retained-preds defaultable-preds)"
                  ;; Check that the variable would be defaulted to a valid type
                  ;; for the given predicates
                  (every (lambda (name)
-                          (entail env nil (ty-predicate name (list type))))
+                          (entail env nil (make-ty-predicate :class name :types (list type))))
                         pred-names))
 
             :collect type)))
@@ -204,4 +204,4 @@ Returns (VALUES deferred-preds retained-preds defaultable-preds)"
   (loop :for ambig :in (ambiguities env tvars preds)
         :for candidates := (candidates env ambig)
         :when candidates
-          :collect (%make-substitution (ambiguity-var ambig) (first candidates))))
+          :collect (make-substitution :from (ambiguity-var ambig) :to (first candidates))))

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -43,7 +43,7 @@
   (and (consp explicit-repr)
        (eq (first explicit-repr) :native)))
 
-(defstruct (type-entry (:constructor type-entry))
+(defstruct type-entry 
   (name         (required 'name)         :type symbol  :read-only t)
   (runtime-type (required 'runtime-type) :type t       :read-only t)
   (type         (required 'type)         :type ty      :read-only t)
@@ -97,7 +97,7 @@
    :data (fset:map
           ;; Early Types
           ('coalton:Boolean
-           (type-entry
+           (make-type-entry
             :name 'coalton:Boolean
             :runtime-type 'cl:boolean
             :type *boolean-type*
@@ -108,7 +108,7 @@
             :location ""))
 
           ('coalton:Char
-           (type-entry
+           (make-type-entry
             :name 'coalton:Char
             :runtime-type 'cl:character
             :type *char-type*
@@ -119,7 +119,7 @@
             :location ""))
 
           ('coalton:Integer
-           (type-entry
+           (make-type-entry
             :name 'coalton:Integer
             :runtime-type 'cl:integer
             :type *integer-type*
@@ -130,7 +130,7 @@
             :location ""))
 
           ('coalton:Single-Float
-           (type-entry
+           (make-type-entry
             :name 'coalton:Single-Float
             :runtime-type 'cl:single-float
             :type *single-float-type*
@@ -141,7 +141,7 @@
             :location ""))
 
           ('coalton:Double-Float
-           (type-entry
+           (make-type-entry
             :name 'coalton:Double-Float
             :runtime-type 'cl:double-float
             :type *double-float-type*
@@ -152,7 +152,7 @@
             :location ""))
 
           ('coalton:String
-           (type-entry
+           (make-type-entry
             :name 'coalton:String
             :runtime-type 'cl:string
             :type *string-type*
@@ -163,7 +163,7 @@
             :location ""))
 
           ('coalton:Fraction
-           (type-entry
+           (make-type-entry
             :name 'coalton:Fraction
             :runtime-type 'cl:rational
             :type *fraction-type*
@@ -174,7 +174,7 @@
             :location ""))
 
           ('coalton:Arrow
-           (type-entry
+           (make-type-entry
             :name 'coalton:Arrow
             :runtime-type nil
             :type *arrow-type*
@@ -185,7 +185,7 @@
             :location ""))
 
           ('coalton:List
-           (type-entry
+           (make-type-entry
             :name 'coalton:List
             :runtime-type 'cl:list
             :type *list-type*
@@ -268,9 +268,7 @@
 ;;; Class environment
 ;;;
 
-(defstruct
-    (ty-class
-     (:constructor ty-class))
+(defstruct ty-class
   (name                (required 'name)                :type symbol              :read-only t)
   (predicate           (required 'predicate)           :type ty-predicate        :read-only t)
   (superclasses        (required 'superclasses)        :type ty-predicate-list   :read-only t)
@@ -299,7 +297,7 @@
 (defmethod apply-substitution (subst-list (class ty-class))
   (declare (type substitution-list subst-list)
            (values ty-class &optional))
-  (ty-class
+  (make-ty-class
    :name (ty-class-name class)
    :predicate (apply-substitution subst-list (ty-class-predicate class))
    :superclasses (apply-substitution subst-list (ty-class-superclasses class))
@@ -325,9 +323,7 @@
 ;;; Instance environment
 ;;;
 
-(defstruct
-    (ty-class-instance
-     (:constructor ty-class-instance))
+(defstruct ty-class-instance
   (constraints         (required 'constraints)         :type ty-predicate-list :read-only t)
   (predicate           (required 'predicate)           :type ty-predicate      :read-only t)
   (codegen-sym         (required 'codegen-sym)         :type symbol            :read-only t)
@@ -352,7 +348,7 @@
 (defmethod apply-substitution (subst-list (instance ty-class-instance))
   (declare (type substitution-list subst-list)
            (values ty-class-instance &optional))
-  (ty-class-instance
+  (make-ty-class-instance
    :constraints (apply-substitution subst-list (ty-class-instance-constraints instance))
    :predicate (apply-substitution subst-list (ty-class-instance-predicate instance))
    :codegen-sym (ty-class-instance-codegen-sym instance)
@@ -435,9 +431,9 @@
 ;;;
 
 (defstruct specialization-entry
-  (from (required 'from) :type symbol :read-only t)
-  (to (required 'to)     :type symbol :read-only t)
-  (to-ty (required 'to-ty) :type ty :read-only t))
+  (from (required 'from)   :type symbol :read-only t)
+  (to (required 'to)       :type symbol :read-only t)
+  (to-ty (required 'to-ty) :type ty     :read-only t))
 
 (defmethod make-load-form ((self specialization-entry) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -455,28 +451,16 @@
 ;;; Environment
 ;;;
 
-(defstruct
-    (environment
-     (:constructor make-environment
-         (value-environment
-          type-environment
-          constructor-environment
-          class-environment
-          instance-environment
-          function-environment
-          name-environment
-          method-inline-environment
-          code-environment
-          specialization-environment)))
-  (value-environment         (required 'value-environment)         :type value-environment         :read-only t)
-  (type-environment          (required 'type-environment)          :type type-environment          :read-only t)
-  (constructor-environment   (requried 'constructor-environment)   :type constructor-environment   :read-only t)
-  (class-environment         (required 'class-environment)         :type class-environment         :read-only t)
-  (instance-environment      (required 'instance-environment)      :type instance-environment      :read-only t)
-  (function-environment      (required 'function-environment)      :type function-environment      :read-only t)
-  (name-environment          (required 'name-environment)          :type name-environment          :read-only t)
-  (method-inline-environment (required 'method-inline-environment) :type method-inline-environment :read-only t)
-  (code-environment          (required 'code-environment)          :type code-environment          :read-only t)
+(defstruct environment
+  (value-environment          (required 'value-environment)          :type value-environment          :read-only t)
+  (type-environment           (required 'type-environment)           :type type-environment           :read-only t)
+  (constructor-environment    (required 'constructor-environment)    :type constructor-environment    :read-only t)
+  (class-environment          (required 'class-environment)          :type class-environment          :read-only t)
+  (instance-environment       (required 'instance-environment)       :type instance-environment       :read-only t)
+  (function-environment       (required 'function-environment)       :type function-environment       :read-only t)
+  (name-environment           (required 'name-environment)           :type name-environment           :read-only t)
+  (method-inline-environment  (required 'method-inline-environment)  :type method-inline-environment  :read-only t)
+  (code-environment           (required 'code-environment)           :type code-environment           :read-only t)
   (specialization-environment (required 'specialization-environment) :type specialization-environment :read-only t))
 
 (defmethod print-object ((env environment) stream)
@@ -494,16 +478,16 @@
 (defun make-default-environment ()
   (declare (values environment))
   (make-environment
-   (make-value-environment)
-   (make-default-type-environment)
-   (make-default-constructor-environment)
-   (make-class-environment)
-   (make-instance-environment)
-   (make-function-environment)
-   (make-name-environment)
-   (make-method-inline-environment)
-   (make-code-environment)
-   (make-specialization-environment)))
+   :value-environment (make-value-environment)
+   :type-environment (make-default-type-environment)
+   :constructor-environment (make-default-constructor-environment)
+   :class-environment (make-class-environment)
+   :instance-environment (make-instance-environment)
+   :function-environment (make-function-environment)
+   :name-environment (make-name-environment)
+   :method-inline-environment (make-method-inline-environment)
+   :code-environment (make-code-environment)
+   :specialization-environment (make-specialization-environment)))
 
 (defun update-environment (env
                            &key
@@ -529,16 +513,16 @@
            (type specialization-environment specialization-environment)
            (values environment))
   (make-environment
-   value-environment
-   type-environment
-   constructor-environment
-   class-environment
-   instance-environment
-   function-environment
-   name-environment
-   method-inline-environment
-   code-environment
-   specialization-environment))
+   :value-environment value-environment
+   :type-environment type-environment
+   :constructor-environment constructor-environment
+   :class-environment class-environment
+   :instance-environment instance-environment
+   :function-environment function-environment
+   :name-environment name-environment
+   :method-inline-environment method-inline-environment
+   :code-environment code-environment
+   :specialization-environment specialization-environment))
 
 ;;;
 ;;; Methods

--- a/src/typechecker/equality.lisp
+++ b/src/typechecker/equality.lisp
@@ -48,7 +48,7 @@
 
     ;; Create a substitution list from the variables
     (let ((subs-list (mapcar (lambda (s)
-                               (%make-substitution (tvar-tyvar (car s)) (cdr s)))
+                               (make-substitution :from (tvar-tyvar (car s)) :to (cdr s)))
                              var-table)))
 
       ;; Now check that all constraints in type1 exist in type2, mapping type variables

--- a/src/typechecker/parse-class-definition.lisp
+++ b/src/typechecker/parse-class-definition.lisp
@@ -245,12 +245,12 @@
                                (setf ksubs (kunify (kind-of type) kstar ksubs))
                                (cons name (apply-ksubstitution ksubs type)))))
 
-            (predicate (ty-predicate
-                        class-name
+            (predicate (make-ty-predicate
+                        :class class-name
                         ;; Collect type variables in the order they were defined on the unparsed predicate
-                        (loop :for var :in (rest unparsed-predicate)
-                              :for tyvar := (second (find var class-tyvars :key #'car :test #'equalp))
-                              :collect (apply-ksubstitution ksubs tyvar)))))
+                        :types (loop :for var :in (rest unparsed-predicate)
+                                     :for tyvar := (second (find var class-tyvars :key #'car :test #'equalp))
+                                     :collect (apply-ksubstitution ksubs tyvar)))))
 
       (setf ksubs (kind-monomorphize-subs (kind-variables predicate) ksubs))
       (setf predicate (apply-ksubstitution ksubs predicate))
@@ -264,17 +264,17 @@
 
              (superclass-dict
                (loop :for super :in superclasses
-                                 :for i :from 0
-                                 :collect (cons super
-                                                (alexandria:format-symbol
-                                                 (symbol-package class-name)
-                                                 (format nil "SUPER-~D" i)))))
+                     :for i :from 0
+                     :collect (cons super
+                                    (alexandria:format-symbol
+                                     (symbol-package class-name)
+                                     (format nil "SUPER-~D" i)))))
 
              (codegen-sym
                (alexandria:format-symbol (symbol-package class-name) "CLASS/~A" class-name)))
 
         (values
-         (ty-class
+         (make-ty-class
           :name class-name
           :predicate predicate
           :superclasses superclasses

--- a/src/typechecker/parse-type-definition.lisp
+++ b/src/typechecker/parse-type-definition.lisp
@@ -22,7 +22,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type type-definition))
 
-(defstruct (partial-define-type (:constructor partial-define-type))
+(defstruct partial-define-type
   (name         (required 'name)         :type symbol           :read-only t)
   (tyvar-names  (required 'tyvar-names)  :type symbol-list      :read-only t)
   (constructors (required 'constructors) :type list             :read-only t)
@@ -104,10 +104,10 @@
          (type-vars
            (loop :for type-name :in type-names
                  :collect (list type-name
-                                (%make-tcon
-                                 (%make-tycon
-                                  :name type-name
-                                  :kind (make-kvariable))))))
+                                (make-tcon
+                                 :tycon (make-tycon
+                                         :name type-name
+                                         :kind (make-kvariable))))))
 
          (ksubs nil)
 
@@ -143,7 +143,7 @@
                 (set-type
                  env
                  name 
-                 (type-entry
+                 (make-type-entry
                   :name name
                   :runtime-type name
                   :type type__
@@ -273,7 +273,7 @@ Returns TYPE-DEFINITIONS"
 
             ;; Push the partialy parsed define-type form
             (push
-             (partial-define-type
+             (make-partial-define-type
               :name tycon-name
               :tyvar-names tyvar-names
               :constructors constructors
@@ -422,7 +422,7 @@ Returns TYPE-DEFINITIONS"
                        (set-type
                         env
                         tycon-name
-                        (type-entry
+                        (make-type-entry
                          :name tycon-name
                          :runtime-type (type-definition-runtime-type type-definition)
                          :type (type-definition-type type-definition)
@@ -503,11 +503,7 @@ Returns TYPE-DEFINITIONS"
          (kinds (mapcar #'kind-of vars))
          (subst (loop :for var :in vars
                       :for id :from 0
-                      :collect (%make-substitution var (%make-tgen id)))))
-    (%make-ty-scheme kinds (apply-substitution subst type))))
-
-(defun tvar-count-to-kind (tvar-count)
-  "Create a KIND from the number of type variables"
-  (if (= 0 tvar-count)
-      kStar
-      (kFun kStar (tvar-count-to-kind (1- tvar-count)))))
+                      :collect (make-substitution :from var :to (make-tgen :id id)))))
+    (make-ty-scheme
+     :kinds kinds
+     :type (apply-substitution subst type))))

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -238,9 +238,11 @@
                    (length (ty-predicate-types (ty-class-predicate class-entry)))
                    (length (cdr expr))))))
 
-      (values (ty-predicate pred-class pred-types)
-              ksubs))))
-
+      (values
+       (make-ty-predicate
+        :class pred-class
+        :types pred-types)
+       ksubs))))
 
 ;;;
 ;;; Arrows

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -4,18 +4,13 @@
 ;;; Type predicates
 ;;;
 
-(defstruct
-    (ty-predicate
-     (:constructor ty-predicate (class types)))
+(defstruct ty-predicate
   "A type predicate indicating that TYPE is of the CLASS"
   (class (required 'class) :type symbol  :read-only t)
   (types (required 'types) :type ty-list :read-only t))
 
 (defmethod make-load-form ((self ty-predicate) &optional env)
-  (make-load-form-saving-slots
-   self
-   :slot-names '(class types)
-   :environment env))
+  (make-load-form-saving-slots self :environment env))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type ty-predicate))
@@ -36,17 +31,12 @@
 ;;; Qualified types
 ;;;
 
-(defstruct
-    (qualified-ty
-     (:constructor qualified-ty (predicates type)))
+(defstruct (qualified-ty)
   (predicates (required 'predicates) :type ty-predicate-list :read-only t)
   (type       (required 'type)       :type ty                :read-only t))
 
 (defmethod make-load-form ((self qualified-ty) &optional env)
-  (make-load-form-saving-slots
-   self
-   :slot-names '(predicates type)
-   :environment env))
+  (make-load-form-saving-slots self :environment env))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type qualified-ty))
@@ -56,8 +46,9 @@
   (declare (type ty type)
            (type ty-predicate-list predicates)
            (values qualified-ty &optional))
-  (qualified-ty predicates type))
-
+  (make-qualified-ty
+   :predicates predicates
+   :type type))
 
 ;;;
 ;;; Methods
@@ -66,14 +57,15 @@
 (defmethod apply-substitution (subst-list (type ty-predicate))
   (declare (type substitution-list subst-list)
            (values ty-predicate &optional))
-  (ty-predicate (ty-predicate-class type)
-                      (apply-substitution subst-list (ty-predicate-types type))))
+  (make-ty-predicate
+   :class (ty-predicate-class type)
+   :types (apply-substitution subst-list (ty-predicate-types type))))
 
 (defmethod apply-ksubstitution (subs (type ty-predicate))
   (declare (type ksubstitution-list subs))
-  (ty-predicate
-   (ty-predicate-class type)
-   (apply-ksubstitution subs (ty-predicate-types type))))
+  (make-ty-predicate
+   :class (ty-predicate-class type)
+   :types (apply-ksubstitution subs (ty-predicate-types type))))
 
 (defmethod type-variables ((type ty-predicate))
   (type-variables (ty-predicate-types type)))
@@ -83,20 +75,21 @@
   (mapcan #'kind-variables (ty-predicate-types type)))
 
 (defmethod instantiate (types (type ty-predicate))
-  (ty-predicate (ty-predicate-class type)
-                      (instantiate types (ty-predicate-types type))))
-
+  (make-ty-predicate
+   :class (ty-predicate-class type)
+   :types (instantiate types (ty-predicate-types type))))
 
 (defmethod apply-substitution (subst-list (type qualified-ty))
   (declare (type substitution-list subst-list))
-  (qualified-ty (apply-substitution subst-list (qualified-ty-predicates type))
-                      (apply-substitution subst-list (qualified-ty-type type))))
+  (make-qualified-ty
+   :predicates (apply-substitution subst-list (qualified-ty-predicates type))
+   :type (apply-substitution subst-list (qualified-ty-type type))))
 
 (defmethod apply-ksubstitution (subs (type qualified-ty))
   (declare (type ksubstitution-list subs))
-  (qualified-ty
-   (apply-ksubstitution subs (qualified-ty-predicates type))
-   (apply-ksubstitution subs (qualified-ty-type type))))
+  (make-qualified-ty
+   :predicates (apply-ksubstitution subs (qualified-ty-predicates type))
+   :type (apply-ksubstitution subs (qualified-ty-type type))))
 
 (defmethod type-variables ((type qualified-ty))
   (remove-duplicates
@@ -111,8 +104,9 @@
    (mapcan #'kind-variables (qualified-ty-predicates type))))
 
 (defmethod instantiate (types (type qualified-ty))
-  (qualified-ty (instantiate types (qualified-ty-predicates type))
-                      (instantiate types (qualified-ty-type type))))
+  (make-qualified-ty
+   :predicates (instantiate types (qualified-ty-predicates type))
+   :type (instantiate types (qualified-ty-type type))))
 
 (defmethod kind-of ((type qualified-ty))
   (kind-of (qualified-ty-type type)))

--- a/src/typechecker/pretty-printing.lisp
+++ b/src/typechecker/pretty-printing.lisp
@@ -21,7 +21,7 @@
 (defun next-pprint-variable-as-tvar (&optional (kind kStar))
   "Get the next type variable as a TVAR"
   ;; This is an awful awful hack
-  (%make-tcon (%make-tycon :name (next-pprint-variable) :kind kind)))
+  (make-tcon :tycon (make-tycon :name (next-pprint-variable) :kind kind)))
 
 (defmacro with-pprint-variable-scope (() &body body)
   "If there is no pretty printing variable scope then create one for BODY"

--- a/src/typechecker/substitutions.lisp
+++ b/src/typechecker/substitutions.lisp
@@ -4,7 +4,7 @@
 ;;; Type substitutions
 ;;;
 
-(defstruct (substitution (:constructor %make-substitution (from to)))
+(defstruct substitution
   (from (required 'from) :type tyvar :read-only t)
   (to   (required 'to)   :type ty    :read-only t))
 
@@ -19,7 +19,7 @@
   "Merge substitution lists S1 and S2 together, erroring on disagreeing entries."
   (let ((overlap (intersection s1 s2 :key #'substitution-from :test #'equalp)))
     (if (every (lambda (x)
-                 (equalp (apply-substitution s1 (%make-tvar x)) (apply-substitution s2 (%make-tvar x))))
+                 (equalp (apply-substitution s1 (make-tvar :tyvar x)) (apply-substitution s2 (make-tvar :tyvar x))))
                (mapcar #'substitution-from overlap))
         (concatenate 'list s1 s2)
         (error 'coalton-type-error))))
@@ -29,9 +29,9 @@
   (append
    (mapcar
     (lambda (s)
-      (%make-substitution
-       (substitution-from s)
-       (apply-substitution s1 (substitution-to s))))
+      (make-substitution
+       :from (substitution-from s)
+       :to (apply-substitution s1 (substitution-to s))))
     s2)
    s1))
 
@@ -45,8 +45,9 @@
           type)))
   ;; For a type application, recurse down into all the types
   (:method (subst-list (type tapp))
-    (%make-tapp (apply-substitution subst-list (tapp-from type))
-                (apply-substitution subst-list (tapp-to type))))
+    (make-tapp
+     :from (apply-substitution subst-list (tapp-from type))
+     :to (apply-substitution subst-list (tapp-to type))))
   ;; Otherwise, do nothing
   (:method (subst-list (type ty))
     type)

--- a/src/typechecker/typed-node.lisp
+++ b/src/typechecker/typed-node.lisp
@@ -22,29 +22,20 @@
 (deftype typed-binding-list ()
   `(satisfies typed-binding-list-p))
 
-(defstruct
-    (typed-node-literal
-     (:include typed-node)
-     (:constructor typed-node-literal (type unparsed value)))
+(defstruct (typed-node-literal (:include typed-node))
   (value (required 'value) :type literal-value :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-literal))
 
-(defstruct
-    (typed-node-variable
-     (:include typed-node)
-     (:constructor typed-node-variable (type unparsed name)))
+(defstruct (typed-node-variable (:include typed-node))
   ;; The name of the variable
   (name (required 'name) :type symbol :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-variable))
 
-(defstruct
-    (typed-node-application
-     (:include typed-node)
-     (:constructor typed-node-application (type unparsed rator rands)))
+(defstruct (typed-node-application (:include typed-node))
   ;; The function
   (rator (required 'rator) :type typed-node :read-only t)
 
@@ -54,10 +45,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-application))
 
-(defstruct
-    (typed-node-abstraction
-     (:include typed-node)
-     (:constructor typed-node-abstraction (type unparsed vars subexpr name-map)))
+(defstruct (typed-node-abstraction (:include typed-node))
   ;; The functions arguments and their types
   (vars (required 'vars)         :type scheme-binding-list :read-only t)
 
@@ -71,10 +59,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-abstraction))
 
-(defstruct
-    (typed-node-let
-     (:include typed-node)
-     (:constructor typed-node-let (type unparsed bindings subexpr explicit-types name-map)))
+(defstruct (typed-node-let (:include typed-node))
   ;; Bindings declared in the let
   (bindings (required 'bindings) :type typed-binding-list :read-only t)
 
@@ -91,10 +76,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-let))
 
-(defstruct
-    (typed-node-lisp
-     (:include typed-node)
-     (:constructor typed-node-lisp (type unparsed variables form)))
+(defstruct (typed-node-lisp (:include typed-node))
   ;; Local variables used in the lisp block
   (variables (required 'variables) :type list :read-only t)
 
@@ -104,9 +86,7 @@
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-lisp))
 
-(defstruct
-    (typed-match-branch
-     (:constructor typed-match-branch (unparsed pattern subexpr bindings name-map)))
+(defstruct typed-match-branch
   (unparsed (required 'unparsed) :type t                   :read-only t)
   (pattern  (required 'pattern)  :type pattern             :read-only t)
   (subexpr  (required 'subexpr)  :type typed-node          :read-only t)
@@ -123,38 +103,26 @@
 (deftype typed-match-branch-list ()
   '(satisfies typed-match-branch-list-p))
 
-(defstruct
-    (typed-node-match
-     (:include typed-node)
-     (:constructor typed-node-match (type unparsed expr branches)))
+(defstruct (typed-node-match (:include typed-node))
   (expr     (required 'expr)     :type typed-node              :read-only t)
   (branches (required 'branches) :type typed-match-branch-list :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-match))
 
-(defstruct
-    (typed-node-seq
-     (:include typed-node)
-     (:constructor typed-node-seq (type unparsed subnodes)))
+(defstruct (typed-node-seq (:include typed-node))
   (subnodes (required 'subnodes) :type typed-node-list :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-seq))
 
-(defstruct
-    (typed-node-return
-     (:include typed-node)
-     (:constructor typed-node-return (type unparsed expr)))
+(defstruct (typed-node-return (:include typed-node))
   (expr (required 'expr) :type typed-node :read-only t))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-return))
 
-(defstruct
-    (typed-node-bind
-     (:include typed-node)
-     (:constructor typed-node-bind (type unparsed name expr body)))
+(defstruct (typed-node-bind (:include typed-node))
   (name (required 'name) :type symbol     :read-only t)
   (expr (required 'expr) :type typed-node :read-only t)
   (body (required 'body) :type typed-node :read-only t))
@@ -172,183 +140,184 @@
 (defmethod apply-substitution (subs (node typed-node-literal))
   (declare (type substitution-list subs)
            (values typed-node-literal &optional))
-  (typed-node-literal
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (typed-node-literal-value node)))
+  (make-typed-node-literal
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :value (typed-node-literal-value node)))
 
 (defmethod apply-substitution (subs (node typed-node-variable))
   (declare (type substitution-list subs)
            (values typed-node-variable &optional))
-  (typed-node-variable
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (typed-node-variable-name node)))
+  (make-typed-node-variable
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :name (typed-node-variable-name node)))
 
 (defmethod apply-substitution (subs (node typed-node-application))
   (declare (type substitution-list subs)
            (values typed-node-application &optional))
-  (typed-node-application
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (apply-substitution subs (typed-node-application-rator node))
-   (apply-substitution subs (typed-node-application-rands node))))
+  (make-typed-node-application
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :rator (apply-substitution subs (typed-node-application-rator node))
+   :rands (apply-substitution subs (typed-node-application-rands node))))
 
 (defmethod apply-substitution (subs (node typed-node-abstraction))
   (declare (type substitution-list subs)
            (values typed-node-abstraction &optional))
-  (typed-node-abstraction
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (mapcar
-    (lambda (binding) (cons (car binding) (apply-substitution subs (cdr binding))))
-    (typed-node-abstraction-vars node))
-   (apply-substitution subs (typed-node-abstraction-subexpr node))
-   (typed-node-abstraction-name-map node)))
+  (make-typed-node-abstraction
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :vars  (mapcar
+           (lambda (binding) (cons (car binding) (apply-substitution subs (cdr binding))))
+           (typed-node-abstraction-vars node))
+   :subexpr (apply-substitution subs (typed-node-abstraction-subexpr node))
+   :name-map (typed-node-abstraction-name-map node)))
 
 (defmethod apply-substitution (subs (node typed-node-let))
   (declare (type substitution-list subs)
            (values typed-node-let &optional))
-  (typed-node-let
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (mapcar
-    (lambda (binding) (cons (car binding) (apply-substitution subs (cdr binding))))
-    (typed-node-let-bindings node))
-   (apply-substitution subs (typed-node-let-subexpr node))
-   (maphash-values-new
-    (lambda (type)
-      (apply-substitution subs type))
-    (typed-node-let-explicit-types node))
-   (typed-node-let-name-map node)))
+  (make-typed-node-let
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :bindings (mapcar
+              (lambda (binding) (cons (car binding) (apply-substitution subs (cdr binding))))
+              (typed-node-let-bindings node))
+   :subexpr (apply-substitution subs (typed-node-let-subexpr node))
+   :explicit-types (maphash-values-new
+                    (lambda (type)
+                      (apply-substitution subs type))
+                    (typed-node-let-explicit-types node))
+   :name-map (typed-node-let-name-map node)))
 
 (defmethod apply-substitution (subs (node typed-node-lisp))
   (declare (type substitution-list subs)
            (values typed-node-lisp &optional))
-  (typed-node-lisp
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (typed-node-lisp-variables node)
-   (typed-node-lisp-form node)))
+  (make-typed-node-lisp
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :variables (typed-node-lisp-variables node)
+   :form (typed-node-lisp-form node)))
 
 (defmethod apply-substitution (subs (node typed-node-match))
   (declare (type substitution-list subs)
            (values typed-node-match &optional))
-  (typed-node-match
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (apply-substitution subs (typed-node-match-expr node))
-   (apply-substitution subs (typed-node-match-branches node))))
+  (make-typed-node-match
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :expr (apply-substitution subs (typed-node-match-expr node))
+   :branches (apply-substitution subs (typed-node-match-branches node))))
 
 (defmethod apply-substitution (subs (node typed-match-branch))
   (declare (type substitution-list subs)
            (values typed-match-branch &optional))
-  (typed-match-branch
-   (typed-match-branch-unparsed node)
-   (typed-match-branch-pattern node)
-   (apply-substitution subs (typed-match-branch-subexpr node))
-   (mapcar (lambda (b)
-             (cons (car b)
-                   (apply-substitution subs (cdr b))))
-           (typed-match-branch-bindings node))
-   (typed-match-branch-name-map node)))
+  (make-typed-match-branch
+   :unparsed (typed-match-branch-unparsed node)
+   :pattern (typed-match-branch-pattern node)
+   :subexpr (apply-substitution subs (typed-match-branch-subexpr node))
+   :bindings (mapcar (lambda (b)
+                       (cons (car b)
+                             (apply-substitution subs (cdr b))))
+                     (typed-match-branch-bindings node))
+   :name-map (typed-match-branch-name-map node)))
 
 (defmethod apply-substitution (subs (node typed-node-seq))
   (declare (type substitution-list subs)
            (values typed-node-seq &optional))
-  (typed-node-seq
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (apply-substitution subs (typed-node-seq-subnodes node))))
+  (make-typed-node-seq
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :subnodes (apply-substitution subs (typed-node-seq-subnodes node))))
 
 (defmethod apply-substitution (subs (node typed-node-return))
   (declare (type substitution-list subs)
            (values typed-node-return &optional))
-  (typed-node-return
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (apply-substitution subs (typed-node-return-expr node))))
+  (make-typed-node-return
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :expr (apply-substitution subs (typed-node-return-expr node))))
 
 (defmethod apply-substitution (subs (node typed-node-bind))
   (declare (type substitution-list subs)
            (values typed-node-bind &optional))
-  (typed-node-bind
-   (apply-substitution subs (typed-node-type node))
-   (typed-node-unparsed node)
-   (typed-node-bind-name node)
-   (apply-substitution subs (typed-node-bind-expr node))
-   (apply-substitution subs (typed-node-bind-body node))))
+  (make-typed-node-bind
+   :type (apply-substitution subs (typed-node-type node))
+   :unparsed (typed-node-unparsed node)
+   :name (typed-node-bind-name node)
+   :expr (apply-substitution subs (typed-node-bind-expr node))
+   :body (apply-substitution subs (typed-node-bind-body node))))
 
 (defgeneric replace-node-type (node new-type)
   (:method ((node typed-node-literal) new-type)
-    (typed-node-literal
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-literal-value node)))
+    (make-typed-node-literal
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :value (typed-node-literal-value node)))
 
   (:method ((node typed-node-variable) new-type)
-    (typed-node-variable
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-variable-name node)))
+    (make-typed-node-variable
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :name (typed-node-variable-name node)))
 
   (:method ((node typed-node-abstraction) new-type)
-    (typed-node-abstraction
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-abstraction-vars node)
-     (typed-node-abstraction-subexpr node)
-     (typed-node-abstraction-name-map node)))
+    (make-typed-node-abstraction
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :vars (typed-node-abstraction-vars node)
+     :subexpr (typed-node-abstraction-subexpr node)
+     :name-map (typed-node-abstraction-name-map node)))
 
   (:method ((node typed-node-lisp) new-type)
-    (typed-node-lisp
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-lisp-variables node)
-     (typed-node-lisp-form node)))
+    (make-typed-node-lisp
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :variables (typed-node-lisp-variables node)
+     :form (typed-node-lisp-form node)))
 
   (:method ((node typed-node-application) new-type)
-    (typed-node-application
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-application-rator node)
-     (typed-node-application-rands node)))
+    (make-typed-node-application
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :rator (typed-node-application-rator node)
+     :rands (typed-node-application-rands node)))
 
   (:method ((node typed-node-let) new-type)
-    (typed-node-let
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-let-bindings node)
-     (typed-node-let-subexpr node)
-     (typed-node-let-explicit-types node)
-     (typed-node-let-name-map node)))
+    (make-typed-node-let
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :bindings (typed-node-let-bindings node)
+     :subexpr (typed-node-let-subexpr node)
+     :explicit-types (typed-node-let-explicit-types node)
+     :name-map (typed-node-let-name-map node)))
 
   (:method ((node typed-node-match) new-type)
-    (typed-node-match
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-match-expr node)
-     (typed-node-match-branches node)))
+    (make-typed-node-match
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :expr (typed-node-match-expr node)
+     :branches (typed-node-match-branches node)))
 
   (:method ((node typed-node-seq) new-type)
-    (typed-node-seq
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-seq-subnodes node)))
+    (make-typed-node-seq
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :subnodes (typed-node-seq-subnodes node)))
 
   (:method ((node typed-node-return) new-type)
-    (typed-node-return
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-return-expr node)))
+    (make-typed-node-return
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :expr (typed-node-return-expr node)))
 
   (:method ((node typed-node-bind) new-type)
-    (typed-node-bind
-     new-type
-     (typed-node-unparsed node)
-     (typed-node-bind-name node)
-     (typed-node-bind-expr node)
-     (typed-node-bind-body node))))
+    (make-typed-node-bind
+     :type new-type
+     :unparsed (typed-node-unparsed node)
+     :name (typed-node-bind-name node)
+     :expr (typed-node-bind-expr node)
+     :body (typed-node-bind-body node))))
+
 (defun collect-variable-namespace (node)
   "Returns the name of every variable that will be referenced in the variable namespace in the generated code."
   (declare (type typed-node node)
@@ -406,69 +375,186 @@
     node)
 
   (:method ((node typed-node-application))
-    (typed-node-application
-     (typed-node-type node)
-     (typed-node-unparsed node)
-     (remove-static-preds (typed-node-application-rator node))
-     (mapcar #'remove-static-preds (typed-node-application-rands node))))
+    (make-typed-node-application
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :rator (remove-static-preds (typed-node-application-rator node))
+     :rands (mapcar #'remove-static-preds (typed-node-application-rands node))))
 
   (:method ((node typed-node-abstraction))
     (let* ((qual-ty (ty-scheme-type (typed-node-type node)))
            (preds (remove-if #'static-predicate-p (qualified-ty-predicates qual-ty)))
            (scheme (quantify nil (qualify preds (qualified-ty-type qual-ty)))))
-      (typed-node-abstraction
-       scheme
-       (typed-node-unparsed node)
-       (typed-node-abstraction-vars node)
-       (remove-static-preds (typed-node-abstraction-subexpr node))
-       (typed-node-abstraction-name-map node))))
+      (make-typed-node-abstraction
+       :type scheme
+       :unparsed (typed-node-unparsed node)
+       :vars (typed-node-abstraction-vars node)
+       :subexpr (remove-static-preds (typed-node-abstraction-subexpr node))
+       :name-map (typed-node-abstraction-name-map node))))
 
   (:method ((node typed-node-let))
-    (typed-node-let
-     (typed-node-type node)
-     (typed-node-unparsed node)
-     (loop :for (name . node) :in (typed-node-let-bindings node)
-           :collect (cons name (remove-static-preds node)))
-     (remove-static-preds (typed-node-let-subexpr node))
-     (typed-node-let-explicit-types node)
-     (typed-node-let-name-map node)))
+    (make-typed-node-let
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :bindings (loop :for (name . node) :in (typed-node-let-bindings node)
+                     :collect (cons name (remove-static-preds node)))
+     :subexpr (remove-static-preds (typed-node-let-subexpr node))
+     :explicit-types (typed-node-let-explicit-types node)
+     :name-map (typed-node-let-name-map node)))
 
   (:method ((node typed-node-lisp))
     node)
 
   (:method ((node typed-match-branch))
-    (typed-match-branch
-     (typed-match-branch-unparsed node)
-     (typed-match-branch-pattern node)
-     (remove-static-preds (typed-match-branch-subexpr node))
-     (typed-match-branch-bindings node)
-     (typed-match-branch-name-map node)))
-
+    (make-typed-match-branch
+     :unparsed (typed-match-branch-unparsed node)
+     :pattern (typed-match-branch-pattern node)
+     :subexpr (remove-static-preds (typed-match-branch-subexpr node))
+     :bindings (typed-match-branch-bindings node)
+     :name-map (typed-match-branch-name-map node)))
 
   (:method ((node typed-node-match))
-    (typed-node-match
-     (typed-node-type node)
-     (typed-node-unparsed node)
-     (remove-static-preds (typed-node-match-expr node))
-     (mapcar #'remove-static-preds (typed-node-match-branches node))))
+    (make-typed-node-match
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :expr (remove-static-preds (typed-node-match-expr node))
+     :branches (mapcar #'remove-static-preds (typed-node-match-branches node))))
 
   (:method ((node typed-node-seq))
-    (typed-node-seq
-     (typed-node-type node)
-     (typed-node-unparsed node)
-     (mapcar #'remove-static-preds (typed-node-seq-subnodes node))))
+    (make-typed-node-seq
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :subnodes (mapcar #'remove-static-preds (typed-node-seq-subnodes node))))
 
   (:method ((node typed-node-return))
-    (typed-node-return
-     (typed-node-type node)
-     (typed-node-unparsed node)
-     (remove-static-preds (typed-node-return-expr node))))
+    (make-typed-node-return
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :expr (remove-static-preds (typed-node-return-expr node))))
 
   (:method ((node typed-node-bind))
-    (typed-node-bind
-     (typed-node-type node)
-     (typed-node-unparsed node)
-     (typed-node-bind-name node)
-     (remove-static-preds (typed-node-bind-expr node))
-     (remove-static-preds (typed-node-bind-body node)))))
+    (make-typed-node-bind
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :name (typed-node-bind-name node)
+     :expr (remove-static-preds (typed-node-bind-expr node))
+     :body (remove-static-preds (typed-node-bind-body node)))))
 
+(defgeneric rewrite-recursive-calls (node bindings)
+  (:method ((node typed-node-literal) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings)
+             (ignore bindings))
+    node)
+
+  (:method ((node typed-node-variable) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+    (let* ((name (typed-node-variable-name node))
+           (binding (find name bindings :key #'car)))
+      (unless binding
+        (return-from rewrite-recursive-calls node))
+      (let* ((node-type (qualified-ty-type (fresh-inst (typed-node-type node))))
+             (new-type (fresh-inst (cdr binding)))
+             (new-type-unqualified (qualified-ty-type new-type))
+             (subs (match new-type-unqualified node-type))
+             (new-type (to-scheme (apply-substitution subs new-type))))
+        (replace-node-type node new-type))))
+
+  (:method ((node typed-node-application) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+    (make-typed-node-application
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :rator (rewrite-recursive-calls
+             (typed-node-application-rator node)
+             bindings)
+     :rands (mapcar
+             (lambda (node)
+               (rewrite-recursive-calls node bindings))
+             (typed-node-application-rands node))))
+
+  (:method ((node typed-node-abstraction) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+    (make-typed-node-abstraction
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :vars (typed-node-abstraction-vars node)
+     :subexpr (rewrite-recursive-calls (typed-node-abstraction-subexpr node) bindings)
+     :name-map (typed-node-abstraction-name-map node)))
+
+  (:method ((node typed-node-let) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+
+    (make-typed-node-let
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :bindings (loop :for (name . node) :in (typed-node-let-bindings node)
+                     :collect (cons
+                               name
+                               (rewrite-recursive-calls node bindings)))
+     :subexpr (rewrite-recursive-calls (typed-node-let-subexpr node) bindings)
+     :explicit-types (typed-node-let-explicit-types node)
+     :name-map (typed-node-let-name-map node)))
+
+  (:method ((node typed-node-lisp) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings)
+             (ignore bindings))
+    node)
+
+  (:method ((branch typed-match-branch) bindings)
+    (declare (type typed-match-branch branch)
+             (type scheme-binding-list bindings))
+    (make-typed-match-branch
+     :unparsed (typed-match-branch-unparsed branch)
+     :pattern (typed-match-branch-pattern branch)
+     :subexpr (rewrite-recursive-calls
+               (typed-match-branch-subexpr branch)
+               bindings)
+     :bindings (typed-match-branch-bindings branch)
+     :name-map (typed-match-branch-name-map branch)))
+
+  (:method ((node typed-node-match) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+    (make-typed-node-match
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :expr (rewrite-recursive-calls (typed-node-match-expr node) bindings)
+     :branches (mapcar
+                (lambda (branch)
+                  (rewrite-recursive-calls branch bindings))
+                (typed-node-match-branches node))))
+
+  (:method ((node typed-node-seq) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+    (make-typed-node-seq
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :subnodes (mapcar
+                (lambda (node)
+                  (rewrite-recursive-calls node bindings))
+                (typed-node-seq-subnodes node))))
+
+  (:method ((node typed-node-return) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+    (make-typed-node-return
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :expr (rewrite-recursive-calls (typed-node-return-expr node) bindings)))
+
+  (:method ((node typed-node-bind) bindings)
+    (declare (type typed-node node)
+             (type scheme-binding-list bindings))
+    (make-typed-node-bind
+     :type (typed-node-type node)
+     :unparsed (typed-node-unparsed node)
+     :name (typed-node-bind-name node)
+     :expr (rewrite-recursive-calls (typed-node-bind-expr node) bindings)
+     :body (rewrite-recursive-calls (typed-node-bind-body node) bindings))))

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -45,7 +45,7 @@
      (error 'kind-mismatch-error
             :type tyvar
             :kind (kind-of type)))
-    (t (list (%make-substitution tyvar type)))))
+    (t (list (make-substitution :from tyvar :to type)))))
 
 (defgeneric match (type1 type2)
   (:documentation "Returns a SUBSTITUTION-LIST which unifies TYPE1 to TYPE2
@@ -57,7 +57,7 @@ apply s type1 == type2")
       (merge-substitution-lists s1 s2)))
   (:method ((type1 tvar) (type2 ty))
     (if (equalp (kind-of (tvar-tyvar type1)) (kind-of type2))
-        (list (%make-substitution (tvar-tyvar type1) type2))
+        (list (make-substitution :from (tvar-tyvar type1) :to type2))
         (error 'type-kind-mismatch-error :type1 type1 :type2 type2)))
   (:method ((type1 tcon) (type2 tcon))
     (if (equalp type1 type2)


### PR DESCRIPTION
This increases consistency and makes printing readably easier.