### PR TITLE
red-black tree and map, for persistent `Ord` sets and maps

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -149,6 +149,8 @@
                (:file "hashtable")
                (:file "monad/state")
                (:file "iterator")
+               (:file "ord-tree")
+               (:file "ord-map")
                (:file "system")
                (:file "prelude")))
 
@@ -284,4 +286,5 @@
                (:file "string-tests")
                (:file "recursive-let-tests")
                (:file "class-tests")
-               (:file "list-tests")))
+               (:file "list-tests")
+               (:file "red-black-tests")))

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -238,14 +238,14 @@ specify `repr :lisp`."
     (alt ((:f :a) -> (:f :a) -> (:f :a)))
     (empty (:f :a)))
 
-  (define-class (Foldable :t)
+  (define-class (Foldable :container)
     "Types which can be folded into a single element.
 
 `fold` is a left tail recursive fold
 
 `foldr` is a right non tail recursive fold"
-    (fold ((:b -> :a -> :b) -> :b -> :t :a -> :b))
-    (foldr ((:a -> :b -> :b) -> :b -> :t :a -> :b)))
+    (fold ((:accum -> :elt -> :accum) -> :accum -> :container :elt -> :accum))
+    (foldr ((:elt -> :accum -> :accum) -> :accum -> :container :elt -> :accum)))
 
   (declare mconcat ((Foldable :f) (Monoid :a) => (:f :a) -> :a))
   (define  mconcat (fold <> mempty))

