### PR TITLE
Iterator classes `IntoIterator` and `FromIterator`

### DIFF
--- a/library/ord-map.lisp
+++ b/library/ord-map.lisp
@@ -121,6 +121,9 @@ Like `replace-or-insert', but prioritizing insertion as a use case."
     (match mp
       ((%Map tre) (coalton-library/classes:map into (tree:increasing-order tre)))))
 
+  (define-instance (iter:IntoIterator (Map :key :value) (Tuple :key :value))
+    (define iter:into-iter entries))
+
   (declare keys ((Map :key :value) -> (iter:Iterator :key)))
   (define (keys mp)
     "Iterate over the keys in MP, sorted least-to-greatest."
@@ -150,6 +153,9 @@ If ITER contains duplicate keys, later values will overwrite earlier values."
                   (uncurry (insert-or-replace mp) tpl))
                 empty
                 iter))
+
+  (define-instance (Ord :key => iter:FromIterator (Map :key :value) (Tuple :key :value))
+    (define iter:collect! collect!))
 
   (declare update ((Ord :key) => (:value -> :value) -> (Map :key :value) -> :key -> (Optional (Map :key :value))))
   (define (update func mp key)

--- a/library/ord-tree.lisp
+++ b/library/ord-tree.lisp
@@ -458,6 +458,9 @@ The result tree may be in an intermediate state with a double-black node."
     "Iterate the elements of a tree, starting with the greatest by `<=>' and ending with the least."
     (tree-iterator stack-for-decreasing-order-traversal))
 
+  (define-instance (iter:IntoIterator (Tree :elt) :elt)
+    (define iter:into-iter increasing-order))
+
   (define-instance ((Eq :elt) => (Eq (Tree :elt)))
     (define (== left right)
       (iter:elementwise==! (increasing-order left) (increasing-order right))))
@@ -472,6 +475,9 @@ The result tree may be in an intermediate state with a double-black node."
 
 If ITER contains duplicates, later elements will overwrite earlier elements."
     (iter:fold! insert-or-replace Empty iter))
