### PR TITLE
Add pattern exhaustiveness and usefulness warnings

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -72,6 +72,10 @@
                              (:file "debug")
                              (:file "translation-unit")
                              (:file "package")))
+               (:module "analysis"
+                :serial t
+                :components ((:file "pattern-exhaustiveness")
+                             (:file "package")))
                (:module "codegen"
                 :serial t
                 :components ((:file "ast")

--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -14,9 +14,9 @@
       ((Id s) s)))
 
   (define-instance (Eq Id)
-      (define (== x y)
-        (== (get-id x)
-            (get-id y))))
+    (define (== x y)
+      (== (get-id x)
+          (get-id y))))
 
   (declare get-id (Id -> String))
   (define (get-id x)
@@ -37,14 +37,14 @@
     (Kfun Kind Kind))
 
   (define-instance (Eq Kind)
-      (define (== k1 k2)
-        (match (Tuple k1 k2)
-          ((Tuple (Star) (Star)) True)
-          ((Tuple (Kfun a1 a2)
-                  (Kfun b1 b2))
-           (and (== a1 b1)
-                (== a2 b2)))
-          (_ False))))
+    (define (== k1 k2)
+      (match (Tuple k1 k2)
+        ((Tuple (Star) (Star)) True)
+        ((Tuple (Kfun a1 a2)
+                (Kfun b1 b2))
+         (and (== a1 b1)
+              (== a2 b2)))
+        (_ False))))
 
   ;;
   ;; Types
@@ -57,37 +57,37 @@
     (TGen UFix))
 
   (define-instance (Eq Type)
-      (define (== t1 t2)
-        (match (Tuple t1 t2)
-          ((Tuple (TVar v1) (TVar v2)) (== v1 v2))
-          ((Tuple (TCon c1) (TCon c2)) (== c1 c2))
-          ((Tuple (TAp a1 a2) (TAp b1 b2))
-           (and (== a1 b1)
-                (== a2 b2)))
-          ((Tuple (TGen g1) (TGen g2)) (== g1 g2))
-          (_ False))))
+    (define (== t1 t2)
+      (match (Tuple t1 t2)
+        ((Tuple (TVar v1) (TVar v2)) (== v1 v2))
+        ((Tuple (TCon c1) (TCon c2)) (== c1 c2))
+        ((Tuple (TAp a1 a2) (TAp b1 b2))
+         (and (== a1 b1)
+              (== a2 b2)))
+        ((Tuple (TGen g1) (TGen g2)) (== g1 g2))
+        (_ False))))
 
 
   (define-type Tyvar
     (Tyvar Id Kind))
 
   (define-instance (Eq Tyvar)
-      (define (== x y)
-        (match (Tuple x y)
-          ((Tuple (Tyvar i1 k1) (Tyvar i2 k2))
-           (and (== i1 i2)
-                (== k1 k2))))))
+    (define (== x y)
+      (match (Tuple x y)
+        ((Tuple (Tyvar i1 k1) (Tyvar i2 k2))
+         (and (== i1 i2)
+              (== k1 k2))))))
 
 
   (define-type Tycon
     (Tycon Id Kind))
 
   (define-instance (Eq Tycon)
-      (define (== x y)
-        (match (Tuple x y)
-          ((Tuple (Tycon i1 k1) (Tycon i2 k2))
-           (and (== i1 i2)
-                (== k1 k2))))))
+    (define (== x y)
+      (match (Tuple x y)
+        ((Tuple (Tycon i1 k1) (Tycon i2 k2))
+         (and (== i1 i2)
+              (== k1 k2))))))
 
 
   (define tUnit (TCon (Tycon (Id "()") Star)))
@@ -118,26 +118,28 @@
 
 
   (define-class (HasKind :t)
-      (kind (:t -> Kind)))
+    (kind (:t -> Kind)))
 
   (define-instance (HasKind Tyvar)
-      (define (kind t)
-        (match t
-          ((Tyvar _ k) k))))
+    (define (kind t)
+      (match t
+        ((Tyvar _ k) k))))
 
   (define-instance (HasKind Tycon)
-      (define (kind t)
-        (match t
-          ((Tycon _ k) k))))
+    (define (kind t)
+      (match t
+        ((Tycon _ k) k))))
 
   (define-instance (HasKind Type)
-      (define (kind t)
-        (match t
-          ((TCon tc) (kind tc))
-          ((TVar u) (kind u))
-          ((TAp t _)
-           (match (kind t)
-             ((Kfun _ k) k))))))
+    (define (kind t)
+      (match t
+        ((TCon tc) (kind tc))
+        ((TVar u) (kind u))
+        ((TAp t _)
+         (match (kind t)
+           ((Kfun _ k) k)
+           (_ (error "unreachable"))))
+        (_ (error "unreachable")))))
 
 
   ;;
