### PR TITLE
Add functional dependency resolution to explicit bindings

### DIFF
--- a/src/typechecker/derive-type.lisp
+++ b/src/typechecker/derive-type.lisp
@@ -843,6 +843,17 @@ TOPLEVEL is set to indicate additional checks should be completed in COALTON-TOP
                                              (not (entail env expr-preds p)))
                                            (apply-substitution local-subs preds))))
 
+        ;;
+        ;; NOTE: this is where functional dependency substitutions are generated
+        ;;
+
+        ;; Like implicit bindings, we only need to apply substitutions
+        ;; for the predicates generated from type inference, not
+        ;; including ones in our explicit type.
+        (setf local-subs (solve-fundeps env (apply-substitution local-subs preds) local-subs)) 
+        (setf expr-type (apply-substitution local-subs expr-type))
+
+
         (multiple-value-bind (deferred-preds retained-preds)
             (split-context env env-tvars local-tvars reduced-preds local-subs)
 

--- a/tests/fundep-tests.lisp
+++ b/tests/fundep-tests.lisp
@@ -178,3 +178,16 @@
 
      (coalton:declare f ((C :b :c) (C :a :b) => :a -> coalton:Unit))
      (coalton:define (f _) coalton:Unit))))
+
+(deftest fundep-implicit-explicit ()
+  (run-coalton-typechecker
+   '((coalton:declare gh-792 (coalton:List coalton:Integer -> coalton:List coalton:Integer))
+     (coalton:define (gh-792 items)
+       (coalton-library/iterator:collect! (coalton-library/iterator:into-iter items)))))
+
+  (run-coalton-typechecker
+   '((coalton:define (gh-792-impl items)
+       (coalton:the (coalton:List coalton:Integer)
+                    (coalton-library/iterator:collect!
+                     (coalton-library/iterator:into-iter
+                      (coalton:the (coalton:List coalton:Integer) items))))))))


### PR DESCRIPTION
Functional dependencies were previously only applied to implicit bindings. Added logic for explicit bindings and a test case. 

Fixes #792 