+
+  (define-instance (Ord :elt => iter:FromIterator (Tree :elt) :elt)
+    (define iter:collect! collect!))
 
   (declare merge (Ord :elt => Tree :elt -> Tree :elt -> Tree :elt))
   (define (merge a b)

--- a/tests/iterator-tests.lisp
+++ b/tests/iterator-tests.lisp
@@ -13,8 +13,7 @@
           (iter:next! iter:empty))))
 
 (define-test iter-string-chars ()
-  ;; FIXME: changing `string-chars' to `into-iter' here breaks type inference. i don't know why.
-  (let ((iter (iter:string-chars "abcdef")))
+  (let ((iter (iter:into-iter "abcdef")))
     (progn
       (is (== (Some #\a)
               (iter:next! iter)))
@@ -133,8 +132,7 @@
                               (iter:into-iter strings)))))))
 
 (define-test iter-enumerate ()
-  ;; FIXME: changing `string-chars' to `into-iter' breaks type inference
-  (let ((iter (iter:enumerate! (iter:string-chars "abcde")))
+  (let ((iter (iter:enumerate! (iter:into-iter "abcde")))
         (expect (fn (idx c)
                   (is (== (Some (Tuple idx c))
                           (iter:next! iter))))))

--- a/tests/iterator-tests.lisp
+++ b/tests/iterator-tests.lisp
@@ -2,9 +2,7 @@
 
 (define-test iter-list-iter-collect-list-id ()
   (is (== (the (List Integer) (make-list 0 1 2 3))
-          ;; FIXME: changing this to `iter:collect! (iter:into-iter (make-list 0 1 2 3))' breaks type
-          ;; inference. i don't know why.
-          (iter:collect-list! (iter:list-iter (make-list 0 1 2 3))))))
+          (iter:collect! (iter:into-iter (make-list 0 1 2 3))))))
 
 (define-test iter-empty-iter-none ()
   (is (== (the (Optional UFix) None)
@@ -46,37 +44,32 @@
 
 (define-test iter-take-10-filter-even ()
   (is (== (the (List Integer) (make-list 0 2 4 6 8))
-          (iter:collect-list! (iter:filter! even?
-                                            (iter:take! 10
-                                                        (iter:count-forever))))))
+          (iter:collect! (iter:filter! even?
+                                       (iter:take! 10
+                                                   (iter:count-forever))))))
   (is (== (the (List Integer) (make-list 0 2 4 6 8 10 12 14 16 18))
-          (iter:collect-list! (iter:take! 10
-                                          (iter:filter! even?
-                                                        (iter:count-forever)))))))
+          (iter:collect! (iter:take! 10
+                                     (iter:filter! even?
+                                                   (iter:count-forever)))))))
 
 (define-test iter-concat-collect-list ()
-  ;; FIXME: changing any of the below `collect-list!' to `collect!' or `list-iter' to `into-iter' breaks type
-  ;; inference. i don't know why.
   (is (== (the (List Integer) (make-list 0 1 2 3 4 5 6 7 8 9))
-          (iter:collect-list! (iter:concat! (iter:up-to 5)
-                                  (iter:range-increasing 1 5 10)))))
+          (iter:collect! (iter:concat! (iter:up-to 5)
+                                       (iter:range-increasing 1 5 10)))))
   (is (== (the (List Integer) (make-list 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14))
-          (iter:collect-list! (iter:flatten! (iter:list-iter (make-list (iter:up-to 5)
-                                                         (iter:range-increasing 1 5 10)
-                                                         (iter:list-iter (make-list 10 11 12 13 14)))))))))
+          (iter:collect! (iter:flatten! (iter:into-iter (make-list (iter:up-to 5)
+                                                                   (iter:range-increasing 1 5 10)
+                                                                   (iter:into-iter (make-list 10 11 12 13 14)))))))))
 
 (define-test iter-remove-duplicates-collect-list ()
-  ;; FIXME: changing `collect-list!' to `collect!' or `list-iter' or `string-chars' to `into-iter' breaks type
-  ;; inference. i don't know why.
   (is (== (the (List Integer) (make-list 0 1 2 3 4))
-          (iter:collect-list! (iter:remove-duplicates! (iter:list-iter (make-list 0
-                                                                                  1 1
-                                                                                  2 2 2
-                                                                                  3 3 3 3
-                                                                                  4 4 4 4 4))))))
+          (iter:collect! (iter:remove-duplicates! (iter:into-iter (make-list 0
+                                                                             1 1
+                                                                             2 2 2
+                                                                             3 3 3 3
+                                                                             4 4 4 4 4))))))
   (is (== (make-list #\a #\b #\c #\d #\e)
-          ;; but changing this `collect-list!' to `collect!' is fine.
-          (iter:collect! (iter:remove-duplicates! (iter:string-chars "abbcccddddeeeee"))))))
+          (iter:collect! (iter:remove-duplicates! (iter:into-iter "abbcccddddeeeee"))))))
 
 (define-test iter-index-of ()
   (is (== (Some 0)
@@ -108,11 +101,10 @@
                       (iter:repeat-item "foo" 10)))))
 
 (define-test iter-downfrom ()
-  ;; FIXME: changing `collect-list!' to `collect!' breaks type inference
   (is (== (the (List Integer) (make-list 9 8 7 6 5 4 3 2 1 0))
-          (iter:collect-list! (iter:down-from 10))))
+          (iter:collect! (iter:down-from 10))))
   (is (== (the (List Integer) (make-list 9 8 7 6 5 4 3 2 1 0))
-          (iter:collect-list! (iter:range-decreasing 1 10 0)))))
+          (iter:collect! (iter:range-decreasing 1 10 0)))))
 
 (define-test iter-min-max ()
   (is (== (Some (the Integer 10))
@@ -156,35 +148,33 @@
               (iter:next! iter))))))
 
 (define-test iter-interleave ()
-  ;; FIXME: changing `list-iter' to `into-iter' or `collect-list!' to `collect!' breaks type inference
-  (is (== (iter:collect-list!
-           (iter:interleave! (iter:list-iter (make-list 1 2 3 4 5 6))
+  (is (== (iter:collect!
+           (iter:interleave! (iter:into-iter (make-list 1 2 3 4 5 6))
                              iter:empty))
           (the (List Integer) (make-list 1 2 3 4 5 6))))
-  (is (== (iter:collect-list!
+  (is (== (iter:collect!
            (iter:interleave! iter:empty
-                             (iter:list-iter (make-list 1 2 3 4 5 6))))
+                             (iter:into-iter (make-list 1 2 3 4 5 6))))
           (the (List Integer) (make-list 1 2 3 4 5 6))))
-  (is (== (iter:collect-list!
-           (iter:interleave! (iter:list-iter (make-list 1 3 5))
-                             (iter:list-iter (make-list 2 4 6))))
+  (is (== (iter:collect!
+           (iter:interleave! (iter:into-iter (make-list 1 3 5))
+                             (iter:into-iter (make-list 2 4 6))))
           (the (List Integer) (make-list 1 2 3 4 5 6))))
-  (is (== (iter:collect-list!
-           (iter:interleave! (iter:list-iter (make-list 1 3 5))
-                             (iter:list-iter (make-list 2 4 6 7 8 9 10))))
+  (is (== (iter:collect!
+           (iter:interleave! (iter:into-iter (make-list 1 3 5))
+                             (iter:into-iter (make-list 2 4 6 7 8 9 10))))
           (the (List Integer) (make-list 1 2 3 4 5 6 7 8 9 10))))
-  (is (== (iter:collect-list!
-           (iter:interleave! (iter:list-iter (make-list 1 3 5 7 8 9 10))
-                             (iter:list-iter (make-list 2 4 6))))
+  (is (== (iter:collect!
+           (iter:interleave! (iter:into-iter (make-list 1 3 5 7 8 9 10))
+                             (iter:into-iter (make-list 2 4 6))))
           (the (List Integer) (make-list 1 2 3 4 5 6 7 8 9 10)))))
 
 (define-test elementwise-match-/= ()
-  ;; FIXME: changing `list-iter' to `into-iter' breaks type inference
-  (is (not (iter:elementwise==! (iter:list-iter (make-list 0 1 2))
-                                (iter:list-iter (make-list 0 1)))))
+  (is (not (iter:elementwise==! (iter:into-iter (make-list 0 1 2))
+                                (iter:into-iter (make-list 0 1)))))
   (is (not (iter:elementwise-match! <
-                                    (iter:list-iter (make-list 0 1 2))
-                                    (iter:list-iter (make-list 0 1))))))
+                                    (iter:into-iter (make-list 0 1 2))
+                                    (iter:into-iter (make-list 0 1))))))
 
 ;;; FIXME: define more tests
 ;; - vector-iter

