### PR TITLE
Add type annotations to toplevel forms

### DIFF
--- a/src/codegen/codegen-class.lisp
+++ b/src/codegen/codegen-class.lisp
@@ -74,11 +74,11 @@
              `(,method-accessor dict)
              `(funcall (the (function ,(make-list (length params) :initial-element t)) (,method-accessor dict)) ,@params)))
       ;; Generate the wrapper functions
-      (global-lexical:define-global-lexical ,(car m)
-          ,(rt:construct-function-entry
-            `#',(car m)
-            (+ arity 1) ; We need a function of arity + 1 to account for DICT
-            ))
+      (global-lexical:define-global-lexical ,(car m) rt:function-entry)
+      (setf ,(car m) ,(rt:construct-function-entry
+                       `#',(car m)
+                       (+ arity 1) ; We need a function of arity + 1 to account for DICT
+                       ))
       (setf (documentation ',(car m) 'variable)
             ,(format nil "~A :: ~A" (car m) (tc:lookup-value-type env (car m))))
       (setf (documentation ',(car m) 'function)

--- a/src/codegen/codegen-type-definition.lisp
+++ b/src/codegen/codegen-type-definition.lisp
@@ -28,19 +28,19 @@
      ((tc:type-definition-enum-repr def)
       (loop :for constructor :in (tc:type-definition-constructors def)
             :append
-            (list `(global-lexical:define-global-lexical
-                       ,(tc:constructor-entry-name constructor)
-                       ',(tc:constructor-entry-compressed-repr constructor))
-                  `(deftype ,(tc:constructor-entry-classname constructor) ()
-                     (quote (member ,(tc:constructor-entry-compressed-repr constructor)))))))
+            `((global-lexical:define-global-lexical ,(tc:constructor-entry-name constructor)
+                  (member ,(tc:constructor-entry-compressed-repr constructor)))
+              (setf ,(tc:constructor-entry-name constructor) ',(tc:constructor-entry-compressed-repr constructor))
+              (deftype ,(tc:constructor-entry-classname constructor) ()
+                (quote (member ,(tc:constructor-entry-compressed-repr constructor)))))))
 
      ((tc:type-definition-newtype def)
       (let ((constructor (first (tc:type-definition-constructors def))))
-        (list `(declaim (inline ,(tc:constructor-entry-name constructor)))
-              `(defun ,(tc:constructor-entry-name constructor) (x) x)
-              `(global-lexical:define-global-lexical
-                   ,(tc:constructor-entry-name constructor)
-                   ,(rt:construct-function-entry `#',(tc:constructor-entry-name constructor) 1)))))
+        `((declaim (inline ,(tc:constructor-entry-name constructor)))
+          (defun ,(tc:constructor-entry-name constructor) (x) x)
+          (global-lexical:define-global-lexical ,(tc:constructor-entry-name constructor) rt:function-entry)
+          (setf ,(tc:constructor-entry-name constructor)
+                ,(rt:construct-function-entry `#',(tc:constructor-entry-name constructor) 1)))))
 
      (t
       `(,(if (settings:coalton-release-p)

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -131,7 +131,7 @@
   (append
    ;; Predeclare symbol macros
    (loop :for (name . node) :in bindings
-         :collect `(global-lexical:define-global-lexical ,name ':|@@unbound@@|))
+         :collect `(global-lexical:define-global-lexical ,name ,(tc:lisp-type (node-type node) env)))
 
    ;; Compile functions
    (loop :for (name . node) :in bindings
@@ -141,14 +141,15 @@
                     `(setf
                       ,name
                       ,(rt:construct-function-entry
-                       `#',name (length (node-abstraction-vars node))))))
+                        `#',name (length (node-abstraction-vars node))))))
 
   ;; Compile variables
   (loop :for (name . node) :in bindings
         :if (not (node-abstraction-p node))
           :collect `(setf
-                     ,name
-                     ,(codegen-expression node nil env)))
+                      ,name
+                      ,(codegen-expression node nil env)))
+
   ;; Docstrings
   (loop :for (name . node) :in bindings
         :for entry := (tc:lookup-name env name :no-error t)

--- a/src/codegen/struct-or-class.lisp
+++ b/src/codegen/struct-or-class.lisp
@@ -80,15 +80,16 @@
                                              `(',field ,field))
                                            field-names)))))))
      (if (not (null fields))
-         (cons
-          `(global-lexical:define-global-lexical ,constructor
-               ,(rt:construct-function-entry `#',constructor (length fields)))
+         (append
+          `((global-lexical:define-global-lexical ,constructor rt:function-entry)
+            (setf ,constructor ,(rt:construct-function-entry `#',constructor (length fields))))
           (loop :for field :in fields
                 :for package := (symbol-package classname)
                 :for field-name := (alexandria:format-symbol package "~A-~A" classname (struct-or-class-field-name field))
-                :collect `(global-lexical:define-global-lexical ,field-name
-                              ,(rt:construct-function-entry `#',field-name 1))))
+                :collect `(global-lexical:define-global-lexical ,field-name rt:function-entry)
+                :collect `(setf ,field-name ,(rt:construct-function-entry `#',field-name 1))))
 
-         (list
-          `(global-lexical:define-global-lexical ,constructor (,constructor)))))))
+         (progn
+           `((global-lexical:define-global-lexical ,constructor ,classname)
+             (setf ,constructor (,constructor))))))))
 

--- a/src/global-lexical.lisp
+++ b/src/global-lexical.lisp
@@ -45,10 +45,9 @@
 (defun (setf top-level-binding-value) (new-value binding)
   (setf (car binding) new-value))
 
-(defmacro define-global-lexical (var val)
+(defmacro define-global-lexical (var type)
   `(progn
      (define-symbol-macro ,var
-         (top-level-binding-value
-          (load-time-value
-           (get-top-level-binding ',var *top-level-environment*))))
-     (setf ,var (load-time-value ,val))))
+         (the ,type
+              (top-level-binding-value (load-time-value
+                                        (get-top-level-binding ',var *top-level-environment*)))))))

--- a/src/typechecker/type-errors.lisp
+++ b/src/typechecker/type-errors.lisp
@@ -31,6 +31,7 @@
    #:context-reduction-failure            ; CONDITION
    #:weak-context-error                   ; CONDITION
    #:recursive-binding-error              ; CONDITION
+   #:self-recursive-toplevel-form         ; CONDITION
    #:self-recursive-non-constructor-call  ; CONDITION
    #:self-recursive-partial-application   ; CONDITION
    #:self-recursive-non-default-repr      ; CONDITION
@@ -276,6 +277,12 @@
 (define-condition self-recursive-variable-definition (recursive-binding-error)
     ((name :initarg :name
            :reader self-recursive-variable-definition-name)))
+
+(define-condition self-recursive-toplevel-form (self-recursive-variable-definition)
+  ()
+  (:report (lambda (c s)
+             (format s "Cannot recursively bind ~S in a toplevel form."
+                     (self-recursive-variable-definition-name c)))))
 
 (defparameter *self-recursive-binding-requirements-message*
   "Recursive data bindings may only be fully-applied direct applications of constructors for default-repr types, or `Cons'.")


### PR DESCRIPTION
Resolves #731

Additionally, adds error when recursive toplevel forms are written since these cannot be represented correctly with global lexicals.