### PR TITLE
Rename various `is*` functions to match Style Guide

### DIFF
--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -736,7 +736,7 @@
     (define (inst ts t)
       (match t
         ((TAp l r) (TAp (inst ts l) (inst ts r)))
-        ((TGen n)  (fromSome "Failed to find TGen type" (list:index n ts)))
+        ((TGen n)  (from-some "Failed to find TGen type" (list:index n ts)))
         (_ t))))
 
   (define-instance (Instantiate :a => (Instantiate (List :a)))
@@ -979,7 +979,7 @@
           (tss (map (candidates ce) vps)))
       (if (any list:null? tss)
           (fail "Cannot resolve ambiguity")
-          (pure (f vps (map (fn (l) (fromSome "" (head l))) tss))))))
+          (pure (f vps (map (fn (l) (from-some "" (head l))) tss))))))
 
   (declare defaultedPreds (MonadFail :m => (ClassEnv -> (List Tyvar) -> (List Pred) -> (:m (List Pred)))))
   (define defaultedPreds

--- a/examples/thih/tests/thih-coalton-tests.lisp
+++ b/examples/thih/tests/thih-coalton-tests.lisp
@@ -1,6 +1,6 @@
 (cl:in-package #:thih-coalton-tests)
 
-(cl:defparameter *initial-env* (coalton-prelude:fromSome "Failed to init classenv"
+(cl:defparameter *initial-env* (coalton-prelude:from-some "Failed to init classenv"
                                                          (compose
                                                           addPreludeClasses
                                                           exampleInsts

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -507,7 +507,7 @@ Returns `True` if ITER is empty."
     "Return `True` as soon as any element of ITER is GOOD?, or `False` if none of them are.
 
 Returns `False` if ITER is empty."
-    (isSome (find! good? iter)))
+    (some? (find! good? iter)))
 
   (declare elementwise-match! ((:elt -> :elt -> Boolean) -> (Iterator :elt) -> (Iterator :elt) -> Boolean))
   (define (elementwise-match! same? left right)

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -226,7 +226,7 @@
   (declare nth (UFix -> List :t -> :t))
   (define (nth n l)
     "Like INDEX, but errors if the index is not found."
-    (fromSome "There is no NTH" (index n l)))
+    (from-some "There is no NTH" (index n l)))
 
   (declare elemIndex (Eq :a => :a -> List :a -> Optional UFix))
   (define (elemIndex x xs)

--- a/library/optional.lisp
+++ b/library/optional.lisp
@@ -6,9 +6,9 @@
   (:local-nicknames
    (#:classes #:coalton-library/classes))
   (:export
-   #:fromSome
-   #:isSome
-   #:isNone))
+   #:from-some
+   #:some?
+   #:none?))
 
 #+coalton-release
 (cl:declaim #.coalton-impl:*coalton-optimize-library*)
@@ -20,23 +20,23 @@
   ;; Optional
   ;;
 
-  (declare fromSome (String -> (Optional :a) -> :a))
-  (define (fromSome str opt)
+  (declare from-some (String -> (Optional :a) -> :a))
+  (define (from-some str opt)
     "Get the value of OPT, erroring with the provided string if it is None."
     (match opt
       ((Some x) x)
       ((None) (lisp :a (str) (cl:error str)))))
 
-  (declare isSome ((Optional :a) -> Boolean))
-  (define (isSome x)
+  (declare some? ((Optional :a) -> Boolean))
+  (define (some? x)
     "Is X Some?"
     (lisp Boolean (x)
       (cl:etypecase x
         (classes::Optional/Some True)
         (classes::Optional/None False))))
 
-  (declare isNone ((Optional :a) -> Boolean))
-  (define (isNone x)
+  (declare none? ((Optional :a) -> Boolean))
+  (define (none? x)
     "Is X None?"
     (lisp Boolean (x)
       (cl:etypecase x

--- a/library/prelude.lisp
+++ b/library/prelude.lisp
@@ -101,13 +101,13 @@
 
   (:import-from
    #:coalton-library/optional
-   #:fromSome
-   #:isSome
-   #:isNone)
+   #:from-some
+   #:some?
+   #:none?)
   (:export
-   #:fromSome
-   #:isSome
-   #:isNone)
+   #:from-some
+   #:some?
+   #:none?)
 
   (:import-from
    #:coalton-library/list

--- a/library/result.lisp
+++ b/library/result.lisp
@@ -7,9 +7,9 @@
   (:local-nicknames
    (#:classes #:coalton-library/classes))
   (:export
-   #:isOk
-   #:isErr
-   #:mapErr
+   #:ok?
+   #:err?
+   #:map-err
    #:flatten))
 
 #+coalton-release
@@ -22,24 +22,24 @@
   ;; Result
   ;;
 
-  (declare isOk (Result :a :b -> Boolean))
-  (define (isOk x)
+  (declare ok? (Result :a :b -> Boolean))
+  (define (ok? x)
     "Returns TRUE if X is ERR"
     (lisp Boolean (x)
       (cl:etypecase x
         (classes::Result/Ok True)
         (classes::Result/Err False))))
 
-  (declare isErr (Result :a :b -> Boolean))
-  (define (isErr x)
+  (declare err? (Result :a :b -> Boolean))
+  (define (err? x)
     "Returns TRUE if X is ERR"
     (lisp Boolean (x)
       (cl:etypecase x
         (classes::Result/Err True)
         (classes::Result/Ok False))))
 
-  (declare mapErr ((:a -> :b) -> Result :a :c -> Result :b :c))
-  (define (mapErr f x)
+  (declare map-err ((:a -> :b) -> Result :a :c -> Result :b :c))
+  (define (map-err f x)
     "Map over the ERR case"
     (match x
       ((Err x) (Err (f x)))

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -105,7 +105,7 @@ does not have that suffix."
   (declare substring? (String -> String -> Boolean))
   (define (substring? small big)
     "Return true if the first argument appears as a substring within the second argument."
-    ;; not a call to `optional:isSome' because this file is loaded before optional.lisp
+    ;; not a call to `optional:some?' because this file is loaded before optional.lisp
     (match (substring-index small big)
       ((None) False)
       ((Some _) True)))

--- a/tests/hashtable-tests.lisp
+++ b/tests/hashtable-tests.lisp
@@ -13,10 +13,10 @@
       (is (== (Some 1) (get "one")))
       (is (== (Some 2) (get "two")))
       (is (== (Some 3) (get "three")))
-      (is (isNone (get "four")))
+      (is (none? (get "four")))
       (is (== 4 (hashtable:count ht)))
       (hashtable:remove! ht "zero")
-      (is (isNone (get "zero")))
+      (is (none? (get "zero")))
       (is (== 3 (hashtable:count ht))))))
 
 (define-test hashtable-constructor-equivalencies ()

--- a/tests/red-black-tests.lisp
+++ b/tests/red-black-tests.lisp
@@ -93,7 +93,7 @@
    (iter:up-to 128)))
 
 (cl:defmacro is-ok (check cl:&optional (message (cl:format cl:nil "~A returned Err" check)))
-  `(is (result:isOk ,check)
+  `(is (result:ok? ,check)
        ,message))
 
 (define-test insertion-upholds-invariants ()


### PR DESCRIPTION
Fixes #804 to make the naming of certain functions more Lispy. There are more such functions around, but for now I've fixed the ones mentioned in the original issue.