### PR TITLE
Fix tests on ccl

### DIFF
--- a/library/math/elementary.lisp
+++ b/library/math/elementary.lisp
@@ -184,7 +184,9 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 
            (True
             (lisp ,coalton-type (x)
-                (cl:sin x)))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:sin x))))))
 
        (define (cos x)
          (cond
@@ -195,7 +197,9 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 
            (True
             (lisp ,coalton-type (x)
-                (cl:cos x)))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:cos x))))))
 
        (define (tan x)
          (cond
@@ -206,7 +210,9 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 
            (True
             (lisp ,coalton-type (x)
-                (cl:tan x)))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:tan x))))))
 
        (define (asin x)
          (cond
@@ -219,13 +225,17 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
             (if (or (nan? x) (> x 1) (< x -1))
                 nan
                 (lisp ,coalton-type (x)
-                    (cl:asin x))))))
+                  (#+(not ccl) cl:progn
+                     #+ccl ff:with-float-traps-masked #+ccl cl:t
+                     (cl:asin x)))))))
 
        (define (acos x)
          (if (or (nan? x) (> x 1) (< x -1))
              nan
              (lisp ,coalton-type (x)
-                 (cl:acos x))))
+               (#+(not ccl) cl:progn
+                  #+ccl ff:with-float-traps-masked #+ccl cl:t
+                  (cl:acos x)))))
 
        (define (atan x)
          (cond
@@ -236,12 +246,16 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 
            (True
             (lisp ,coalton-type (x)
-                (cl:atan x))))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:atan x)))))))
 
      (define-instance (Polar ,coalton-type)
        (define (phase x)
          (lisp ,coalton-type (x)
-             (cl:phase x)))
+           (#+(not ccl) cl:progn
+              #+ccl ff:with-float-traps-masked #+ccl cl:t
+              (cl:phase x))))
        (define (polar x)
          (Tuple (magnitude x) (phase x))))
 
@@ -264,7 +278,9 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 
            (True
             (lisp ,coalton-type (x y)
-                (cl:expt x y)))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:expt x y))))))
 
        (define (exp x)
          (cond
@@ -278,10 +294,12 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 
            (True
             (lisp ,coalton-type (x)
-                (cl:let ((res (cl:exp x)))
-                  (cl:if (cl:complexp res)
-                         (cl:realpart res)
-                         res))))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:let ((res (cl:exp x)))
+                   (cl:if (cl:complexp res)
+                          (cl:realpart res)
+                          res)))))))
 
        (define (log b x)
          (cond
@@ -293,7 +311,9 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
               (True nan)))
            ((and (> b 0) (> x 0))
             (lisp ,coalton-type (b x)
-                (cl:log x b)))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:log x b))))
            (True nan)))
 
        (define (ln x)
@@ -301,7 +321,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
            ((nan? x) nan)
            ((> x 0)
             (lisp ,coalton-type (x)
-                (cl:log x)))
+              (cl:log x)))
            ((< x 0) nan)
            (True negative-infinity))))
 
@@ -310,7 +330,9 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
          (if (or (nan? x) (< x 0))
              nan
              (lisp ,coalton-type (x)
-                 (cl:sqrt x))))
+               (#+(not ccl) cl:progn
+                  #+ccl ff:with-float-traps-masked #+ccl cl:t
+                  (cl:sqrt x)))))
        (define (nth-root n x)
          (canonical-nth-root n x)))
 

--- a/library/math/num.lisp
+++ b/library/math/num.lisp
@@ -14,6 +14,7 @@
    #:coalton-library/hash
    #:define-sxhash-hasher)
   (:local-nicknames
+   (#:ff #:float-features)
    (#:bits #:coalton-library/bits)))
 
 (in-package #:coalton-library/math/num)
@@ -226,13 +227,19 @@
      (define-instance (Num ,coalton-type)
        (define (+ a b)
          (lisp ,coalton-type (a b)
-           (cl:+ a b)))
+           (#+(not ccl) cl:progn
+              #+ccl ff:with-float-traps-masked #+ccl cl:t
+              (cl:+ a b))))
        (define (- a b)
          (lisp ,coalton-type (a b)
-           (cl:- a b)))
+           (#+(not ccl) cl:progn
+              #+ccl ff:with-float-traps-masked #+ccl cl:t
+              (cl:- a b))))
        (define (* a b)
          (lisp ,coalton-type (a b)
-           (cl:* a b)))
+           (#+(not ccl) cl:progn
+              #+ccl ff:with-float-traps-masked #+ccl cl:t
+              (cl:* a b))))
        (define (fromInt x)
          (match (lisp (Optional ,coalton-type) (x)
                   (%optional-coerce x ,underlying-type))
@@ -263,7 +270,9 @@
 
            (True
             (lisp ,coalton-type (x y)
-              (cl:/ x y)))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:/ x y))))))
 
        (define (reciprocal x)
          (cond
@@ -273,7 +282,9 @@
 
            (True
             (lisp ,coalton-type (x)
-              (cl:/ x))))))
+              (#+(not ccl) cl:progn
+                 #+ccl ff:with-float-traps-masked #+ccl cl:t
+                 (cl:/ x)))))))
 
      (define-instance (Dividable Integer ,coalton-type)
        (define (general/ x y)


### PR DESCRIPTION
For some reason float traps are re-enabled when running the tests? This causes the tests to loop forever? This commit "fixes" the problem.