### PR TITLE
Adding Big-Float constructors for variable prec constants

### DIFF
--- a/library/big-float/README.md
+++ b/library/big-float/README.md
@@ -8,6 +8,12 @@ By default SBCL will use the `sb-mpfr` library.
 This depends on the MPFR library being installed, and visible within your
 dynamic linker path. Otherwise, you will get an error while compiling.
 
+When using the `sb-mpfr` library, two different float types are implemented:
+- `MPFR-Float`, a Coalton wrapper on the typical `mpfr-float`, and 
+- `Big-Float`, a Coalton type with two constructors:
+  - `(BFValue MPFR-Float)` and
+  - `(BFConst (:a -> MPFR-Float))` which allows constants to have variable precision.
+
 Before coalton is compiled set the environment
 variable`COALTON_PORTABLE_BIGFLOAT=1` or add the feature
 `:coalton-portable-bigfloat` to proceed anyways.

--- a/library/big-float/package.lisp
+++ b/library/big-float/package.lisp
@@ -29,6 +29,7 @@
    #:get-precision
    #:with-precision
 
+   #:MPFR-Float
    #:Big-Float
    #:with-precision-rounding
 


### PR DESCRIPTION
This addresses issue #1013 

I've renamed the existing `sb-mpfr` compatible `Big-Float` type to `MPFR-Float` type, and added a new `Big-Float` type with two constructors: `(BFValue MPFR-Float)` and `(BFConst (:a -> MPFR-Float))`. 

This allows for constants to readjust to current precision. 