### PR TITLE
Permit recursive lets which use `the` around their initforms

### DIFF
--- a/src/parser/binding.lisp
+++ b/src/parser/binding.lisp
@@ -96,19 +96,29 @@
     (declare (values boolean))
     t))
 
+(defgeneric initform-abstraction-p (expr)
+  (:method ((expr node-abstraction))
+    (declare (ignorable expr))
+    t)
+  (:method ((expr node-the))
+    (initform-abstraction-p (node-the-expr expr)))
+  (:method (expr)
+    (declare (ignorable expr))
+    nil))
+
 (defgeneric binding-function-p (binding)
   (:documentation "Returns t if BINDING is a lambda.")
 
   (:method ((binding node-let-binding))
     (declare (values boolean))
-     (node-abstraction-p (node-let-binding-value binding)))
+    (initform-abstraction-p (node-let-binding-value binding)))
 
   (:method ((binding toplevel-define))
     (declare (values boolean))
     (and (or (toplevel-define-vars binding)
 
              (and (null (node-body-nodes (toplevel-define-body binding)))
-                  (node-abstraction-p (node-body-last-node (toplevel-define-body binding)))))
+                  (initform-abstraction-p (node-body-last-node (toplevel-define-body binding)))))
          t))
 
   (:method ((binding instance-method-definition))
@@ -116,7 +126,7 @@
     (and (or (instance-method-definition-vars binding)
 
              (and (null (node-body-nodes (instance-method-definition-body binding)))
-                  (node-abstraction-p (node-body-last-node (instance-method-definition-body binding)))))
+                  (initform-abstraction-p (node-body-last-node (instance-method-definition-body binding)))))
          t)))
 
 (defgeneric binding-last-node (binding)

--- a/tests/recursive-let-tests.lisp
+++ b/tests/recursive-let-tests.lisp
@@ -36,6 +36,31 @@
     (is list)
     (is (eq list (cdr list)))))
 
+(deftest recursive-let-the ()
+  "Test that recusive `let`-bindings whose initforms are `the` are accepted as long as the inner initform is acceptable."
+  (check-coalton-types
+   "(define foo
+      (let ((circle (the (List Integer)
+                         (Cons 0 circle))))
+        circle))"
+   '("foo" . "(List Integer)"))
+
+  (check-coalton-types
+   "(define foo
+      (let ((loop-times (the (UFix -> Unit)
+                             (fn (n)
+                               (unless (== n 0)
+                                 (loop-times (- n 1)))))))
+        (loop-times 100)))"
+   '("foo" . "Unit"))
+
+  (signals tc:tc-error
+    (check-coalton-types
+     "(define foo
+        (let ((invalid (the Integer
+                            (+ invalid 0))))
+          invalid))")))
+
 (deftest recursively-construct-via-non-constructor-function ()
   (signals tc:tc-error
     (check-coalton-types


### PR DESCRIPTION
Re: #833

This commit re-jiggers `binding-abstraction-p` to recognize forms like `(the ... (fn ...))`, and the local function `valid-recursive-constructor-call-p` within `check-for-invalid-recursive-scc` to recognize forms like `(the ... (Ctor ...))`, where `Ctor` is a constructor. This should allow recursive `let` bindings with declared types via `the`.