--- a/tests/red-black-tests.lisp
+++ b/tests/red-black-tests.lisp
@@ -62,7 +62,8 @@
                                                     5)
                   11)
                  2))
-  (let iterated = (red-black/tree:collect! (iter:list-iter (make-list 5 11 2))))
+  ;; FIXME: replacing `red-black/tree:collect!' with `iter:collect!' below fails type inference
+  (let iterated = (red-black/tree:collect! (iter:into-iter (make-list 5 11 2))))
   (is (== manual iterated))
   (is (== (hash manual) (hash iterated))))
 
@@ -70,11 +71,12 @@
   (let increasing? = (fn (lst)
                        (== (list:sort lst) lst)))
   (let random-tree! = (fn (size)
+                        ;; FIXME: replacing `red-black/tree:collect!' with `iter:collect!' below fails type inference
                         (red-black/tree:collect! (random-iter! size))))
   (let increasing-list = (fn (tree)
-                           (iter:collect-list! (red-black/tree:increasing-order tree))))
+                           (iter:collect! (red-black/tree:increasing-order tree))))
   (let decreasing-list = (fn (tree)
-                           (iter:collect-list! (red-black/tree:decreasing-order tree))))
+                           (iter:collect! (red-black/tree:decreasing-order tree))))
   (let tree-good? = (fn (tree)
                       (let increasing = (increasing-list tree))
                       (let decreasing = (decreasing-list tree))
@@ -106,19 +108,22 @@
     (collect-tree-checking-invariants (iter:down-from 1024)))
   (is (== up-to-1024 down-from-1024))
   (is (== (hash up-to-1024) (hash down-from-1024)))
-  (let range-1024 = (iter:collect-list! (iter:up-to 1024)))
+  (let range-1024 = (the (List Integer)
+                         (iter:collect! (iter:up-to 1024))))
   (let range-shuffled = (lisp (List Integer) (range-1024)
                           (alexandria:shuffle range-1024)))
   (let shuffled =
-    (collect-tree-checking-invariants (iter:list-iter range-shuffled)))
+    (collect-tree-checking-invariants (iter:into-iter range-shuffled)))
   (is (== up-to-1024 shuffled))
   (is (== (hash up-to-1024) (hash shuffled))))
 
 (coalton-toplevel
   (declare tree-4 (red-black/tree:Tree Integer))
+  ;; FIXME: changing `red-black/tree:collect!' to `iter:collect!' below breaks type inference
   (define tree-4 (red-black/tree:collect! (iter:up-to 4)))
 
   (declare tree-1024 (red-black/tree:Tree Integer))
+  ;; FIXME: changing `red-black/tree:collect!' to `iter:collect!' below breaks type inference
   (define tree-1024 (red-black/tree:collect! (iter:up-to 1024)))
 
   (declare remove-and-check-invariants ((red-black/tree:Tree Integer) -> Integer -> (red-black/tree:Tree Integer)))
@@ -147,10 +152,12 @@
   (destroy-tree-checking-invariants tree-1024 (iter:down-from 1024)))
 
 (define-test removal-upholds-invariants-shuffled ()
-  (let range-1024 = (iter:collect-list! (iter:up-to 1024)))
+  (let range-1024 = (the (List Integer)
+                         ;; FIXME: changing `collect-list!' to `collect!' below breaks type inference
+                         (iter:collect-list! (iter:up-to 1024))))
   (let range-shuffled = (lisp (List Integer) (range-1024)
                           (alexandria:shuffle range-1024)))
-  (destroy-tree-checking-invariants tree-1024 (iter:list-iter range-shuffled)))
+  (destroy-tree-checking-invariants tree-1024 (iter:into-iter range-shuffled)))
 
 (define-test detect-bad-tree ()
   (let red-with-red-child = (red-black/tree::Branch red-black/tree::Red
@@ -171,6 +178,7 @@
                   (red-black/map:insert-or-replace red-black/map:empty 0 "zero")
                   11 "eleven")
                  5 "five"))
