### PR TITLE
Attach source information to all forms in reader

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -42,6 +42,7 @@
                (:module "parser"
                 :serial t
                 :components ((:file "base")
+                             (:file "reader")
                              (:file "types")
                              (:file "pattern")
                              (:file "macro")

--- a/src/parser/package.lisp
+++ b/src/parser/package.lisp
@@ -1,6 +1,7 @@
 (uiop:define-package #:coalton-impl/parser
   (:mix-reexport
    #:coalton-impl/parser/base
+   #:coalton-impl/parser/reader
    #:coalton-impl/parser/types
    #:coalton-impl/parser/pattern
    #:coalton-impl/parser/expression

--- a/src/parser/reader.lisp
+++ b/src/parser/reader.lisp
@@ -1,0 +1,53 @@
+(defpackage #:coalton-impl/parser/reader
+  (:use #:cl)
+  (:local-nicknames
+   (#:cst #:concrete-syntax-tree))
+  (:export
+   #:*coalton-eclector-client*
+   #:maybe-read-form))
+
+(in-package #:coalton-impl/parser/reader)
+
+(defclass coalton-eclector-client (eclector.parse-result:parse-result-client)
+  ())
+
+(defvar *coalton-eclector-client* (make-instance 'coalton-eclector-client))
+
+(defmethod eclector.parse-result:make-expression-result
+    ((client coalton-eclector-client) expression children source)
+
+  ;; All of our nodes need access to source into so we will tag all
+  ;; children with source info.
+  (cst:reconstruct expression children client :default-source source))
+
+(defun maybe-read-form (stream &optional (eclector-client eclector.base:*client*))
+  "Read the next form or return if there is no next form.
+
+Returns (VALUES FORM PRESENTP EOFP)"
+  (loop :do
+    ;; On empty lists report nothing
+    (when (eq #\) (peek-char t stream nil))
+      (read-char stream)
+      (return (values nil nil nil)))
+
+    ;; Otherwise, try to read in the next form
+    (eclector.reader:call-as-top-level-read
+     eclector-client
+     (lambda ()
+       (multiple-value-call
+           (lambda (form type &optional parse-result)
+
+             ;; Return the read form when valid
+             (when (eq :object type)
+               (return (values (or parse-result form) t nil)))
+
+             (when (eq :eof type)
+               (return (values nil nil t))))
+
+         (eclector.reader:read-maybe-nothing
+          eclector-client
+          stream
+          nil 'eof)))
+     stream
+     nil 'eof
+     nil)))

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -3,6 +3,7 @@
    #:cl
    #:coalton-impl/error
    #:coalton-impl/parser/base
+   #:coalton-impl/parser/reader
    #:coalton-impl/parser/types
    #:coalton-impl/parser/pattern
    #:coalton-impl/parser/macro
@@ -393,16 +394,16 @@
 
       ;; Read the (package) form
       (multiple-value-bind (form presentp)
-          (util:maybe-read-form stream eclector.concrete-syntax-tree::*cst-client*)
+          (maybe-read-form stream *coalton-eclector-client*)
 
         (unless presentp
           (error 'parse-error
-               :err (coalton-error
-                     :span (cons (- (file-position stream) 2)
-                                 (- (file-position stream) 1))
-                     :file file
-                     :message "Unexpected EOF"
-                     :primary-note "missing package form")))
+                 :err (coalton-error
+                       :span (cons (- (file-position stream) 2)
+                                   (- (file-position stream) 1))
+                       :file file
+                       :message "Unexpected EOF"
+                       :primary-note "missing package form")))
 
         (setf *package* (parse-package form file))))
 
@@ -421,16 +422,16 @@
 
       (loop :do
         (multiple-value-bind (form presentp eofp)
-            (util:maybe-read-form stream eclector.concrete-syntax-tree::*cst-client*)
+            (maybe-read-form stream *coalton-eclector-client*)
 
           (when (and eofp (eq :toplevel-macro mode))
             (error 'parse-error
-               :err (coalton-error
-                     :span (cons (- (file-position stream) 2)
-                                 (- (file-position stream) 1))
-                     :file file
-                     :message "Unexpected EOF"
-                     :primary-note "missing close parenthesis")))
+                   :err (coalton-error
+                         :span (cons (- (file-position stream) 2)
+                                     (- (file-position stream) 1))
+                         :file file
+                         :message "Unexpected EOF"
+                         :primary-note "missing close parenthesis")))
 
           (unless presentp
             (return))
@@ -466,7 +467,7 @@ consume all attributes"))))
 
     ;; Read the coalton form
     (multiple-value-bind (form presentp)
-        (util:maybe-read-form stream eclector.concrete-syntax-tree::*cst-client*)
+        (maybe-read-form stream *coalton-eclector-client*)
 
       (unless presentp
         (error 'parse-error
@@ -479,7 +480,7 @@ consume all attributes"))))
 
       ;; Ensure there is only one form
       (multiple-value-bind (form presentp)
-          (util:maybe-read-form stream eclector.concrete-syntax-tree::*cst-client*)
+          (maybe-read-form stream *coalton-eclector-client*)
 
         (when presentp
           (error 'parse-error

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -25,7 +25,7 @@ Used to forbid reading while inside quasiquoted forms.")
 
   (let ((first-form
           (multiple-value-bind (form presentp)
-              (util:maybe-read-form stream)
+              (parser:maybe-read-form stream)
             (unless presentp
               (return-from read-coalton-toplevel-open-paren
                 nil))
@@ -176,7 +176,7 @@ Used to forbid reading while inside quasiquoted forms.")
          (loop :do
            (handler-case
                (multiple-value-bind (form presentp)
-                   (util:maybe-read-form stream)
+                   (parser:maybe-read-form stream)
 
                  (cond
                    ((and (not presentp)
@@ -188,7 +188,7 @@ Used to forbid reading while inside quasiquoted forms.")
                       (nreverse collected-forms)))
 
                    (dotted-context
-                    (when (nth-value 1 (util:maybe-read-form stream))
+                    (when (nth-value 1 (parser:maybe-read-form stream))
                       (error "Invalid dotted list"))
 
                     (return-from read-coalton-toplevel-open-paren
@@ -232,12 +232,12 @@ Used to forbid reading while inside quasiquoted forms.")
 (named-readtables:defreadtable coalton:coalton
   (:merge :standard)
   (:macro-char #\( #'read-coalton-toplevel-open-paren)
-  (:macro-char #\` #'(lambda (s c)
-                       (let ((*coalton-reader-allowed* nil))
-                         (funcall (get-macro-character #\` (named-readtables:ensure-readtable :standard)) s c))))
-  (:macro-char #\, #'(lambda (s c)
-                       (let ((*coalton-reader-allowed* t))
-                         (funcall (get-macro-character #\, (named-readtables:ensure-readtable :standard)) s c)))))
+  (:macro-char #\` (lambda (s c)
+                     (let ((*coalton-reader-allowed* nil))
+                       (funcall (get-macro-character #\` (named-readtables:ensure-readtable :standard)) s c))))
+  (:macro-char #\, (lambda (s c)
+                     (let ((*coalton-reader-allowed* t))
+                       (funcall (get-macro-character #\, (named-readtables:ensure-readtable :standard)) s c)))))
 
 (defmacro coalton:coalton-toplevel (&body forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -206,35 +206,3 @@
           :collect (gethash key map))
     #'<)
    data))
-
-(defun maybe-read-form (stream &optional (eclector-client eclector.base:*client*))
-  "Read the next form or return if there is no next form.
-
-Returns (VALUES FORM PRESENTP EOFP)"
-  (loop :do
-    ;; On empty lists report nothing
-    (when (eq #\) (peek-char t stream nil))
-      (read-char stream)
-      (return (values nil nil nil)))
-
-    ;; Otherwise, try to read in the next form
-    (eclector.reader:call-as-top-level-read
-     eclector-client
-     (lambda ()
-       (multiple-value-call
-           (lambda (form type &optional parse-result)
-
-             ;; Return the read form when valid
-             (when (eq :object type)
-               (return (values (or parse-result form) t nil)))
-
-             (when (eq :eof type)
-               (return (values nil nil t))))
-
-         (eclector.reader:read-maybe-nothing
-          eclector-client
-          stream
-          nil 'eof)))
-     stream
-     nil 'eof
-     nil)))


### PR DESCRIPTION
This should prevent issues caused by the reader returning nodes with SOURCE set to NIL, which caused later failures in the compiler.