### PR TITLE
loop sampler

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -32,6 +32,7 @@
                (:file "settings")
                (:file "utilities")
                (:file "global-lexical")
+               (:file "constants")
                (:module "algorithm"
                 :serial t
                 :components ((:file "tarjan-scc")
@@ -324,4 +325,5 @@
                (:file "red-black-tests")
                (:file "seq-tests")
                (:file "unused-variables")
-               (:file "pattern-matching-tests")))
+               (:file "pattern-matching-tests")
+               (:file "looping-native-tests")))

--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -556,15 +556,15 @@
 
   (declare simplify (ClassEnv -> (List Pred) -> (List Pred)))
   (define (simplify ce xs)
-    (let ((loop (fn (rs xs)
-                  (match xs
-                    ((Nil)
-                     rs)
-                    ((Cons p ps)
-                     (if (entail ce (append rs ps) p)
-                         (loop rs ps)
-                         (loop (Cons p rs) ps)))))))
-      (loop Nil xs)))
+    (let ((rec (fn (rs xs)
+                 (match xs
+                   ((Nil)
+                    rs)
+                   ((Cons p ps)
+                    (if (entail ce (append rs ps) p)
+                        (rec rs ps)
+                        (rec (Cons p rs) ps)))))))
+      (rec Nil xs)))
 
   (declare reduce (MonadFail :m => (ClassEnv -> (List Pred) -> (:m (List Pred)))))
   (define (reduce ce ps)

--- a/src/codegen/pattern.lisp
+++ b/src/codegen/pattern.lisp
@@ -6,7 +6,7 @@
    (#:tc #:coalton-impl/typechecker))
   (:export
    #:pattern                            ; STRUCT
-   #:pattern-source                     ; ACCESSOR
+   #:pattern-type                       ; ACCESSOR
    #:pattern-list                       ; TYPE
    #:pattern-var                        ; STRUCT
    #:make-pattern-var                   ; ACCESSOR

--- a/src/codegen/transformations.lisp
+++ b/src/codegen/transformations.lisp
@@ -119,6 +119,44 @@
                         (node-match-branches node)))))
       (call-if node :match funs bound-variables)))
 
+  (:method ((node node-while) funs bound-variables)
+    (declare (type util:symbol-list bound-variables))
+    (let ((node
+            (make-node-while
+             :type (node-type node)
+             :label (node-while-label node)
+             :expr (traverse (node-while-expr node) funs bound-variables)
+             :body (traverse (node-while-body node) funs bound-variables))))
+      (call-if node :while funs bound-variables)))
+
+  (:method ((node node-while-let) funs bound-variables)
+    (declare (type util:symbol-list bound-variables))
+    (let ((node
+            (make-node-while-let
+             :type tc:*unit-type*
+             :label (node-while-let-label node)
+             :pattern (node-while-let-pattern node)
+             :expr (traverse (node-while-let-expr node) funs bound-variables)
+             :body (traverse (node-while-let-body node) funs bound-variables))))
+      (call-if node :while-let funs bound-variables)))
+
+  (:method ((node node-loop) funs bound-variables)
+    (declare (type util:symbol-list bound-variables))
+    (let ((node
+            (make-node-loop
+             :type tc:*unit-type*
+             :label (node-loop-label node)
+             :body (traverse (node-loop-body node) funs bound-variables))))
+      (call-if node :loop funs bound-variables)))
+
+  (:method ((node node-break) funs bound-variables)
+    (declare (type util:symbol-list bound-variables))
+    (call-if node :break funs bound-variables))
+
+  (:method ((node node-continue) funs bound-variables)
+    (declare (type util:symbol-list bound-variables))
+    (call-if node :continue funs bound-variables))
+
   (:method ((node node-seq) funs bound-variables)
     (declare (type util:symbol-list bound-variables))
     (let ((node

--- a/src/codegen/typecheck-node.lisp
+++ b/src/codegen/typecheck-node.lisp
@@ -113,6 +113,33 @@
                 (setf subs (tc:unify subs subexpr-ty type))))
       type))
 