+  ;; FIXME: changing `red-black/map:collect!' to `iter:collect!' below breaks type inference
   (let iterated = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "zero")
                                                                      (Tuple 11 "eleven")
                                                                      (Tuple 5 "five")))))
@@ -178,12 +186,13 @@
   (is (== (hash manual) (hash iterated))))
 
 (define-test map-non-equal ()
-  (let map-012 = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "zero")
+  ;; FIXME: changing `red-black/map:collect!' to `iter:collect!' below breaks type inference
+  (let map-012 = (red-black/map:collect! (iter:into-iter (make-list (Tuple 0 "zero")
                                                                     (Tuple 1 "one")
                                                                     (Tuple 2 "two")))))
-  (let map-01 = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "zero")
+  (let map-01 = (red-black/map:collect! (iter:into-iter (make-list (Tuple 0 "zero")
                                                                    (Tuple 1 "one")))))
-  (let map-wrong-names = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "one")
+  (let map-wrong-names = (red-black/map:collect! (iter:into-iter (make-list (Tuple 0 "one")
                                                                             (Tuple 1 "zero")))))
 
   (is (/= map-012 map-01))

--- a/tests/red-black-tests.lisp
+++ b/tests/red-black-tests.lisp
@@ -62,8 +62,8 @@
                                                     5)
                   11)
                  2))
-  ;; FIXME: replacing `red-black/tree:collect!' with `iter:collect!' below fails type inference
-  (let iterated = (red-black/tree:collect! (iter:into-iter (make-list 5 11 2))))
+  (let iterated = (red-black/tree:collect! (iter:into-iter (the (List Integer)
+                                                                (make-list 5 11 2)))))
   (is (== manual iterated))
   (is (== (hash manual) (hash iterated))))
 
