### PR TITLE
Callbacks in foreach functions now return Unit

### DIFF
--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -108,7 +108,7 @@
     (lisp Integer (table)
       (coalton/hashtable-shim:custom-hash-table-count table)))
 
-  (declare foreach ((:key -> :value -> :a) -> (Hashtable :key :value) -> Unit))
+  (declare foreach ((:key -> :value -> Unit) -> (Hashtable :key :value) -> Unit))
   (define (foreach f table)
     "Call F once for each key value pair in TABLE"
     (lisp Unit (f table)
@@ -124,7 +124,8 @@
     "Returns the key-values pairs as a list."
     (let lst = (cell:new Nil))
     (foreach (fn (key val)
-               (cell:push! lst (Tuple key val)))
+               (cell:push! lst (Tuple key val))
+               Unit)
              table)
     (cell:read lst))
 
@@ -133,7 +134,8 @@
     "Returns the keys in TABLE as a list"
     (let lst = (cell:new Nil))
     (foreach (fn (key _)
-               (cell:push! lst key))
+               (cell:push! lst key)
+               Unit)
              table)
     (cell:read lst))
 
@@ -142,7 +144,8 @@
     "Returns the values in TABLE as a list"
     (let lst = (cell:new Nil))
     (foreach (fn (_ val)
-               (cell:push! lst val))
+               (cell:push! lst val)
+               Unit)
              table)
     (cell:read lst)))
 

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -448,7 +448,7 @@ This operation could be called `length!`, but `count!` emphasizes the fact that 
 afterwards, ITER will be exhausted."
     (sum! (map (const 1) iter)))
 
-  (declare for-each! ((:elt -> :any) -> Iterator :elt -> Unit))
+  (declare for-each! ((:elt -> Unit) -> Iterator :elt -> Unit))
   (define (for-each! thunk iter)
     "Call THUNK on each element of ITER in order for side effects.
 Discard values returned by THUNK."
@@ -562,7 +562,10 @@ The empty iterator will hash as 0."
 
 The vector will be resized if ITER contains more than SIZE elements."
     (let v = (vector:with-capacity size))
-    (for-each! ((flip vector:push!) v) iter)
+    (for-each! (fn (x)
+                 (vector:push! x v)
+                 Unit)
+               iter)
     v)
 
   (declare collect-vector! (types:RuntimeRepr :elt => Iterator :elt -> Vector :elt))

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -104,7 +104,7 @@
     (lisp :a (idx s)
       (cl:aref s idx)))
 
-  (declare foreach ((:a -> :b) -> (Slice :a) -> Unit))
+  (declare foreach ((:a -> Unit) -> (Slice :a) -> Unit))
   (define (foreach f s)
     "Call the function F once for each item in S"
     (lisp :a (f s)
@@ -112,7 +112,7 @@
          :do (call-coalton-function f elem)))
     Unit)
 
-  (declare foreach-index ((UFix -> :a -> :b) -> (Slice :a) -> Unit))
+  (declare foreach-index ((UFix -> :a -> Unit) -> (Slice :a) -> Unit))
   (define (foreach-index f s)
     "Call the function F once for each item in S with its index"
     (lisp :a (f s)
@@ -122,7 +122,7 @@
          :do (call-coalton-function f i elem)))
     Unit)
 
-  (declare foreach2 ((:a -> :b -> :c) -> (Slice :a) -> (Slice :b) -> Unit))
+  (declare foreach2 ((:a -> :b -> Unit) -> (Slice :a) -> (Slice :b) -> Unit))
   (define (foreach2 f s1 s2)
     "Iterate over S1 and S2 calling F once on each iteration"
     (lisp :a (f s1 s2)
@@ -202,7 +202,8 @@
       (let v = (vector:with-capacity (length s)))
       (foreach
        (fn (x)
-         (vector:push! x v))
+         (vector:push! x v)
+         Unit)
        s)
       v))
 

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -178,7 +178,7 @@
                  (Some pos)
                  None)))))
 
-  (declare foreach ((:a -> :b) -> Vector :a -> Unit))
+  (declare foreach ((:a -> Unit) -> Vector :a -> Unit))
   (define (foreach f v)
     "Call the function F once for each item in V"
     (lisp Void (f v)
@@ -186,7 +186,7 @@
          :do (call-coalton-function f elem)))
     Unit)
 
-  (declare foreach-index ((UFix -> :a -> :b) -> Vector :a -> Unit))
+  (declare foreach-index ((UFix -> :a -> Unit) -> Vector :a -> Unit))
   (define (foreach-index f v)
     "Call the function F once for each item in V with its index"
     (lisp Void (f v)
@@ -196,7 +196,7 @@
          :do (call-coalton-function f i elem)))
     Unit)
 
-  (declare foreach2 ((:a -> :b -> :c) -> Vector :a -> Vector :b -> Unit))
+  (declare foreach2 ((:a -> :b -> Unit) -> Vector :a -> Vector :b -> Unit))
   (define (foreach2 f v1 v2)
     "Iterate in parallel over V1 and V2 calling F once for each pair of elements. Iteration stops when the shorter vector runs out of elements."
     (lisp Void (f v1 v2)
@@ -212,7 +212,8 @@
     (let out = (with-capacity (+ (length v1) (length v2))))
     (let f =
       (fn (item)
-        (push! item out)))
+        (push! item out)
+        Unit))
 
     (foreach f v1)
     (foreach f v2)
@@ -280,7 +281,8 @@
                   (length v)))
       (foreach
        (fn (item)
-         (push! (f item) out))
+         (push! (f item) out)
+         Unit)
        v)
       out))
 

--- a/tests/vector-tests.lisp
+++ b/tests/vector-tests.lisp
@@ -6,7 +6,9 @@
 
 (define-test vector-constructor-equivalencies ()
   (let vec = (vector:with-capacity 10))
-  (iter:for-each! (flip vector:push! vec)
+  (iter:for-each! (fn (x)
+                    (vector:push! x vec)
+                    Unit)
                   (iter:up-to 10))
   (is (== (vector:make 0 1 2 3 4 5 6 7 8 9)
           vec))


### PR DESCRIPTION
Previously callbacks in forach functions could return an arbitrary value. This made code slightly denser, but adding another parameter to a callback function could cause it to be partially applied instead of evaluating. This would be difficult to debug without a type error.

Fixes #755