### PR TITLE
Add RuntimeRepr auto-generated typeclass

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -44,6 +44,10 @@
                              (:file "parse-error")
                              (:file "parse-form")
                              (:file "package")))
+               (:module "runtime"
+                :serial t
+                :components ((:file "function-entry")
+                             (:file "package")))
                (:module "typechecker"
                 :serial t
                 :components ((:file "errors")
@@ -57,6 +61,7 @@
                              (:file "equality")
                              (:file "typed-node")
                              (:file "environment")
+                             (:file "lisp-type")
                              (:file "context-reduction")
                              (:file "parse-type")
                              (:file "derive-type")
@@ -77,8 +82,6 @@
                              (:file "transformations")
                              (:file "compile-expression")
                              (:file "compile-instance")
-                             (:file "function-entry")
-                             (:file "lisp-type")
                              (:file "struct-or-class")
                              (:file "codegen-pattern")
                              (:file "codegen-type-definition")
@@ -117,6 +120,7 @@
   :pathname "library/"
   :serial t
   :components ((:file "utils")
+               (:file "types")
                (:file "fixed-size-numbers")
                (:file "classes")
                (:file "builtin")

--- a/library/big-float/impl-default.lisp
+++ b/library/big-float/impl-default.lisp
@@ -93,7 +93,7 @@
     (lisp :a (f prec-bits rnd)
       (cl:let ((*bf-precision* prec-bits)
                (*bf-rounding-mode* rnd))
-        (coalton-impl/codegen::A1 f Unit))))
+        (call-coalton-function f Unit))))
 
   (declare with-precision (UFix -> (Unit -> :a) -> :a))
   (define (with-precision prec-bits f)

--- a/library/big-float/impl-sbcl.lisp
+++ b/library/big-float/impl-sbcl.lisp
@@ -126,7 +126,7 @@
     (lisp :a (f prec-bits rnd)
       (cl:let ((sb-mpfr:+mpfr-precision+ prec-bits)
                (sb-mpfr:*mpfr-rnd* rnd))
-        (coalton-impl/codegen::A1 f Unit))))
+        (call-coalton-function f Unit))))
 
   (declare with-precision (UFix -> (Unit -> :a) -> :a))
   (define (with-precision prec-bits f)

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -2,7 +2,8 @@
   (:use
    #:coalton)
   (:export
-   #:Addressable #:eq?
+   #:Addressable #:eq?)
+  (:export
    #:Eq #:==
    #:Num #:+ #:- #:* #:fromInt)
   (:export
@@ -41,7 +42,6 @@
 (in-package #:coalton-library/classes)
 
 (coalton-toplevel
-
   (define-class (Addressable :obj)
     "Types for which object identity is meaningful.
 

--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -50,9 +50,9 @@
     "Inner function: allocate a hash table using the COALTON/HASHTABLE-SHIM interface"
     (lisp (Hashtable :key :value) (cap test hash_)
       (cl:flet ((coalton-hashtable-test (a b)
-                  (coalton-impl/codegen:a2 test a b))
+                  (call-coalton-function test a b))
                 (coalton-hashtable-hash (key)
-                  (coalton-impl/codegen:a1 hash_ key)))
+                  (call-coalton-function hash_ key)))
         (coalton/hashtable-shim:make-custom-hash-table cap
                                                        #'coalton-hashtable-hash
                                                        #'coalton-hashtable-test))))
@@ -113,7 +113,7 @@
         (coalton/hashtable-shim:custom-hash-table-foreach
          table
          (cl:lambda (key value)
-           (coalton-impl/codegen:A2 f key value)))
+           (call-coalton-function f key value)))
         Unit)))
 
   (declare entries ((Hashtable :key :value) -> (List (Tuple :key :value))))

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -453,7 +453,7 @@
     (lisp (List :a) (cmp xs)
       (cl:sort (cl:copy-list xs)
                (cl:lambda (a b)
-                 (cl:eq 'coalton-library/classes::ord/lt (coalton-impl/codegen:a2 cmp a b))))))
+                 (cl:eq 'coalton-library/classes::ord/lt (call-coalton-function cmp a b))))))
 
   (declare intersperse (:a -> (List :a) -> (List :a)))
   (define (intersperse e xs)

--- a/library/prelude.lisp
+++ b/library/prelude.lisp
@@ -203,6 +203,7 @@
    #:coalton
    #:coalton-prelude)
   (:local-nicknames
+   (#:types #:coalton-library/types)
    (#:bits #:coalton-library/bits)
    (#:math #:coalton-library/math)
    (#:char #:coalton-library/char)

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -92,7 +92,7 @@
     "Call the function F once for each item in S"
     (lisp :a (f s)
       (cl:loop :for elem :across s
-         :do (coalton-impl/codegen::A1 f elem)))
+         :do (call-coalton-function f elem)))
     Unit)
 
   (declare foreach-index ((UFix -> :a -> :b) -> (Slice :a) -> Unit))
@@ -102,7 +102,7 @@
       (cl:loop
          :for elem :across s
          :for i :from 0
-         :do (coalton-impl/codegen::A2 f i elem)))
+         :do (call-coalton-function f i elem)))
     Unit)
 
   (declare foreach2 ((:a -> :b -> :c) -> (Slice :a) -> (Slice :b) -> Unit))
@@ -112,7 +112,7 @@
       (cl:loop
          :for e1 :across s1
          :for e2 :across s2
-         :do (coalton-impl/codegen::A2 f e1 e2)))
+         :do (call-coalton-function f e1 e2)))
     Unit)
 
   ;;
@@ -168,14 +168,14 @@
       (lisp :a (f init s)
         (cl:reduce
          (cl:lambda (b a)
-           (coalton-impl/codegen::A2 f b a))
+           (call-coalton-function f b a))
          s
          :initial-value init)))
     (define (foldr f init s)
       (lisp :a (f init s)
         (cl:reduce
          (cl:lambda (a b)
-           (coalton-impl/codegen::A2 f a b))
+           (call-coalton-function f a b))
          s
          :initial-value init
          :from-end cl:t))))

