### PR TITLE
Don't fail CI on benchmark alerts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
           tool: "customSmallerIsBetter"
           output-file-path: "./bench.json"
           external-data-json-path: "./cache/benchmark-data.json"
-          fail-on-alert: true
+          fail-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
           alert-comment-cc-users: "@eliaslfox"


### PR DESCRIPTION
This is a stop-gap for the current failing CI. In the future it would be best to just ensure benchmarks run for long enough that the runtime can't be zero.