@@ -160,19 +162,19 @@
 
 
   (define-class (Types :t)
-      (apply (Subst -> :t -> :t))
+    (apply (Subst -> :t -> :t))
     (tv (:t -> (List Tyvar))))
 
   (define-instance (Types Type)
-      (define (apply s t)
-        (match t
-          ((TVar u)
-           (match (list:lookup u (get-subst s))
-             ((Some t) t)
-             ((None) (Tvar u))))
-          ((TAp l r)
-           (TAp (apply s l) (apply s r)))
-          (x x)))
+    (define (apply s t)
+      (match t
+        ((TVar u)
+         (match (list:lookup u (get-subst s))
+           ((Some t) t)
+           ((None) (Tvar u))))
+        ((TAp l r)
+         (TAp (apply s l) (apply s r)))
+        (x x)))
     (define (tv t)
       (match t
         ((TVar u) (make-list u))
@@ -181,8 +183,8 @@
 
 
   (define-instance (Types :a => (Types (List :a)))
-      (define (apply s t)
-        (map (apply s) t))
+    (define (apply s t)
+      (map (apply s) t))
     (define (tv t)
       (remove-duplicates (fold append Nil (map tv t)))))
 
@@ -277,18 +279,18 @@
     (Qual (List Pred) :t))
 
   (define-instance (Eq :t => (Eq (Qual :t)))
-      (define (== x y)
-        (match (Tuple x y)
-          ((Tuple (Qual xs t1) (Qual ys t2))
-           (and (== xs ys)
-                (== t1 t2))))))
+    (define (== x y)
+      (match (Tuple x y)
+        ((Tuple (Qual xs t1) (Qual ys t2))
+         (and (== xs ys)
+              (== t1 t2))))))
 
   (define-instance (Types :t => (Types (Qual :t)))
-      (define (apply s q)
-        (match q
-          ((Qual ps t)
-           (Qual (apply s ps)
-                 (apply s t)))))
+    (define (apply s q)
+      (match q
+        ((Qual ps t)
+         (Qual (apply s ps)
+               (apply s t)))))
     (define (tv q)
       (match q
         ((Qual ps t)
@@ -299,17 +301,17 @@
     (IsIn Id Type))
 
   (define-instance (Eq Pred)
-      (define (== x y)
-        (match (Tuple x y)
-          ((Tuple (IsIn id1 t1) (IsIn id2 t2))
-           (and (== id1 id2)
-                (== t1 t2))))))
+    (define (== x y)
+      (match (Tuple x y)
+        ((Tuple (IsIn id1 t1) (IsIn id2 t2))
+         (and (== id1 id2)
+              (== t1 t2))))))
 
   (define-instance (Types Pred)
-      (define (apply s p)
-        (match p
-          ((IsIn i t)
-           (IsIn i (apply s t)))))
+    (define (apply s p)
+      (match p
+        ((IsIn i t)
+         (IsIn i (apply s t)))))
     (define (tv p)
       (match p
         ((IsIn _ t)
@@ -368,13 +370,17 @@
   (define (super ce i)
     (match (classes ce i)
       ((Some c)
-       (fst (get-class c)))))
+       (fst (get-class c)))
+      (_
+       (error "unreachable"))))
 
   (declare insts (ClassEnv -> Id -> (List Inst)))
   (define (insts ce i)
     (match (classes ce i)
       ((Some c)
-       (snd (get-class c)))))
+       (snd (get-class c)))
+      (_
+       (error "unreachable"))))
 
   (declare defined ((Optional :a) -> Boolean))
   (define (defined x)
@@ -527,7 +533,8 @@
                  (match t
                    ((TVar _) True)
                    ((TCon _) False)
-                   ((TAp t _) (hnf t))))))
+                   ((TAp t _) (hnf t))
+                   (_ (error "unreachable"))))))
       (match pred
         ((IsIn _ t) (hnf t)))))
 
@@ -579,18 +586,18 @@
     (Forall (List Kind) (Qual Type)))
 
   (define-instance (Eq Scheme)
-      (define (== x y)
-        (match (Tuple x y)
-          ((Tuple (Forall ks1 q1)
-                  (Forall ks2 q2))
-           (and (== ks1 ks2)
-                (== q1 q2))))))
+    (define (== x y)
+      (match (Tuple x y)
+        ((Tuple (Forall ks1 q1)
+                (Forall ks2 q2))
+         (and (== ks1 ks2)
+              (== q1 q2))))))
 
   (define-instance (Types Scheme)
-      (define (apply s t)
-        (match t
-          ((Forall ks qt)
-           (Forall ks (apply s qt)))))
+    (define (apply s t)
+      (match t
+        ((Forall ks qt)
+         (Forall ks (apply s qt)))))
     (define (tv t)
       (match t
         ((Forall _ qt)
@@ -627,10 +634,10 @@
               (== scheme-a scheme-b))))))
 
   (define-instance (Types Assump)
-      (define (apply s a)
-        (match a
-          ((Assump i sc)
-           (Assump i (apply s sc)))))
+    (define (apply s a)
+      (match a
+        ((Assump i sc)
+         (Assump i (apply s sc)))))
     (define (tv a)
       (match a
         ((Assump _ sc)
@@ -660,15 +667,15 @@
       ((TI y) y)))
 
   (define-instance (Functor TI)
-      (define (map f x)
-        (>>= x
-             (fn (x)
-               (pure (f x))))))
+    (define (map f x)
+      (>>= x
+           (fn (x)
+             (pure (f x))))))
 
   (define-instance (Applicative TI)
-      (define (pure x)
-        (TI (fn (s n)
-              (Tuple3 s n x))))
+    (define (pure x)
+      (TI (fn (s n)
+            (Tuple3 s n x))))
     (define (liftA2 f m1 m2)
       (>>= m1
            (fn (a)
@@ -677,15 +684,15 @@
                     (pure (f a b))))))))
 
   (define-instance (Monad TI)
-      (define (>>= f g)
-        (TI (fn (s n)
-              (match ((get-ti f) s n)
-                ((Tuple3 s_ m x)
-                 (let ((gx (get-ti (g x))))
-                   (gx s_ m))))))))
+    (define (>>= f g)
+      (TI (fn (s n)
+            (match ((get-ti f) s n)
+              ((Tuple3 s_ m x)
+               (let ((gx (get-ti (g x))))
+                 (gx s_ m))))))))
 
   (define-instance (MonadFail TI)
-      (define fail error))
+    (define fail error))
 
   (declare runTI ((TI :a) -> :a))
   (define (runTI t)
@@ -723,29 +730,29 @@
 
 
   (define-class (Instantiate :t)
-      (inst ((List Type) -> :t -> :t)))
+    (inst ((List Type) -> :t -> :t)))
 
   (define-instance (Instantiate Type)
-      (define (inst ts t)
-        (match t
-          ((TAp l r) (TAp (inst ts l) (inst ts r)))
-          ((TGen n)  (fromSome "Failed to find TGen type" (list:index n ts)))
-          (_ t))))
+    (define (inst ts t)
+      (match t
+        ((TAp l r) (TAp (inst ts l) (inst ts r)))
+        ((TGen n)  (fromSome "Failed to find TGen type" (list:index n ts)))
+        (_ t))))
 
   (define-instance (Instantiate :a => (Instantiate (List :a)))
-      (define (inst ts)
-        (map (inst ts))))
+    (define (inst ts)
+      (map (inst ts))))
 
   (define-instance (Instantiate :t => (Instantiate (Qual :t)))
-      (define (inst ts q)
-        (match q
-          ((Qual ps t) (Qual (inst ts ps)
-                             (inst ts t))))))
+    (define (inst ts q)
+      (match q
+        ((Qual ps t) (Qual (inst ts ps)
+                           (inst ts t))))))
 
   (define-instance (Instantiate Pred)
-      (define (inst ts p)
-        (match p
-          ((IsIn c t) (IsIn c (inst ts t))))))
+    (define (inst ts p)
+      (match p
+        ((IsIn c t) (IsIn c (inst ts t))))))
 
 
   ;;
