### PR TITLE
    don't specialize Lisp vector underlying VECTOR/SLICE :A

### DIFF
--- a/examples/quil-coalton/src/quil-coalton.lisp
+++ b/examples/quil-coalton/src/quil-coalton.lisp
@@ -5,12 +5,12 @@
   (declare parse-quil-string (Parser String))
   (define parse-quil-string
     (map3
-     (fn (a b c) (into b))
+     (fn (_a b _c) (into b))
      (char #\")
      (many0
       (alt
        (not-char #\")
-       (map2 (fn (a b) b)
+       (map2 (fn (_a b) b)
              (char #\\)
              (char #\"))))
      (char #\")))
@@ -259,14 +259,14 @@
 
   (declare parse-quil-comment (Parser Unit))
   (define parse-quil-comment
-    (map3 (fn (a b c) Unit)
+    (map3 (fn (_a _b _c) Unit)
           (many0 non-newline-whitespace)
           (char #\#)
           (many0 (not-char #\Newline))))
 
   (declare parse-quil-comment-line (Parser Unit))
   (define parse-quil-comment-line
-    (map3 (fn (_ __ ___) Unit)
+    (map3 (fn (_a _b _c) Unit)
           (many0 whitespace)
           parse-quil-comment
           (alt (map (const Unit) (char #\Newline))
@@ -285,10 +285,10 @@
      QuilProgram
      (map2 const
            (many0
-            (map2 (fn (a _) a)
+            (map2 (fn (a _b) a)
                   ;; Quil statements
                   (map4
-                   (fn (_ a __ ___) a)
+                   (fn (_a b _c _d) b)
                    ;; Allow leading whitespace (including newlines) and comments
                    (many0 (alt parse-quil-comment-line whitespace))
                    parse-quil-statement

--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -399,7 +399,7 @@
 
   (declare initialEnv ClassEnv)
   (define initialEnv
-    (ClassEnv (fn (i) (fail "Class not defined"))
+    (ClassEnv (fn (_i) (fail "Class not defined"))
               (make-list tInteger tDouble)))
 
   ;; (define-type-alias EnvTransformer (ClassEnv -> (Optional ClassEnv)))
@@ -924,7 +924,7 @@
     (Ambiguity Tyvar (List Pred)))
 
   (declare ambiguities (ClassEnv -> (List Tyvar) -> (List Pred) -> (List Ambiguity)))
-  (define (ambiguities ce vs ps)
+  (define (ambiguities _ce vs ps)
     (map (fn (v)
            (Ambiguity v (filter
                          (fn (x)
@@ -983,7 +983,7 @@
 
   (declare defaultedPreds (MonadFail :m => (ClassEnv -> (List Tyvar) -> (List Pred) -> (:m (List Pred)))))
   (define defaultedPreds
-    (withDefaults (fn (vps ts) (concat (map (fn (a)
+    (withDefaults (fn (vps _ts) (concat (map (fn (a)
                                               (match a
                                                 ((Ambiguity _ x) x)))
                                             vps)))))

--- a/library/math/integral.lisp
+++ b/library/math/integral.lisp
@@ -186,7 +186,6 @@ are floored and truncated division, respectively."
            (gcd (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-GCD")))
            (^ (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-^")))
            (lcm (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-LCM")))
-           (ilog (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-ILOG")))
            (isqrt (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-ISQRT"))))
     `(coalton-toplevel
        (define-instance (Remainder ,type)

--- a/library/seq.lisp
+++ b/library/seq.lisp
@@ -391,7 +391,7 @@ shifts the each member of `target` down by `n` positions.  Mutates both
       (vector:set! (- (vector:length v) 1) a cv)
       cv))
 
-  (declare butfirst (iter:FromIterator (vector:Vector :a) :a =>  vector:Vector :a -> vector:Vector :a))
+  (declare butfirst (vector:Vector :a -> vector:Vector :a))
   (define (butfirst v)
     (iter:collect!
      (map (flip vector:index-unsafe v)

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -73,7 +73,7 @@
   
   (declare strip-prefix (String -> String -> (Optional String)))
   (define (strip-prefix prefix str)
-    "Returns a string without a give prefix, or None if the string
+    "Returns a string without a give prefix, or `None` if the string
 does not have that suffix."
     (let prefix-len = (length prefix))
     (let substr = (substring str 0 prefix-len))
@@ -83,7 +83,7 @@ does not have that suffix."
 
   (declare strip-suffix (String -> String -> (Optional String)))
   (define (strip-suffix suffix str)
-    "Returns a string without a give suffix, or None if the string
+    "Returns a string without a give suffix, or `None` if the string
 does not have that suffix."
     (let suffix-len = (length suffix))
     (let str-len = (length str))
@@ -94,7 +94,7 @@ does not have that suffix."
 
   (declare parse-int (String -> (Optional Integer)))
   (define (parse-int str)
-    "Parse the integer in string STR."
+    "Parse the integer in string `str`."
     (lisp (Optional Integer) (str)
       (cl:let ((x (cl:parse-integer str :junk-allowed cl:t)))
         (cl:if x
@@ -103,13 +103,13 @@ does not have that suffix."
   
   (declare ref-unchecked (String -> UFix -> Char))
   (define (ref-unchecked str idx)
-    "Return the IDXth character of STR. This function is partial."
+    "Return the `idx`th character of `str`. This function is partial."
     (lisp Char (str idx)
       (cl:char str idx)))
 
   (declare ref (String -> UFix -> (Optional Char)))
   (define (ref str idx)
-    "Return the IDXth character of STR."
+    "Return the `idx`th character of `str`."
     (if (< idx (length str))
         (Some (ref-unchecked str idx))
         None))
@@ -132,7 +132,7 @@ does not have that suffix."
 
   (declare chars (String -> iter:Iterator Char))
   (define (chars str)
-    "Returns an iterator over the characters in STR."
+    "Returns an iterator over the characters in `str`."
     (iter:into-iter str))
 
   ;;
@@ -165,7 +165,8 @@ does not have that suffix."
   (define-instance (iter:FromIterator String Char)
     (define (iter:collect! iter)
       (let vec = (the (Vector Char) (iter:collect! iter)))
-      (lisp String (vec) vec)))
+      (lisp String (vec)
+        (cl:coerce vec 'cl:string))))
 
   ;;
   ;; Conversions

--- a/tests/slice-tests.lisp
+++ b/tests/slice-tests.lisp
@@ -48,7 +48,8 @@
               (List Integer)
               (make-list 1 2 3 4 5 6 7 8)))))
 
-        (out (vector:new)))
+        (out (the (Vector (List Integer))
+                  (vector:new))))
 
     (iter:for-each!
      (fn (s)
@@ -102,7 +103,8 @@
               (List Integer)
               (make-list 1 2 3 4 5 6 7 8)))))
 
-        (out (vector:new)))
+        (out (the (Vector (List Integer))
+                  (vector:new))))
 
     (iter:for-each!
      (fn (s)
@@ -119,29 +121,3 @@
             (make-list
              (make-list 1 2 3)
              (make-list 4 5 6))))))
-
-(define-test slice-specialize-element-type ()
-  (is (== (slice:element-type
-           (slice:new 0 1
-                      (the (Vector (Optional Integer))
-                           (into (the (List (Optional Integer))
-                                      (make-list (Some 97)))))))
-          (lisp types:LispType () 'cl:t)))
-  (is (== (slice:element-type
-           (slice:new 0 1
-                      (the (Vector IFix)
-                           (into (the (List IFix)
-                                      (make-list 97))))))
-          (lisp types:LispType () 'cl:fixnum)))
-  (is (== (slice:element-type
-           (slice:new 0 1
-                      (the (Vector String)
-                           (into (the (List String)
-                                      (make-list "a"))))))
-          (lisp types:LispType () 'cl:t)))
-  (is (== (slice:element-type
-           (slice:new 0 1
-                      (the (Vector Char)
-                           (into (the (List Char)
-                                      (make-list #\a))))))
-          (lisp types:LispType () 'cl:character))))

--- a/tests/vector-tests.lisp
+++ b/tests/vector-tests.lisp
@@ -11,15 +11,5 @@
   (is (== (iter:collect! (iter:up-to 10))
           vec)))
 
-(define-test test-vector-specialize-element-type ()
-  (is (== (vector:element-type (the (Vector (Optional Integer)) (vector:new)))
-          (lisp types:LispType () 'cl:t)))
-  (is (== (vector:element-type (the (Vector IFix) (vector:new)))
-          (lisp types:LispType () 'cl:fixnum)))
-  (is (== (vector:element-type (the (Vector String) (vector:new)))
-          (lisp types:LispType () 'cl:t)))
-  (is (== (vector:element-type (the (Vector Char) (vector:new)))
-          (lisp types:LispType () 'cl:character))))
-
 (define-test test-vector-initial-element ()
   (== (vector:make "x" "x" "x") (vector:with-initial-element 3 "x")))


### PR DESCRIPTION

    
    We remove the type specialization of the VECTOR :A representation
    because it provides no (or worse) speed benefit, and only sometimes
    a space benefit. The space benefit is actually unpredictable from
    the programmer's perspective (it's not obvious when an array will
    specialize), and fragile (changing the vector type might change
    the space performance).
    
    Making this change is also beneficial because the user no longer
    has to write "RuntimeRepr" every time they use vectors.
