### PR TITLE
Fix tree:make macro

### DIFF
--- a/library/ord-tree.lisp
+++ b/library/ord-tree.lisp
@@ -534,4 +534,4 @@ B'. Which one is chosen for the result is undefined."
   "Construct a tree containing the ELEMENTS.
 
 e.g. (tree:make 5 6 1 8 9) => tree containing 1, 5, 6, 8, 9."
-  `(collect-tree! (iter:into-iter (make-list ,@elements))))
+  `(collect! (iter:into-iter (make-list ,@elements))))


### PR DESCRIPTION
I've identified and fixed an issue in the tree:make macro. It was mistakenly expanding to use a non-existent `collect-tree!` function, when it should be using `collect!`.