### PR TITLE
Add: impossible macro

### DIFF
--- a/library/builtin.lisp
+++ b/library/builtin.lisp
@@ -3,6 +3,7 @@
    #:coalton
    #:coalton-library/classes)
   (:export
+   #:impossible
    #:undefined
    #:error ; re-export from classes
    #:not
@@ -18,6 +19,11 @@
 
 #+coalton-release
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
+
+(cl:defmacro impossible (cl:&optional datum cl:&rest arguments)
+  "Signal an error with CL format string DATUM and optional format arguments ARGUMENTS."
+  `(lisp :a ()
+     (cl:error ,datum ,@arguments)))
 
 (coalton-toplevel
   (define (undefined _)

--- a/library/builtin.lisp
+++ b/library/builtin.lisp
@@ -20,7 +20,7 @@
 #+coalton-release
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
-(cl:defmacro impossible (cl:&optional datum cl:&rest arguments)
+(cl:defmacro impossible (cl:&optional (datum "Impossible") cl:&rest arguments)
   "Signal an error with CL format string DATUM and optional format arguments ARGUMENTS."
   `(lisp :a ()
      (cl:error ,datum ,@arguments)))


### PR DESCRIPTION
Pattern matches on ADTs often require matching on cases that are never intended to be encountered in reality, but would fail exhaustiveness checks if not matched. The `impossible` macro produces an expression of type `:a` and signals an error at runtime.