--- a/library/types.lisp
+++ b/library/types.lisp
@@ -1,0 +1,94 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/types
+  (:use
+   #:coalton)
+  (:export
+   #:Proxy
+   #:proxy-of
+   #:LispType
+   #:RuntimeRepr #:runtime-repr
+   #:runtime-repr-of))
+
+#+coalton-release
+(cl:declaim #.coalton-impl:*coalton-optimize-library*)
+
+(in-package #:coalton-library/types)
+
+(coalton-toplevel
+  (repr :enum)
+  (define-type (Proxy :a)
+    "Proxy holds no data, but has a phantom type parameter."
+    Proxy)
+
+  (declare proxy-of (:a -> Proxy :a))
+  (define (proxy-of _)
+    "Returns a Proxy containing the type of the parameter."
+    Proxy)
+
+  (repr :native (cl:or cl:symbol cl:list))
+  (define-type LispType
+    "The runtime representation of a Coalton type as a lisp type.")
+  
+  (define-class (RuntimeRepr :a)
+    "Types which have a runtime LispType representation.
+
+`runtime-repr` corresponds to the type emitted by the Coalton compiler for the type parameter to the given Proxy.
+
+The compiler will auto-generate instances of `RuntimeRepr` for all defined types."
+    (runtime-repr (Proxy :a -> LispType)))
+
+  (declare runtime-repr-of (RuntimeRepr :a => :a -> LispType))
+  (define (runtime-repr-of x)
+    "Returns the runtime representation of the type of the given value."
+    (runtime-repr (proxy-of x)))
+
+  ;; Additional RuntimeRepr instances for early-defined types
+
+  (define-instance (RuntimeRepr Boolean)
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:boolean)))
+
+  (define-instance (RuntimeRepr Char)
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:character)))
+
+  (define-instance (RuntimeRepr Integer)
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:integer)))
+
+  (define-instance (RuntimeRepr Single-Float)
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:single-float)))
+
+  (define-instance (RuntimeRepr Double-Float)
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:double-float)))
+
+  (define-instance (RuntimeRepr String)
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:string)))
+
+  (define-instance (RuntimeRepr Fraction)
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:rational)))
+
+  (define-instance (RuntimeRepr (:a -> :b))
+    (define (runtime-repr _)
+      (lisp LispType () 'coalton-impl/runtime/function-entry:function-entry)))
+
+  (define-instance (RuntimeRepr (List :a))
+    (define (runtime-repr _)
+      (lisp LispType () 'cl:list)))
+
+  ;; The compiler will not auto-generate RuntimeRepr instances for
+  ;; types defined in this file to avoid circular dependencies.
+  
+  (define-instance (RuntimeRepr LispType)
+    (define (runtime-repr _)
+      (lisp LispType () '(cl:or cl:symbol cl:list))))
+
+  (define-instance (RuntimeRepr (Proxy :a))
+    (define (runtime-repr _)
+      (lisp LispType () '(cl:member 'proxy/proxy)))))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/TYPES")

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -155,7 +155,7 @@
       (lisp (Optional UFix) (v test)
         (cl:let ((pos (cl:position-if
                        (cl:lambda (x)
-                         (cl:equalp True (coalton-impl/codegen::A1 test x)))
+                         (cl:eq cl:t (call-coalton-function test x)))
                        v)))
           (cl:if pos
                  (Some pos)
@@ -166,7 +166,7 @@
     "Call the function F once for each item in V"
     (lisp Void (f v)
       (cl:loop :for elem :across v
-         :do (coalton-impl/codegen::A1 f elem)))
+         :do (call-coalton-function f elem)))
     Unit)
 
   (declare foreach-index ((UFix -> :a -> :b) -> Vector :a -> Unit))
@@ -176,7 +176,7 @@
       (cl:loop
          :for elem :across v
          :for i :from 0
-         :do (coalton-impl/codegen::A2 f i elem)))
+         :do (call-coalton-function f i elem)))
     Unit)
 
   (declare foreach2 ((:a -> :b -> :c) -> Vector :a -> Vector :b -> Unit))
@@ -186,7 +186,7 @@
       (cl:loop
          :for e1 :across v1
          :for e2 :across v2
-         :do (coalton-impl/codegen::A2 f e1 e2)))
+         :do (call-coalton-function f e1 e2)))
     Unit)
 
   (declare append (Vector :a -> Vector :a -> Vector :a))
