### PR TITLE
Add coalton reader macro for coalton-toplevel and coalton

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -25,6 +25,7 @@
                #:float-features
                #:split-sequence
                #:eclector-concrete-syntax-tree
+               #:named-readtables
                #:uiop)
   :pathname "src/"
   :serial t
@@ -118,6 +119,7 @@
                (:file "toplevel-specializations")
                (:file "unlock-package" :if-feature :sb-package-locks)
                (:file "coalton")
+               (:file "reader")
                (:file "debug")
                (:file "faux-macros")
                (:file "language-macros")

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -447,7 +447,7 @@
 
 (defun parse-expression (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node &optional))
 
   (cond
@@ -883,7 +883,7 @@
 
 (defun parse-variable (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-variable &optional))
 
   (unless (and (cst:atom form)
@@ -901,7 +901,7 @@
 
 (defun parse-literal (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node &optional))
 
   (assert (cst:atom form))
@@ -927,7 +927,7 @@
 
 (defun parse-body (form enclosing-form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-body &optional))
 
   (when (cst:atom form)
@@ -989,7 +989,7 @@
 ;; Forms passed to parse-node-bind must be previously verified by `shorthand-let-p'
 (defun parse-node-bind (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-bind))
 
   (when (cst:consp (cst:rest (cst:rest (cst:rest (cst:rest form)))))
@@ -1007,7 +1007,7 @@
 
 (defun parse-body-element (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-body-element &optional))
 
   (when (cst:atom form)
@@ -1029,7 +1029,7 @@
 
 (defun parse-body-last-node (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node &optional))
 
   (when (shorthand-let-p form)
@@ -1044,7 +1044,7 @@
 
 (defun parse-let-binding (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-let-binding &optional))
 
   (when (cst:atom form)
@@ -1089,7 +1089,7 @@
 
 (defun parse-match-branch (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-match-branch &optional))
 
   (when (cst:atom form)
@@ -1125,7 +1125,7 @@
 
 (defun parse-cond-clause (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-cond-clause))
 
   (when (cst:atom form)
@@ -1151,7 +1151,7 @@
 
 (defun parse-do (form file)
   (declare (type cst:cst form)
-           (type file-stream))
+           (type coalton-file))
 
   (assert (cst:consp form))
 
@@ -1226,7 +1226,7 @@
 
 (defun parse-do-body-element (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-do-body-element &optional))
 
   (cond
@@ -1242,7 +1242,7 @@
 (defun parse-do-body-last-node (form parent-form file)
   (declare (type cst:cst form)
            (type cst:cst parent-form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node &optional))
 
   (when (shorthand-let-p form)
@@ -1277,7 +1277,7 @@
 
 (defun parse-let-declare (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values node-let-declare))
 
   (assert (cst:consp form))

--- a/src/parser/pattern.lisp
+++ b/src/parser/pattern.lisp
@@ -75,7 +75,7 @@
 
 (defun parse-pattern (form file)
   (declare (type cst:cst form)
-           (type file-stream file))
+           (type coalton-file file))
 
   (cond
     ((and (cst:atom form)

--- a/src/parser/types.lisp
+++ b/src/parser/types.lisp
@@ -129,7 +129,7 @@
 
 (defun parse-qualified-type (form file)
   (declare (type cst:cst form)
-           (type file-stream file))
+           (type coalton-file file))
 
   (if (cst:atom form)
 
@@ -224,7 +224,7 @@
 (defun parse-predicate (forms source file)
   (declare (type util:cst-list forms)
            (type cons source)
-           (type file-stream file)
+           (type coalton-file file)
            (values ty-predicate))
 
   (assert forms)
@@ -274,7 +274,7 @@
 
 (defun parse-type (form file)
   (declare (type cst:cst form)
-           (type file-stream file)
+           (type coalton-file file)
            (values ty &optional))
 
   (cond
@@ -309,7 +309,7 @@
 (defun parse-type-list (forms source file)
   (declare (type util:cst-list forms)
            (type cons source)
-           (type file-stream file)
+           (type coalton-file file)
            (values ty &optional))
 
   (assert forms)

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -1,0 +1,160 @@
+(defpackage #:coalton-impl/reader
+  (:use
+   #:cl
+   #:coalton-impl/parser/base
+   #:coalton-impl/parser/types
+   #:coalton-impl/parser/expression
+   #:coalton-impl/parser/parser)
+  (:shadowing-import-from
+   #:coalton-impl/parser/base
+   #:parse-error)
+  (:local-nicknames
+   (#:cst #:concrete-syntax-tree)
+   (#:util #:coalton-impl/util)))
+
+(in-package #:coalton-impl/reader)
+
+(defun read-coalton-toplevel-open-paren (stream char)
+  (labels ((try-read-string (expected-string)
+             (%try-read-string (coerce expected-string 'list) nil))
+           (%try-read-string (expected taken)
+             (cond
+               ((null expected)
+                ;; Check if the next character is whitespace, hackily!
+                (not (eql (peek-char nil stream) (peek-char t stream))))
+               ((not (char-equal (car expected) (peek-char nil stream)))
+                nil)
+               (t
+                (read-char stream)
+                (cond
+                  ((%try-read-string (cdr expected) (cons (car expected) taken))
+                   t)
+                  (t
+                   (unread-char (car expected) stream)
+                   nil))))))
+    (cond
+      ((try-read-string "coalton-toplevel")
+       (let* ((pathname (or *compile-file-truename* *load-truename*))
+              (filename (if pathname (namestring pathname) "<unknown>"))
+
+              ;; Setup eclector readtable
+              (eclector.readtable:*readtable*
+                (eclector.readtable:copy-readtable eclector.readtable:*readtable*))
+
+              ;; Read unspecified floats as double floats
+              (*read-default-float-format* 'double-float))
+         (let* ((file-input-stream
+                  (cond
+                    ((or #+sbcl (sb-int:form-tracking-stream-p stream)
+                         nil)
+                     (open (pathname stream)))
+                    (t
+                     stream)))
+                (file (make-coalton-file :stream file-input-stream :name filename))
+
+                (program (make-program :package *package* :file file))
+
+                (attributes (make-array 0 :adjustable t :fill-pointer t)))
+
+           (handler-case
+               (progn
+                 (loop :named parse-loop
+                       :with elem := nil
+
+                       :when (eql #\) (peek-char t stream))
+                         :do (read-char stream)
+                             (return-from parse-loop)
+                  
+                       :do (setf elem (eclector.concrete-syntax-tree:read stream nil 'eof))
+
+                       :when (eq elem 'eof)
+                         :do (error "unexpected EOF")
+
+                       :do (when (and (parse-toplevel-form elem program attributes file)
+                                      (plusp (length attributes)))
+                             (util:coalton-bug "parse-toplevel-form indicated that a form was parsed but did not consume all attributes")))
+
+                 (unless (zerop (length attributes))
+                   (error 'parse-error
+                          :err (coalton-error
+                                :span (cst:source (cdr (aref attributes 0)))
+                                :file file
+                                :message "Orphan attribute"
+                                :primary-note "attribute must be attached to another form"))))
+             (parse-error (c)
+               (let* ((err (parse-error-err c))
+                      (loc (coalton-error-location err)))
+                 ;; In SBCL, we can unread characters to step back the
+                 ;; FILE-POSITION so that when Slime grabs the location of
+                 ;; the error it highlights the correct form.
+                 #+sbcl
+                 (loop :for i :below (- (file-position stream) loc 1) :do
+                   (unread-char #\Null stream))
+                 (error c))))
+
+           (setf (program-types program) (nreverse (program-types program)))
+           (setf (program-declares program) (nreverse (program-declares program)))
+           (setf (program-defines program) (nreverse (program-defines program)))
+           (setf (program-classes program) (nreverse (program-classes program)))
+
+           `(format t "~A" ,(format nil "~A" program)))))
+      ((try-read-string "coalton")
+       (let* ((pathname (or *compile-file-truename* *load-truename*))
+              (filename (if pathname (namestring pathname) "<unknown>"))
+
+              ;; Setup eclector readtable
+              (eclector.readtable:*readtable*
+                (eclector.readtable:copy-readtable eclector.readtable:*readtable*))
+
+              ;; Read unspecified floats as double floats
+              (*read-default-float-format* 'double-float))
+         (let* ((file-input-stream
+                  (cond
+                    ((or #+sbcl (sb-int:form-tracking-stream-p stream)
+                         nil)
+                     (open (pathname stream)))
+                    (t
+                     stream)))
+                (file (make-coalton-file :stream file-input-stream :name filename))
+
+                expression)
+
+           (handler-case
+               (let* ((forms
+                        (loop :named parse-loop
+                              :with forms := nil
+                              :with elem := nil
+
+                              :when (eql #\) (peek-char t stream))
+                                :do (read-char stream)
+                                    (return-from parse-loop (nreverse forms))
+                                   
+                              :do (setf elem (eclector.concrete-syntax-tree:read stream nil 'eof))
+                                  
+                              :when (eq elem 'eof)
+                                :do (error "unexpected EOF")
+
+                              :do (push elem forms)))
+                      (form (cst:cstify forms :source (cons (car (cst:source (first forms)))
+                                                            (cdr (cst:source (car (last forms))))))))
+                 
+                 (setf expression (parse-expression form file)))
+             (parse-error (c)
+               (let* ((err (parse-error-err c))
+                      (loc (coalton-error-location err)))
+                 ;; In SBCL, we can unread characters to step back the
+                 ;; FILE-POSITION so that when Slime grabs the location of
+                 ;; the error it highlights the correct form.
+                 #+sbcl
+                 (loop :for i :below (- (file-position stream) loc 1) :do
+                   (unread-char #\Null stream))
+                 (error c))))
+
+           `(format t "~A" ,(format nil "~A" expression)))))
+      ;; Fall back to the default open paren reader
+      (t
+       (funcall #'#.(get-macro-character #\() stream char)))))
+
+(named-readtables:defreadtable coalton:coalton
+  (:merge :standard)
+  (:macro-char #\( #'read-coalton-toplevel-open-paren))

--- a/src/typechecker2/base.lisp
+++ b/src/typechecker2/base.lisp
@@ -3,10 +3,12 @@
    #:cl)
   (:import-from
    #:coalton-impl/parser/base
+   #:coalton-file
    #:coalton-error
    #:make-coalton-error-note
    #:make-coalton-error-help)
   (:export
+   #:coalton-file
    #:coalton-error
    #:make-coalton-error-note
    #:make-coalton-error-help)

--- a/src/typechecker2/define-type.lisp
+++ b/src/typechecker2/define-type.lisp
@@ -25,7 +25,7 @@
 
 (defun toplevel-define-type (types file env)
   (declare (type parser:toplevel-define-type-list types)
-           (type file-stream file)
+           (type coalton-file file)
            (type tc:environment env)
            (values tc:type-definition-list tc:environment))
 
@@ -220,7 +220,7 @@
 (defun infer-define-type-scc-kinds (types env file)
   (declare (type parser:toplevel-define-type-list types)
            (type partial-type-env env)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:type-definition-list))
 
   (let ((ksubs nil)

--- a/src/typechecker2/define.lisp
+++ b/src/typechecker2/define.lisp
@@ -81,7 +81,7 @@
   "Lookup a variable named VAR in ENV."
   (declare (type tc-env env)
            (type parser:node-variable var)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty tc:ty-predicate-list))
 
   (let* ((scheme (or (gethash (parser:node-variable-name var) (tc-env-ty-table env))
@@ -160,7 +160,7 @@
 (defun tc-env-ambigious-pred (env pred file subs)
   (declare (type tc-env env)
            (type tc:ty-predicate pred)
-           (type file-stream file)
+           (type coalton-file file)
            (type tc:substitution-list subs))
 
   (tc:apply-substitution subs env)
@@ -211,7 +211,7 @@
   "Entrypoint for typechecking a group of parsed defines and declares."
   (declare (type parser:toplevel-define-list defines)
            (type parser:toplevel-declare-list declares)
-           (type file-stream file)
+           (type coalton-file file)
            (type tc:environment env))
 
   (let ((def-table (make-hash-table :test #'eq))
@@ -302,7 +302,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let ((ty (etypecase (parser:node-literal-value node)
@@ -334,7 +334,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (multiple-value-bind (ty preds)
@@ -361,7 +361,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (when (null (parser:node-application-rands node))
@@ -429,7 +429,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values null tc:ty-predicate-list tc:substitution-list))
 
     (multiple-value-bind (expr-ty preds subs)
@@ -457,7 +457,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let ((preds nil))
@@ -483,7 +483,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let (;; Setup return environment
@@ -566,7 +566,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (multiple-value-bind (subs preds)
@@ -588,7 +588,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let ((declared-ty (parse-type (parser:node-lisp-type node) (tc-env-env env) file)))
@@ -614,7 +614,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     ;; Infer the type of the expression being cased on
@@ -654,7 +654,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list &optional))
 
     (infer-expression-type (parser:node-progn-body node)
@@ -668,7 +668,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let ((declared-ty (parse-type (parser:node-the-type node) (tc-env-env env) file)))
@@ -735,7 +735,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     ;; Returns must be inside a lambda
@@ -766,7 +766,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let ((preds nil))
@@ -803,7 +803,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let ((preds))
@@ -840,7 +840,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (multiple-value-bind (expr-ty preds subs)
@@ -888,7 +888,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (multiple-value-bind (expr-ty preds subs)
@@ -928,7 +928,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (multiple-value-bind (expr-ty preds subs)
@@ -968,7 +968,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (multiple-value-bind (expr-ty preds subs)
@@ -996,7 +996,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ty-predicate-list tc:substitution-list))
 
     (let ((preds))
@@ -1044,7 +1044,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:substitution-list))
 
     (let ((ty (tc-env-add-variable env (parser:pattern-var-name pat))))
@@ -1060,7 +1060,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:substitution-list))
 
     (let ((ty (etypecase (parser:pattern-literal-value pat)
@@ -1095,7 +1095,7 @@
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:substitution-list))
 
     (let ((ctor (tc:lookup-constructor (tc-env-env env) (parser:pattern-constructor-name pat) :no-error t)))
@@ -1163,7 +1163,7 @@
            (type parser:node-let-declare-list declares)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type file-stream file))
+           (type coalton-file file))
 
   (let ((def-table (make-hash-table :test #'eq))
 
@@ -1205,8 +1205,8 @@
                              :primary-note "second decleration here"
                              :notes
                              (list
-                              make-coalton-error-note
-                              (:type :primary
+                              (make-coalton-error-note
+                               :type :primary
                                :span (parser:node-source
                                       (parser:node-let-declare-name
                                        (gethash name dec-table)))
@@ -1240,7 +1240,7 @@
            (type hash-table dec-table)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty-predicate-list tc:substitution-list))
   ;;
   ;; Binding type inference has several steps.
@@ -1330,7 +1330,7 @@
            (type cons source)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty-predicate-list tc:substitution-list))
 
   (let* ((name (parser:node-variable-name (parser:name binding)))
@@ -1424,7 +1424,7 @@
   (declare (type (or parser:toplevel-define-list parser:node-let-binding-list) bindings)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty-predicate-list tc:substitution-list))
 
   (let* (;; track variables bound before typechecking
@@ -1480,7 +1480,7 @@
   (declare (type (or parser:toplevel-define parser:node-let-binding) binding)
            (type tc:ty expected-type)
            (type tc:substitution-list subs)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty-predicate-list tc:substitution-list))
 
   (let ((vars (loop :for var :in (parser:parameters binding)

--- a/src/typechecker2/parse-type.lisp
+++ b/src/typechecker2/parse-type.lisp
@@ -71,7 +71,7 @@
 (defun partial-type-env-lookup-type (env tycon file)
   (declare (type partial-type-env env)
            (type parser:tycon tycon)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty))
   (let* ((name (parser:tycon-name tycon))
 
@@ -99,7 +99,7 @@
 (defun parse-type (ty env file)
   (declare (type parser:ty ty)
            (type tc:environment env)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty &optional))
 
   (let ((tvars (collect-type-variables ty))
@@ -125,7 +125,7 @@
 (defun parse-qualified-type (ty env file)
   (declare (type parser:qualified-ty ty)
            (type tc:environment env)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:qualified-ty &optional))
 
   (let ((tvars (collect-type-variables ty))
@@ -174,7 +174,7 @@
     (declare (type tc:kind expected-kind)
              (type symbol current-type)
              (type tc:ksubstitution-list ksubs)
-             (type file-stream file))
+             (type coalton-file file))
     (let* ((tvar (partial-type-env-lookup-var env current-type (parser:tyvar-name type)))
 
            (kvar (tc:kind-of tvar)))
@@ -199,7 +199,7 @@
              (type symbol current-type)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ksubstitution-list))
 
     (let ((type_ (partial-type-env-lookup-type env type file)))
@@ -222,7 +222,7 @@
              (type symbol current-type)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type file-stream file)
+             (type coalton-file file)
              (values tc:ty tc:ksubstitution-list &optional))
 
     (let ((fun-kind (tc:make-kvariable))
@@ -263,7 +263,7 @@
            (type symbol current-type)
            (type tc:ksubstitution-list ksubs)
            (type partial-type-env env)
-           (type file-stream file)
+           (type coalton-file file)
            (values tc:ty-predicate tc:ksubstitution-list))
 
   (let* ((class-name (parser:ty-predicate-class pred))


### PR DESCRIPTION
These will simply invoke the new parser for now, but can be threaded through the whole compiler. This allows existing coalton code to compile with the new frontend.

Additionally, replace raw files with coalton-file wrapper