### PR TITLE
add `(LispArray :t)`, add specialized representations of `LispArray` and `Complex`

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -168,6 +168,7 @@
                (:file "optional")
                (:file "result")
                (:file "tuple")
+               (:file "lisparray")
                (:file "list")
                (:file "vector")
                (:file "char")

--- a/library/lisparray.lisp
+++ b/library/lisparray.lisp
@@ -1,0 +1,78 @@
+;;;; lisparray.lisp
+;;;;
+;;;; An interface to Common Lisp rank-1 SIMPLE-ARRAYs.
+
+(coalton-library/utils:defstdlib-package #:coalton-library/lisparray
+  (:use #:coalton)
+  (:local-nicknames
+   (#:types #:coalton-library/types))
+  (:export
+   #:LispArray
+   #:make
+   #:make-uninitialized
+   #:length
+   #:aref
+   #:set!))
+
+(in-package #:coalton-library/lisparray)
+
+(named-readtables:in-readtable coalton:coalton)
+
+#+coalton-release
+(cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
+
+(coalton-toplevel
+  ;; The representation of (LispArray :t) is specially dealt with by
+  ;; the compiler in lisp-type.lisp.
+  (define-type (LispArray :t)
+    "A one-dimensional, non-resizable array of elements.
+
+These arrays are represented as possibly specialized `(cl:simple-array <type> (cl:*))` and are meant to be used as a tool either to interface with Lisp code or to implement efficient data structures. One should consult `Vector` or `Seq` for more general sequential data structure needs.
+
+Whether or not the arrays are specialized depends on the underlying Lisp implementation. Consult `cl:upgraded-array-element-type` to determine whether `LispArray` may get specialized.")
+
+  (declare make (types:RuntimeRepr :t => UFix -> :t -> LispArray :t))
+  (define (make n x)
+    "Make a new `LispArray` of length `n` initialized to `x`.
+
+If the type of `x` represents a specialized array "
+    ;; FIXME: how can we get this statically?
+    (let ((type (types:runtime-repr (types:proxy-of x))))
+      (lisp (LispArray :t) (n x type)
+        (cl:make-array n :element-type type :initial-element x))))
+
+  (declare make-uninitialized (types:RuntimeRepr :t => UFix -> LispArray :t))
+  (define (make-uninitialized n)
+    "Make a new LispArray of length `n` that can store elements of type `:t`.
+
+WARNING: The consequences are undefined if an uninitialized element is read before being set.
+"
+    (let p = types:Proxy)
+    (let p_ = (types:proxy-inner p))
+    (let type = (types:runtime-repr p_))
+    (types:as-proxy-of
+     (lisp (LispArray :t) (n type)
+       (cl:make-array n :element-type type))
+     p))
+
+  (declare length (LispArray :t -> UFix))
+  (define (length v)
+    "Return the length of the `LispArray` `v`."
+    (lisp UFix (v)
+      (cl:length v)))
+
+  (declare aref (LispArray :t -> UFix -> :t))
+  (define (aref v i)
+    "Read the `i`th value of the `LispArray` `v`."
+    (lisp :t (v i)
+      (cl:aref v i)))
+
+  (declare set! (LispArray :t -> UFix -> :t -> Unit))
+  (define (set! v i x)
+    "Set the `i`th value of the `LispArray` `v` to `x`."
+    (lisp Unit (v i x)
+      (cl:setf (cl:aref v i) x)
+      Unit)))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/LISPARRAY")

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -25,11 +25,18 @@
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
 (coalton-toplevel
-  (repr :native (cl:or cl:number complex))
+  ;; The representation of (Complex :t) is specially dealt with by the
+  ;; compiler in lisp-type.lisp.
   (define-type (Complex :a)
     "Complex number that may either have a native or constructed representation."
     (%Complex :a :a))
+)
 
+;; Quirk: We had to split the above COALTON-TOPLEVEL from the bottom
+;; one because Allegro needs to know about Complex before it gets used
+;; as a Lisp type in codegen. SBCL and CCL tolerate it fine.
+
+(coalton-toplevel
   (define-class (Num :a => Complex :a)
     (complex (:a -> :a -> (Complex :a)))
     (real-part (Complex :a -> :a))

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -121,6 +121,7 @@
                coalton-library/char
                coalton-library/string
                coalton-library/tuple
+               coalton-library/lisparray
                coalton-library/optional
                coalton-library/list
                coalton-library/result

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -232,7 +232,7 @@ Used to forbid reading while inside quasiquoted forms.")
 
 (named-readtables:defreadtable coalton:coalton
   (:merge :standard)
-  (:macro-char #\( #'read-coalton-toplevel-open-paren)
+  (:macro-char #\( 'read-coalton-toplevel-open-paren)
   (:macro-char #\` (lambda (s c)
                      (let ((*coalton-reader-allowed* nil))
                        (funcall (get-macro-character #\` (named-readtables:ensure-readtable :standard)) s c))))


### PR DESCRIPTION
This PR does three things:

- Adds a `LispArray` type to match the semantics of `(simple-array <t> (*))`. I think this is a good compromise between my concerns and @eliaslfox's suggestions. The name `LispArray` was chosen intentionally to emphasize this behavior, and not place itself as a "competitor" to `Vector` or `Seq`.
- Adds specialization of `(Complex :t)` type.
- Adds specialization of `(LispArray :t)` type.

Addresses #1008 in principle.

```
COALTON-USER> (coalton-codegen
                (declare f ((coalton-library/math/complex:Complex Single-Float) -> Single-Float))
                (define (f z)
                  (coalton-library/math/complex:square-magnitude z))
                
                (define (g z)
                  (coalton-library/math/complex:square-magnitude z)))
firing type specialization: (COALTON-LIBRARY/MATH/COMPLEX:COMPLEX #T20689) => (COMMON-LISP:OR COMMON-LISP:NUMBER COALTON-LIBRARY/MATH/COMPLEX:COMPLEX)
firing type specialization: (COALTON-LIBRARY/MATH/COMPLEX:COMPLEX COALTON:SINGLE-FLOAT) => (COMMON-LISP:COMPLEX COMMON-LISP:SINGLE-FLOAT)
(COMMON-LISP:PROGN
 (COMMON-LISP:DECLAIM
  (SB-EXT:MUFFLE-CONDITIONS SB-KERNEL:REDEFINITION-WARNING))
 (COALTON-IMPL/GLOBAL-LEXICAL:DEFINE-GLOBAL-LEXICAL G
                                                    COALTON-IMPL/RUNTIME/FUNCTION-ENTRY:FUNCTION-ENTRY)
 (COMMON-LISP:DEFUN G (#:DICT1872 Z-3371)
   (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:DICT1872 Z-3371)
                        (COMMON-LISP:TYPE
                         COALTON-LIBRARY/MATH/COMPLEX::CLASS/COMPLEX
                         #:DICT1872)
                        (COMMON-LISP:TYPE
                         (COMMON-LISP:OR COMMON-LISP:NUMBER COMPLEX) Z-3371)
                        (COMMON-LISP:VALUES COMMON-LISP:T
                                            COMMON-LISP:&OPTIONAL))
   (COALTON-LIBRARY/MATH/COMPLEX:SQUARE-MAGNITUDE #:DICT1872 Z-3371))
 (COMMON-LISP:SETF G (COALTON-IMPL/RUNTIME/FUNCTION-ENTRY::F2 #'G))
 (COALTON-IMPL/GLOBAL-LEXICAL:DEFINE-GLOBAL-LEXICAL F
                                                    COALTON-IMPL/RUNTIME/FUNCTION-ENTRY:FUNCTION-ENTRY)
 (COMMON-LISP:DEFUN F (Z-3370)
   (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE Z-3370)
                        (COMMON-LISP:TYPE
                         (COMMON-LISP:COMPLEX COMMON-LISP:SINGLE-FLOAT) Z-3370)
                        (COMMON-LISP:VALUES COMMON-LISP:SINGLE-FLOAT
                                            COMMON-LISP:&OPTIONAL))
   (COALTON-LIBRARY/MATH/COMPLEX:SQUARE-MAGNITUDE
    COALTON-LIBRARY/MATH/COMPLEX::|INSTANCE/COMPLEX SINGLE-FLOAT| Z-3370))
 (COMMON-LISP:SETF F (COALTON-IMPL/RUNTIME/FUNCTION-ENTRY::F1 #'F))
 (COMMON-LISP:DECLAIM
  (SB-EXT:UNMUFFLE-CONDITIONS SB-KERNEL:REDEFINITION-WARNING))
 (COMMON-LISP:VALUES))
```
