### PR TITLE
If the method is declared inline, then inline its method instances

### DIFF
--- a/library/math/num.lisp
+++ b/library/math/num.lisp
@@ -229,6 +229,7 @@
            (Some x))))
 
 (cl:eval-when (:compile-toplevel :load-toplevel)
+  (cl:declaim (inline + - * fromInt))
   (cl:defmacro define-num-float (type lisp-type)
     "Define `Num' for TYPE"
 


### PR DESCRIPTION
Here is an attempt to fix https://github.com/coalton-lang/coalton/issues/985

The idea is this: if a method is known to have been declared inline, then while defining the method instances, we also proclaim the method instance to be inline. If the method is not declared inline, then its method instances will not be declared inline either. Thus this maintains the default lispy behavior of not requiring call sites to be recompiled when the function being called is redefined, but allows for inlining when the user demands so.

One problem I'm facing is that the inlining works as expected on the first compile-load. But when the lisp image is subsequently restarted, and coalton is loaded without compilation again, then the inlining does not work. EDIT: I got why this is happening - I'm proclaiming during a macroexpansion, so the effects do not reoccur after the expanded macro form is loaded. But, at the moment, I don't know what would be the appropriate place to make the change proposed in this PR.