### PR TITLE
Fix rewrite-pattern-vars

### DIFF
--- a/src/algorithm/immutable-map.lisp
+++ b/src/algorithm/immutable-map.lisp
@@ -29,7 +29,7 @@
 (defun immutable-map-lookup (m key)
   "Lookup KEY in M"
   (declare (type immutable-map m)
-           (values t))
+           (values t boolean &optional))
   (fset:lookup (immutable-map-data m) key))
 
 (defun immutable-map-set (m key value &optional (constructor #'make-immutable-map))

--- a/src/ast/pattern.lisp
+++ b/src/ast/pattern.lisp
@@ -102,9 +102,12 @@
                  (pattern-constructor-patterns pattern))))
 
     (pattern-var
-     (make-pattern-var
-      :id (or (immutable-map-lookup m (pattern-var-id pattern))
-              (util:coalton-bug "Invalid state reached in rewrite-pattern-vars"))))))
+     (multiple-value-bind (id found-p)
+         (immutable-map-lookup m (pattern-var-id pattern))
+       (unless found-p
+         (util:coalton-bug "Invalid state reached in rewrite-pattern-vars"))
+
+       (make-pattern-var :id id)))))
 
 
 (defun pattern-variables (pattern)

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -902,7 +902,7 @@
   (declare (type environment env)
            (type symbol function-name)
            (values util:symbol-list &optional))
-  (immutable-map-lookup (environment-source-name-environment env) function-name))
+  (values (immutable-map-lookup (environment-source-name-environment env) function-name)))
 
 (defun set-function-source-parameter-names (env function-name source-parameter-names)
   (declare (type environment env)


### PR DESCRIPTION
Previously this function would error if a pattern variable was cl:nil.