@@ -908,10 +915,10 @@
   (define (split ce fs gs ps)
     (do (ps_ <- (reduce ce ps))
         (match (list:partition (fn (x) (all (flip list:member fs) (tv x)))
-                          ps_)
-        ((Tuple ds rs)
-         (do (rs_ <- (defaultedPreds ce (append fs gs) rs))
-             (pure (Tuple ds (list:difference rs rs_))))))))
+                               ps_)
+          ((Tuple ds rs)
+           (do (rs_ <- (defaultedPreds ce (append fs gs) rs))
+               (pure (Tuple ds (list:difference rs rs_))))))))
 
   (define-type Ambiguity
     (Ambiguity Tyvar (List Pred)))
@@ -958,10 +965,10 @@
                        (all (flip list:member stdClasses) is)))
              (let ((ts_ (defaults ce)))
                (if (all (fn (t_)
-                               (all (entail ce Nil)
-                                    (map (fn (i) (IsIn i t_))
-                                         is)))
-                             ts_)
+                          (all (entail ce Nil)
+                               (map (fn (i) (IsIn i t_))
+                                    is)))
+                        ts_)
                    ts_
                    Nil))
              Nil)))))
@@ -1004,23 +1011,23 @@
              ((Qual qs t)
               (do (ps <- (tiAlts ce as alts t))
                   (s <- getSubst)
-                  (let qs_ = (apply s qs))
-                  (let t_  = (apply s t))
-                  (let fs  = (tv (apply s as)))
-                  (let gs  = (list:difference (tv t_) fs))
-                  (let sc_ = (quantify gs (Qual qs_ t_)))
-                  (let ps_ = (filter (fn (p) (not (entail ce qs_ p)))
-                                     (apply s ps)))
-                  (ps <- (split ce fs gs ps_))
-                  (match ps
-                    ((Tuple ds rs)
-                     (cond
-                       ((/= sc sc_)
-                        (fail "Signature too general"))
-                       ((not (list:null? rs))
-                        (fail "Context too weak"))
-                       (True
-                        (pure ds))))))))))))
+                (let qs_ = (apply s qs))
+                (let t_  = (apply s t))
+                (let fs  = (tv (apply s as)))
+                (let gs  = (list:difference (tv t_) fs))
+                (let sc_ = (quantify gs (Qual qs_ t_)))
+                (let ps_ = (filter (fn (p) (not (entail ce qs_ p)))
+                                   (apply s ps)))
+                (ps <- (split ce fs gs ps_))
+                (match ps
+                  ((Tuple ds rs)
+                   (cond
+                     ((/= sc sc_)
+                      (fail "Signature too general"))
+                     ((not (list:null? rs))
+                      (fail "Context too weak"))
+                     (True
+                      (pure ds))))))))))))
 
 
   (define-type Impl
@@ -1044,43 +1051,45 @@
         (let is    = (map (fn (b)
                             (match b
                               ((Impl i _) i)))
-                      bs))
-        (let scs   = (map toScheme ts))
-        (let as_   = (append (zipWith Assump is scs) as))
-        (let altss = (map (fn (b)
-                            (match b
-                              ((Impl _ a) a)))
                           bs))
-        (pss <- (sequence (zipWith (tiAlts ce as_) altss ts)))
-        (s <- getSubst)
-        (let ps_ = (apply s (concat pss)))
-        (let ts_ = (apply s ts))
-        (let fs  = (tv (apply s as)))
-        (let vss = (map tv ts_))
-        (let gs  = (list:difference
+      (let scs   = (map toScheme ts))
+      (let as_   = (append (zipWith Assump is scs) as))
+      (let altss = (map (fn (b)
+                          (match b
+                            ((Impl _ a) a)))
+                        bs))
+      (pss <- (sequence (zipWith (tiAlts ce as_) altss ts)))
+      (s <- getSubst)
+      (let ps_ = (apply s (concat pss)))
+      (let ts_ = (apply s ts))
+      (let fs  = (tv (apply s as)))
+      (let vss = (map tv ts_))
+      (let gs  = (list:difference
+                  (match vss
+                    ((Cons vs vss)
+                     (foldr list:union vs vss))
+                    (_ (error "unreachable")))
+                  fs))
+      (ps <- (split ce fs
                     (match vss
                       ((Cons vs vss)
-                       (foldr list:union vs vss)))
-                    fs))
-        (ps <- (split ce fs
-                      (match vss
-                        ((Cons vs vss)
-                         (foldr list:intersection vs vss)))
-                      ps_))
-        (match ps
-          ((Tuple ds rs)
-           (if (restricted bs)
-               (let ((gs_ (list:difference gs (tv rs)))
-                     (scs_ (map (fn (x)
-                                  (quantify gs_ (Qual Nil x)))
-                                ts_)))
-                 (pure (Tuple (append ds rs)
-                              (zipWith Assump is scs_))))
-               (let ((scs_ (map (fn (x)
-                                  (quantify gs (Qual rs x)))
-                                ts_)))
-                 (pure (Tuple ds
-                              (zipWith Assump is scs_)))))))))
+                       (foldr list:intersection vs vss))
+                      (_ (error "unreachable")))
+                    ps_))
+      (match ps
+        ((Tuple ds rs)
+         (if (restricted bs)
+             (let ((gs_ (list:difference gs (tv rs)))
+                   (scs_ (map (fn (x)
+                                (quantify gs_ (Qual Nil x)))
+                              ts_)))
+               (pure (Tuple (append ds rs)
+                            (zipWith Assump is scs_))))
+             (let ((scs_ (map (fn (x)
+                                (quantify gs (Qual rs x)))
+                              ts_)))
+               (pure (Tuple ds
+                            (zipWith Assump is scs_)))))))))
 
   (define-type BindGroup
     (BindGroup (List Expl) (List (List Impl))))