@@ -225,7 +225,7 @@
       (cl:sort
        v
        (cl:lambda (a b)
-         (coalton-impl/codegen::A2 f a b))))
+         (call-coalton-function f a b))))
     Unit)
 
   (declare sort! (Ord :a => Vector :a -> Unit))
@@ -269,14 +269,14 @@
       (lisp :a (f init vec)
         (cl:reduce
          (cl:lambda (b a)
-           (coalton-impl/codegen::A2 f b a))
+           (call-coalton-function f b a))
          vec
          :initial-value init)))
     (define (foldr f init vec)
       (lisp :a (f init vec)
         (cl:reduce
          (cl:lambda (a b)
-           (coalton-impl/codegen::A2 f a b))
+           (call-coalton-function f a b))
          vec
          :initial-value init
          :from-end cl:t)))) 

--- a/src/codegen/codegen-class.lisp
+++ b/src/codegen/codegen-class.lisp
@@ -6,15 +6,10 @@
    #:coalton-impl/codegen/struct-or-class
    #:struct-or-class
    #:make-struct-or-class-field)
-  (:import-from
-   #:coalton-impl/codegen/lisp-type
-   #:lisp-type)
-  (:import-from
-   #:coalton-impl/codegen/function-entry
-   #:construct-function-entry)
   (:local-nicknames
    (#:settings #:coalton-impl/settings)
    (#:global-lexical #:coalton-impl/global-lexical)
+   (#:rt #:coalton-impl/runtime)
    (#:tc #:coalton-impl/typechecker))
   (:export
    #:codegen-class-definitions))
@@ -41,7 +36,7 @@
               (loop :for method :in (tc:ty-class-unqualified-methods class)
                     :collect (make-struct-or-class-field
                               :name (car method)
-                              :type (lisp-type (cdr method) env))))
+                              :type (tc:lisp-type (cdr method) env))))
 
         :append (struct-or-class
                   :classname codegen-name
@@ -82,7 +77,7 @@
              `(funcall (the (function ,(make-list (length params) :initial-element t)) (,method-accessor dict)) ,@params)))
       ;; Generate the wrapper functions
       (global-lexical:define-global-lexical ,(car m)
-          ,(construct-function-entry
+          ,(rt:construct-function-entry
             `#',(car m)
             (+ arity 1) ; We need a function of arity + 1 to account for DICT
             ))

--- a/src/codegen/codegen-type-definition.lisp
+++ b/src/codegen/codegen-type-definition.lisp
@@ -3,21 +3,15 @@
    #:cl
    #:coalton-impl/util)
   (:import-from
-   #:coalton-impl/codegen/lisp-type
-   #:lisp-type)
-  (:import-from
    #:coalton-impl/codegen/struct-or-class
    #:struct-or-class
    #:make-struct-or-class-field
    #:struct-or-class-field-name)
-  (:import-from
-   #:coalton-impl/codegen/function-entry
-   #:construct-function-entry
-   #:F1)
   (:local-nicknames
    (#:settings #:coalton-impl/settings)
    (#:global-lexical #:coalton-impl/global-lexical)
-   (#:tc #:coalton-impl/typechecker))
+   (#:tc #:coalton-impl/typechecker)
+   (#:rt #:coalton-impl/runtime))
   (:export
    #:codegen-type-definition
    #:constructor-slot-name))
@@ -46,7 +40,7 @@
               `(defun ,(tc:constructor-entry-name constructor) (x) x)
               `(global-lexical:define-global-lexical
                    ,(tc:constructor-entry-name constructor)
-                   (F1 #',(tc:constructor-entry-name constructor))))))
+                   ,(rt:construct-function-entry `#',(tc:constructor-entry-name constructor) 1)))))
 
      (t
       `(,(if (settings:coalton-release-p)
@@ -71,7 +65,7 @@
             :for constructor-name :=  (tc:constructor-entry-name constructor)
             :for fields
               := (loop :for field :in (tc:constructor-arguments constructor-name env)
-                       :for runtime-type := (lisp-type field env)
+                       :for runtime-type := (tc:lisp-type field env)
                        :for i :from 0
                        :for name := (constructor-slot-name constructor i)
                        :collect (make-struct-or-class-field

--- a/src/codegen/package.lisp
+++ b/src/codegen/package.lisp
@@ -29,12 +29,4 @@
    #:coalton-impl/codegen/program
    #:compile-translation-unit)
   (:export
-   #:compile-translation-unit)
-
-  (:import-from
-   #:coalton-impl/codegen/function-entry
-   #:a1 #:a2 #:a3 #:a4 #:a5 #:a6 #:a7 #:a8 #:a9
-   #:f1 #:f2 #:f3 #:f4 #:f5 #:f6 #:f7 #:f8 #:f9)
-  (:export
-   #:a1 #:a2 #:a3 #:a4 #:a5 #:a6 #:a7 #:a8 #:a9
-   #:f1 #:f2 #:f3 #:f4 #:f5 #:f6 #:f7 #:f8 #:f9))
+   #:compile-translation-unit))

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -4,12 +4,6 @@
    #:coalton-impl/util
    #:coalton-impl/codegen/ast)
   (:import-from
-   #:coalton-impl/codegen/lisp-type
-   #:lisp-type)
-  (:import-from
-   #:coalton-impl/codegen/function-entry
-   #:construct-function-entry)
-  (:import-from
    #:coalton-impl/codegen/compile-expression
    #:compile-toplevel)
   (:import-from
@@ -30,6 +24,7 @@
   (:local-nicknames
    (#:settings #:coalton-impl/settings)
    (#:global-lexical #:coalton-impl/global-lexical)
+   (#:rt #:coalton-impl/runtime)
    (#:tc #:coalton-impl/typechecker))
   (:export
    #:compile-translation-unit))
@@ -121,8 +116,8 @@
               (loop :for name :in (node-abstraction-vars node)
                     :for i :from 0
                     :for arg-ty := (nth i (tc:function-type-arguments (node-type node)))
-                    :collect `(type ,(lisp-type arg-ty env) ,name))
-              (list `(values ,(lisp-type (node-type (node-abstraction-subexpr node)) env)
+                    :collect `(type ,(tc:lisp-type arg-ty env) ,name))
+              (list `(values ,(tc:lisp-type (node-type (node-abstraction-subexpr node)) env)
                              &optional))))))
 
     `(defun ,name ,(node-abstraction-vars node)
@@ -145,7 +140,7 @@
                     (compile-function name node env)
                     `(setf
                       ,name
-                      ,(construct-function-entry
+                      ,(rt:construct-function-entry
                        `#',name (length (node-abstraction-vars node))))))
 
   ;; Compile variables

--- a/src/codegen/struct-or-class.lisp
+++ b/src/codegen/struct-or-class.lisp
@@ -2,11 +2,9 @@
   (:use
    #:cl
    #:coalton-impl/util)
-  (:import-from
-   #:coalton-impl/codegen/function-entry
-   #:construct-function-entry)
   (:local-nicknames
-   (#:global-lexical #:coalton-impl/global-lexical))
+   (#:global-lexical #:coalton-impl/global-lexical)
+   (#:rt #:coalton-impl/runtime))
   (:export
    #:struct-or-class
    #:struct-or-class-field
@@ -81,14 +79,13 @@
      (if (not (null fields))
          (cons
           `(global-lexical:define-global-lexical ,constructor
-               ,(construct-function-entry `#',constructor (length fields)))
+               ,(rt:construct-function-entry `#',constructor (length fields)))
           (loop :for field :in fields
                 :for package := (symbol-package classname)
                 :for field-name := (alexandria:format-symbol package "~A-~A" classname (struct-or-class-field-name field))
                 :collect `(global-lexical:define-global-lexical ,field-name
-                              ,(construct-function-entry `#',field-name 1))))
+                              ,(rt:construct-function-entry `#',field-name 1))))
 
          (list
           `(global-lexical:define-global-lexical ,constructor (,constructor)))))))
-
 

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -83,6 +83,7 @@
    :backend backend
    :packages '(coalton
                coalton-library/classes
+               coalton-library/types
                coalton-library/builtin
                coalton-library/functions
                coalton-library/math

--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -41,7 +41,7 @@
 
 (defmacro coalton:fn (vars &body form)
   "A lambda abstraction callable within coalton."
-  (coalton-impl/codegen/function-entry:construct-function-entry `(lambda ,vars ,@form) (length vars)))
+  (rt:construct-function-entry `(lambda ,vars ,@form) (length vars)))
 
 (define-coalton-editor-macro coalton:match (expr &body patterns)
   "Pattern matching construct.")

--- a/src/impl-package.lisp
+++ b/src/impl-package.lisp
@@ -7,6 +7,7 @@
    (#:util #:coalton-impl/util)
    (#:algo #:coalton-impl/algorithm)
    (#:ast #:coalton-impl/ast)
+   (#:rt #:coalton-impl/runtime)
    (#:tc #:coalton-impl/typechecker))
 
   (:import-from

--- a/src/runtime/function-entry.lisp
+++ b/src/runtime/function-entry.lisp
@@ -1,10 +1,15 @@
-(defpackage #:coalton-impl/codegen/function-entry
+(defpackage #:coalton-impl/runtime/function-entry
   (:use
    #:cl
    #:coalton-impl/util)
+  (:import-from
+   #:coalton
+   #:call-coalton-function)
   (:export
-   #:*function-constructor-functions*
-   #:*function-application-functions*
+   #:function-entry
+   #:function-entry-arity
+   #:function-entry-function
+   #:function-entry-curried
    #:construct-function-entry
    #:call-coalton-function
    #:too-many-arguments-to-coalton-function
@@ -12,7 +17,7 @@
    #:too-many-arguments-count
    #:too-many-arguments-arguments))
 
-(in-package #:coalton-impl/codegen/function-entry)
+(in-package #:coalton-impl/runtime/function-entry)
 
 (defconstant function-arity-limit 32)
 

--- a/src/runtime/package.lisp
+++ b/src/runtime/package.lisp
@@ -1,0 +1,3 @@
+(uiop:define-package #:coalton-impl/runtime
+  (:mix-reexport
+   #:coalton-impl/runtime/function-entry))

--- a/src/toplevel-define-type.lisp
+++ b/src/toplevel-define-type.lisp
@@ -18,9 +18,8 @@
      parsed-deftypes
      env
      (loop :for parsed-deftype :in parsed-deftypes
-           :for addressable := (maybe-auto-addressable-instance parsed-deftype)
-           :when addressable
-             :collect addressable))))
+           :append (maybe-auto-addressable-instance parsed-deftype)
+           :append (maybe-auto-runtime-repr-instance parsed-deftype)))))
 
 ;;;
 ;;; Compiler written instances
@@ -40,13 +39,45 @@
 
          (eq?
            (alexandria:ensure-symbol "EQ?" (find-package "COALTON-LIBRARY/CLASSES"))))
-    `(coalton:define-instance (,addressable-class ,full-type)
-       (coalton:define (,eq? a b)
-         (coalton:lisp coalton:Boolean (a b)
-           (eq a b))))))
+    `((coalton:define-instance (,addressable-class ,full-type)
+         (coalton:define (,eq? a b)
+           (coalton:lisp coalton:Boolean (a b)
+             (eq a b)))))))
 
 (defun maybe-auto-addressable-instance (type-def)
   (declare (type tc:type-definition type-def)
            (values list &optional))
-  (when (tc:explicit-repr-auto-addressable-p (tc:type-definition-explicit-repr type-def))
+  (when (and (not (equalp (symbol-package (tc:type-definition-name type-def))
+                          (find-package "COALTON-LIBRARY/TYPES")))
+             (tc:explicit-repr-auto-addressable-p (tc:type-definition-explicit-repr type-def)))
     (make-auto-addressable-instance type-def)))
+
+(defun make-auto-runtime-repr-instance (type-def)
+  (declare (type tc:type-definition type-def)
+           (values list &optional))
+  (let* ((name (tc:type-definition-name type-def))
+         (tvars (loop :for i :below (tc:kind-arity (tc:tycon-kind (tc:type-definition-type type-def)))
+                      :collect (alexandria:format-symbol :keyword "~d" i)))
+         (full-type (if tvars
+                        `(,name ,@tvars)
+                        name))
+         (addressable-class
+           (alexandria:ensure-symbol "RUNTIMEREPR" (find-package "COALTON-LIBRARY/TYPES")))
+
+         (runtime-repr
+           (alexandria:ensure-symbol "RUNTIME-REPR" (find-package "COALTON-LIBRARY/TYPES")))
+
+         (lisp-type
+           (alexandria:ensure-symbol "LISPTYPE" (find-package "COALTON-LIBRARY/TYPES"))))
+    `((coalton:define-instance (,addressable-class ,full-type)
+         (coalton:define (,runtime-repr p)
+           (coalton:lisp ,lisp-type ()
+             ',(tc:type-definition-runtime-type type-def)))))))
+
+(defun maybe-auto-runtime-repr-instance (type-def)
+  (declare (type tc:environment env)
+           (type tc:type-definition type-def)
+           (values list &optional))
+  (unless (equalp (symbol-package (tc:type-definition-name type-def))
+                  (find-package "COALTON-LIBRARY/TYPES"))
+    (make-auto-runtime-repr-instance type-def)))

--- a/src/typechecker/debug.lisp
+++ b/src/typechecker/debug.lisp
@@ -164,4 +164,9 @@
                                      (specialization-entry-to-ty spec)))
                            (format t "~%")))
                (format t "~%")))
-      (maphash #'print-package sorted-by-package))))
+      (if package
+          (let ((p (find-package package)))
+            (unless p
+              (error "Invalid package ~A" package))
+            (print-package p (gethash p sorted-by-package)))
+          (maphash #'print-package sorted-by-package)))))

--- a/src/typechecker/package.lisp
+++ b/src/typechecker/package.lisp
@@ -11,6 +11,7 @@
    #:coalton-impl/typechecker/unify
    #:coalton-impl/typechecker/equality
    #:coalton-impl/typechecker/environment
+   #:coalton-impl/typechecker/lisp-type
    #:coalton-impl/typechecker/context-reduction
    #:coalton-impl/typechecker/parse-type
    #:coalton-impl/typechecker/parse-type-definition

--- a/src/typechecker/parse-type-definition.lisp
+++ b/src/typechecker/parse-type-definition.lisp
@@ -13,6 +13,9 @@
   (:import-from
    #:coalton-impl/typechecker/substitutions
    #:apply-substitution)
+  (:import-from
+   #:coalton-impl/typechecker/lisp-type
+   #:lisp-type)
   (:local-nicknames
    (#:util #:coalton-impl/util)
    (#:algo #:coalton-impl/algorithm))
@@ -409,7 +412,7 @@ Returns TYPE-DEFINITIONS"
                              (make-type-definition
                               :name tycon-name
                               :type tcon
-                              :runtime-type runtime-type
+                              :runtime-type (lisp-type runtime-type env)
                               :explicit-repr repr
                               :enum-repr nil
                               :newtype t

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -250,7 +250,7 @@
 (defvar *double-float-type* (make-tycon :name 'coalton:Double-Float :kind +kstar+))
 (defvar *string-type*       (make-tycon :name 'coalton:String      :kind +kstar+))
 (defvar *fraction-type*     (make-tycon :name 'coalton:Fraction :kind +kstar+))
-(defvar *arrow-type*        (make-tycon :name 'coalton:-> :kind (make-kfun :from +kstar+ :to (make-kfun :from +kstar+ :to +kstar+))))
+(defvar *arrow-type*        (make-tycon :name 'coalton:Arrow :kind (make-kfun :from +kstar+ :to (make-kfun :from +kstar+ :to +kstar+))))
 (defvar *list-type*         (make-tycon :name 'coalton:List :kind (make-kfun :from +kstar+ :to +kstar+)))
 
 

--- a/tests/call-coalton-from-lisp.lisp
+++ b/tests/call-coalton-from-lisp.lisp
@@ -6,10 +6,10 @@
                                       ;; extra instance args injected
                                       (coalton-prelude:+ (coalton:the coalton:UFix a)
                                                          (coalton:the coalton:UFix b))))))
-    (is (typep coalton+ 'coalton-impl/codegen/function-entry::function-entry))
-    (is (= (coalton-impl/codegen/function-entry::function-entry-arity coalton+)
+    (is (typep coalton+ 'coalton-impl/runtime:function-entry))
+    (is (= (coalton-impl/runtime:function-entry-arity coalton+)
            2))
     (is (= 3 (coalton:call-coalton-function coalton+ 1 2)))
     (is (= 3 (apply #'coalton:call-coalton-function coalton+ '(1 2))))
-    (signals coalton-impl/codegen/function-entry:too-many-arguments-to-coalton-function
+    (signals coalton-impl/runtime:too-many-arguments-to-coalton-function
       (apply #'coalton:call-coalton-function coalton+ (loop :for i :below 100 :collect i)))))

--- a/tests/slice-tests.lisp
+++ b/tests/slice-tests.lisp
@@ -54,7 +54,7 @@
          (out nil))
 
     (coalton-library/slice:iter-sliding
-     (coalton-impl/codegen::F1
+     (coalton-impl/runtime/function-entry::F1
       (lambda (s)
         (push
          (list (coalton-library/slice:index-unsafe 0 s)
@@ -82,7 +82,7 @@
          (out nil))
 
     (coalton-library/slice:iter-chunked
-     (coalton-impl/codegen::F1
+     (coalton-impl/runtime/function-entry::F1
       (lambda (s)
         (push
          (list (coalton-library/slice:index-unsafe 0 s)


### PR DESCRIPTION
- Add RuntimeRepr for retrieving the lisp type corresponding to a coalton type
- Add Proxy type
- Remove coalton-impl::a# calls in favor of call-coalton-function
- Fixes #233
- Misc refactoring and bugfixes