@@ -71,8 +71,8 @@
   (let increasing? = (fn (lst)
                        (== (list:sort lst) lst)))
   (let random-tree! = (fn (size)
-                        ;; FIXME: replacing `red-black/tree:collect!' with `iter:collect!' below fails type inference
-                        (red-black/tree:collect! (random-iter! size))))
+                        (the (red-black/tree:Tree Ufix)
+                             (iter:collect! (random-iter! size)))))
   (let increasing-list = (fn (tree)
                            (iter:collect! (red-black/tree:increasing-order tree))))
   (let decreasing-list = (fn (tree)
@@ -119,12 +119,10 @@
 
 (coalton-toplevel
   (declare tree-4 (red-black/tree:Tree Integer))
-  ;; FIXME: changing `red-black/tree:collect!' to `iter:collect!' below breaks type inference
-  (define tree-4 (red-black/tree:collect! (iter:up-to 4)))
+  (define tree-4 (red-black/tree:collect! (iter:up-to (the Integer 4))))
 
   (declare tree-1024 (red-black/tree:Tree Integer))
-  ;; FIXME: changing `red-black/tree:collect!' to `iter:collect!' below breaks type inference
-  (define tree-1024 (red-black/tree:collect! (iter:up-to 1024)))
+  (define tree-1024 (red-black/tree:collect! (iter:up-to (the Integer 1024))))
 
   (declare remove-and-check-invariants ((red-black/tree:Tree Integer) -> Integer -> (red-black/tree:Tree Integer)))
   (define (remove-and-check-invariants tre elt-to-remove)
@@ -153,7 +151,6 @@
 
 (define-test removal-upholds-invariants-shuffled ()
   (let range-1024 = (the (List Integer)
-                         ;; FIXME: changing `collect-list!' to `collect!' below breaks type inference
                          (iter:collect-list! (iter:up-to 1024))))
   (let range-shuffled = (lisp (List Integer) (range-1024)
                           (alexandria:shuffle range-1024)))
@@ -173,27 +170,28 @@
   (matches (Err (DifferentCountToBlack _ _ _ _)) (count-blacks-to-leaf unbalanced)))
 
 (define-test map-from-iter-equiv-to-manual-construction ()
-  (let manual = (red-black/map:insert-or-replace
-                 (red-black/map:insert-or-replace
-                  (red-black/map:insert-or-replace red-black/map:empty 0 "zero")
-                  11 "eleven")
-                 5 "five"))
-  ;; FIXME: changing `red-black/map:collect!' to `iter:collect!' below breaks type inference
-  (let iterated = (red-black/map:collect! (iter:list-iter (make-list (Tuple 0 "zero")
-                                                                     (Tuple 11 "eleven")
-                                                                     (Tuple 5 "five")))))
+  (let manual = (the (red-black/map:Map Integer String)
+                     (red-black/map:insert-or-replace
+                      (red-black/map:insert-or-replace
+                       (red-black/map:insert-or-replace red-black/map:empty 0 "zero")
+                       11 "eleven")
+                      5 "five")))
+  (let iterated = (iter:collect! (iter:into-iter (the (List (Tuple Integer String))
+                                                      (make-list (Tuple 0 "zero")
+                                                                 (Tuple 11 "eleven")
+                                                                 (Tuple 5 "five"))))))
   (is (== manual iterated))
   (is (== (hash manual) (hash iterated))))
 
 (define-test map-non-equal ()
-  ;; FIXME: changing `red-black/map:collect!' to `iter:collect!' below breaks type inference
-  (let map-012 = (red-black/map:collect! (iter:into-iter (make-list (Tuple 0 "zero")
-                                                                    (Tuple 1 "one")
-                                                                    (Tuple 2 "two")))))
-  (let map-01 = (red-black/map:collect! (iter:into-iter (make-list (Tuple 0 "zero")
-                                                                   (Tuple 1 "one")))))
-  (let map-wrong-names = (red-black/map:collect! (iter:into-iter (make-list (Tuple 0 "one")
-                                                                            (Tuple 1 "zero")))))
+  (let map-012 = (the (red-black/map:Map Integer String)
+                      (iter:collect! (iter:into-iter (make-list (Tuple 0 "zero")
+                                                                (Tuple 1 "one")
+                                                                (Tuple 2 "two"))))))
+  (let map-01 = (iter:collect! (iter:into-iter (make-list (Tuple 0 "zero")
+                                                          (Tuple 1 "one")))))
+  (let map-wrong-names = (iter:collect! (iter:into-iter (make-list (Tuple 0 "one")
+                                                                   (Tuple 1 "zero")))))
 
   (is (/= map-012 map-01))
   (is (/= (hash map-012) (hash map-01)))


### PR DESCRIPTION
note FIXME comments in tests/iterator-tests.lisp: type inference fails using the generic versions in some places i would expect to work.