### PR TITLE
Fix style warnings from unused variables

### DIFF
--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -393,10 +393,12 @@ both CL namespaces appearing in NODE"
 
   (:method ((node node-break) &key variable-namespace-only)
     (declare (values parser:identifier-list &optional))
+    (declare (ignore variable-namespace-only))
     nil)
 
   (:method ((node node-continue) &key variable-namespace-only)
     (declare (values parser:identifier-list &optional))
+    (declare (ignore variable-namespace-only))
     nil)
   
   (:method ((node node-seq) &key variable-namespace-only)


### PR DESCRIPTION
This fixes the following style warning that shows when Coalton is built:
```
; caught STYLE-WARNING:
;   The variable VARIABLE-NAMESPACE-ONLY is defined but never used.
WARNING:
   Lisp compilation had style-warnings while
   compiling #<CL-SOURCE-FILE "coalton/compiler" "codegen" "ast">
```