### PR TITLE
Ensure objects are re-read correctly when running Coalton in macros

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -290,6 +290,7 @@
   :components ((:file "package")
                (:file "utilities")
                (:file "tarjan-scc-tests")
+               (:file "reader-tests")
                (:file "parser-tests")
                (:file "type-inference-tests")
                (:file "fundep-tests")

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -8,7 +8,8 @@
     (loop :for file :in files
           :do (with-open-file (stream file)
                 (signals parser:parse-error
-                  (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file)))))
+                  (parser:with-reader-context stream
+                    (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file))))))
 
   (let* ((glob (merge-pathnames "tests/parser/*.good.coalton" (asdf:system-source-directory "coalton/tests")))
 
@@ -16,4 +17,5 @@
 
     (loop :for file :in files
           :do (with-open-file (stream file)
-                (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file)))))
+                (parser:with-reader-context stream
+                  (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file))))))

--- a/tests/reader-tests.lisp
+++ b/tests/reader-tests.lisp
@@ -1,0 +1,11 @@
+(in-package #:coalton-tests)
+
+(defmacro coalton-example-with-gensym ()
+  (let ((x (gensym)))
+    `(coalton:coalton
+      (coalton:let ((,x 5))
+        ,x))))
+
+(deftest test-uninterned-symbols ()
+  (let ((y (coalton-example-with-gensym)))
+    (is (= y 5))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -24,7 +24,8 @@
 
                 (file (error:make-coalton-file :stream stream :name "<test>"))
 
-                (program (parser:read-program stream file :mode :test)))
+                (program (parser:with-reader-context stream
+                           (parser:read-program stream file :mode :test))))
 
            (multiple-value-bind (program env)
                (entry:entry-point program)


### PR DESCRIPTION
This ensures that objects are re-read correctly when invoked as macros, preventing uninterned symbols from being split into multiple objects on macroexpand/read.

Fixes #891 