+  (:method ((expr node-while) env)
+    (declare (type tc:environment env)
+             (values tc:ty))
+    (typecheck-node (node-while-expr expr) env)
+    (typecheck-node (node-while-body expr) env))
+
+  (:method ((expr node-while-let) env)
+    (declare (type tc:environment env)
+             (values tc:ty))
+    (typecheck-node (node-while-let-expr expr) env)
+    (typecheck-node (node-while-let-body expr) env))
+
+  (:method ((expr node-loop) env)
+    (declare (type tc:environment env)
+             (values tc:ty))
+    (typecheck-node (node-loop-body expr) env))
+
+  (:method ((expr node-break) env)
+    (declare (type tc:environment env)
+             (values tc:ty))
+    tc:*unit-type*)
+
+  (:method ((expr node-continue) env)
+    (declare (type tc:environment env)
+             (values tc:ty))
+    tc:*unit-type*)
+
   (:method ((expr node-seq) env)
     (declare (type tc:environment env)
              (values tc:ty))

--- a/src/constants.lisp
+++ b/src/constants.lisp
@@ -1,0 +1,15 @@
+;;;; constants.lisp
+;;;;
+;;;; This file contains constant values used throughout compilation.
+
+(defpackage #:coalton-impl/constants
+  (:use #:cl)
+  (:export
+   #:+default-loop-label+               ; VARIABLE
+   ))
+
+(in-package #:coalton-impl/constants)
+
+(defconstant +default-loop-label+ :coalton-loop
+  "Suррlіеԁ аs а lоор lаbеl оr wһіlе, whіlе-lеt, fоr, lоор, brеаk, аnԁ
+соntіnuе whеn а lаbеl іs nоt suррlіеԁ bу thе usеr.")

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -67,7 +67,15 @@
    #:<-                                 ; Syntax
    #:_
    #:return
-   #:the)
+   #:the
+   #:while
+   #:while-let
+   #:loop
+   #:break
+   #:continue
+   #:for
+   #:in                                 ; Syntax
+   )
 
   ;; Macros
   (:export

--- a/src/parser/collect.lisp
+++ b/src/parser/collect.lisp
@@ -232,6 +232,33 @@ in expressions. May not include all bound variables."
     (declare (values node-variable-list))
     (mapcan #'collect-variables-generic% (node-cond-clauses node)))
 
+  (:method ((node node-while))
+    (declare (values node-variable-list))
+    (nconc (collect-variables-generic% (node-while-expr node))
+           (collect-variables-generic% (node-while-body node))))
+
+  (:method ((node node-while-let))
+    (declare (values node-variable-list))
+    (nconc (collect-variables-generic% (node-while-let-expr node))
+           (collect-variables-generic% (node-while-let-body node))))
+
+  (:method ((node node-for))
+    (declare (values node-variable-list))
+    (nconc (collect-variables-generic% (node-for-expr node))
+           (collect-variables-generic% (node-for-body node))))  
+  
+  (:method ((node node-loop))
+    (declare (values node-variable-list))
+    (collect-variables-generic% (node-loop-body node)))
+
+  (:method ((node node-break))
+    (declare (values node-variable-list &optional))
+    nil)
+
+  (:method ((node node-continue))
+    (declare (values node-variable-list &optional))
+    nil)
+
   (:method ((node node-do-bind))
     (declare (values node-variable-list &optional))
     (collect-variables-generic% (node-do-bind-expr node)))

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -279,6 +279,84 @@
       :source (node-source node))
      ctx))
 
+  (:method ((node node-while) ctx)
+    (declare (type algo:immutable-map ctx)
+             (values node algo:immutable-map))
+    (values
+     (make-node-while
+      :expr (rename-variables-generic% (node-while-expr node) ctx)
+      :label (node-while-label node)
+      :body (rename-variables-generic% (node-while-body node) ctx)
+      :source (node-source node))
+     ctx))
+
+  (:method ((node node-while-let) ctx)
+    (declare (type algo:immutable-map ctx)
+             (values node algo:immutable-map))
+    (let*
+        ((new-bindings
+           (make-local-vars
+            (mapcar #'pattern-var-name
+                    (pattern-variables (node-while-let-pattern node)))))
+
+           (new-ctx
+             (algo:immutable-map-set-multiple ctx new-bindings)))
+
+
+      (values
+       (make-node-while-let
+        :label (node-while-let-label node)
+        :pattern (rename-variables-generic% (node-while-let-pattern node) new-ctx)
+        :expr (rename-variables-generic% (node-while-let-expr node) ctx)
+        :body (rename-variables-generic% (node-while-let-body node) new-ctx)
+        :source (node-source node))
+       new-ctx)))
+
+  (:method ((node node-for) ctx)
+    (declare (type algo:immutable-map ctx)
+             (values node algo:immutable-map))
+    (let*
+        ((new-bindings
+           (make-local-vars
+            (mapcar #'pattern-var-name
+                    (pattern-variables (node-for-pattern node)))))
+
+           (new-ctx
+             (algo:immutable-map-set-multiple ctx new-bindings)))
+
+      (values
+       (make-node-for
+        :label (node-for-label node)
+        :pattern (rename-variables-generic% (node-for-pattern node) new-ctx)
+        :expr (rename-variables-generic% (node-for-expr node) ctx)
+        :body (rename-variables-generic% (node-for-body node) new-ctx)
+        :source (node-source node))
+       new-ctx)))
+
+  (:method ((node node-loop) ctx)
+    (declare (type algo:immutable-map ctx)
+             (values node algo:immutable-map))
+    (values
+     (make-node-loop
+      :source (node-source node)
+      :label (node-loop-label node)
+      :body (rename-variables-generic% (node-loop-body node) ctx))
+     ctx))
+
+  (:method ((node node-break) ctx)
+    (declare (type algo:immutable-map ctx)
+             (values node algo:immutable-map))
+    (values
+     node
+     ctx))
+
+  (:method ((node node-continue) ctx)
+    (declare (type algo:immutable-map ctx)
+             (values node algo:immutable-map))
+    (values
+     node
+     ctx))
+  
   (:method ((node node-unless) ctx)
     (declare (type algo:immutable-map ctx)
              (values node algo:immutable-map))

--- a/src/typechecker/expression.lisp
+++ b/src/typechecker/expression.lisp
@@ -111,6 +111,33 @@
    #:make-node-unless                   ; CONSTRUCTOR
    #:node-unless-expr                   ; ACCESSOR
    #:node-unless-body                   ; ACCESSOR
+   #:node-while                         ; STRUCT
+   #:make-node-while                    ; CONSTRUCTOR
+   #:node-while-label                   ; ACCESSOR
+   #:node-while-expr                    ; ACCESSOR
+   #:node-while-body                    ; ACCESSOR
+   #:node-while-let                     ; STRUCT
+   #:make-node-while-let                ; CONSTRUCTOR
+   #:node-while-let-label               ; ACCESSOR
+   #:node-while-let-pattern             ; ACCESSOR 
+   #:node-while-let-expr                ; ACCESSOR
+   #:node-while-let-body                ; ACCESSOR
+   #:node-for                           ; STRUCT
+   #:make-node-for                      ; CONSTRUCTOR
+   #:node-for-label                     ; ACCESSOR
+   #:node-for-pattern                   ; ACCESSOR 
+   #:node-for-expr                      ; ACCESSOR
+   #:node-for-body                      ; ACCESSOR
+   #:node-loop                          ; STRUCT
+   #:make-node-loop                     ; CONSTRUCTOR
+   #:node-loop-label                    ; ACCESSOR
+   #:node-loop-body                     ; ACCESSOR
+   #:node-break                         ; STRUCT
+   #:make-node-break                    ; CONSTRUCTOR
+   #:node-break-label                   ; ACCESSOR
+   #:node-continue                      ; STRUCT
+   #:make-node-continue                 ; CONSTRUCTOR
+   #:node-continue-label                ; ACCESSOR
    #:node-cond-clause                   ; STRUCT
    #:make-node-cond-clause              ; CONSTRUCTOR
    #:node-cond-clause-expr              ; ACCESSOR
@@ -301,6 +328,45 @@
             (:copier nil))
   (expr (util:required 'expr) :type node      :read-only t)
   (body (util:required 'body) :type node-body :read-only t))
+
+(defstruct (node-while
+            (:include node)
+            (:copier nil))
+  (label (util:required 'label) :type keyword   :read-only t)
+  (expr  (util:required 'expr)  :type node      :read-only t)
+  (body  (util:required 'body)  :type node-body :read-only t))
+
+(defstruct (node-while-let
+            (:include node)
+            (:copier nil))
+  (label   (util:required 'label)   :type keyword   :read-only t)
+  (pattern (util:required 'pattern) :type pattern   :read-only t)
+  (expr    (util:required 'expr)    :type node      :read-only t)
+  (body    (util:required 'body)    :type node-body :read-only t))
+
+(defstruct (node-for
+            (:include node)
+            (:copier nil))
+  (label   (util:required 'label)   :type keyword   :read-only t)
+  (pattern (util:required 'pattern) :type pattern   :read-only t)
+  (expr    (util:required 'expr)    :type node      :read-only t)
+  (body    (util:required 'body)    :type node-body :read-only t))
+
+(defstruct (node-loop
+            (:include node)
+            (:copier nil))
+  (label (util:required 'label) :type keyword   :read-only t)
+  (body  (util:required 'body)  :type node-body :read-only t))
+
+(defstruct (node-break 
+            (:include node)
+            (:copier nil))
+  (label (util:required 'label) :type keyword :read-only t))
+
+(defstruct (node-continue
+            (:include node)
+            (:copier nil))
+  (label (util:required 'label) :type keyword :read-only t))
 
 (defstruct (node-cond-clause
             (:copier nil))
@@ -517,6 +583,57 @@
    :source (node-source node)
    :expr (tc:apply-substitution subs (node-unless-expr node))
    :body (tc:apply-substitution subs (node-unless-body node))))
+
+(defmethod tc:apply-substitution (subs (node node-while))
+  (declare (type tc:substitution-list subs)
+           (values node-while))
+  (make-node-while
+   :type (tc:apply-substitution subs (node-type node))
+   :source (node-source node)
+   :label (node-while-label node)
+   :expr (tc:apply-substitution subs (node-while-expr node))
+   :body (tc:apply-substitution subs (node-while-body node))))
+
+(defmethod tc:apply-substitution (subs (node node-while-let))
+  (declare (type tc:substitution-list subs)
+           (values node-while-let))
+  (make-node-while-let
+   :type (tc:apply-substitution subs (node-type node))
+   :source (node-source node)
+   :label (node-while-let-label node)
+   :pattern (tc:apply-substitution subs (node-while-let-pattern node))
+   :expr (tc:apply-substitution subs (node-while-let-expr node))
+   :body (tc:apply-substitution subs (node-while-let-body node))))
+
+(defmethod tc:apply-substitution (subs (node node-for))
+  (declare (type tc:substitution-list subs)
+           (values node-for))
+  (make-node-for
+   :type (tc:apply-substitution subs (node-type node))
+   :source (node-source node)
+   :label (node-for-label node)
+   :pattern (tc:apply-substitution subs (node-for-pattern node))
+   :expr (tc:apply-substitution subs (node-for-expr node))
+   :body (tc:apply-substitution subs (node-for-body node))))
+
+(defmethod tc:apply-substitution (subs (node node-loop))
+  (declare (type tc:substitution-list subs)
+           (values node-loop))
+  (make-node-loop
+   :type (tc:apply-substitution subs (node-type node))
+   :source (node-source node)
+   :label (node-loop-label node)
+   :body (tc:apply-substitution subs (node-loop-body node))))
+
+(defmethod tc:apply-substitution (subs (node node-break))
+  (declare (type tc:substitution-list subs)
+           (values node-break))
+  node)
+
+(defmethod tc:apply-substitution (subs (node node-continue))
+  (declare (type tc:substitution-list subs)
+           (values node-continue))
+  node)
 
 (defmethod tc:apply-substitution (subs (node node-cond-clause))
   (declare (type tc:substitution-list subs)

--- a/src/typechecker/traverse.lisp
+++ b/src/typechecker/traverse.lisp
@@ -34,6 +34,12 @@
   (unless          #'identity :type function :read-only t)
   (cond-clause     #'identity :type function :read-only t)
   (cond            #'identity :type function :read-only t)
+  (while           #'identity :type function :read-only t)
+  (while-let       #'identity :type function :read-only t)
+  (for             #'identity :type function :read-only t)
+  (loop            #'identity :type function :read-only t)
+  (break           #'identity :type function :read-only t)
+  (continue        #'identity :type function :read-only t)
   (do-bind         #'identity :type function :read-only t)
   (do              #'identity :type function :read-only t))
 
@@ -270,6 +276,69 @@
       :source (node-source node)
       :clauses (traverse (node-cond-clauses node) block))))
 
+  (:method ((node node-while) block)
+    (declare (type traverse-block block)
+             (values node &optional))
+    (funcall
+     (traverse-while block)
+     (make-node-while
+      :type (node-type node)
+      :source (node-source node)
+      :label (node-while-label node)
+      :expr (traverse (node-while-expr node) block)
+      :body (traverse (node-while-body node) block))))
+
+  (:method ((node node-while-let) block)
+    (declare (type traverse-block block)
+             (values node &optional))
+    (funcall
+     (traverse-while-let block)
+     (make-node-while-let
+      :type (node-type node)
+      :source (node-source node)
+      :label (node-while-let-label node)
+      :pattern (node-while-let-pattern node)
+      :expr (traverse (node-while-let-expr node) block)
+      :body (traverse (node-while-let-body node) block))))
+
+  (:method ((node node-for) block)
+    (declare (type traverse-block block)
+             (values node &optional))
+    (funcall
+     (traverse-for block)
+     (make-node-for
+      :type (node-type node)
+      :source (node-source node)
+      :label (node-for-label node)
+      :pattern (node-for-pattern node)
+      :expr (traverse (node-for-expr node) block)
+      :body (traverse (node-for-body node) block))))
+  
+  (:method ((node node-loop) block)
+    (declare (type traverse-block block)
+             (values node &optional))
+    (funcall
+     (traverse-loop block)
+     (make-node-loop
+      :type (node-type node)
+      :source (node-source node)
+      :label (node-loop-label node)
+      :body (traverse (node-loop-body node) block))))
+  
+  (:method ((node node-break) block)
+    (declare (type traverse-block block)
+             (values node &optional))
+    (funcall
+     (traverse-break block)
+     node))
+  
+  (:method ((node node-continue) block)
+    (declare (type traverse-block block)
+             (values node &optional))
+    (funcall
+     (traverse-continue block)
+     node))
+  
   (:method ((node node-do-bind) block)
     (declare (type traverse-block block)
              (values node-do-bind &optional))

--- a/tests/looping-native-tests.lisp
+++ b/tests/looping-native-tests.lisp
@@ -1,0 +1,156 @@
+(in-package #:coalton-native-tests)
+
+(define-test test-while-loop ()
+  (let ((countdown (cell:new 10))
+        (sum (cell:new 0)))
+    (while (< 0 (cell:decrement! countdown))
+      (cell:update! (+ (cell:read countdown)) sum))
+    (is (== 0 (cell:read countdown)))
+    (is (== 45 (cell:read sum)))))
+
+
+(define-test test-while-loop-break ()
+  (let countdown = (cell:new 10))
+  (let sum = (cell:new 0))
+
+  (while (< 0 (cell:decrement! countdown))
+    (cell:update! (+ (cell:read countdown)) sum)
+    (when (== (cell:read countdown) 5) (break)))
+
+  (is (== 5 (cell:read countdown)))
+  (is (== 35 (cell:read sum)))
+
+  ;; again but now we break with labels
+  (cell:swap! countdown 10)
+  (cell:swap! sum 0)
+
+  (while :aloop (< 0 (cell:decrement! countdown))
+    (cell:update! (+ (cell:read countdown)) sum)
+    (when (== (cell:read countdown) 5) (break :aloop)))
+
+  (is (== 5 (cell:read countdown)))
+  (is (== 35 (cell:read sum)))
+
+  ;; just evens
+  (cell:swap! countdown 10)
+  (cell:swap! sum 0)
+
+  (while :aloop (< 0 (cell:decrement! countdown))
+    (when (odd? (cell:read countdown)) (continue :aloop))
+    (cell:update! (+ (cell:read countdown)) sum))
+
+  (is (== 20 (cell:read sum))))
+
+
+(define-test test-while-let ()
+  (let ((iter (iter:up-to 10))
+        (sum (cell:new 0)))
+    (while-let
+     (Some wtf) = (iter:next! iter)
+     (cell:update! (+ wtf) sum))
+    (is (== 45 (cell:read sum)))))
+
+
+(define-test test-for ()
+  (let ((sum (cell:new 0)))
+
+    (for x in (iter:up-to 10) (cell:update! (+ x) sum))
+    (is (== 45 (cell:read sum)))
+
+    (cell:swap! sum 0)
+    (for x in (iter:up-to 20)
+         (cell:update! (+ x) sum)
+         (when (== 9 x) (break)))
+    (is (== 45 (cell:read sum )))
+
+    (cell:swap! sum 0)
+    (for x in (iter:up-to 20)
+         (when (even? x) (continue))
+         (cell:update! (+ x) sum))
+    (is (== 100 (cell:read sum)))
+
+
+    (cell:swap! sum 0)
+    (for :aloop x in (iter:up-to 20)
+         (cell:update! (+ x) sum)
+         (when (== 9 x) (break :aloop)))
+    (is (== 45 (cell:read sum )))
+
+
+    (cell:swap! sum 0)
+    (for :aloop x in (iter:up-to 20)
+         (when (even? x) (continue :aloop))
+         (cell:update! (+ x) sum))
+    (is (== 100 (cell:read sum)))))
+
+(define-test test-loop-control ()
+  ;; These first few just test that escape works at all. Tests will
+  ;; hang if it doesn't.
+  (loop (break))
+  (is True)
+
+  (loop :outer (break))
+  (is True)
+
+  (loop :outer (break :outer))
+  (is True)
+
+  (loop :outer (while True (break :outer)))
+  (is True)
+
+  ;; test breaking from an outer loop in an inner loop.
+  (let counter = (cell:new 0))
+  (let acc = (cell:new Nil))
+  (loop :outer
+        (while (< (cell:increment! counter) 10)
+          (let x = (fold + (cell:read counter) (cell:read acc)))
+          (when (< 500 x)
+            (break :outer))
+          (when (/= 0 (mod (cell:read counter) 3)) 
+            (cell:push! acc x)
+            Unit))
+        
+        (when (< (length (cell:read acc)) 500)
+          (cell:swap! counter 0)
+          Unit))
+  (is (== 279 (list:car (cell:read acc))))
+
+
+  ;; the same thing but using continue in the inner loop  
+  (cell:swap! counter 0)
+  (cell:swap! acc Nil)
+  (loop :outer
+        (while (< (cell:increment! counter) 10)
+          (let x = (fold + (cell:read counter) (cell:read acc)))
+          (when (< 500 x)
+            (break :outer))
+          (when (== 0 (mod (cell:read counter) 3)) 
+            (continue))
+          (cell:push! acc x))
+
+        (when (< (length (cell:read acc)) 500)
+          (cell:swap! counter 0)
+          Unit))
+  (is (== 279 (list:car (cell:read acc))))
+
+  ;; the same thing again, but just using loop
+  (cell:swap! counter 0)
+  (cell:swap! acc Nil)
+  (loop :outer
+        (loop
+          (unless (< (cell:increment! counter) 10)
+            (break))                ; break inner
+          (let x = (fold + (cell:read counter) (cell:read acc)))
+          (when (< 500 x)
+            (break :outer))         ; break outer
+          (when (== 0 (mod (cell:read counter) 3))
+            (continue))             ; continue inner
+          (cell:push! acc x)
+          (unless (< (length (cell:read acc)) 500)
+            (continue :outer)))     ; we can continue from outer in inner
+        (cell:swap! counter 0))
+  (is (== 279 (list:car (cell:read acc)))))
+
+
+
+

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -26,6 +26,7 @@
    (#:vector #:coalton-library/vector)
    (#:slice #:coalton-library/slice)
    (#:hashtable #:coalton-library/hashtable)
+   (#:cell #:coalton-library/cell)
    (#:iter #:coalton-library/iterator)
    (#:list #:coalton-library/list)
    (#:red-black/tree #:coalton-library/ord-tree)

--- a/tests/parser/parse-break.1.bad.coalton
+++ b/tests/parser/parse-break.1.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse-Break
+(package test-parser)
+
+(define f (break))

--- a/tests/parser/parse-break.2.bad.coalton
+++ b/tests/parser/parse-break.2.bad.coalton
@@ -1,0 +1,5 @@
+;; BAD: Parse-Break
+(package test-parser)
+
+(define f
+  (while :x True (break :y)))

--- a/tests/parser/parse-break.3.bad.coalton
+++ b/tests/parser/parse-break.3.bad.coalton
@@ -1,0 +1,5 @@
+;; BAD: Parse-Break
+(package test-parser)
+
+(define f
+  (while :x True (return (fn () (break :x)))))

--- a/tests/parser/parse-break.4.bad.coalton
+++ b/tests/parser/parse-break.4.bad.coalton
@@ -1,0 +1,5 @@
+;; BAD: Parse-Break
+(package test-parser)
+
+(define f
+  (while True (return (fn () (break)))))

--- a/tests/parser/parse-break.good.coalton
+++ b/tests/parser/parse-break.good.coalton
@@ -1,0 +1,30 @@
+;; GOOD: Parse Break
+(package test-package)
+
+(define f
+  (loop
+    (break)))
+
+(define g
+  (for x in "hello"
+       (break)))
+
+(define h
+  (while true
+    (break)))
+
+(define k
+  (while-let (Some x) = (get-next)
+             (break)))
+
+(define m
+  (loop :alabel (break)))
+
+(define n
+  (loop :alabel
+        (break :alabel)))
+
+  
+(define o
+  (while :somelabel true
+    (break :somelabel)))

--- a/tests/parser/parse-continue.1.bad.coalton
+++ b/tests/parser/parse-continue.1.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse Continue
+(package test-parser)
+
+(define f (continue))

--- a/tests/parser/parse-continue.2.bad.coalton
+++ b/tests/parser/parse-continue.2.bad.coalton
@@ -1,0 +1,6 @@
+;; BAD: Parse Continue
+(package test-parser)
+
+(define f
+  (loop :foo        
+    (continue notakeyword)))

--- a/tests/parser/parse-continue.3.bad.coalton
+++ b/tests/parser/parse-continue.3.bad.coalton
@@ -1,0 +1,6 @@
+;; BAD: Parse Continue
+(package test-parser)
+
+(define f
+  (loop :foo        
+    (continue :not-foo)))

--- a/tests/parser/parse-continue.4.bad.coalton
+++ b/tests/parser/parse-continue.4.bad.coalton
@@ -1,0 +1,7 @@
+;; BAD: Parse Continue
+(package test-parser)
+
+(define f
+  (loop
+    (let ((continuer (fn () (continue))))
+      (continuer))))

--- a/tests/parser/parse-continue.5.bad.coalton
+++ b/tests/parser/parse-continue.5.bad.coalton
@@ -1,0 +1,8 @@
+;; BAD: Parse Continue
+(package test-parser)
+
+(define f
+  (loop :blech
+        (let ((continuer (fn () (continue :blech))))
+          (continuer))))
+

--- a/tests/parser/parse-continue.good.coalton
+++ b/tests/parser/parse-continue.good.coalton
@@ -1,0 +1,29 @@
+;; GOOD: Parse Continue
+(package test-package)
+
+(define f
+  (loop
+    (continue)))
+
+(define g
+  (for x in "hello"
+       (continue)))
+
+(define h
+  (while true
+    (continue)))
+
+(define k
+  (while-let (Some x) = (get-next)
+             (continue)))
+(define m
+  (loop :alabel (continue)))
+
+(define n
+  (loop :alabel
+        (continue :alabel)))
+
+(define o
+  (while :somelabel true
+    (loop :anotherlabel
+          (continue :somelabel))))

--- a/tests/parser/parse-for.1.bad.coalton
+++ b/tests/parser/parse-for.1.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse For
+(package test-parser)
+
+(define f (for))

--- a/tests/parser/parse-for.2.bad.coalton
+++ b/tests/parser/parse-for.2.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse For
+(package test-parser)
+
+(define f (for x))

--- a/tests/parser/parse-for.3.bad.coalton
+++ b/tests/parser/parse-for.3.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse For
+(package test-parser)
+
+(define f (for x y))

--- a/tests/parser/parse-for.4.bad.coalton
+++ b/tests/parser/parse-for.4.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse For
+(package test-parser)
+
+(define f (for x in iter))

--- a/tests/parser/parse-for.5.bad.coalton
+++ b/tests/parser/parse-for.5.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse For
+(package test-parser)
+
+(define f (for :label x in iter))

--- a/tests/parser/parse-loop.1.bad.coalton
+++ b/tests/parser/parse-loop.1.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse Loop
+(package test-parser)
+
+(define f (loop))

--- a/tests/parser/parse-loop.2.bad.coalton
+++ b/tests/parser/parse-loop.2.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse Loop
+(package test-parser)
+
+(define f (loop :alabel))

--- a/tests/parser/parse-while-let.1.bad.coalton
+++ b/tests/parser/parse-while-let.1.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let))

--- a/tests/parser/parse-while-let.2.bad.coalton
+++ b/tests/parser/parse-while-let.2.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let (Some x)))

--- a/tests/parser/parse-while-let.3.bad.coalton
+++ b/tests/parser/parse-while-let.3.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let (Some x) z))

--- a/tests/parser/parse-while-let.4.bad.coalton
+++ b/tests/parser/parse-while-let.4.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let (Some x) = (moo)))

--- a/tests/parser/parse-while-let.5.bad.coalton
+++ b/tests/parser/parse-while-let.5.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let :label (Some x) = (moo)))

--- a/tests/parser/parse-while-let.6.bad.coalton
+++ b/tests/parser/parse-while-let.6.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let :label))

--- a/tests/parser/parse-while-let.7.bad.coalton
+++ b/tests/parser/parse-while-let.7.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let :label foo))

--- a/tests/parser/parse-while-let.8.bad.coalton
+++ b/tests/parser/parse-while-let.8.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let :label foo nope))

--- a/tests/parser/parse-while-let.9.bad.coalton
+++ b/tests/parser/parse-while-let.9.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While-Let
+(package test-parser)
+
+(define f (while-let :label foo = bar))

--- a/tests/parser/parse-while.1.bad.coalton
+++ b/tests/parser/parse-while.1.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While
+(package test-parser)
+
+(define f (while))

--- a/tests/parser/parse-while.2.bad.coalton
+++ b/tests/parser/parse-while.2.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While
+(package test-parser)
+
+(define f (while false))

--- a/tests/parser/parse-while.3.bad.coalton
+++ b/tests/parser/parse-while.3.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While
+(package test-parser)
+
+(define f (while :label))

--- a/tests/parser/parse-while.4.bad.coalton
+++ b/tests/parser/parse-while.4.bad.coalton
@@ -1,0 +1,4 @@
+;; BAD: Parse While
+(package test-parser)
+
+(define f (while :label True))

--- a/tests/parser/parse-while.good.coalton
+++ b/tests/parser/parse-while.good.coalton
@@ -1,0 +1,6 @@
+;; GOOD: Parse While
+(package test-package)
+
+(define f
+  (while :alabel True (trace "one") (trace "two")))
+

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -145,9 +145,9 @@
   ;; Check higher kinded type variables
   (check-coalton-types
    "(define-type (TFix :f)
-      (In (:f (TFix :f))))"
+      (InType (:f (TFix :f))))"
 
-   '("In" . "(:f (TFix :f) -> TFix :f)"))
+   '("InType" . "(:f (TFix :f) -> TFix :f)"))
 
   ;; Check that constructors are properly typed
   (signals tc:tc-error


### PR DESCRIPTION
This PR introduces looping constructs into Coalton. 

Some algorithms are more naturally expressed with imperative and go-to style iteration than they are with recursion. This is especially the case with complex search algorithms and scheduling algorithms that utilize some form of backtracking.  It is not that these algorithms *cannot* be expressed in a recursive style, only that sometimes it is awkward to do so. 

This PR takes a crack at addressing this need. It enlarges the toolbox of Coalton programmers without sacrificing the things that make Coalton great: excellent error messages, and statically typed programs.

Here's what this PR lets you do:

``` lisp

;; loop while a predicate is true
(while <predicate> 
   <action1> 
   <action2>
   ... )

;; loop while a pattern matches
(while-let  pattern = expression 
   <action1> 
   <action2>
   ...)

;; loop over values in an intoiterator instance
(for <pattern> in <intoiterator-value>
   <action1> 
   <action2>
   ...)

;; loop forever
(loop [optional-label] 
    <action1>
    <action2> 
    ...)


```

Moreover, `(continue)` and `(break)` are available in all of the above loops. If in a `loop`, both `continue` and `break` accept an optional `label` form.  A parse error will signal when the provided label does not match the label of a lexically enclosing loop.  (i.e. you cannot escape from a loop by calling `(break :moo)` in some function that a loop happens to call).

- [x] `while`
- [x] `while-let` 
- [x] `for` (iterators)
- [x] `loop`
- [x] a `break` and `continue` for use in `while` and `loop`
- [x] `break` and `continue` in `while`-style loops
- [x] labelled `loop` with labelled `break` and `continue`

Any and all of these can be scrapped.