### PR TITLE
Fix several type inference related issues

### DIFF
--- a/src/impl-package.lisp
+++ b/src/impl-package.lisp
@@ -9,7 +9,8 @@
    (#:error #:coalton-impl/error)
    (#:ast #:coalton-impl/ast)
    (#:rt #:coalton-impl/runtime)
-   (#:tc #:coalton-impl/typechecker))
+   (#:tc #:coalton-impl/typechecker)
+   (#:codegen #:coalton-impl/codegen))
 
   (:import-from
    #:coalton-impl/settings

--- a/src/testing/coalton-native-test-utils.lisp
+++ b/src/testing/coalton-native-test-utils.lisp
@@ -52,14 +52,15 @@ BODY within a `coalton' expression."
                (names (cl:mapcar #'cl:first name-els)))
        `(progn
           (%register-assertion) 
-          (let ,name-els
-            (if ,names
-                (%register-success)
-                (lisp :a ,names
-                  (fiasco::record-failure
-                   'coalton-failure
-                   :format-control "IS assertion ~A~%Evaluates to application ~A~%Evaluates to False~%~A"
-                   :format-arguments (cl:list ',check ,(cons 'cl:list names) ,message))))))))
+          ,@(cl:loop :for (name value) :in name-els
+               :collect `(let ,name = ,value))
+          (if ,names
+              (%register-success)
+              (lisp :a ,names
+                (fiasco::record-failure
+                 'coalton-failure
+                 :format-control "IS assertion ~A~%Evaluates to application ~A~%Evaluates to False~%~A"
+                 :format-arguments (cl:list ',check ,(cons 'cl:list names) ,message)))))))
     (_
      `(progn
         (%register-assertion)

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -139,17 +139,11 @@ apply s type1 == type2")
   "Returns true if all of the types in LIST2 match the types in LIST1 pairwise"
   (declare (type ty-list list1)
            (type ty-list list2))
-  (handler-case
-      (progn
-        (reduce #'merge-substitution-lists
-                (loop :for t1 :in list1
-                      :for t2 :in list2
+  (reduce #'merge-substitution-lists
+          (loop :for t1 :in list1
+                :for t2 :in list2
 
-                      :collect (match t2 t1)))
-        (return-from match-list t))
-
-    (coalton-type-error ()
-      (return-from match-list nil))))
+                :collect (match t2 t1))))
 
 (defun unify-list (subs list1 list2)
   (declare (type substitution-list subs)


### PR DESCRIPTION
* Fundep improvements were not always being applied in `coalton` forms
* Fundep impvovements when matching against more general instances were not always improving types

Example:
`(define-class (C :a :b (:a -> :b))`
`(define-instance (C (List :a) :a)`
The predicate `(C (List String) :c)` should become `(C (List String) String)` but instead it was becomming `(C (List String) :a)`

* Is assertions in tests were lifting values into let expressions which effected type inference. Is assertions will now use shorthand let forms to preserve the intended type checking behavior.