@@ -1095,11 +1104,11 @@
                                 (Assump v sc))))
                            es))
            (tiI <- (tiSeq tiImpls ce (append as_ as) iss))
-           (match tiI
-             ((Tuple ps as__)
-              (do (qss <- (traverse (tiExpl ce (append as__ (append as_ as))) es))
-                  (pure (Tuple (append ps (concat qss))
-                               (append as__ as_))))))))))
+         (match tiI
+           ((Tuple ps as__)
+            (do (qss <- (traverse (tiExpl ce (append as__ (append as_ as))) es))
+                (pure (Tuple (append ps (concat qss))
+                             (append as__ as_))))))))))
 
   (declare tiSeq ((ClassEnv -> (List Assump) -> :bg -> (TI (Tuple (List Pred) (List Assump)))) ->
                   (ClassEnv -> (List Assump) -> (List :bg) -> (TI (Tuple (List Pred) (List Assump))))))

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -340,7 +340,7 @@
        (if (member x xs)
            (remove-duplicates-rev xs acc)
            (remove-duplicates-rev xs (Cons x acc))))))
-        
+
   (declare remove-duplicates (Eq :a => ((List :a) -> (List :a))))
   (define (remove-duplicates xs)
     "Returns a new list without duplicate elements."
@@ -432,7 +432,7 @@
   (declare insertBy ((:a -> :a -> Ord) -> :a -> (List :a) -> (List :a)))
   (define (insertBy cmp x ys)
     "Generic version of insert"
-    (let ((rec 
+    (let ((rec
             (fn (ys acc)
               (match ys
                 ((Nil) (Cons x acc))
@@ -489,12 +489,15 @@
        (Cons (Cons x (map
                       (fn (ys)
                         (match ys
-                          ((Cons h _) h)))
+                          ((Cons h _) h)
+                          ((Nil) (error "Invalid shape"))))
                       xss))
+
              (transpose (Cons xs (map
                                   (fn (ys)
                                     (match ys
-                                      ((Cons _ t) t)))
+                                      ((Cons _ t) t)
+                                      ((Nil) (error "Invalid shape"))))
                                   xss)))))))
 
   (declare partition ((:a -> Boolean) -> (List :a) -> (Tuple (List :a) (List :a))))
@@ -617,7 +620,7 @@ This function is equivalent to all size-N elements of `(COMBS L)`."
                   ((Cons x xs) (append
                                 (map (Cons x) (combsOf (- n 1) xs)) ; combs with X
                                 (combsOf n xs)))))))                ; and without x
-                              
+
 
   ;;
   ;; List instances

--- a/library/ord-map.lisp
+++ b/library/ord-map.lisp
@@ -174,7 +174,9 @@ If ITER contains duplicate keys, later values will overwrite earlier values."
                                                       (helper less)))
                    ((Eq) (Some (tree::Branch clr less (MapPair pivot (func val)) more)))
                    ((GT) (coalton-library/classes:map (tree::Branch clr less (MapPair pivot val))
-                                                      (helper more)))))))))
+                                                      (helper more)))))
+                ((tree::Branch _ _ (JustKey _) _) (error "Map contains `JustKey` rather than `MapPair`"))
+                ((tree::DoubleBlackEmpty) (error "Encountered double-black node in ordered map outside of removal operation"))))))
       (coalton-library/classes:map %Map
                                    (helper tre))))
 
@@ -203,7 +205,9 @@ operation, and therefore Map cannot implement Monoid."
                          (tree::Branch clr
                                        (helper left)
                                        (MapPair key (func value))
-                                       (helper right)))))))
+                                       (helper right)))
+                        ((tree::Branch _ _ (JustKey _) _) (error "Map contains `JustKey` rather than `MapPair`"))
+                        ((tree::DoubleBlackEmpty) (error "Encountered double-black node in ordered map outside of removal operation"))))))
         (%Map (helper tre)))))
 
   ;; As with `tree:Tree', `Map' should probably implement `Traversable'.

