### PR TITLE
Synchronized names for uninintialized slot reporters

### DIFF
--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -175,8 +175,8 @@
 
 (defstruct (node-field (:include node))
   "Accessing a superclass on a typeclass dictionary"
-  (name (util:required 'field) :type parser:identifier :read-only t)
-  (dict (util:required 'dict)  :type node              :read-only t))
+  (name (util:required 'name) :type parser:identifier :read-only t)
+  (dict (util:required 'dict) :type node              :read-only t))
 
 (defstruct (node-dynamic-extent (:include node))
   "A single stack allocated binding"

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -23,11 +23,11 @@
 
 (defstruct (documentation-struct-entry
             (:include documentation-entry))
-  (type      (util:required 'type)        :type tc:ty                     :read-only t)
-  (tyvars    (util:required 'tyvars)      :type tc:tyvar-list             :read-only t)
-  (fields    (util:required 'fields)      :type util:string-list          :read-only t)
-  (field-tys (util:required 'field-types) :type hash-table                :read-only t)
-  (instances (util:required 'instances)   :type tc:ty-class-instance-list :read-only t))
+  (type      (util:required 'type)      :type tc:ty                     :read-only t)
+  (tyvars    (util:required 'tyvars)    :type tc:tyvar-list             :read-only t)
+  (fields    (util:required 'fields)    :type util:string-list          :read-only t)
+  (field-tys (util:required 'field-tys) :type hash-table                :read-only t)
+  (instances (util:required 'instances) :type tc:ty-class-instance-list :read-only t))
 
 (defun documentation-struct-entry-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -129,7 +129,7 @@
 (defstruct (coalton-file
             (:copier nil))
   (stream (util:required 'stream) :type stream :read-only t)
-  (name   (util:required 'file)   :type string :read-only t))
+  (name   (util:required 'name)   :type string :read-only t))
 
 (defstruct (coalton-error
             (:copier nil))

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -299,7 +299,7 @@
 ;;
 (defstruct (node-body
             (:copier nil))
-  (nodes     (util:required 'node)      :type node-body-element-list :read-only t)
+  (nodes     (util:required 'nodes)     :type node-body-element-list :read-only t)
   (last-node (util:required 'last-node) :type node                   :read-only t))
 
 (defstruct (node-abstraction

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -255,7 +255,7 @@
 (defstruct (struct-field
             (:copier nil))
   (name   (util:required 'name)   :type string :read-only t)
-  (type   (util:required 'ty)     :type ty     :read-only t)
+  (type   (util:required 'type)   :type ty     :read-only t)
   (source (util:required 'source) :type cons   :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -366,7 +366,7 @@
 (defstruct (instance-method-definition
             (:copier nil))
   (name      (util:required 'name)      :type node-variable       :read-only t)
-  (params    (util:required 'vars)      :type pattern-list        :read-only t)
+  (params    (util:required 'params)    :type pattern-list        :read-only t)
   (body      (util:required 'body)      :type node-body           :read-only t)
   (source    (util:required 'source)    :type cons                :read-only t))
 

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -222,7 +222,7 @@
   (name         (util:required 'name)         :type symbol           :read-only t)
   (runtime-type (util:required 'runtime-type) :type t                :read-only t)
   (type         (util:required 'type)         :type ty               :read-only t)
-  (tyvars       (util:required 'tvars)        :type tyvar-list       :read-only t)
+  (tyvars       (util:required 'tyvars)       :type tyvar-list       :read-only t)
   (constructors (util:required 'constructors) :type util:symbol-list :read-only t)
 
   ;; An explicit repr defined in the source, or nil if none was supplied. Computed repr will be reflected in

--- a/src/typechecker/expression.lisp
+++ b/src/typechecker/expression.lisp
@@ -200,14 +200,14 @@
 
 (defstruct (node-body
             (:copier nil))
-  (nodes     (util:required 'node)      :type node-body-element-list :read-only t)
+  (nodes     (util:required 'nodes)     :type node-body-element-list :read-only t)
   (last-node (util:required 'last-node) :type node                   :read-only t))
 
 (defstruct (node-abstraction
             (:include node)
             (:copier nil))
-  (params  (util:required 'vars)    :type pattern-list :read-only t)
-  (body    (util:required 'body)    :type node-body    :read-only t))
+  (params  (util:required 'params) :type pattern-list :read-only t)
+  (body    (util:required 'body)   :type node-body    :read-only t))
 
 (defstruct (node-let-binding
             (:copier nil))
@@ -287,7 +287,7 @@
             (:include node)
             (:copier nil))
   (expr (util:required 'expr) :type node :read-only t)
-  (then (util:required 'expr) :type node :read-only t)
+  (then (util:required 'then) :type node :read-only t)
   (else (util:required 'else) :type node :read-only t))
 
 (defstruct (node-when
@@ -322,9 +322,9 @@
 
 (defstruct (node-do-bind
             (:copier nil))
-  (pattern (util:required 'name)   :type pattern :read-only t)
-  (expr    (util:required 'expr)   :type node    :read-only t)
-  (source  (util:required 'source) :type cons    :read-only t))
+  (pattern (util:required 'pattern) :type pattern :read-only t)
+  (expr    (util:required 'expr)    :type node    :read-only t)
+  (source  (util:required 'source)  :type cons    :read-only t))
 
 (deftype node-do-body-element ()
   '(or node node-bind node-do-bind))

--- a/src/typechecker/toplevel.lisp
+++ b/src/typechecker/toplevel.lisp
@@ -43,10 +43,10 @@
 
 (defstruct (toplevel-define
             (:copier nil))
-  (name    (util:required 'name)         :type node-variable :read-only t)
-  (params  (util:required 'pattern-list) :type pattern-list  :read-only t)
-  (body    (util:required 'body)         :type node-body     :read-only t)
-  (source  (util:required 'source)       :type cons          :read-only t))
+  (name    (util:required 'name)   :type node-variable :read-only t)
+  (params  (util:required 'params) :type pattern-list  :read-only t)
+  (body    (util:required 'body)   :type node-body     :read-only t)
+  (source  (util:required 'source) :type cons          :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-list-p (x)


### PR DESCRIPTION
util:require raises a condition that reports the slot name for for uninitialized slots: make sure that all cases match the real slot name