### PR TITLE
check if unsigned numbers underflow

### DIFF
--- a/library/math/num.lisp
+++ b/library/math/num.lisp
@@ -191,7 +191,18 @@
 
        (define (- a b)
          (lisp ,type (a b)
-           (cl:values (cl:mod (cl:- a b) ,(cl:expt 2 bits)))))
+	   (cl:if (cl:< a b)
+		  (cl:cond
+		    ((cl:= ,bits 8)
+		     255)
+		    ((cl:= ,bits 16)
+		     65535)
+		    ((cl:= ,bits 32)
+		     4294967295)
+		    ((cl:= ,bits 64)
+		     18446744073709551615)
+		    (cl:t 4611686018427387903))
+		  (cl:values (cl:mod (cl:- a b) ,(cl:expt 2 bits))))))
 
        (define (* a b)
          (lisp ,type (a b)
@@ -199,7 +210,18 @@
 
        (define (fromInt x)
          (lisp ,type (x)
-           (cl:values (cl:mod x ,(cl:expt 2 bits))))))))
+	   (cl:if (cl:minusp x)
+		  (cl:cond
+		    ((cl:= ,bits 8)
+		     255)
+		    ((cl:= ,bits 16)
+		     65535)
+		    ((cl:= ,bits 32)
+		     4294967295)
+		    ((cl:= ,bits 64)
+		     18446744073709551615)
+		    (cl:t 4611686018427387903))
+		  (cl:values (cl:mod x ,(cl:expt 2 bits)))))))))
 
 (coalton-toplevel
   (define-num-checked Integer cl:identity)


### PR DESCRIPTION
@Izaakwltn  Hopefully this is not an issue that I made another pr. I had git issues with the other one.

This solves #921.

This is the interaction I just had in this new pr:

```
(coalton-toplevel 
		(declare add-8bit (U8 -> U8 -> U8))
		(define (add-8bit x y)
		  (+ x y))
		(declare sub-8bit (U8 -> U8 -> U8))
		(define (sub-8bit x y)
		  (- x y))
		(declare mul-8bit (U8 -> U8 -> U8))
		(define (mul-8bit x y)
		  (* x y))
		(declare fint (Integer -> U8))
		(define (fint x)
		  (fromInt x)))
; No value
COALTON-USER> (coalton (add-8bit 2 3))
5
COALTON-USER> (coalton (add-8bit 3 -4))
; Evaluation aborted on #<SIMPLE-ERROR "Unsigned value underflowed 8 bits." {1007939573}>.
COALTON-USER> (coalton (sub-8bit 3 2))
1
COALTON-USER> (coalton (sub-8bit 3 5))
; Evaluation aborted on #<SIMPLE-ERROR "Unsigned value underflowed 8 bits." {100835E453}>.
COALTON-USER> (coalton (mul-8bit 3 4))
12
COALTON-USER> (coalton (mul-8bit 3 -4))
; Evaluation aborted on #<SIMPLE-ERROR "Unsigned value underflowed 8 bits." {1008C8C2B3}>.
COALTON-USER> (coalton (fint 4))
4
COALTON-USER> (coalton (fint -2))
; Evaluation aborted on #<SIMPLE-ERROR "Unsigned value underflowed 8 bits." {10017D9693}>.
```

Thanks 