--- a/src/analysis/package.lisp
+++ b/src/analysis/package.lisp
@@ -1,0 +1,4 @@
+(uiop:define-package #:coalton-impl/analysis
+  (:documentation "Static analysis passes for COALTON.")
+  (:mix-reexport
+   #:coalton-impl/analysis/pattern-exhaustiveness))

--- a/src/analysis/pattern-exhaustiveness.lisp
+++ b/src/analysis/pattern-exhaustiveness.lisp
@@ -1,0 +1,298 @@
+(defpackage #:coalton-impl/analysis/pattern-exhaustiveness
+  (:use #:cl)
+  (:local-nicknames
+   (#:settings #:coalton-impl/settings)
+   (#:rt #:coalton-impl/runtime)
+   (#:tc #:coalton-impl/typechecker)
+   (#:ast #:coalton-impl/ast)
+   (#:util #:coalton-impl/util)
+   (#:error #:coalton-impl/error))
+  (:export
+   #:coalton-non-exhaustive-match-warning
+   #:coalton-useless-pattern-warning
+   #:exhaustive-patterns-p
+   #:useful-pattern-p
+   #:find-non-matching-value))
+
+(in-package #:coalton-impl/analysis/pattern-exhaustiveness)
+
+;;;
+;;; This file provides an implementation of pattern matching
+;;; exhaustiveness and usefulness analysis as described in
+;;; Maranget 2007, http://moscova.inria.fr/~maranget/papers/warn/index.html
+;;;
+
+
+(define-condition coalton-non-exhaustive-match-warning (error:coalton-warning)
+  ((missing-clause :initarg :missing-clause
+                   :initform nil
+                   :reader coalton-non-exhaustive-match-warning-missing-clause))
+  (:report
+   (lambda (c s)
+     (let ((*print-circle* nil) ; Prevent printing using reader macros
+           (missing-clause (coalton-non-exhaustive-match-warning-missing-clause c)))
+       (if (null missing-clause)
+           (format s "Match patterns are non-exhaustive.")
+           (format s "Match patterns are non-exhaustive. Missing pattern ~W" missing-clause))))))
+
+(define-condition coalton-useless-pattern-warning (error:coalton-warning)
+  ((pattern :initarg :pattern
+            :initform (util:required 'pattern)
+            :reader coalton-useless-pattern-warning-pattern))
+  (:report
+   (lambda (c s)
+     (let ((*print-circle* nil) ; Prevent printing using reader macros
+           (pattern (coalton-useless-pattern-warning-pattern c)))
+       (format s "Useless match pattern ~W" pattern)))))
+
+(defun exhaustive-patterns-p (patterns env)
+  "Are PATTERNS exhaustive?"
+  (not
+   (useful-pattern-clause-p
+    (mapcar #'list patterns)
+    (list (ast:make-pattern-wildcard))
+    env)))
+
+(defun useful-pattern-p (patterns pattern env)
+  "Is PATTERN useful within list PATTERNS? PATTERN must EQ one element of PATTERNS."
+  (useful-pattern-clause-p
+   (loop :for p :in patterns
+         :while (not (eq p pattern))
+         :collect (list p))
+   (list pattern)
+   env))
+
+(defun pattern-matrix-p (x)
+  ;; TODO: Check that all lengths are equal
+  (and (alexandria:proper-list-p x)
+       (every #'ast:pattern-list-p x)))
+
+(deftype pattern-matrix ()
+  '(satisfies pattern-matrix-p))
+
+(defun useful-pattern-clause-p (pattern-matrix clause env)
+  "Is CLAUSE useful with respect to PATTERN-MATRIX?
+
+PATTERN-MATRIX is a list of lists representing a pattern matrix in row-major format.
+CLAUSE is a list representing a row-vector of patterns."
+  (declare (type pattern-matrix pattern-matrix)
+           (type ast:pattern-list clause)
+           (type tc:environment env)
+           (values boolean &optional))
+
+  ;; NOTE: It is assumed that all rows of PATTERN-MATRIX have the same number of columns.
+  (cond
+    ;;
+    ;; Check our base cases
+    ;;
+
+    ;; If there are no rows then the pattern is useful.
+    ((zerop (length pattern-matrix))
+     t)
+    ;; If both PATTERN-MATRIX and CLAUSE have no columns then the pattern is not useful.
+    ((zerop (length (first pattern-matrix)))
+     nil)
+
+    ;;
+    ;; Now, we check based on the first member of CLAUSE.
+    ;;
+
+    ;; Sub-case 1: The first member of CLAUSE is a constructor (or literal).
+    ((or (ast:pattern-literal-p (first clause))
+         (ast:pattern-constructor-p (first clause)))
+     (useful-pattern-clause-p
+      (specialize-matrix pattern-matrix (first clause))
+      (first (specialize-matrix (list clause) (first clause)))
+      env))
+
+    ;; Sub-case 2: The first member of CLAUSE is a wildcard (or variable)
+    ((or (ast:pattern-wildcard-p (first clause))
+         (ast:pattern-var-p (first clause)))
+
+     (let ((first-column-constructors
+             (loop :for row :in pattern-matrix
+                   :for elem := (first row)
+                   :when (or (ast:pattern-literal-p elem)
+                             (ast:pattern-constructor-p elem))
+                     :collect elem)))
+       (cond
+         ;; If the constructors form a complete signature then CLAUSE
+         ;; is only useful if it is useful when specialized over the
+         ;; constructor.
+         ((complete-signature-p first-column-constructors env)
+          (loop :for pattern :in first-column-constructors
+                :when (useful-pattern-clause-p
+                       (specialize-matrix pattern-matrix pattern)
+                       (first (specialize-matrix (list clause) pattern))
+                       env)
+                  :do (return t)
+                :finally (return nil)))
+         ;; Otherwise, create a defaulted matrix and recurse, removing
+         ;; the first member of CLAUSE.
+         (t
+          (useful-pattern-clause-p
+           (default-matrix pattern-matrix)
+           (rest clause)
+           env)))))
+    (t
+     (util:coalton-bug "Not reachable."))))
+
+(defun specialize-matrix (pattern-matrix pattern)
+  "Specialize the given PATTERN-MATRIX to the constructor given in PATTERN."
+  (declare (type pattern-matrix pattern-matrix)
+           (type (or ast:pattern-literal ast:pattern-constructor) pattern)
+           (values pattern-matrix))
+  (loop :for row :in pattern-matrix
+        ;; Only specialize on the first component of each row.
+        :for elem := (first row)
+        ;; NOTE: ELEM cannot be a literal when PATTERN is a
+        ;;       constructor nor the other way around.
+        :append (cond
+                  ;; If ELEM is the same literal then remove this pattern.
+                  ((and (ast:pattern-literal-p elem)
+                        ;; TODO: Figure out a better equality check
+                        (equal (ast:pattern-literal-value pattern)
+                               (ast:pattern-literal-value elem)))
+                   (list (rest row)))
+                  ;; If ELEM is not the same literal then emit nothing.
+                  ((ast:pattern-literal-p elem)
+                   nil)
+
+                  ;; If ELEM is the same constructor then expand the inner patterns.
+                  ((and (ast:pattern-constructor-p elem)
+                        (eq (ast:pattern-constructor-name pattern)
+                            (ast:pattern-constructor-name elem)))
+                   (list (append (ast:pattern-constructor-patterns elem)
+                                 (rest row))))
+                  ;; If ELEM is not the same constructor then emit nothing.
+                  ((ast:pattern-constructor-p elem)
+                   nil)
+
+                  ;; If ELEM is a wildcard (or variable) then emit
+                  ;; wildcards for each pattern in the constructor (or
+                  ;; literal).
+                  ((or (ast:pattern-wildcard-p elem)
+                       (ast:pattern-var-p elem))
+                   (etypecase pattern
+                     (ast:pattern-literal
+                      (list (rest row)))
+                     (ast:pattern-constructor
+                      (list (append (mapcar (constantly (ast:make-pattern-wildcard))
+                                            (ast:pattern-constructor-patterns pattern))
+                                    (rest row))))))
+                  (t
+                   (util:coalton-bug "Not reachable.")))))
+
+(defun complete-signature-p (patterns env)
+  "Do the set of PATTERNS form a complete signature of the constructed type?"
+  (declare (type ast:pattern-list patterns)
+           (type tc:environment env)
+           (values boolean))
+  (cond
+    ;; Zero constructors cannot form a complete signature.
+    ((zerop (length patterns))
+     nil)
+
+    ;; Literals cannot have complete signatures.
+    ;; NOTE: This will change when we allow number literals to take on finite types.
+    ((some #'ast:pattern-literal-p patterns)
+     nil)
+
+    ;; Otherwise ensure that all constructors are accounted for in PATTERNS.
+    (t
+     (let* ((constructor-names (mapcar #'ast:pattern-constructor-name patterns))
+            (constructed-type (tc:constructor-entry-constructs (tc:lookup-constructor env (first constructor-names))))
+            (type-constructors (tc:type-entry-constructors (tc:lookup-type env constructed-type))))
+       (null (set-difference type-constructors constructor-names :test #'eq))))))
+
+(defun default-matrix (pattern-matrix)
+  "Default the given PATTERN-MATRIX."
+  (declare (type pattern-matrix pattern-matrix)
+           (values pattern-matrix))
+  (loop :for row :in pattern-matrix
+        ;; Only consider the first component of each row.
+        :for elem := (first row)
+        :append (cond
+                  ;; If ELEM is a constructor (or literal) then don't emit a row.
+                  ((or (ast:pattern-literal-p elem)
+                       (ast:pattern-constructor-p elem))
+                   nil)
+                  ;; If ELEM is a wildcard (or variable) then remove ELEM.
+                  ((or (ast:pattern-wildcard-p elem)
+                       (ast:pattern-var-p elem))
+                   (list (rest row)))
+                  (t
+                   (util:coalton-bug "Not reachable.")))))
+
+(defun find-non-matching-value (pattern-matrix n env)
+  "Finds an example of a non-matching value for PATTERN-MATRIX or, if PATTERN-MATRIX is exhaustive returns T."
+  (declare (type pattern-matrix pattern-matrix)
+           (type (integer 0) n)
+           (optimize (debug 3)))
+  (cond
+    ;; An empty pattern generates n wildcards.
+    ((and (zerop (length pattern-matrix)))
+     (loop :for i :below n :collect (ast:make-pattern-wildcard)))
+    ;; Zero wildcards with a pattern matrix that has zero columns indicates the matrix is exhaustive.
+    ((and (zerop n)
+          (zerop (length (first pattern-matrix))))
+     t)
+    (t
+     (let ((first-column-constructors
+             (loop :for row :in pattern-matrix
+                   :for elem := (first row)
+                   :when (ast:pattern-constructor-p elem)
+                     :collect elem)))
+       (cond
+         ;; If the constructors in the PATTERN-MATRIX form a complete
+         ;; signature then specialize and return the first
+         ;; non-matching sub-value.
+         ((complete-signature-p first-column-constructors env)
+          (loop :for ctor :in first-column-constructors
+                :for ctor-arity := (length (ast:pattern-constructor-patterns ctor))
+                :for val := (find-non-matching-value
+                             (specialize-matrix pattern-matrix ctor)
+                             (+ ctor-arity n -1)
+                             env)
+                :unless (eq val t)
+                  :do (return (cons (ast:make-pattern-constructor
+                                     :name (ast:pattern-constructor-name ctor)
+                                     :patterns (subseq val 0 ctor-arity))
+                                    (subseq val ctor-arity (+ ctor-arity n -1))))
+                :finally (return t)))
+         ;; Otherwise, check the defaulted matrix.
+         (t
+          (let ((val (find-non-matching-value
+                      (default-matrix pattern-matrix)
+                      (1- n)
+                      env)))
+            (cond
+              ;; If this is exhaustive then PATTERN-MATRIX is exhaustive.
+              ((eq val t)
+               t)
+              ;; If there are no constructors then emit a wildcard.
+              ((null first-column-constructors)
+               (cons (ast:make-pattern-wildcard) val))
+              ;; Or emit a constructor which was not named in this pattern.
+              (t
+               (cons (find-unnamed-constructor first-column-constructors env)
+                     val))))))))))
+
+(defun find-unnamed-constructor (patterns env)
+  "Find and create a pattern constructor with the type of, but not named in PATTERNS."
+  (declare (type ast:pattern-list patterns)
+           (type tc:environment env)
+           (values ast:pattern))
+  (let* ((constructor-names (mapcar #'ast:pattern-constructor-name patterns))
+         (constructed-type (tc:constructor-entry-constructs (tc:lookup-constructor env (first constructor-names))))
+         (type-constructors (tc:type-entry-constructors (tc:lookup-type env constructed-type)))
+         (unnamed-constructor (first (set-difference type-constructors constructor-names :test #'eq)))
+         (unnamed-constructor-entry (tc:lookup-constructor env unnamed-constructor)))
+    (unless unnamed-constructor
+      (util:coalton-bug "Not reachable."))
+
+    ;; TODO: Return all constructors?
+    (ast:make-pattern-constructor
+     :name unnamed-constructor
+     :patterns (loop :for i :below (tc:constructor-entry-arity unnamed-constructor-entry)
+                     :collect (ast:make-pattern-wildcard)))))

--- a/src/ast/pattern.lisp
+++ b/src/ast/pattern.lisp
@@ -6,6 +6,7 @@
    (#:util #:coalton-impl/util))
   (:export
    #:pattern                            ; STRUCT
+   #:pattern-list-p                     ; FUNCTION
    #:pattern-list                       ; TYPE
    #:pattern-var                        ; STRUCT
    #:make-pattern-var                   ; CONSTRUCTOR

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -2,6 +2,8 @@
   (:use #:cl)
   (:export
    #:coalton-error                      ; CONDITION
+   #:coalton-warning                    ; CONDITION
+   #:coalton-style-warning              ; CONDITION
    #:with-context                       ; MACRO
    #:coalton-type-error                 ; CONDITION
    ))
@@ -16,10 +18,26 @@
   ()
   (:documentation "Supertype for Coalton type errors"))
 
+(define-condition coalton-warning (warning)
+  ()
+  (:documentation "Supertype for Coalton warnings"))
+
+(define-condition coalton-style-warning (style-warning)
+  ()
+  (:documentation "Supertype for Coalton style warnings"))
+
 (defvar *error-context-stack* '()
   "The stack of context frames for the current operation")
 
 (defmethod print-object :after ((er coalton-error) stream)
+  (dolist (ctx *error-context-stack*)
+    (format stream "~%In ~A" ctx)))
+
+(defmethod print-object :after ((er coalton-warning) stream)
+  (dolist (ctx *error-context-stack*)
+    (format stream "~%In ~A" ctx)))
+
+(defmethod print-object :after ((er coalton-style-warning) stream)
   (dolist (ctx *error-context-stack*)
     (format stream "~%In ~A" ctx)))
 

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -32,6 +32,7 @@
    #:type-entry-name                        ; ACCESSOR
    #:type-entry-runtime-type                ; ACCESSOR
    #:type-entry-type                        ; ACCESSOR
+   #:type-entry-constructors                ; ACCESSOR
    #:type-entry-explicit-repr               ; ACCESSOR
    #:type-entry-enum-repr                   ; ACCESSOR
    #:type-entry-newtype                     ; ACCESSOR
@@ -194,12 +195,11 @@
   (name         (util:required 'name)         :type symbol  :read-only t)
   (runtime-type (util:required 'runtime-type) :type t       :read-only t)
   (type         (util:required 'type)         :type ty      :read-only t)
+  (constructors (util:required 'constructors) :type list    :read-only t)
 
   ;; An explicit repr defined in the source, or nil if none was supplied. Computed repr will be reflected in
   ;; ENUM-REPR, NEWTYPE, and/or RUNTIME-TYPE.
-  (explicit-repr (util:required 'explicit-repr)
-                                         :type explicit-repr
-                                                       :read-only t)
+  (explicit-repr (util:required 'explicit-repr) :type explicit-repr  :read-only t)
 
   ;; If this is true then the type is compiled to a more effecient
   ;; enum representation at runtime
@@ -243,6 +243,7 @@
             :name 'coalton:Boolean
             :runtime-type 'cl:boolean
             :type *boolean-type*
+            :constructors '(coalton:True coalton:False)
             :explicit-repr '(:native cl:boolean)
             :enum-repr t
             :newtype nil
@@ -254,6 +255,7 @@
             :name 'coalton:Char
             :runtime-type 'cl:character
             :type *char-type*
+            :constructors nil
             :explicit-repr '(:native cl:character)
             :enum-repr nil
             :newtype nil
@@ -265,6 +267,7 @@
             :name 'coalton:Integer
             :runtime-type 'cl:integer
             :type *integer-type*
+            :constructors nil
             :explicit-repr '(:native cl:integer)
             :enum-repr nil
             :newtype nil
@@ -276,6 +279,7 @@
             :name 'coalton:Single-Float
             :runtime-type 'cl:single-float
             :type *single-float-type*
+            :constructors nil
             :explicit-repr '(:native cl:single-float)
             :enum-repr nil
             :newtype nil
@@ -287,6 +291,7 @@
             :name 'coalton:Double-Float
             :runtime-type 'cl:double-float
             :type *double-float-type*
+            :constructors nil
             :explicit-repr '(:native cl:double-float)
             :enum-repr nil
             :newtype nil
@@ -298,6 +303,7 @@
             :name 'coalton:String
             :runtime-type 'cl:string
             :type *string-type*
+            :constructors nil
             :explicit-repr '(:native cl:string)
             :enum-repr nil
             :newtype nil
@@ -309,6 +315,7 @@
             :name 'coalton:Fraction
             :runtime-type 'cl:rational
             :type *fraction-type*
+            :constructors nil
             :explicit-repr '(:native cl:rational)
             :enum-repr nil
             :newtype nil
@@ -320,6 +327,7 @@
             :name 'coalton:Arrow
             :runtime-type nil
             :type *arrow-type*
+            :constructors nil
             :explicit-repr nil
             :enum-repr nil
             :newtype nil
@@ -331,6 +339,7 @@
             :name 'coalton:List
             :runtime-type 'cl:list
             :type *list-type*
+            :constructors '(coalton:Cons coalton:Nil)
             :explicit-repr '(:native cl:list)
             :enum-repr nil
             :newtype nil

--- a/src/typechecker/parse-type-definition.lisp
+++ b/src/typechecker/parse-type-definition.lisp
@@ -186,6 +186,7 @@
                   :name name
                   :runtime-type name
                   :type type__
+                  :constructors nil
                   :explicit-repr nil
                   :enum-repr nil
                   :newtype nil
@@ -465,6 +466,7 @@ Returns TYPE-DEFINITIONS"
                          :name tycon-name
                          :runtime-type (type-definition-runtime-type type-definition)
                          :type (type-definition-type type-definition)
+                         :constructors (mapcar #'constructor-entry-name (type-definition-constructors type-definition))
                          :explicit-repr (type-definition-explicit-repr type-definition)
                          :enum-repr (type-definition-enum-repr type-definition)
                          :newtype (type-definition-newtype type-definition)
@@ -481,7 +483,8 @@ Returns TYPE-DEFINITIONS"
                            (setf env
                                  (set-constructor
                                   env
-                                  (constructor-entry-name ctor) ctor))
+                                  ctor-name
+                                  ctor))
 
                            ;; Add the constructor as a value to the value environment
                            (setf env
@@ -494,9 +497,9 @@ Returns TYPE-DEFINITIONS"
                            (setf env
                                  (set-name
                                   env
-                                  (constructor-entry-name ctor)
+                                  ctor-name
                                   (make-name-entry
-                                   :name (constructor-entry-name ctor)
+                                   :name ctor-name
                                    :type :constructor
                                    :docstring nil
                                    :location (or *compile-file-pathname*
@@ -508,9 +511,9 @@ Returns TYPE-DEFINITIONS"
                                (setf env
                                      (set-function
                                       env
-                                      (constructor-entry-name ctor)
+                                      ctor-name
                                       (make-function-env-entry
-                                       :name (constructor-entry-name ctor)
+                                       :name ctor-name
                                        :arity (constructor-entry-arity ctor))))
 
                                ;; If the constructor does not take
@@ -519,7 +522,7 @@ Returns TYPE-DEFINITIONS"
                                (setf env
                                      (unset-function
                                       env
-                                      (constructor-entry-name ctor))))))
+                                      ctor-name)))))
 
                  type-definition)))
        env))))

--- a/tests/red-black-tests.lisp
+++ b/tests/red-black-tests.lisp
@@ -7,7 +7,8 @@
     (RedWithRedRightChild (red-black/tree:Tree :elt))
     (DifferentCountToBlack UFix (red-black/tree:Tree :elt)
                            UFix (red-black/tree:Tree :elt))
-    (BothChildrenErrors (InvariantError :elt) (InvariantError :elt)))
+    (BothChildrenErrors (InvariantError :elt) (InvariantError :elt))
+    (IllegalColor (red-black/tree:Tree :elt)))
 
   (declare count-blacks-to-leaf ((red-black/tree:Tree :elt) -> (Result (InvariantError :elt) UFix)))
   (define (count-blacks-to-leaf tre)
@@ -34,11 +35,13 @@
           (Err right-err))
          ((Tuple (Ok left-ct) (Ok right-ct))
           (if (== left-ct right-ct)
-              (Ok (+ left-ct (match c
-                               ((red-black/tree::Black) 1)
-                               ((red-black/tree::Red) 0))))
+              (match c
+                ((red-black/tree::Black) (Ok (+ left-ct 1)))
+                ((red-black/tree::Red) (Ok left-ct))
+                (_ (Err (IllegalColor tre))))
               (Err (DifferentCountToBlack left-ct left
-                                          right-ct right)))))))))
+                                          right-ct right))))))
+      (_ (Err (IllegalColor tre))))))
 
 (coalton-toplevel
   (declare random-below! (UFix -> UFix))


### PR DESCRIPTION
This adds pattern exhaustiveness and usefulness warnings to Coalton `match` forms.

Implementation based on http://moscova.inria.fr/~maranget/papers/warn/index.html

Resolves #8 