### PR TITLE
Add structs with accessors

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -51,6 +51,7 @@
                              (:file "collect")
                              (:file "renamer")
                              (:file "binding")
+                             (:file "type-definition")
                              (:file "package")))
                (:module "runtime"
                 :serial t
@@ -76,6 +77,7 @@
                              (:file "traverse")
                              (:file "toplevel")
                              (:file "binding")
+                             (:file "accessor")
                              (:file "partial-type-env")
                              (:file "parse-type")
                              (:file "define-type")

--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -14,7 +14,9 @@ When making a new project, you will want to define a new package and establish y
 
 ```lisp
 (defpackage #:my-package
-  (:use #:coalton #:coalton-prelude))
+  (:use 
+   #:coalton 
+   #:coalton-prelude))
 ```
 
 The `#:coalton-prelude` package does not contain any functionality that isn't also found elsewhere in the standard library, and hence, it is a convenience.
@@ -23,18 +25,22 @@ In idiomatic usage, this minimal package definition would be far too limiting to
 
 ```lisp
 (defpackage #:my-package
-  (:use #:coalton)
-  (:local-nicknames (#:str #:coalton-library/string)))
+  (:use 
+   #:coalton)
+  (:local-nicknames 
+   (#:str #:coalton-library/string)))
 ```
 
 This way, we can now just type `str:strip-prefix`. Any time we make use of a new function, either from the Coalton standard library or from a third-party library, we might add nicknames that function's package to our `:local-nicknames` list. For example:
 
 ```lisp
 (defpackage #:my-package
-  (:use #:coalton)
-  (:local-nicknames (#:str  #:coalton-library/string)
-                    (#:vec  #:coalton-library/vector)
-                    (#:math #:coalton-library/math)))
+  (:use 
+   #:coalton)
+  (:local-nicknames 
+   (#:str  #:coalton-library/string)
+   (#:vec  #:coalton-library/vector)
+   (#:math #:coalton-library/math)))
 ```
 
 **We do not recommend `:use`ing any other Coalton built-in packages besides `#:coalton` and `#:coalton-prelude`.** Historically, in Common Lisp, this has caused backwards-compatibility issues when the packages themselves introduce new exported symbols. Moreover, unlike Common Lisp, Coalton follows a pattern of using the same symbol name for similarly defined functions of different packages. For example, both the string package and the vector package have a symbol named `length`, i.e., `str:length` and `vec:length` both exist.
@@ -265,6 +271,45 @@ Type definitions introduce type constructors. For example, we may construct a so
 ```
 
 We'll see how to unpack these types using `match` later in this document.
+
+
+### Structs
+
+There is also support for defining structs.
+
+```lisp
+(coalton-toplevel
+  (define-type Point
+    (x Integer)
+    (y Integer)))
+```
+
+Structs are like single constructor ADTs, and are constructed equivelently:
+
+```lisp
+(coalton (Point 1 2))
+```
+
+Field accessors can be used to read individual fields:
+
+```lisp
+(coalton (.x (Point 1 2)))
+```
+
+Field accessors can be passed by value:
+
+```
+(coalton (map .x (make-list (Point 1 2) (Point 2 3))))
+```
+
+Structs can also be parametric:
+
+```lisp
+(coalton-toplevel
+  (define-struct (Pair :a)
+    (first :a)
+    (second :a)))
+```
 
 ## Numbers
 

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -51,9 +51,10 @@
   ;; Base Types
   ;;
 
-  (define-type (Tuple :a :b)
+  (define-struct (Tuple :a :b)
     "A heterogeneous collection of items."
-    (Tuple :a :b))
+    (first :a)
+    (second :b))
 
   (define-type (Optional :a)
     "Represents something that may not have a value."

--- a/library/tuple.lisp
+++ b/library/tuple.lisp
@@ -34,14 +34,23 @@
     "Get the second element of a tuple."
     b)
 
-  (define-type (Tuple3 :a :b :c)
-    (Tuple3 :a :b :c))
+  (define-struct (Tuple3 :a :b :c)
+    (first :a)
+    (second :b)
+    (third :c))
 
-  (define-type (Tuple4 :a :b :c :d)
-    (Tuple4 :a :b :c :d))
+  (define-struct (Tuple4 :a :b :c :d)
+    (first :a)
+    (second :b)
+    (third :c)
+    (fourth :d))
 
-  (define-type (Tuple5 :a :b :c :d :e)
-    (Tuple5 :a :b :c :d :e))
+  (define-struct (Tuple5 :a :b :c :d :e)
+    (first :a)
+    (second :b)
+    (third :c)
+    (fourth :d)
+    (fifth :e))
 
   ;;
   ;; Tuple instances
@@ -69,11 +78,9 @@
 
   (define-instance ((Hash :a) (Hash :b) => Hash (Tuple :a :b))
     (define (hash item)
-      (match item
-        ((Tuple a b)
-         (combine-hashes
-          (hash a)
-          (hash b))))))
+      (combine-hashes
+       (hash (.first item))
+       (hash (.second item)))))
 
   (define-instance (Bifunctor Tuple)
     (define (bimap f g (Tuple a b))
@@ -85,55 +92,54 @@
 
   (define-instance ((Eq :a) (Eq :b) (Eq :c) => Eq (Tuple3 :a :b :c))
     (define (== a b)
-      (match (Tuple a b)
-        ((Tuple (Tuple3 a1 b1 c1)
-                (Tuple3 a2 b2 c2))
-         (and (== a1 a2)
-              (== b1 b2)
-              (== c1 c2))))))
+      (and (== (.first a)
+               (.first b))
+           (== (.second a)
+               (.second b))
+           (== (.third a)
+               (.third b)))))
 
   (define-instance ((Hash :a) (Hash :b) (Hash :c) => Hash (Tuple3 :a :b :c))
     (define (hash item)
-      (match item
-        ((Tuple3 a b c)
-         (combine-hashes
-          (hash a)
-          (combine-hashes
-           (hash b)
-           (hash c)))))))
+      (combine-hashes
+       (hash (.first item))
+       (combine-hashes
+        (hash (.second item))
+        (hash (.third item))))))
 
   (define-instance ((Eq :a) (Eq :b) (Eq :c) (Eq :d) => Eq (Tuple4 :a :b :c :d))
     (define (== a b)
-      (match (Tuple a b)
-        ((Tuple (Tuple4 a1 b1 c1 d1)
-                (Tuple4 a2 b2 c2 d2))
-         (and (== a1 a2)
-              (== b1 b2)
-              (== c1 c2)
-              (== d1 d2))))))
+      (and (== (.first a)
+               (.first b))
+           (== (.second a)
+               (.second b))
+           (== (.third a)
+               (.third b))
+           (== (.fourth a)
+               (.fourth b)))))
 
   (define-instance ((Hash :a) (Hash :b) (Hash :c) (Hash :d) => Hash (Tuple4 :a :b :c :d))
     (define (hash item)
-      (match item
-        ((Tuple4 a b c d)
-         (combine-hashes
-          (hash a)
-          (combine-hashes
-           (hash b)
-           (combine-hashes
-            (hash c)
-            (hash d))))))))
+      (combine-hashes
+       (hash (.first item))
+       (combine-hashes
+        (hash (.second item))
+        (combine-hashes
+         (hash (.third item))
+         (hash (.fourth item)))))))
 
   (define-instance ((Eq :a) (Eq :b) (Eq :c) (Eq :d) (Eq :e) => Eq (Tuple5 :a :b :c :d :e))
     (define (== a b)
-      (match (Tuple a b)
-        ((Tuple (Tuple5 a1 b1 c1 d1 e1)
-                (Tuple5 a2 b2 c2 d2 e2))
-         (and (== a1 a2)
-              (== b1 b2)
-              (== c1 c2)
-              (== d1 d2)
-              (== e1 e2))))))
+      (and (== (.first a)
+               (.first b))
+           (== (.second a)
+               (.second b))
+           (== (.third a)
+               (.third b))
+           (== (.fourth a)
+               (.fourth b))
+           (== (.fifth a)
+               (.fifth b)))))
 
   (define-instance ((Hash :a)
                     (Hash :b)
@@ -142,17 +148,15 @@
                     (Hash :e)
                     => Hash (Tuple5 :a :b :c :d :e))
     (define (hash item)
-      (match item
-        ((Tuple5 a b c d e)
+      (combine-hashes
+       (hash (.first item))
+       (combine-hashes
+        (hash (.second item))
+        (Combine-hashes
+         (hash (.third item))
          (combine-hashes
-          (hash a)
-          (combine-hashes
-           (hash b)
-           (combine-hashes
-            (hash c)
-            (combine-hashes
-             (hash d)
-             (hash e)))))))))
+          (hash (.fourth item))
+          (hash (.fifth item))))))))
 
   ;;
   ;; Default instances

--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -33,6 +33,9 @@
 (define-coalton-editor-macro coalton:define-type (name &body definition)
   "Create a new algebraic data type named NAME. (Coalton top-level operator.)")
 
+(define-coalton-editor-macro coalton:define-struct (name &body definition)
+  "Create a new sruct named NAME. (Coalton top-level operator.)")
+
 (define-coalton-editor-macro coalton:declare (var type)
   "Declare the type of a variable. (Coalton top-level operator.)")
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -22,6 +22,7 @@
    #:declare
    #:define
    #:define-type
+   #:define-struct
    #:define-class
    #:define-instance
    #:repr

--- a/src/parser/base.lisp
+++ b/src/parser/base.lisp
@@ -4,6 +4,7 @@
   (:shadow
    #:parse-error)
   (:local-nicknames
+   (#:cst #:concrete-syntax-tree)
    (#:util #:coalton-impl/util)
    (#:error #:coalton-impl/error))
   (:export
@@ -22,6 +23,7 @@
    #:identifier-src-list                ; TYPE
    #:parse-error                        ; CONDITION
    #:parse-error-err                    ; ACCESSOR
+   #:parse-list                         ; FUNCTION
    ))
 
 (in-package #:coalton-impl/parser/base)
@@ -69,3 +71,13 @@
 
 (define-condition parse-error (error:coalton-base-error)
   ())
+
+(defun parse-list (f list_ file)
+  (declare (type function f)
+           (type cst:cst list_)
+           (type error:coalton-file file)
+           (values list))
+
+  (loop :for list := list_ :then (cst:rest list)
+        :while (cst:consp list)
+        :collect (funcall f (cst:first list) file)))

--- a/src/parser/collect.lisp
+++ b/src/parser/collect.lisp
@@ -58,7 +58,15 @@
 
   (:method ((type toplevel-define-type))
     (declare (values tycon-list))
-    (mapcan #'collect-referenced-types-generic% (toplevel-define-type-ctors type))))
+    (mapcan #'collect-referenced-types-generic% (toplevel-define-type-ctors type)))
+
+  (:method ((field struct-field))
+    (declare (values tycon-list &optional))
+    (collect-referenced-types-generic% (struct-field-type field)))
+
+  (:method ((type toplevel-define-struct))
+    (declare (values tycon-list))
+    (mapcan #'collect-referenced-types-generic% (toplevel-define-struct-fields type))))
 
 (defun collect-type-variables (type)
   "Returns a deduplicated list of all `TYVAR's in TYPE."
@@ -118,6 +126,10 @@ in expressions. May not include all bound variables."
   (:method ((node node-variable))
     (declare (values node-variable-list))
     (list node))
+
+  (:method ((node node-accessor))
+    (declare (values node-variable-list))
+    nil)
 
   (:method ((node node-literal))
     (declare (values node-variable-list))

--- a/src/parser/package.lisp
+++ b/src/parser/package.lisp
@@ -8,4 +8,5 @@
    #:coalton-impl/parser/toplevel
    #:coalton-impl/parser/collect
    #:coalton-impl/parser/renamer
-   #:coalton-impl/parser/binding))
+   #:coalton-impl/parser/binding
+   #:coalton-impl/parser/type-definition))

--- a/src/parser/type-definition.lisp
+++ b/src/parser/type-definition.lisp
@@ -1,0 +1,124 @@
+;;;;
+;;;; This file defines a generic protocol for writing code that
+;;;; operates on both toplevel-define-type and toplevel-define-struct
+;;;; structs.
+;;;;
+
+(defpackage #:coalton-impl/parser/type-definition
+  (:use
+   #:cl
+   #:coalton-impl/parser/base
+   #:coalton-impl/parser/types
+   #:coalton-impl/parser/toplevel)
+  (:shadowing-import-from
+   #:coalton-impl/parser/base
+   #:parse-error)
+  (:export
+   #:type-definition                    ; TYPE
+   #:type-definition-list               ; TYPE
+   #:type-definition-name               ; FUNCTION
+   #:type-definition-source             ; FUNCTION
+   #:type-definition-vars               ; FUNCTION
+   #:type-definition-repr               ; FUNCTION
+   #:type-definition-docstring          ; FUNCTION
+   #:type-definition-ctors              ; FUNCTION
+   #:type-definition-ctor-name          ; FUNCTION
+   #:type-definition-ctor-source        ; FUNCTION
+   #:type-definition-ctor-field-types   ; FUNCTION
+   ))
+
+(in-package #:coalton-impl/parser/type-definition)
+
+(deftype type-definition ()
+  '(or toplevel-define-type toplevel-define-struct))
+
+(defun type-definition-p (x)
+  (typep x 'type-definition))
+
+(defun type-definition-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'type-definition-p x)))
+
+(deftype type-definition-list ()
+  '(satisfies type-definition-list-p))
+
+(defgeneric type-definition-name (def)
+  (:method ((def toplevel-define-type))
+    (declare (values identifier-src))
+    (toplevel-define-type-name def))
+
+  (:method ((def toplevel-define-struct))
+    (declare (values identifier-src))
+    (toplevel-define-struct-name def)))
+
+(defgeneric type-definition-source (def)
+  (:method ((def toplevel-define-type))
+    (declare (values cons))
+    (toplevel-define-type-source def))
+
+  (:method ((def toplevel-define-struct))
+    (declare (values cons))
+    (toplevel-define-struct-source def)))
+
+(defgeneric type-definition-vars (def)
+  (:method ((def toplevel-define-type))
+    (declare (values keyword-src-list))
+    (toplevel-define-type-vars def))
+
+  (:method ((def toplevel-define-struct))
+    (declare (values keyword-src-list))
+    (toplevel-define-struct-vars def)))
+
+(defgeneric type-definition-repr (def)
+  (:method ((def toplevel-define-type))
+    (declare (values (or null attribute-repr)))
+    (toplevel-define-type-repr def))
+
+  (:method ((def toplevel-define-struct))
+    (declare (values (or null attribute-repr)))
+    (toplevel-define-struct-repr def)))
+
+(defgeneric type-definition-docstring (def)
+  (:method ((def toplevel-define-type))
+    (declare (values (or null string)))
+    (toplevel-define-type-docstring def))
+
+  (:method ((def toplevel-define-struct))
+    (declare (values (or null string)))
+    (toplevel-define-struct-docstring def)))
+
+(defgeneric type-definition-ctors (def)
+  (:method ((def toplevel-define-type))
+    (declare (values constructor-list))
+    (toplevel-define-type-ctors def))
+
+  (:method ((def toplevel-define-struct))
+    (declare (values toplevel-define-struct-list))
+    (list def)))
+
+(defgeneric type-definition-ctor-name (ctor)
+  (:method ((ctor constructor))
+    (declare (values identifier-src))
+    (constructor-name ctor))
+
+  (:method ((ctor toplevel-define-struct))
+    (declare (values identifier-src))
+    (toplevel-define-struct-name ctor)))
+
+(defgeneric type-definition-ctor-source (ctor)
+  (:method ((ctor constructor))
+    (declare (values cons))
+    (constructor-source ctor))
+
+  (:method ((ctor toplevel-define-struct))
+    (declare (values cons))
+    (toplevel-define-struct-source ctor)))
+
+(defgeneric type-definition-ctor-field-types (ctor)
+  (:method ((ctor constructor))
+    (declare (values ty-list))
+    (constructor-fields ctor))
+
+  (:method ((ctor toplevel-define-struct))
+    (declare (values ty-list))
+    (mapcar #'struct-field-type (toplevel-define-struct-fields ctor))))

--- a/src/typechecker/accessor.lisp
+++ b/src/typechecker/accessor.lisp
@@ -1,0 +1,147 @@
+(defpackage #:coalton-impl/typechecker/accessor
+  (:use
+   #:cl
+   #:coalton-impl/typechecker/base)
+  (:local-nicknames
+   (#:util #:coalton-impl/util)
+   (#:error #:coalton-impl/error)
+   (#:tc #:coalton-impl/typechecker/stage-1))
+  (:export
+   #:accessor                           ; STRUCT
+   #:make-accessor                      ; CONSTRUCTOR
+   #:accessor-from                      ; ACCESSOR
+   #:accessor-to                        ; ACCESSOR
+   #:accessor-field                     ; ACCESSOR
+   #:accessor-source                    ; ACCESSOR
+   #:accessor-list                      ; TYPE
+   #:base-type                          ; FUNCTION
+   #:solve-accessors                    ; FUNCTION
+   ))
+
+(in-package #:coalton-impl/typechecker/accessor)
+
+(defstruct (accessor
+            (:copier nil))
+  (from   (util:required 'from)   :type tc:ty  :read-only t)
+  (to     (util:required 'to)     :type tc:ty  :read-only t)
+  (field  (util:required 'field)  :type string :read-only t)
+  (source (util:required 'source) :type cons   :read-only t))
+
+(defun accessor-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'accessor-p x)))
+
+(deftype accessor-list ()
+  '(satisfies accessor-list-p))
+
+(defun base-type (ty)
+  (declare (type tc:ty ty)
+           (values tc:ty &optional))
+  (cond
+    ((tc:tycon-p ty)
+     ty)
+
+    ((tc:tyvar-p ty)
+     ty)
+
+    ((tc:tapp-p ty)
+     (base-type (tc:tapp-from ty)))
+
+    (t
+     (util:unreachable))))
+
+(defun solve-accessors (accessors file env)
+  (declare (type accessor-list accessors)
+           (type error:coalton-file file)
+           (type tc:environment env))
+
+  (let ((subs nil)
+        (solved-accessors nil))
+
+    (loop :with continue := t
+          :while continue
+
+          :for i :from 0
+
+          :do (loop :for accessor :in accessors
+                    :do (multiple-value-bind (matchp subs_)
+                            (solve-accessor accessor file env)
+                          (when matchp
+                            (push accessor solved-accessors))
+                          (setf subs (tc:compose-substitution-lists subs subs_))))
+
+          :if solved-accessors
+            :do (setf accessors
+                      (tc:apply-substitution
+                       subs
+                       (set-difference accessors solved-accessors :test #'eq)))
+          :else
+            :do (setf continue nil)
+
+          :do (setf solved-accessors nil))
+
+    (values accessors subs)))
+
+(defun solve-accessor (accessor file env)
+  (declare (type accessor accessor)
+           (type error:coalton-file file)
+           (type tc:environment env)
+           (values boolean tc:substitution-list))
+
+  (let ((ty (base-type (accessor-from accessor))))
+
+    (unless (tc:tycon-p ty)
+      (return-from solve-accessor (values nil nil)))
+
+    (let* ((ty-name (tc:tycon-name ty))
+
+           (type-entry (tc:lookup-type env ty-name))
+
+           (struct-ty (tc:apply-type-argument-list
+                       (tc:type-entry-type type-entry)
+                       (tc:type-entry-tyvars type-entry)))
+
+           (struct-entry (tc:lookup-struct env ty-name :no-error t)))
+
+      (unless struct-entry
+        (error 'tc-error
+               :err (error:coalton-error
+                     :span (accessor-source accessor)
+                     :file file
+                     :message "Invalid accessor"
+                     :primary-note
+                     (format nil "type '~S' is not a struct" ty-name))))
+
+      (let* ((subs (tc:match struct-ty (accessor-from accessor)))
+             (field-ty (gethash (accessor-field accessor)
+                                (tc:struct-entry-field-tys struct-entry))))
+
+        (unless field-ty
+          (error 'tc-error
+                 :err (error:coalton-error
+                       :span (accessor-source accessor)
+                       :file file
+                       :message "Invalid accessor"
+                       :primary-note
+                       (format nil "struct '~S' does not have the field '~A'"
+                               ty-name
+                               (accessor-field accessor)))))
+
+        ;; the order of unification matters here
+        (setf subs (tc:unify subs (accessor-to accessor) field-ty))
+
+        (values t subs)))))
+
+(defmethod tc:apply-substitution (subs (accessor accessor))
+  (declare (type tc:substitution-list subs)
+           (values accessor))
+
+  (make-accessor
+   :from (tc:apply-substitution subs (accessor-from accessor))
+   :to (tc:apply-substitution subs (accessor-to accessor))
+   :field (accessor-field accessor)
+   :source (accessor-source accessor)))
+
+(defmethod tc:type-variables ((accessor accessor))
+  (append (tc:type-variables (accessor-from accessor))
+          (tc:type-variables (accessor-to accessor))))

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -61,6 +61,7 @@
   (check-duplicates
    classes
    (alexandria:compose #'parser:identifier-src-name #'parser:toplevel-define-class-name)
+   #'parser:toplevel-define-class-source
    (lambda (first second)
      (error 'tc-error
             :err (coalton-error
@@ -79,6 +80,7 @@
   (check-duplicates
    (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-class-methods) classes)
    (alexandria:compose #'parser:identifier-src-name #'parser:method-definition-name)
+   #'parser:method-definition-source
    (lambda (first second)
      (error 'tc-error
             :err (coalton-error
@@ -98,6 +100,7 @@
     (check-duplicates
      (parser:toplevel-define-class-vars class)
      #'parser:keyword-src-name
+     #'parser:keyword-src-source
      (lambda (first second)
        (error 'tc-error
               :err (coalton-error
@@ -377,6 +380,7 @@
                (check-duplicates
                 vars
                 #'parser:keyword-src-name
+                #'parser:keyword-src-source
                 (lambda (first second)
                   (error 'tc-error
                          :err (coalton-error

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -229,6 +229,7 @@
     (check-duplicates
      (parser:toplevel-define-instance-methods unparsed-instance)
      (alexandria:compose #'parser:node-variable-name #'parser:instance-method-definition-name)
+     #'parser:instance-method-definition-source
      (lambda (first second)
        (error 'tc-error
               :err (coalton-error

--- a/src/typechecker/expression.lisp
+++ b/src/typechecker/expression.lisp
@@ -20,6 +20,9 @@
    #:make-node-variable                 ; CONSTRUCTOR
    #:node-variable-name                 ; ACCESSOR
    #:node-variable-list                 ; TYPE
+   #:node-accessor                      ; STRUCT
+   #:make-node-accessor                 ; CONSTRUCTOR
+   #:node-accessor-name                 ; ACCESSOR
    #:node-literal                       ; STRUCT
    #:make-node-literal                  ; CONSTRUCTOR
    #:node-literal-value                 ; ACCESSOR
@@ -160,6 +163,11 @@
 
 (deftype node-variable-list ()
   '(satisfies node-variable-list-p))
+
+(defstruct (node-accessor
+            (:include node)
+            (:copier nil))
+  (name (util:required 'name) :type string :read-only t))
 
 (defstruct (node-literal
             (:include node)
@@ -348,6 +356,14 @@
    :type (tc:apply-substitution subs (node-type node))
    :source (node-source node)
    :name (node-variable-name node)))
+
+(defmethod tc:apply-substitution (subs (node node-accessor))
+  (declare (type tc:substitution-list subs)
+           (values node-accessor))
+  (make-node-accessor
+   :type (tc:apply-substitution subs (node-type node))
+   :source (node-source node)
+   :name (node-accessor-name node)))
 
 (defmethod tc:apply-substitution (subs (node node-literal))
   (declare (type tc:substitution-list subs)

--- a/src/typechecker/package.lisp
+++ b/src/typechecker/package.lisp
@@ -7,6 +7,7 @@
    #:coalton-impl/typechecker/traverse
    #:coalton-impl/typechecker/toplevel
    #:coalton-impl/typechecker/binding
+   #:coalton-impl/typechecker/accessor
    #:coalton-impl/typechecker/partial-type-env
    #:coalton-impl/typechecker/parse-type
    #:coalton-impl/typechecker/define-type

--- a/src/typechecker/traverse.lisp
+++ b/src/typechecker/traverse.lisp
@@ -13,6 +13,7 @@
 (defstruct (traverse-block
             (:conc-name traverse-))
   (variable        #'identity :type function :read-only t)
+  (accessor        #'identity :type function :read-only t)
   (literal         #'identity :type function :read-only t)
   (integer-literal #'identity :type function :read-only t)
   (bind            #'identity :type function :read-only t)
@@ -42,6 +43,12 @@
              (values node &optional))
 
     (funcall (traverse-variable block) node))
+
+  (:method ((node node-accessor) block)
+    (declare (type traverse-block block)
+             (values node &optional))
+
+    (funcall (traverse-accessor block) node))
 
   (:method ((node node-literal) block)
     (declare (type traverse-block block)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -15,6 +15,7 @@
    #:debug-tap                          ; MACRO
    #:runtime-quote                      ; FUNCTION
    #:symbol-list                        ; TYPE
+   #:string-list                        ; TYPE
    #:cst-list                           ; TYPE
    #:cst-source-range                   ; FUNCTION
    #:literal-value                      ; TYPE
@@ -40,6 +41,13 @@
 
 (deftype symbol-list ()
   '(satisfies symbol-list-p))
+
+(defun string-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'stringp x)))
+
+(deftype string-list ()
+  '(satisfies string-list-p))
 
 (defun cst-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/tests/struct-tests.lisp
+++ b/tests/struct-tests.lisp
@@ -1,0 +1,91 @@
+;;;; struct-tests.lisp
+
+(in-package #:coalton-tests)
+
+(deftest test-struct-definition ()
+  (check-coalton-types
+   "(define-struct Point
+      (x Integer)
+      (y Integer))")
+
+  (check-coalton-types
+   "(define-type (Point :a)
+      (x :a)
+      (y :a))"))
+
+(deftest test-struct-accessors ()
+  (check-coalton-types
+   "(define-struct Point
+      (x Integer)
+      (y Integer))
+
+    (define p (Point 1 2))
+    (define x (.x p))
+    (define y (.y p))"
+
+   '("p" . "Point")
+   '("x" . "Integer")
+   '("y" . "Integer"))
+
+  (check-coalton-types
+   "(define-struct (Wrapper :a)
+      (inner :a))
+
+    (define x (.inner (Wrapper #\\X)))"
+
+   '("x" . "Char"))
+
+  (check-coalton-types
+   "(define-struct (Wrapper :a)
+      (inner :a))
+
+    (define x (.inner (.inner (.inner (Wrapper (Wrapper (Wrapper #\\X)))))))"
+
+   '("x" . "Char")))
+
+(deftest test-invalid-struct-accessors ()
+  (signals tc:tc-error
+    (check-coalton-types
+     "(define x (.x #\\X))"))
+
+  (signals tc:tc-error
+    (check-coalton-types
+     "(define-struct Point
+        (x Integer)
+        (y Integer))
+
+      (define x (.q (Point 1 2)))")))
+
+(deftest test-struct-accessors-as-functions ()
+  (check-coalton-types
+   "(define-struct Point
+      (x Integer)
+      (y Integer))
+
+    (define xs (map .x (make-list (Point 1 2) (Point 3 4) (Point 5 6))))"
+
+   '("xs" . "(List Integer)"))
+
+  (check-coalton-types
+   "(define-struct Point
+      (x Integer)
+      (y Integer))
+
+    (declare f (Point -> Integer))
+    (define f .x)"))
+
+(deftest test-ambigious-accessors ()
+  (signals tc:tc-error
+    (check-coalton-types
+     "(define (f p)
+      (.x p))"))
+
+  (signals tc:tc-error
+    (check-coalton-types
+     "(define-type Point
+       (x Integer)
+       (y Integer))
+
+      (define (f _)
+        (let ((g (fn (p) (.x p))))
+          (g (Point 1 2))))")))


### PR DESCRIPTION
Adds the ability to define structs:

```lisp
(coalton-toplevel
  (define-struct Point
    (x Integer)
    (y Integer)))
```

Defining a struct is equivalent to defining a single constructor ADT. Structs can also use the new accessor syntax to get individual fields.

```lisp
(coalton-toplevel
  (define p (Point 1 2))

  (define x (.x p))

  (define y (.y p)))
```

Accessors can be passed by value like functions:

```lisp
(coalton (map .x (make-list (Point 1 2) (Point 3 4) (Point 5 6))))
```

Accessors must access a field from a single unambiguous struct type. The following are invalid:

```lisp
(coalton-toplevel
  (define (f p)
    (.x p)) ;; the type of p is unknown

  (define-struct Point3
    (x Integer)
    (y Integer)
    (z Integer))
    
  (define g
    (let h = .x)
    (h (Point 1 2))
    (h (Point3 1 2 3))) ;; h is used on different structs

  (define i (.x "q")) ;; accessors can only be used on structs

  (define j (.q (Point 1 2)))) ;; accessors must be for valid fields
```

Structs can have type variables:

```lisp
(coalton-toplevel
  (define-struct (ThreeOfThem :a)
    (the-first :a)
    (the-second :a)
    (the-third :a)))
```

## Still TODO:
- [x] updating documentation
- [x] updating the doc generator to display struct fields

## Future work:
* Add pattern matching and constructors that are named rather than positional:
```lisp
(match p
  ((Point { x y }) (+ x y)))
```
* Add a syntax for immutable partial updates
* Add mutable struct fields