--- a/library/ord-map.lisp
+++ b/library/ord-map.lisp
@@ -1,0 +1,204 @@
+(coalton-library/utils:defstdlib-package :coalton-library/ord-map
+    (:use
+     :coalton
+     :coalton-library/classes
+     :coalton-library/tuple
+     :coalton-library/functions)
+  (:local-nicknames (#:tree :coalton-library/ord-tree)
+                    (#:iter :coalton-library/iterator))
+  (:shadow #:Map #:empty)
+  (:export
+   #:Map
+   #:empty
+   #:lookup
+   #:insert
+   #:replace
+   #:replace-or-insert #:insert-or-replace
+   #:remove
+   #:keys
+   #:values
+   #:entries
+   #:collect!
+   #:update
+   #:merge))
+(cl:in-package :coalton-library/ord-map)
+
+(coalton-toplevel
+  (define-type (MapPair :key :value)
+    (MapPair :key :value)
+
+    ;; hack: when searching for an entry, we need a thing that holds just a key, but is of type `MapPair :key
+    ;; :any', to pass to `tree:lookup' or `tree:remove'. A `Map' will never hold a `JustKey'.
+    (JustKey :key))
+
+  (define (key pair)
+    (match pair
+      ((MapPair k _) k)
+      ((JustKey k) k)))
+
+  (define (value pair)
+    (match pair
+      ((MapPair _ v) v)
+      (_ (error "Misuse of `JustKey': Cannot read the Value of a JustKey"))))
+
+  (define-instance (Into (MapPair :key :value) (Tuple :key :value))
+    (define (into pair)
+      (Tuple (key pair) (value pair))))
+
+  (define-instance ((Eq :key) => (Eq (MapPair :key :value)))
+    (define (== left right)
+      (== (key left) (key right))))
+
+  (define-instance ((Ord :key) => (Ord (MapPair :key :value)))
+    (define (<=> left right)
+      (<=> (key left) (key right))))
+
+  (repr :transparent)
+  (define-type (Map :key :value)
+    "A red-black binary tree which associates each :KEY with a :VALUE, sorted by `<=>' on the keys and unique by `==' on the keys."
+    (%Map (tree:Tree (MapPair :key :value))))
+
+  (declare empty (Map :key :value))
+  (define empty
+    "A Map containing no mappings."
+    (%Map tree:Empty))
+
+  (declare lookup ((Ord :key) => ((Map :key :value) -> :key -> (Optional :value))))
+  (define (lookup mp k)
+    "Retrieve the value associated with K in MP, or None if MP does not contain K."
+    (match mp
+      ((%Map tre) (coalton-library/classes:map value (tree:lookup tre (JustKey k))))))
+
+  (declare insert ((Ord :key) => ((Map :key :value) -> :key -> :value -> (Optional (Map :key :value)))))
+  (define (insert mp k v)
+    "Associate K with V in MP. If MP already contains a mapping for K, return None."
+    (coalton-library/classes:map %Map
+                                 (match mp
+                                   ((%Map tre) (tree:insert tre (MapPair k v))))))
+
+  (declare replace ((Ord :key) => ((Map :key :value) -> :key -> :value -> (Optional (Tuple (Map :key :value)
+                                                                                           :value)))))
+  (define (replace mp k v)
+    "Change the association of K to V in MP. If MP did not already contain a mapping for K, return None."
+    (let (%Map tre) = mp)
+    (match (tree:replace tre (MapPair k v))
+      ((None) None)
+      ((Some (Tuple new-tre removed-pair))
+       (Some (Tuple (%Map new-tre)
+                    (value removed-pair))))))
+
+  (declare replace-or-insert ((Ord :key) => ((Map :key :value) -> :key -> :value -> (Tuple (Map :key :value)
+                                                                                           (Optional :value)))))
+  (define (replace-or-insert mp k v)
+    "Update MP to associate K with V.
+
+If MP already contains a mapping for K, replace it and return the old value."
+    (let (%Map tre) = mp)
+    (let (Tuple new-tre removed-pair) = (tree:replace-or-insert tre (MapPair k v)))
+    (Tuple (%Map new-tre)
+           (coalton-library/classes:map value removed-pair)))
+
+  (declare insert-or-replace ((Ord :key) => ((Map :key :value) -> :key -> :value -> (Map :key :value))))
+  (define (insert-or-replace mp k v)
+    "Update MP to associate K with V.
+
+If MP already contains a mapping for K, replace it and discard the old value.
+
+Like `replace-or-insert', but prioritizing insertion as a use case."
+    (let (%Map tre) = mp)
+    (%Map (tree:insert-or-replace tre (MapPair k v))))
+
+  (declare remove ((Ord :key) => ((Map :key :value) -> :key -> (Optional (Map :key :value)))))
+  (define (remove mp k)
+    "Remove the mapping associated with K in MP. If K does not have a value in MP, return None."
+    (coalton-library/classes:map %Map
+                                 (match mp
+                                   ((%Map tre) (tree:remove tre (JustKey k))))))
+
+  (declare entries ((Map :key :value) -> (iter:Iterator (Tuple :key :value))))
+  (define (entries mp)
+    "Iterate over the (key value) pairs in MP, sorted by the keys in least-to-greatest order."
+    (match mp
+      ((%Map tre) (coalton-library/classes:map into (tree:increasing-order tre)))))
+
+  (declare keys ((Map :key :value) -> (iter:Iterator :key)))
+  (define (keys mp)
+    "Iterate over the keys in MP, sorted least-to-greatest."
+    (match mp
+      ((%Map tre) (coalton-library/classes:map key (tree:increasing-order tre)))))
+
+  (declare values ((Map :key :value) -> (iter:Iterator :value)))
+  (define (values mp)
+    "Iterate over the values in MP, sorted by their corresponding keys in least-to-greatest order."
+    (match mp
+      ((%Map tre) (coalton-library/classes:map value (tree:increasing-order tre)))))
+
+  (define-instance ((Eq :key) (Eq :value) => (Eq (Map :key :value)))
+    (define (== left right)
+      (iter:elementwise-match! == (entries left) (entries right))))
+
+  (define-instance ((Hash :key) (Hash :value) => (Hash (Map :key :value)))
+    (define (hash mp)
+      (iter:elementwise-hash! (entries mp))))
+
+  (declare collect! ((Ord :key) => ((iter:Iterator (Tuple :key :value)) -> (Map :key :value))))
+  (define (collect! iter)
+    "Construct a Map containing all the (key value) pairs in ITER.
+
+If ITER contains duplicate keys, later values will overwrite earlier values."
+    (iter:fold! (fn (mp tpl)
+                  (uncurry (insert-or-replace mp) tpl))
+                empty
+                iter))
+
+  (declare update ((Ord :key) => (:value -> :value) -> (Map :key :value) -> :key -> (Optional (Map :key :value))))
+  (define (update func mp key)
+    "Apply FUNC to the value corresponding to KEY in MP, returning a new `Map' which maps KEY to the result of the function."
+    (let (%Map tre) = mp)
+    (let ((helper
+            (fn (subtree)
+              (match subtree
+                ((tree:Empty) None)
+                ;; `Branch' intentionally unexported from the tree package, but needed here because this
+                ;; operation does tree search but is meaningless on trees that aren't maps.
+                ((tree::Branch clr less (MapPair pivot val) more)
+                 (match (<=> key pivot)
+                   ((LT) (coalton-library/classes:map (fn (new-less)
+                                                        (tree::Branch clr new-less (MapPair pivot val) more))
+                                                      (helper less)))
+                   ((Eq) (Some (tree::Branch clr less (MapPair pivot (func val)) more)))
+                   ((GT) (coalton-library/classes:map (tree::Branch clr less (MapPair pivot val))
+                                                      (helper more)))))))))
+      (coalton-library/classes:map %Map
+                                   (helper tre))))
+
+  (declare merge (Ord :key => Map :key :value -> Map :key :value -> Map :key :value))
+  (define (merge a b)
+    "Construct a Tree containing all the mappings of both A and B.
+
+If A and B contain mappings X -> A' and X -> B', it is undefined whether the result maps X to A' or B'.
+
+Because of the possibility that A and B will map the same X to different A' and B', this is not an associative
+operation, and therefore Map cannot implement Monoid."
+    (let (%Map a) = a)
+    (let (%Map b) = b)
+    (%Map (tree:merge a b)))
+
+  (define-instance (Ord :key => Semigroup (Map :key :value))
+    (define <> merge))
+
+  (define-instance (Functor (Map :key))
+    (define (coalton-library/classes:map func mp)
+      (let (%Map tre) = mp)
+      (let ((helper (fn (subtree)
+                      (match subtree
+                        ((tree::Empty) tree:Empty)
+                        ((tree::Branch clr left (MapPair key value) right)
+                         (tree::Branch clr
+                                       (helper left)
+                                       (MapPair key (func value))
+                                       (helper right)))))))
+        (%Map (helper tre)))))
+
+  ;; As with `tree:Tree', `Map' should probably implement `Traversable'.
+  )

--- a/library/ord-tree.lisp
+++ b/library/ord-tree.lisp
@@ -1,0 +1,510 @@
+(coalton-library/utils:defstdlib-package :coalton-library/ord-tree
+  (:use
+   :coalton
+   :coalton-library/classes
+   :coalton-library/tuple
+   :coalton-library/functions)
+  (:local-nicknames (#:iter :coalton-library/iterator)
+                    (#:cell :coalton-library/cell))
+  (:shadow #:empty)
+  (:export
+   #:Tree #:Empty
+   #:lookup
+   #:insert
+   #:replace
+   #:replace-or-insert #:insert-or-replace
+   #:remove
+   #:increasing-order
+   #:decreasing-order
+   #:collect!
+   #:merge
+   #:make))
+(cl:in-package :coalton-library/ord-tree)
+
+;; adapted from https://matt.might.net/articles/red-black-delete/
+
+(coalton-toplevel
+  ;; the red-black tree invariants:
+  ;; - the left child of a node is less than the node, and the right child is greater
+  ;; - a red node has no red children
+  ;; - a leaf is black
+  ;; - every path from the root to a leaf passes through the same number of black nodes
+
+  ;; unexported; a marker held by trees to enable self-balancing.
+  (repr :enum)
+  (define-type Color
+    ;; has no red children
+    Red
+
+    ;; may have either red or black children
+    Black
+
+    ;; intermediate states during deletion; will never exist outside of a `remove' operation
+    DoubleBlack
+    NegativeBlack)
+
+  (define-instance (Eq Color)
+    (define (== a b)
+      (match (Tuple a b)
+        ((Tuple (Red) (Red)) True)
+        ((Tuple (Black) (Black)) True)
+        ((Tuple (DoubleBlack) (DoubleBlack)) True)
+        ((Tuple (NegativeBlack) (NegativeBlack)) True)
+        (_ False))))
+
+  (declare color-plus-black (Color -> Color))
+  (define (color-plus-black c)
+    (match c
+      ((DoubleBlack) (error "cannot add black to double-black"))
+      ((Black) DoubleBlack)
+      ((Red) Black)
+      ((NegativeBlack) Red)))
+
+  (declare color-minus-black (Color -> Color))
+  (define (color-minus-black c)
+    (match c
+      ((DoubleBlack) Black)
+      ((Black) Red)
+      ((Red) NegativeBlack)
+      ((NegativeBlack) (error "cannot subtract black from negative-black"))))
+
+  (define-type (Tree :elt)
+    "A red-black balanced binary tree, sorted by `<=>' and unique by `=='."
+    ;; exported; an empty tree.
+    ;; considered black for the purpose of the invariants.
+    Empty
+
+    ;; unexported; a tree with at least one element, and possibly children.
+    ;; (Brach clr less elt right)
+    ;; every element of LESS is less than ELT, and every element of RIGHT is greater than ELT.
+    (Branch Color (Tree :elt) :elt (Tree :elt))
+
+    ;; unexported: a double-black leaf node. intermediate stage during deletion; will never exist outside of a
+    ;; `remove' operation.
+    DoubleBlackEmpty
+    )
+
+  ;;; color operations
+
+  (declare tree-plus-black ((Tree :elt) -> (Tree :elt)))
+  (define (tree-plus-black tre)
+    (match tre
+      ((Empty) DoubleBlackEmpty)
+      ((Branch c left pivot right) (Branch (color-plus-black c) left pivot right))
+      ((DoubleBlackEmpty) (error "cannot add black to double-black empty tree"))))
+
+  (declare tree-minus-black ((Tree :elt) -> (Tree :elt)))
+  (define (tree-minus-black tre)
+    (match tre
+      ((Empty) (error "cannot subtract black from empty tree"))
+      ((Branch c left pivot right) (Branch (color-minus-black c) left pivot right))
+      ((DoubleBlackEmpty) Empty)))
+
+  (declare as-black ((Tree :elt) -> (Tree :elt)))
+  (define (as-black tre)
+    (match tre
+      ((Empty) Empty)
+      ((DoubleBlackEmpty) Empty)
+      ((Branch _ left elt right) (Branch Black left elt right))))
+
+  (declare tree-double-black? ((Tree :elt) -> Boolean))
+  (define (tree-double-black? tre)
+    (match tre
+      ((Branch clr _ _ _) (== clr DoubleBlack))
+      ((Empty) False)
+      ((DoubleBlackEmpty) True)))
+
+  ;;; searching trees
+
+  (declare lookup ((Ord :elt) => ((Tree :elt) -> :elt -> (Optional :elt))))
+  (define (lookup haystack needle)
+    "If HAYSTACK contains an element `==' to NEEDLE, return it."
+    (match haystack
+      ((Empty) None)
+      ((Branch _ left elt right)
+       (match (<=> needle elt)
+         ((LT) (lookup left needle))
+         ((EQ) (Some elt))
+         ((GT) (lookup right needle))))))
+
+  ;;; inserting into and replacing elements of trees
+
+  (declare balance (Color -> (Tree :elt) -> :elt -> (Tree :elt) -> (Tree :elt)))
+  (define (balance clr left elt right)
+    (match (Branch clr left elt right)
+      ;; cases for insertion violations
+      ((Branch (Black)
+               (Branch (Red)
+                       (Branch (Red) a x b)
+                       y
+                       c)
+               z
+               d)
+       (Branch Red
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+      ((Branch (Black)
+               (Branch (Red)
+                       a
+                       x
+                       (Branch (Red) b y c))
+               z
+               d)
+       (Branch Red
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+      ((Branch (Black)
+               a
+               x
+               (Branch (Red)
+                       (Branch (Red)
+                               b
+                               y
+                               c)
+                       z
+                       d))
+       (Branch Red
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+      ((Branch (Black)
+               a
+               x
+               (Branch (Red)
+                       b
+                       y
+                       (Branch (Red)
+                               c
+                               z
+                               d)))
+       (Branch Red
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+
+      ;; duplicates of above cases with black swapped for double-black
+      ((Branch (DoubleBlack)
+               (Branch (Red)
+                       (Branch (Red) a x b)
+                       y
+                       c)
+               z
+               d)
+       (Branch Black
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+      ((Branch (DoubleBlack)
+               (Branch (Red)
+                       a
+                       x
+                       (Branch (Red) b y c))
+               z
+               d)
+       (Branch Black
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+      ((Branch (DoubleBlack)
+               a
+               x
+               (Branch (Red)
+                       (Branch (Red)
+                               b
+                               y
+                               c)
+                       z
+                       d))
+       (Branch Black
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+      ((Branch (DoubleBlack)
+               a
+               x
+               (Branch (Red)
+                       b
+                       y
+                       (Branch (Red)
+                               c
+                               z
+                               d)))
+       (Branch Black
+               (Branch Black a x b)
+               y
+               (Branch Black c z d)))
+
+      ;; cases for removal violations with double-blacks and/or negative-blacks
+      ((Branch (DoubleBlack)
+               a
+               x
+               (Branch (NegativeBlack)
+                       (Branch (Black) b y c)
+                       z
+                       (Branch (Black) d-left d-value d-right)))
+       (Branch Black
+               (Branch Black a x b)
+               y
+               (balance Black c z (Branch Red d-left d-value d-right))))
+
+      ((Branch (DoubleBlack)
+               (Branch (NegativeBlack)
+                       (Branch (Black) a-left a-value a-right)
+                       x
+                       (Branch (Black) b y c))
+               z
+               d)
+       (Branch Black
+               (balance Black
+                        (Branch Red a-left a-value a-right)
+                        x
+                        b)
+               y
+               (Branch Black c z d)))
+
+      (tre tre)))
+
+  (declare insert ((Ord :elt) => ((Tree :elt) -> :elt -> (Optional (Tree :elt)))))
+  (define (insert tre elt)
+    "Construct a new Tree like TRE but containing ELT. If TRE already had an element `==' to ELT, return None."
+    (let ((ins (fn (subtree)
+                 (match subtree
+                   ((Empty) (Some (Branch Red Empty elt Empty)))
+                   ((Branch clr left pivot right)
+                    (match (<=> elt pivot)
+                      ((LT) (map (fn (new-left) (balance clr new-left pivot right))
+                                 (ins left)))
+                      ((EQ) None)
+                      ((GT) (map (fn (new-right) (balance clr left pivot new-right))
+                                 (ins right)))))))))
+      (ins tre)))
+
+  (declare replace ((Ord :elt) => ((Tree :elt) -> :elt -> (Optional (Tuple (Tree :elt) :elt)))))
+  (define (replace tre elt)
+    "Construct a new Tree like TRE but with ELT replacing an old element `==' to ELT.
+
+Return the new tree and the removed element.
+
+If TRE did not have an element `==' to ELT, return None."
+    (let ((ins (fn (subtree)
+                 (match subtree
+                   ((Empty) None)
+                   ((Branch clr left pivot right)
+                    (match (<=> elt pivot)
+                      ((LT) (map (uncurry (fn (new-left removed-elt) (Tuple (balance clr new-left pivot right) removed-elt)))
+                                 (ins left)))
+                      ((EQ) (Some (Tuple (Branch clr left elt right)
+                                         pivot)))
+                      ((GT) (map (uncurry (fn (new-right removed-elt) (Tuple (balance clr left pivot new-right) removed-elt)))
+                                 (ins right)))))))))
+      (ins tre)))
+
+  (declare replace-or-insert ((Ord :elt) => ((Tree :elt) -> :elt -> (Tuple (Tree :elt) (Optional :elt)))))
+  (define (replace-or-insert tre elt)
+    "Construct a new Tree like TRE but containing ELT.
+
+If TRE already had an element `==' to ELT, remove it, replace it with ELT, and return the removed value
+alongside the new tree."
+    (let ((ins (fn (subtree)
+                 (match subtree
+                   ((Empty) (Tuple (Branch Red Empty elt Empty)
+                                   None))
+                   ((Branch clr left pivot right)
+                    (match (<=> elt pivot)
+                      ((LT)
+                       (let (Tuple new-left removed-elt) = (ins left))
+                       (Tuple (balance clr new-left pivot right)
+                              removed-elt))
+                      ((EQ) (Tuple (Branch clr left elt right)
+                                   (Some pivot)))
+                      ((GT)
+                       (let (Tuple new-right removed-elt) = (ins right))
+                       (Tuple (balance clr left pivot new-right)
+                              removed-elt))))))))
+      (let (Tuple new-tree removed-elt) = (ins tre))
+      (Tuple (as-black new-tree) removed-elt)))
+
+  (declare insert-or-replace ((Ord :elt) => ((Tree :elt) -> :elt -> (Tree :elt))))
+  (define (insert-or-replace tre elt)
+    "Construct a new Tree like TRE but containing ELT.
+
+If TRE already had an element `==' to ELT, remove it, replace it with ELT, and discard the removed value.
+
+Like `replace-or-insert', but prioritizing insertion as a use case."
+    (fst (replace-or-insert tre elt)))
+
+  ;;; removing from trees
+
+  ;; matt might calls this operation `sorted-map-delete'
+  (declare remove ((Ord :elt) => ((Tree :elt) -> :elt -> (Optional (Tree :elt)))))
+  (define (remove tre elt)
+    "Construct a new Tree like TRE but without an element `==' to ELT. Return None if TRE does not contain an element `==' to ELT."
+    (map as-black
+         (remove-without-as-black tre elt)))
+
+  ;; matt might calls this operation `del'
+  (declare remove-without-as-black ((Ord :elt) => ((Tree :elt) -> :elt -> (Optional (Tree :elt)))))
+  (define (remove-without-as-black tre elt)
+    (match tre
+      ((Empty) None)
+      ((Branch clr left pivot right)
+       (match (<=> elt pivot)
+         ((LT)
+          (map (fn (new-left) (bubble-double-black clr new-left pivot right))
+               (remove-without-as-black left elt)))
+         ((EQ) (Some (remove-leaving-double-black tre)))
+         ((GT)
+          (map (fn (new-right) (bubble-double-black clr left pivot new-right))
+               (remove-without-as-black right elt)))))))
+
+  ;; matt might calls this operation `remove'
+  (declare remove-leaving-double-black (((Tree :elt) -> (Tree :elt))))
+  (define (remove-leaving-double-black tre)
+    "Remove the pivot of TRE from TRE, fusing its left and right children to form a new tree.
+
+The result tree may be in an intermediate state with a double-black node."
+    (match tre
+      ;; nodes with no subtrees
+      ((Branch (Red) (Empty) _ (Empty)) Empty)
+      ((Branch (Black) (Empty) _ (Empty)) DoubleBlackEmpty)
+
+      ;; nodes with one subtree
+      ((Branch (Black)
+               (Empty)
+               _
+               (Branch child-clr child-left child-value child-right))
+       (assert (== child-clr Red)
+           "Black node with black leaf and black non-empty child violates red-black constraints")
+       (Branch Black child-left child-value child-right))
+      ((Branch (Black)
+               (Branch child-clr child-left child-value child-right)
+               _
+               (Empty))
+       (assert (== child-clr Red)
+           "Black node with black leaf and black non-empty child violates red-black constraints")
+       (Branch Black child-left child-value child-right))
+      ;; all other one-child cases should be impossible because they violate red-black constraints
+
+      ;; nodes with two subtrees
+      ((Branch clr left _ right)
+       (let (Tuple new-left new-pivot) = (remove-max left))
+       (bubble-double-black clr new-left new-pivot right))))
+
+  ;; matt might calls this operation `bubble'
+  (declare bubble-double-black ((Color -> (Tree :elt) -> :elt -> (Tree :elt) -> (Tree :elt))))
+  (define (bubble-double-black clr left pivot right)
+    (if (or (tree-double-black? left) (tree-double-black? right))
+        (balance (color-plus-black clr) (tree-minus-black left) pivot (tree-minus-black right))
+        (Branch clr left pivot right)))
+
+  ;; matt might has this in two operations, `remove-max' and `sorted-map-max'
+  (declare remove-max ((Tree :elt) -> (Tuple (Tree :elt) :elt)))
+  (define (remove-max tre)
+    (match tre
+      ((Branch _ _ pivot (Empty)) (Tuple (remove-leaving-double-black tre) pivot))
+      ((Branch clr left pivot right)
+       (let (Tuple new-right removed-max) = (remove-max right))
+       (Tuple (bubble-double-black clr left pivot new-right)
+              removed-max))))
+
+  ;;; iterating through trees
+
+  (define-type (IteratorStackNode :elt)
+    (Yield :elt)
+    (Expand (Tree :elt)))
+
+  (declare tree-iterator (((cell:Cell (List (IteratorStackNode :elt))) -> (Tree :elt) -> Unit)
+                          -> (Tree :elt)
+                          -> (iter:Iterator :elt)))
+  (define (tree-iterator add-to-stack tre)
+    (let ((stack (cell:new (make-list (Expand tre))))
+          (next!
+            (fn ()
+              (match (cell:pop! stack)
+                ((None) None)
+                ((Some (Yield elt)) (Some elt))
+                ((Some (Expand node)) (add-to-stack stack node) (next!))))))
+      (iter:new next!)))
+
+  (declare stack-for-increasing-order-traversal ((cell:Cell (List (IteratorStackNode :elt))) -> (Tree :elt) -> Unit))
+  (define (stack-for-increasing-order-traversal stack node)
+    (match node
+      ((Empty) Unit)
+      ((Branch _ less elt more)
+       (cell:push! stack (Expand more))
+       (cell:push! stack (Yield elt))
+       (cell:push! stack (Expand less))
+       Unit)))
+
+  (declare increasing-order ((Tree :elt) -> (iter:Iterator :elt)))
+  (define increasing-order
+    "Iterate the elements of a tree, starting with the least by `<=>' and ending with the greatest."
+    (tree-iterator stack-for-increasing-order-traversal))
+
+  (declare stack-for-decreasing-order-traversal ((cell:Cell (List (IteratorStackNode :elt))) -> (Tree :elt) -> Unit))
+  (define (stack-for-decreasing-order-traversal stack node)
+    (match node
+      ((Empty) Unit)
+      ((Branch _ less elt more)
+       (cell:push! stack (Expand less))
+       (cell:push! stack (Yield elt))
+       (cell:push! stack (Expand more))
+       Unit)))
+
+  (declare decreasing-order ((Tree :elt) -> (iter:Iterator :elt)))
+  (define decreasing-order
+    "Iterate the elements of a tree, starting with the greatest by `<=>' and ending with the least."
+    (tree-iterator stack-for-decreasing-order-traversal))
+
+  (define-instance ((Eq :elt) => (Eq (Tree :elt)))
+    (define (== left right)
+      (iter:elementwise==! (increasing-order left) (increasing-order right))))
+
+  (define-instance ((Hash :elt) => (Hash (Tree :elt)))
+    (define (hash tre)
+      (iter:elementwise-hash! (increasing-order tre))))
+
+  (declare collect! ((Ord :elt) => (iter:Iterator :elt) -> (Tree :elt)))
+  (define (collect! iter)
+    "Construct a Tree containing all the elements of ITER.
+
+If ITER contains duplicates, later elements will overwrite earlier elements."
+    (iter:fold! insert-or-replace Empty iter))
+
+  (declare merge (Ord :elt => Tree :elt -> Tree :elt -> Tree :elt))
+  (define (merge a b)
+    "Construct a Tree containing all the elements of both A and B.
+
+If A and B contain elements A' and B' respectively where (== A' B'), the result will contain either A' or
+B'. Which one is chosen for the result is undefined."
+    (iter:fold! insert-or-replace
+                a
+                (increasing-order b)))
+
+  (define-instance (Ord :elt => Semigroup (Tree :elt))
+    (define <> merge))
+
+  (define-instance (Ord :elt => Monoid (Tree :elt))
+    (define mempty Empty))
+
+  (define-instance (Foldable Tree)
+    (define (fold func init tre)
+      (iter:fold! func init (increasing-order tre)))
+    (define (foldr func init tre)
+      (iter:fold! (flip func) init (decreasing-order tre))))
+
+  ;; We possibly should have an instance (Traversable Tree). Open questions:
+  ;; - Is it necessary (or desirable) that `traverse' walk the tree in the same order as `fold',
+  ;;   i.e. left-to-right? My gut says yes.
+  ;; - Is it possible to write a better instance than one which converts the tree to an iterator using
+  ;;   `increasing-order', then traverses it via `liftA2' of `insert-or-replace'? My gut says no, given the
+  ;;   previous point.
+  )
+
+(cl:defmacro make (cl:&rest elements)
+  "Construct a tree containing the ELEMENTS.
+
+e.g. (tree:make 5 6 1 8 9) => tree containing 1, 5, 6, 8, 9."
+  `(collect-tree! (iter:list-iter (make-list ,@elements))))

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -108,7 +108,9 @@
                coalton-library/slice
                coalton-library/hashtable
                coalton-library/monad/state
-               coalton-library/iterator)
+               coalton-library/iterator
+               coalton-library/ord-tree
+               coalton-library/ord-map)
    :asdf-system :coalton/library
    :file-link-prefix "https://github.com/coalton-lang/coalton/tree/main/library/"))
 

--- a/tests/iterator-tests.lisp
+++ b/tests/iterator-tests.lisp
@@ -167,6 +167,13 @@
                              (iter:list-iter (make-list 2 4 6))))
           (the (List Integer) (make-list 1 2 3 4 5 6 7 8 9 10)))))
 
+(define-test elementwise-match-/= ()
+  (is (not (iter:elementwise==! (iter:list-iter (make-list 0 1 2))
+                                (iter:list-iter (make-list 0 1)))))
+  (is (not (iter:elementwise-match! <
+                                    (iter:list-iter (make-list 0 1 2))
+                                    (iter:list-iter (make-list 0 1))))))
+
 ;;; FIXME: define more tests
 ;; - vector-iter
 ;; - recursive-iter

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -36,7 +36,10 @@
    (#:slice #:coalton-library/slice)
    (#:hashtable #:coalton-library/hashtable)
    (#:iter #:coalton-library/iterator)
-   (#:list #:coalton-library/list)))
+   (#:list #:coalton-library/list)
+   (#:red-black/tree #:coalton-library/ord-tree)
+   (#:red-black/map #:coalton-library/ord-map)
+   (#:result #:coalton-library/result)))
 
 (in-package #:coalton-native-tests)
 

--- a/tests/red-black-tests.lisp
+++ b/tests/red-black-tests.lisp
@@ -1,0 +1,194 @@
+(cl:in-package #:coalton-native-tests)
+
+;; invariant checking
+(coalton-toplevel
+  (define-type (InvariantError :elt)
+    (RedWithRedLeftChild (red-black/tree:Tree :elt))
+    (RedWithRedRightChild (red-black/tree:Tree :elt))
+    (DifferentCountToBlack UFix (red-black/tree:Tree :elt)
+                           UFix (red-black/tree:Tree :elt))
+    (BothChildrenErrors (InvariantError :elt) (InvariantError :elt)))
+
+  (declare count-blacks-to-leaf ((red-black/tree:Tree :elt) -> (Result (InvariantError :elt) UFix)))
+  (define (count-blacks-to-leaf tre)
+    (match tre
+      ((red-black/tree:Empty) (Ok 0))
+      ((red-black/tree::Branch (red-black/tree::Red)
+                               (red-black/tree::Branch (red-black/tree::Red) _ _ _)
+                               _
+                               _)
+       (Err (RedWithRedLeftChild tre)))
+      ((red-black/tree::Branch (red-black/tree::Red)
+                               _
+                               _
+                               (red-black/tree::Branch (red-black/tree::Red) _ _ _))
+       (Err (RedWithRedRightChild tre)))
+      ((red-black/tree::Branch c left _ right)
+       (match (Tuple (count-blacks-to-leaf left)
+                     (count-blacks-to-leaf right))
+         ((Tuple (Err left-err) (Err right-err))
+          (Err (BothChildrenErrors left-err right-err)))
+         ((Tuple (Err left-err) _)
+          (Err left-err))
+         ((Tuple _ (Err right-err))
+          (Err right-err))
+         ((Tuple (Ok left-ct) (Ok right-ct))
+          (if (== left-ct right-ct)
+              (Ok (+ left-ct (match c
+                               ((red-black/tree::Black) 1)
+                               ((red-black/tree::Red) 0))))
+              (Err (DifferentCountToBlack left-ct left
+                                          right-ct right)))))))))
+
+(coalton-toplevel
+  (declare random-below! (UFix -> UFix))
+  (define (random-below! limit)
+    (lisp UFix (limit)
+      (cl:random limit)))
+
+  (declare random! (Unit -> UFix))
+  (define (random!)
+    (random-below! (lisp UFix () cl:most-positive-fixnum)))
+
+  (declare random-iter! (UFix -> (iter:Iterator UFix)))
+  (define (random-iter! length)
+    (map (fn (_) (random!))
+         (iter:up-to length))))
+
+(define-test tree-from-iter-equiv-to-manual-construction ()
+  (let manual = (red-black/tree:insert-or-replace
+                 (red-black/tree:insert-or-replace
+                  (red-black/tree:insert-or-replace red-black/tree:Empty
+                                                    5)
+                  11)
+                 2))
+  (let iterated = (red-black/tree:collect! (iter:list-iter (make-list 5 11 2))))
+  (is (== manual iterated))
+  (is (== (hash manual) (hash iterated))))
+
+(define-test tree-always-increasing-order ()
+  (let increasing? = (fn (lst)
+                       (== (list:sort lst) lst)))
+  (let random-tree! = (fn (size)
+                        (red-black/tree:collect! (random-iter! size))))
+  (let increasing-list = (fn (tree)
+                           (iter:collect-list! (red-black/tree:increasing-order tree))))
+  (let decreasing-list = (fn (tree)
+                           (iter:collect-list! (red-black/tree:decreasing-order tree))))
+  (let tree-good? = (fn (tree)
+                      (let increasing = (increasing-list tree))
+                      (let decreasing = (decreasing-list tree))
+                      (is (increasing? increasing))
+                      (is (== (reverse decreasing) increasing))))
+  (iter:for-each!
+   (fn (length)
+     (pipe length
+           random-tree!
+           tree-good?))
+   (iter:up-to 128)))
+
+(cl:defmacro is-ok (check cl:&optional (message (cl:format cl:nil "~A returned Err" check)))
+  `(is (result:isOk ,check)
+       ,message))
+
+(define-test insertion-upholds-invariants ()
+  (let insert-and-check-invariants =
+    (fn (tre new-elt)
+      (let new-tre = (red-black/tree:insert-or-replace tre new-elt))
+      (is-ok (count-blacks-to-leaf new-tre))
+      new-tre))
+  (let collect-tree-checking-invariants =
+    (fn (iter)
+      (iter:fold! insert-and-check-invariants red-black/tree:Empty iter)))
+  (let up-to-1024 =
+    (collect-tree-checking-invariants (iter:up-to 1024)))
+  (let down-from-1024 =
+    (collect-tree-checking-invariants (iter:down-from 1024)))
+  (is (== up-to-1024 down-from-1024))
+  (is (== (hash up-to-1024) (hash down-from-1024)))
+  (let range-1024 = (iter:collect-list! (iter:up-to 1024)))
+  (let range-shuffled = (lisp (List Integer) (range-1024)
+                          (alexandria:shuffle range-1024)))
+  (let shuffled =
+    (collect-tree-checking-invariants (iter:list-iter range-shuffled)))
+  (is (== up-to-1024 shuffled))
+  (is (== (hash up-to-1024) (hash shuffled))))
+
+(coalton-toplevel
+  (declare tree-4 (red-black/tree:Tree Integer))
+  (define tree-4 (red-black/tree:collect! (iter:up-to 4)))
+
+  (declare tree-1024 (red-black/tree:Tree Integer))
+  (define tree-1024 (red-black/tree:collect! (iter:up-to 1024)))
+
+  (declare remove-and-check-invariants ((red-black/tree:Tree Integer) -> Integer -> (red-black/tree:Tree Integer)))
+  (define (remove-and-check-invariants tre elt-to-remove)
+    (match (red-black/tree:remove tre elt-to-remove)
+      ((None) (error "Tried to remove non-present element in `remove-and-check-invariants'"))
+      ((Some new-tre)
+       (is-ok (count-blacks-to-leaf new-tre))
+       new-tre)))
+
+  (declare destroy-tree-checking-invariants ((red-black/tree:Tree Integer) -> (iter:Iterator Integer) -> Unit))
+  (define (destroy-tree-checking-invariants start iter)
+    (let should-be-empty = (iter:fold! remove-and-check-invariants start iter))
+    (matches (red-black/tree:Empty) should-be-empty "Non-empty tree after removing all elements")))
+
+(define-test removal-upholds-invariants-small-upward ()
+  (destroy-tree-checking-invariants tree-4 (iter:up-to 4)))
+
+(define-test removal-upholds-invariants-large-upward ()
+  (destroy-tree-checking-invariants tree-1024 (iter:up-to 1024)))
+
+(define-test removal-upholds-invariants-small-downward ()
+  (destroy-tree-checking-invariants tree-4 (iter:down-from 4)))
+
+(define-test removal-upholds-invariants-large-downward ()
+  (destroy-tree-checking-invariants tree-1024 (iter:down-from 1024)))
+
+(define-test removal-upholds-invariants-shuffled ()
+  (let range-1024 = (iter:collect-list! (iter:up-to 1024)))
+  (let range-shuffled = (lisp (List Integer) (range-1024)
+                          (alexandria:shuffle range-1024)))
+  (destroy-tree-checking-invariants tree-1024 (iter:list-iter range-shuffled)))
+
+(define-test detect-bad-tree ()
+  (let red-with-red-child = (red-black/tree::Branch red-black/tree::Red
+                                                    (red-black/tree::Branch red-black/tree::Red red-black/tree:Empty 0 red-black/tree:Empty)
+                                                    1
+                                                    red-black/tree:Empty))
+  (matches (Err (RedWithRedLeftChild _)) (count-blacks-to-leaf red-with-red-child))
+
+  (let unbalanced = (red-black/tree::Branch red-black/tree::Black
+                                            (red-black/tree::Branch red-black/tree::Black red-black/tree:Empty 0 red-black/tree:Empty)
+                                            1
+                                            red-black/tree:Empty))
+  (matches (Err (DifferentCountToBlack _ _ _ _)) (count-blacks-to-leaf unbalanced)))
+
+(define-test map-from-iter-equiv-to-manual-construction ()
+  (let manual = (red-black/map:insert-or-replace
+                 (red-black/map:insert-or-replace
+                  (red-black/map:insert-or-replace red-black/map:empty 0 "zero")
+                  11 "eleven")
+                 5 "five"))
+  (let iterated = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "zero")
+                                                                     (Tuple 11 "eleven")
+                                                                     (Tuple 5 "five")))))
+  (is (== manual iterated))
+  (is (== (hash manual) (hash iterated))))
+
+(define-test map-non-equal ()
+  (let map-012 = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "zero")
+                                                                    (Tuple 1 "one")
+                                                                    (Tuple 2 "two")))))
+  (let map-01 = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "zero")
+                                                                   (Tuple 1 "one")))))
+  (let map-wrong-names = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "one")
+                                                                            (Tuple 1 "zero")))))
+
+  (is (/= map-012 map-01))
+  (is (/= (hash map-012) (hash map-01)))
+  (is (/= map-01 map-wrong-names))
+  (is (/= (hash map-01) (hash map-wrong-names)))
+  (is (/= map-012 map-wrong-names))
+  (is (/= (hash map-012) (hash map-wrong-names))))


### PR DESCRIPTION
Add a submodule `coalton-library/red-black` containing files `tree` and `map`; `tree` defines a persistent red-black tree sorted by the `Ord` instance of its contents, and `map` defines a `:key :value` mapping sorted by the `Ord` instance of `:key`.

Names for discussion:
- insertion operators are named `insert`, unlike hashtable which has `set!`.
  - Tree and Map's `insert` behaves differently in the presence of an already-existing element; `hashtable:set!` overwrites, while `tree:insert` fails.
  - Also offer `insert-or-replace`, which overwrites already-present keys.
  - And `replace-or-insert`, which overwrites already-present entries and returns the old entry alongside the new tree.
- Searching operators are named `lookup`, unlike hashtable which has `get`.