### PR TITLE
Rename `vector:extend` to `vector:extend!`

### DIFF
--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -20,6 +20,7 @@
    #:entries
    #:keys
    #:values
+   #:extend!
    #:make))
 
 (in-package #:coalton-library/hashtable)
@@ -154,9 +155,9 @@
                      None))))
       (with-default 0 (tryinto (count table))))) 
 
-  (declare extend ((Hash :key) (iter:IntoIterator :container (Tuple :key :value))
+  (declare extend! ((Hash :key) (iter:IntoIterator :container (Tuple :key :value))
                    => Hashtable :key :value -> :container -> Unit))
-  (define (extend table iter)
+  (define (extend! table iter)
     "Insert all of the key value pairs from ITER into TABLE, overwriting duplicate keys."
     (let iter = (iter:into-iter iter))
     (iter:for-each!

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -186,7 +186,7 @@
       ;; NOTE: This will create a non displaced array. It should be
       ;; fine, because it isn't observable with the slice API.
       (let vec = (vector:with-capacity (with-default 0 (iter:size-hint iter))))
-      (vector:extend vec iter)
+      (vector:extend! vec iter)
       (lisp (Slice :a) (vec) vec)))
 
   (define-instance (Eq :a => Eq (Slice :a))
@@ -215,7 +215,7 @@
   (define-instance (types:RuntimeRepr :a => Into (Slice :a) (Vector :a))
     (define (into s)
       (let v = (vector:with-capacity (length s)))
-      (vector:extend v (iter:into-iter s))
+      (vector:extend! v (iter:into-iter s))
       v))
 
   (define-instance (types:RuntimeRepr :a => Into (Vector :a) (Slice :a))

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -30,7 +30,7 @@
    #:head-unsafe
    #:last
    #:last-unsafe
-   #:extend
+   #:extend!
    #:find-elem
    #:append
    #:swap-remove!
@@ -196,8 +196,8 @@
   (define (append v1 v2)
     "Create a new VECTOR containing the elements of v1 followed by the elements of v2"
     (let out = (with-capacity (+ (length v1) (length v2))))
-    (extend out v1)
-    (extend out v2)
+    (extend! out v1)
+    (extend! out v2)
     out)
 
   (declare swap-remove! (UFix -> Vector :a -> Optional :a))
@@ -232,8 +232,8 @@
     "Sort a vector inplace"
     (sort-by! < v))
 
-  (declare extend (iter:IntoIterator :container :elt => Vector :elt -> :container -> Unit))
-  (define (extend vec iter)
+  (declare extend! (iter:IntoIterator :container :elt => Vector :elt -> :container -> Unit))
+  (define (extend! vec iter)
     "Push every element in ITER to the end of VEC."
     (let iter = (iter:into-iter iter))
 


### PR DESCRIPTION
Also export `hashtable:extend!`.

Fixes #937