### PR TITLE
emit function param names in documentation

### DIFF
--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -186,6 +186,24 @@
           (format stream "- <code>~A</code>~%" (to-markdown instance))))
       (format stream "~%</details>~%~%"))))
 
+(defmethod write-documentation ((backend (eql ':markdown)) stream (object documentation-function-entry))
+  (with-slots (name type documentation location param-names)
+      object
+    (let ((encoded-name (html-entities:encode-entities (symbol-name name))))
+      (format stream "#### <code>(~A~{ ~A~})/code> <sup><sub>FUNCTION</sub></sup><a name=\"~(~A-value~)\"></a>~%"
+              encoded-name
+              param-names
+              encoded-name)
+
+      (with-pprint-variable-context ()
+        (format stream "<code>~A</code>~%" (to-markdown type)))
+
+      (when documentation
+        (format stream "~%~A~%~%"
+                (html-entities:encode-entities
+                 documentation
+                 :regex "[<>&]"))))))
+
 (defmethod write-documentation ((backend (eql ':markdown)) stream (object documentation-value-entry))
   (with-slots (name type documentation location)
       object

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -227,6 +227,7 @@
    #:typed-node-abstraction-vars          ; ACCESSOR
    #:typed-node-abstraction-subexpr       ; ACCESSOR
    #:typed-node-abstraction-name-map      ; ACCESSOR
+   #:typed-node-abstraction-source-parameter-names ; FUNCTION
    #:typed-node-bound-abstraction         ; STRUCT
    #:typed-node-bound-abstraction-vars    ; ACCESSOR
    #:typed-node-bound-abstraction-subexpr ; ACCESSSOR
@@ -280,6 +281,9 @@
    #:lookup-name                        ; FUNCTION
    #:lookup-method-inline               ; FUNCTION
    #:lookup-code                        ; FUNCTION
+   #:lookup-function-source-parameter-names ; FUNCTION
+   #:set-function-source-parameter-names ; FUNCTION
+   #:unset-function-source-parameter-names ; FUNCTION
    #:add-specialization                 ; FUNCTION
    #:lookup-specialization              ; FUNCTION
    #:lookup-specialization-by-type      ; FUNCTION

--- a/src/toplevel-define.lisp
+++ b/src/toplevel-define.lisp
@@ -167,11 +167,16 @@ Returns new environment, binding list of declared nodes, and a DAG of dependenci
           (progn
             (setf env
                   (set-name env name
-                            (make-name-entry
-                             :name name
-                             :type :value
-                             :docstring (second (find name docstrings :key #'car))
-                             :location (or *compile-file-pathname* *load-truename*))))))
+                            (make-name-entry :name name
+                                             :type :value
+                                             :docstring (second (find name docstrings :key #'car))
+                                             :location (or *compile-file-pathname* *load-truename*))))
+            (when (typed-node-abstraction-p node)
+              ;; for functions, stash the original parameter names so documentation generation can get at them
+              (setf env
+                    (set-function-source-parameter-names env
+                                                         name
+                                                         (typed-node-abstraction-source-parameter-names node))))))
 
         (values
          env

--- a/src/typechecker/translation-unit.lisp
+++ b/src/typechecker/translation-unit.lisp
@@ -35,7 +35,12 @@
         :collect `(set-code env ',name ,(lookup-code env name))
         :collect (if function-entry
                      `(set-function env ',name ,function-entry)
-                     `(unset-function env ',name))))
+                     `(unset-function env ',name))
+        :collect (if (typed-node-abstraction-p def)
+                     `(set-function-source-parameter-names env
+                                                           ',name
+                                                           ',(typed-node-abstraction-source-parameter-names def))
+                     `(unset-function-source-parameter-names env ',name))))
 
 (defun generate-instance-diff (instances env)
   (declare (type instance-definition-list instances))

--- a/src/typechecker/typed-node.lisp
+++ b/src/typechecker/typed-node.lisp
@@ -56,6 +56,11 @@
   ;; to their origional names
   (name-map (required 'name-map) :type list                :read-only t))
 
+(defun typed-node-abstraction-source-parameter-names (node)
+  (declare (type typed-node-abstraction node)
+           (values symbol-list &optional))
+  (mapcar #'cdr (typed-node-abstraction-name-map node)))
+
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type typed-node-abstraction))
 


### PR DESCRIPTION
in documentation, functions defined in a way that produces parameter
names (i.e. either (define (foo bar) baz) or (define foo (fn (bar) baz))) will now have
those parameter names shown in generated documentation.

where previously the documentation would show

```
FOO [FUNCTION]
```

it now shows

```
(FOO BAR) [FUNCTION]
```

this requires subclassing `name-entry` and `documentation-value-entry` with
`function-name-entry` and `documentation-function-entry` respectively to store the
original source form's `param-names`.

this allows us to reference parameter names in docstrings rather than refering to
parameters by index, like in the documentation for `<`:

```
"Is X less than Y?"
```