### PR TITLE
Add Practical Common Lisp port to examples

### DIFF
--- a/examples/practical-coalton/15_pathnames.lisp
+++ b/examples/practical-coalton/15_pathnames.lisp
@@ -1,12 +1,4 @@
-;; To load this file, you need to load Chapter 15 from the Practical
-;; Common Lisp repository. The source code can be found at the link
-;; below. Then you can copy the Chapter 15 directory into
-;; ~/quicklisp/local-projects and run (quickload "Chapter-15").
-;; https://gigamonkeys.com/book/
-
 (in-package :cl-user)
-(ql:quickload "coalton")
-(ql:quickload "Chapter-15")
 (defpackage :practical-coalton.pathnames
   (:use
    #:coalton

--- a/examples/practical-coalton/15_pathnames.lisp
+++ b/examples/practical-coalton/15_pathnames.lisp
@@ -1,0 +1,177 @@
+;; To load this file, you need to load Chapter 15 from the Practical
+;; Common Lisp repository. The source code can be found at the link
+;; below. Then you can copy the Chapter 15 directory into
+;; ~/quicklisp/local-projects and run (quickload "Chapter-15").
+;; https://gigamonkeys.com/book/
+
+(in-package :cl-user)
+(ql:quickload "coalton")
+(ql:quickload "Chapter-15")
+(defpackage :practical-coalton.pathnames
+  (:use
+   #:coalton
+   #:coalton-prelude)
+  (:local-nicknames
+    (#:pth #:com.gigamonkeys.pathnames))
+  (:export
+   :list-directory
+   :file-exists-p
+   :directory-pathname-p
+   :file-pathname-p
+   :pathname-as-directory
+   :pathname-as-file
+   :walk-directory
+   :directory-p
+   :file-p))
+(in-package :practical-coalton.pathnames)
+
+(named-readtables:in-readtable coalton:coalton)
+
+;; Port of Chapter 15 from Practical Common Lisp, by Peter Seibel,
+;; to Coalton.
+;;
+;; In the previous chapter, we took the approach of rewriting the
+;; Common Lisp functions in Coalton. In this chapter, we instead
+;; write a thin wrapper around the Common Lisp functions.
+;;
+;; First, we start by defining a few Coalton types that provide
+;; a type-safe interface to the Common Lisp pathname functions.
+;; For example, in several of the Common Lisp functions a wildcard
+;; pathname is an invalid argument. Instead of checking for wildcard
+;; paths and erroring if found, we can use the type system to ensure
+;; that we never pass a wildcard path to a function that doesn't
+;; accept it.
+;;
+;; Second, we define a corresponding Coalton function for each
+;; function exported by the Common Lisp pathname package.
+
+;; TODO: I'm open to any suggestions to make this code less verbose.
+;; If you count the comments at the top of the file and the package
+;; definition (which the original doesn't have), this is almost
+;; as long as the Common Lisp implementation this is wrapping!
+
+(cl:defmacro wrap-lisp-call (type function value)
+  "Wrap a call to a Lisp function that returns a value of type TYPE
+in a Coalton function that returns a value of type (Optional TYPE).
+A nil return value is converted to None."
+  `(lisp (Optional ,type) (,value)
+     (cl:let ((result (,function ,value)))
+       (cl:if result
+         (coalton (Some (lisp ,type () result)))
+         (coalton None)))))
+
+(coalton-toplevel
+
+  (define-class (Path :a))
+
+  (define-instance (Path String))
+
+  (repr :native cl:pathname)
+  (define-type Pathname)
+
+  (declare pathname->string (Pathname -> String))
+  (define (pathname->string pathname)
+    (lisp String (pathname)
+      (cl:write-to-string pathname)))
+
+  (define-instance (Path Pathname))
+
+  (repr :native cl:pathname)
+  (define-type WildPathname)
+
+  (define-instance (Path WildPathname)))
+
+(coalton-toplevel
+
+  ;; TODO: It's a little unforunate that the Either type is called
+  ;; Result in Coalton, because it makes a usage to represent one of two
+  ;; possible values a little confusing. Is there a more idiomatic way
+  ;; to represent this?
+  (declare list-directory ((Result String Pathname) -> (List Pathname)))
+  (define (list-directory dirname)
+    "Return a list of pathnames for the files in the directory named by DIRNAME."
+    (match dirname
+      ((Err str)
+       (lisp (List Pathname) (str)
+         (pth:list-directory str)))
+      ((Ok pth)
+       (lisp (List Pathname) (pth)
+         (pth:list-directory pth)))))
+
+  (declare file-exists-p ((Path :a) => :a -> (Optional Pathname)))
+  (define (file-exists-p pth)
+    "Return a pathname for the file named by PTH if it exists, otherwise return None."
+    (wrap-lisp-call :a pth:file-exists-p pth))
+
+  (declare directory-pathname-p ((Path :a) => :a -> (Optional :a)))
+  (define (directory-pathname-p pth)
+    (wrap-lisp-call :a pth:directory-pathname-p pth))
+
+  (declare file-pathname-p ((Path :a) => :a -> (Optional :a)))
+  (define (file-pathname-p pth)
+    (wrap-lisp-call :a pth:file-pathname-p pth))
+
+  (declare pathname-as-directory ((Result String Pathname) -> Pathname))
+  (define (pathname-as-directory pth)
+    (match pth
+      ((Err str)
+       (lisp :a (str)
+         (pth:pathname-as-directory str)))
+      ((Ok pth)
+       (lisp :a (pth)
+         (pth:pathname-as-directory pth)))))
+
+  (declare pathname-as-file ((Result String Pathname) -> Pathname))
+  (define (pathname-as-file pth)
+    (match pth
+      ((Err str)
+       (lisp :a (str)
+         (pth:pathname-as-file str)))
+      ((Ok pth)
+       (lisp :a (pth)
+         (pth:pathname-as-file pth)))))
+
+  (declare directory-p ((Path :a) => :a -> (Optional :a)))
+  (define (directory-p pth)
+    "Return a pathname for the directory named by PTH if it is an existing directory.
+Otherwise return None."
+    (wrap-lisp-call :a pth:directory-p pth))
+  
+  (declare file-p ((Path :a) => :a -> (Optional :a)))
+  (define (file-p pth)
+    "Return a pathname for the file named by PTH if it is an existing file.
+Otherwise return None."
+    (wrap-lisp-call :a pth:file-p pth)))
+
+(coalton-toplevel
+  
+  ;; Create an enum type to make the :directories argument to walk-directory
+  ;; more discoverable from the type signature.
+  (define-type WalkDirectoryOptions
+    IncludeDirs
+    ExcludeDirs)
+  
+  ;; TODO: Is there a better way to be able to check if two WalkDirectoryOptions
+  ;; are equal? This seems inefficient at runtime and verbose.
+  (define-instance (Eq WalkDirectoryOptions)
+    (define (== x y)
+      (match (Tuple x y)
+        ((Tuple (IncludeDirs) (IncludeDirs))
+         True)
+        ((Tuple (ExcludeDirs) (ExcludeDirs))
+         True)
+        (_ False))))
+  
+  (declare walk-directory-if (String -> (Pathname -> :b) -> WalkDirectoryOptions -> (Pathname -> Boolean) -> Unit))
+  (define (walk-directory-if dirname map-fn include-dirs test-fn)
+    "Walk the directory named by DIRNAME and call MAP-FN on each file. If INCLUDE-DIRS
+is IncludeDirs, MAP-FN will be called on each directory as well. TEST-FN is called
+on each pathname to determine if it should be included in the walk."
+    (let should-include-dirs = (== include-dirs IncludeDirs))
+    (lisp :t (dirname map-fn should-include-dirs test-fn)
+        (pth:walk-directory dirname
+                            (cl:lambda (pthnm)
+                              (call-coalton-function map-fn pthnm))
+                            :directories should-include-dirs
+                            :test (cl:lambda (pthnm)
+                                    (call-coalton-function test-fn pthnm))))))

--- a/examples/practical-coalton/1_simple_database.lisp
+++ b/examples/practical-coalton/1_simple_database.lisp
@@ -98,8 +98,7 @@ query DSL, like:
 
 Example:
 
-(keyword-to-struct-accessor :title) => .TITLE
-"
+(keyword-to-struct-accessor :title) => .TITLE"
   (cl:intern (cl:concatenate 'cl:string (cl:string '#:.) (cl:string keyword))))
 
 (cl:defun comparison-clause (attr-keyword value var-sym)
@@ -107,8 +106,7 @@ Example:
 
 Example:
 
-(comparison-clause :rating 5 'cd) => `(== 5 (.rating cd))
-"
+(comparison-clause :rating 5 'cd) => `(== 5 (.rating cd))"
     `(== ,value (,(keyword-to-struct-accessor attr-keyword) ,var-sym)))
 
 (cl:defun comparison-clauses (var-sym clauses)
@@ -127,8 +125,7 @@ CD matches the specified criteria.
 Example:
 
 (where :rating 5 :artist ''Peter Siebel'')
-  => (fn (cd) (and (== 5 (.rating cd)) (== ''Peter Siebel'' (.artist cd))))
-"
+  => (fn (cd) (and (== 5 (.rating cd)) (== ''Peter Siebel'' (.artist cd))))"
   (with-gensyms (cd-sym)
     `(fn (,cd-sym)
        (and ,@(comparison-clauses cd-sym clauses)))))

--- a/examples/practical-coalton/1_simple_database.lisp
+++ b/examples/practical-coalton/1_simple_database.lisp
@@ -1,4 +1,3 @@
-;; Make sure to load :coalton and :alexandria before loading this file.
 (in-package :cl-user)
 (defpackage :practical-coalton.simple-database
   (:use
@@ -87,34 +86,35 @@
 ;;; Query DSL implemented as Common Lisp macros that generate Coalton code.
 ;;;
 
-(cl:defun keyword-to-struct-accessor (keyword)
-  "Converts a keyword to a Coalton struct accessor.
+(cl:eval-when (:compile-toplevel :load-toplevel :execute)
+  (cl:defun keyword-to-struct-accessor (keyword)
+    "Converts a keyword to a Coalton struct accessor.
 
-This is useful for converting keywords to Coalton struct accessors in the
-query DSL, like:
+  This is useful for converting keywords to Coalton struct accessors in the
+  query DSL, like:
 
-(where :rating 8), in which :rating will eventually be transformed into
-(.rating cd) in the generated Coalton code.
+  (where :rating 8), in which :rating will eventually be transformed into
+  (.rating cd) in the generated Coalton code.
 
-Example:
+  Example:
 
-(keyword-to-struct-accessor :title) => .TITLE"
-  (cl:intern (cl:concatenate 'cl:string (cl:string '#:.) (cl:string keyword))))
+  (keyword-to-struct-accessor :title) => .TITLE"
+    (cl:intern (cl:concatenate 'cl:string (cl:string '#:.) (cl:string keyword))))
 
-(cl:defun comparison-clause (attr-keyword value var-sym)
-  "Generates a comparison clause for the query DSL.
+  (cl:defun comparison-clause (attr-keyword value var-sym)
+    "Generates a comparison clause for the query DSL.
 
-Example:
+  Example:
 
-(comparison-clause :rating 5 'cd) => `(== 5 (.rating cd))"
-    `(== ,value (,(keyword-to-struct-accessor attr-keyword) ,var-sym)))
+  (comparison-clause :rating 5 'cd) => `(== 5 (.rating cd))"
+      `(== ,value (,(keyword-to-struct-accessor attr-keyword) ,var-sym)))
 
-(cl:defun comparison-clauses (var-sym clauses)
-  "Generates a list of comparison clauses for the query DSL."
-  (cl:loop while clauses
-    collecting (comparison-clause (cl:pop clauses)
-                                  (cl:pop clauses)
-                                  var-sym)))
+  (cl:defun comparison-clauses (var-sym clauses)
+    "Generates a list of comparison clauses for the query DSL."
+    (cl:loop while clauses
+      collecting (comparison-clause (cl:pop clauses)
+                                    (cl:pop clauses)
+                                    var-sym))))
 
 (cl:defmacro where (cl:&rest clauses)
   "Provides a query DSL to select records from a database.

--- a/examples/practical-coalton/1_simple_database.lisp
+++ b/examples/practical-coalton/1_simple_database.lisp
@@ -1,0 +1,253 @@
+;; Make sure to load :coalton and :alexandria before loading this file.
+(in-package :cl-user)
+(defpackage :practical-coalton.simple-database
+  (:use
+    #:coalton
+    #:coalton-prelude)
+  (:import-from
+   #:alexandria
+   :with-gensyms)
+  (:local-nicknames
+   (#:vec #:coalton-library/vector)
+   (#:lst #:coalton-library/list)
+   (#:cel #:coalton-library/cell)
+   (#:str #:coalton-library/string)))
+(in-package :practical-coalton.simple-database)
+
+(named-readtables:in-readtable coalton:coalton)
+
+;;; Port of Chapter 3 from Practical Common Lisp, by Peter Seibel,
+;;; to Coalton.
+;;;
+;;; In PCL, the database is stored in a global variable. The functions
+;;; modifying the database write to that global. This is possible in
+;;; Coalton (by defining a CELL global variable), and we take that approach
+;;; in the port of chapter 23. In this chapter, we define a mutable Database
+;;; type, and each of the functions that read or write to a Database take
+;;; it as an argument.
+;;;
+;;; Note that the CL macros generating Coalton functions work very well
+;;; with the type system. Even though the macro code itself is not type
+;;; checked, the code it generates is. This way the type system will catch
+;;; any type errors caused by incorrect macro code or incorrect usage of
+;;; a macro.
+
+;;;
+;;; Define the types required to create a mutable database and basic
+;;; functions to work with them.
+;;;
+
+(coalton-toplevel
+  (define-struct CD
+    (title String)
+    (artist String)
+    (rating Integer)
+    (ripped Boolean))
+
+  (repr :transparent)
+  (define-type Database
+    (Database (Cell (List CD))))
+
+  (declare cd-data (Database -> (Cell (List CD))))
+  (define (cd-data (Database cd-cell))
+    cd-cell)
+
+  (declare from-cds ((List CD) -> Database))
+  (define (from-cds cd-list)
+    (Database (cel:new cd-list)))
+
+  (declare cds (Database -> (List CD)))
+  (define (cds (Database cds-data))
+    (cel:read cds-data))
+
+  (declare new-database (Unit -> Database))
+  (define (new-database)
+    (Database (cel:new Nil)))
+
+  (declare add-record (Database -> CD -> Database))
+  (define (add-record db cd)
+    (cel:push! (cd-data db) cd)
+    db)
+
+  (declare dump-cd (CD -> Unit))
+  (define (dump-cd cd)
+    (traceobject "title" (.title cd))
+    (traceobject "artist" (.artist cd))
+    (traceobject "rating" (.rating cd))
+    (traceobject "ripped" (.ripped cd)))
+
+  (declare dump-db (Database -> Unit))
+  (define (dump-db (Database cd-data))
+    (for cd in (cel:read cd-data)
+        (dump-cd cd)
+        (trace "--"))
+    Unit))
+
+;;;
+;;; Query DSL implemented as Common Lisp macros that generate Coalton code.
+;;;
+
+(cl:defun keyword-to-struct-accessor (keyword)
+  "Converts a keyword to a Coalton struct accessor.
+
+This is useful for converting keywords to Coalton struct accessors in the
+query DSL, like:
+
+(where :rating 8), in which :rating will eventually be transformed into
+(.rating cd) in the generated Coalton code.
+
+Example:
+
+(keyword-to-struct-accessor :title) => .TITLE
+"
+  (cl:intern (cl:concatenate 'cl:string (cl:string '#:.) (cl:string keyword))))
+
+(cl:defun comparison-clause (attr-keyword value var-sym)
+  "Generates a comparison clause for the query DSL.
+
+Example:
+
+(comparison-clause :rating 5 'cd) => `(== 5 (.rating cd))
+"
+    `(== ,value (,(keyword-to-struct-accessor attr-keyword) ,var-sym)))
+
+(cl:defun comparison-clauses (var-sym clauses)
+  "Generates a list of comparison clauses for the query DSL."
+  (cl:loop while clauses
+    collecting (comparison-clause (cl:pop clauses)
+                                  (cl:pop clauses)
+                                  var-sym)))
+
+(cl:defmacro where (cl:&rest clauses)
+  "Provides a query DSL to select records from a database.
+
+Creates an anonymous function that takes a CD and returns True if the
+CD matches the specified criteria.
+
+Example:
+
+(where :rating 5 :artist ''Peter Siebel'')
+  => (fn (cd) (and (== 5 (.rating cd)) (== ''Peter Siebel'' (.artist cd))))
+"
+  (with-gensyms (cd-sym)
+    `(fn (,cd-sym)
+       (and ,@(comparison-clauses cd-sym clauses)))))
+
+(cl:defmacro to (cl:&key title artist rating (ripped nil ripped-p))
+  "Provides a query DSL to produce updated records for the database.
+
+Creates an anonymyous function that takes a CD and returns a new CD with
+the specified attributes updated. The attributes that are not specified
+are copied from the original CD.
+
+Example:
+
+(to :ripped True :rating 1)
+  => (fn (cd) (CD (.title cd) (.artist cd) 1 True))"
+  (with-gensyms (cd-sym)
+    `(fn (,cd-sym)
+      (CD
+        ,(cl:if title title `(.title ,cd-sym))
+        ,(cl:if artist artist `(.artist ,cd-sym))
+        ,(cl:if rating rating `(.rating ,cd-sym))
+        ,(cl:if ripped-p ripped `(.ripped ,cd-sym))))))
+
+;;;
+;;; Functions to ask the user for database input, and to save/load the
+;;; database to/from a file.
+;;;
+
+(coalton-toplevel
+  (declare prompt-read (String -> String))
+  (define (prompt-read prompt)
+    (lisp String (prompt)
+      (cl:format cl:*query-io* "~a: " prompt)
+      (cl:force-output cl:*query-io*)
+      (cl:read-line cl:*query-io*)))
+
+  (declare prompt-y-n (String -> Boolean))
+  (define (prompt-y-n prompt)
+    (lisp Boolean (prompt)
+      (cl:y-or-n-p (cl:format cl:nil "~a [y/n]: " prompt))))
+
+  (declare prompt-for-cd (Unit -> CD))
+  (define (prompt-for-cd)
+    (CD
+      (prompt-read "Title")
+      (prompt-read "Artist")
+      (with-default 0 (str:parse-int (prompt-read "Rating")))
+      (prompt-y-n "Ripped")))
+
+  (declare add-cds (Database -> Database))
+  (define (add-cds db)
+    (add-record db (prompt-for-cd))
+    (if (prompt-y-n "Another?")
+          (add-cds db)
+        db))
+
+  (declare save-db (Database -> String -> Database))
+  (define (save-db db filename)
+    (let ((cd-list (cds db)))
+      (lisp :a (cd-list filename)
+        (cl:with-open-file (out filename
+                                :direction :output
+                                :if-exists :supersede)
+          (cl:with-standard-io-syntax
+            (cl:print cd-list out)))))
+    db)
+
+  (declare load-db (String -> Database))
+  (define (load-db filename)
+    (from-cds
+      (lisp (List CD) (filename)
+        (cl:with-open-file (in filename)
+          (cl:with-standard-io-syntax
+            (cl:read in)))))))
+
+;;;
+;;; Functions to query the database using the DSL.
+;;;
+
+(coalton-toplevel
+  (declare select (Database -> (CD -> Boolean) -> (List CD)))
+  (define (select db selector-fn)
+    (lst:filter selector-fn (cds db)))
+
+  (declare delete! (Database -> (CD -> Boolean) -> Database))
+  (define (delete! db selector-fn)
+    (cel:write! (cd-data db) (lst:remove-if selector-fn (cds db)))
+    db)
+
+  (declare update! (Database -> (CD -> Boolean) -> (CD -> CD) -> Database))
+  (define (update! db selector-fn update-fn)
+    (cel:write! (cd-data db)
+      (map (fn (cd) (if (selector-fn cd)
+                      (update-fn cd)
+                      cd))
+           (cds db)))
+    db))
+
+;;;
+;;; Example code. These are Common Lisp functions that call Coalton code,
+;;; so they can be easily called from the REPL.
+;;;
+
+(cl:defun save-prompted-db ()
+  (coalton
+    (traceobject "Saved database to file:"
+      (save-db (add-cds (new-database)) "cds.db"))))
+
+(cl:defun load-and-update-snoop ()
+  (coalton
+    (traceobject "Database:"
+      (update!
+        (load-db "cds.db")
+        (where :artist "Snoop Dogg")
+        (to :ripped True :rating 5)))))
+
+(cl:defun prompt-and-select ()
+  (coalton
+    (traceobject "Ripped tracks with a perfect rating:"
+      (select
+        (add-cds (new-database))
+        (where :rating 10 :ripped True)))))

--- a/examples/practical-coalton/README.md
+++ b/examples/practical-coalton/README.md
@@ -1,0 +1,2 @@
+This folder contains ports of some of the "practical" chapters from _Practical Common Lisp_
+by Peter Seibel. 

--- a/examples/practical-coalton/practical-coalton.asd
+++ b/examples/practical-coalton/practical-coalton.asd
@@ -1,0 +1,24 @@
+(defsystem pcl-pathnames
+  :name "pcl-pathnames"
+  :author "Peter Seibel <peter@gigamonkeys.com>"
+  :version "1.0"
+  :maintainer "Peter Seibel <peter@gigamonkeys.com>"
+  :licence "BSD"
+  :description "Portable pathname manipulation functions."
+  :long-description ""
+  :pathname "practical-common-lisp"
+  :components
+  ((:module "Chapter15"
+    :components ((:file "packages")
+                 (:file "pathnames" :depends-on ("packages"))))))
+
+(defsystem practical-coalton
+  :name "practical-coalton"
+  :author "Jason Walker <Jason0@pm.me>"
+  :version "0.1"
+  :description "A port of Peter Seibel's Practical Common Lisp to Coalton."
+  :depends-on (#:pcl-pathnames
+               #:alexandria
+               #:coalton)
+  :components ((:file "1_simple_database")
+               (:file "15_pathnames")))

--- a/examples/practical-coalton/practical-common-lisp/Chapter15/chapter-15.asd
+++ b/examples/practical-coalton/practical-common-lisp/Chapter15/chapter-15.asd
@@ -1,0 +1,14 @@
+(defpackage :com.gigamonkeys.chapter-15-system (:use :asdf :cl))
+(in-package :com.gigamonkeys.chapter-15-system)
+
+(defsystem chapter-15
+  :name "chapter-15"
+  :author "Peter Seibel <peter@gigamonkeys.com>"
+  :version "1.0"
+  :maintainer "Peter Seibel <peter@gigamonkeys.com>"
+  :licence "BSD"
+  :description "Code from Chapter 15 of Practical Common Lisp"
+  :long-description ""
+  :depends-on ("pathnames"))
+
+        

--- a/examples/practical-coalton/practical-common-lisp/Chapter15/packages.lisp
+++ b/examples/practical-coalton/practical-common-lisp/Chapter15/packages.lisp
@@ -1,0 +1,14 @@
+(in-package :cl-user)
+
+(defpackage :com.gigamonkeys.pathnames
+  (:use :common-lisp)
+  (:export
+   :list-directory
+   :file-exists-p
+   :directory-pathname-p
+   :file-pathname-p
+   :pathname-as-directory
+   :pathname-as-file
+   :walk-directory
+   :directory-p
+   :file-p))

--- a/examples/practical-coalton/practical-common-lisp/Chapter15/pathnames.asd
+++ b/examples/practical-coalton/practical-common-lisp/Chapter15/pathnames.asd
@@ -1,0 +1,17 @@
+(defpackage :com.gigamonkeys.pathnames-system (:use :asdf :cl))
+(in-package :com.gigamonkeys.pathnames-system)
+
+(defsystem pathnames
+  :name "pathnames"
+  :author "Peter Seibel <peter@gigamonkeys.com>"
+  :version "1.0"
+  :maintainer "Peter Seibel <peter@gigamonkeys.com>"
+  :licence "BSD"
+  :description "Portable pathname manipulation functions."
+  :long-description ""
+  :components
+  ((:file "packages")
+   (:file "pathnames" :depends-on ("packages"))))
+
+
+        

--- a/examples/practical-coalton/practical-common-lisp/Chapter15/pathnames.lisp
+++ b/examples/practical-coalton/practical-common-lisp/Chapter15/pathnames.lisp
@@ -1,0 +1,194 @@
+(in-package #:com.gigamonkeys.pathnames)
+
+(defun list-directory (dirname)
+  "Return a list of the contents of the directory named by dirname.
+Names of subdirectories will be returned in `directory normal
+form'. Unlike CL:DIRECTORY, LIST-DIRECTORY does not accept
+wildcard pathnames; `dirname' should simply be a pathname that
+names a directory. It can be in either file or directory form."
+  (when (wild-pathname-p dirname)
+    (error "Can only list concrete directory names."))
+
+  (let ((wildcard (directory-wildcard dirname)))
+
+    #+(or sbcl cmu lispworks)
+    ;; SBCL, CMUCL, and Lispworks return subdirectories in directory
+    ;; form just the way we want.
+    (directory wildcard)
+    
+    #+openmcl
+    ;; OpenMCl by default doesn't return subdirectories at all. But
+    ;; when prodded to do so with the special argument :directories,
+    ;; it returns them in directory form.
+    (directory wildcard :directories t)
+            
+    #+allegro
+    ;; Allegro normally return directories in file form but we can
+    ;; change that with the :directories-are-files argument.
+    (directory wildcard :directories-are-files nil)
+            
+    #+clisp
+    ;; CLISP has a particularly idiosyncratic view of things. But we
+    ;; can bludgeon even it into doing what we want.
+    (nconc 
+     ;; CLISP won't list files without an extension when :type is
+     ;; wild so we make a special wildcard for it.
+     (directory wildcard)
+     ;; And CLISP doesn't consider subdirectories to match unless
+     ;; there is a :wild in the directory component.
+     (directory (clisp-subdirectories-wildcard wildcard)))
+
+    #-(or sbcl cmu lispworks openmcl allegro clisp)
+    (error "list-directory not implemented")))
+
+
+
+
+(defun file-exists-p (pathname)
+  "Similar to CL:PROBE-FILE except it always returns directory names
+in `directory normal form'. Returns truename which will be in
+`directory form' if file named is, in fact, a directory."
+
+  #+(or sbcl lispworks openmcl)
+  ;; These implementations do "The Right Thing" as far as we are
+  ;; concerned. They return a truename of the file or directory if it
+  ;; exists and the truename of a directory is in directory normal
+  ;; form.
+  (probe-file pathname)
+
+  #+(or allegro cmu)
+  ;; These implementations accept the name of a directory in either
+  ;; form and return the name in the form given. However the name of a
+  ;; file must be given in file form. So we try first with a directory
+  ;; name which will return NIL if either the file doesn't exist at
+  ;; all or exists and is not a directory. Then we try with a file
+  ;; form name.
+  (or (probe-file (pathname-as-directory pathname))
+      (probe-file pathname))
+
+  #+clisp
+  ;; Once again CLISP takes a particularly unforgiving approach,
+  ;; signalling ERRORs at the slightest provocation.
+
+  ;; pathname in file form and actually a file      -- (probe-file file)      ==> truename
+  ;; pathname in file form and doesn't exist        -- (probe-file file)      ==> NIL
+  ;; pathname in dir form and actually a directory  -- (probe-directory file) ==> truename
+  ;; pathname in dir form and doesn't exist         -- (probe-directory file) ==> NIL
+
+  ;; pathname in file form and actually a directory -- (probe-file file)      ==> ERROR
+  ;; pathname in dir form and actually a file       -- (probe-directory file) ==> ERROR
+  (or (ignore-errors
+        ;; PROBE-FILE will return the truename if file exists and is a
+        ;; file or NIL if it doesn't exist at all. If it exists but is
+        ;; a directory PROBE-FILE will signal an error which we
+        ;; ignore.
+        (probe-file (pathname-as-file pathname)))
+      (ignore-errors
+        ;; PROBE-DIRECTORY returns T if the file exists and is a
+        ;; directory or NIL if it doesn't exist at all. If it exists
+        ;; but is a file, PROBE-DIRECTORY will signal an error.
+        (let ((directory-form (pathname-as-directory pathname)))
+          (when (ext:probe-directory directory-form)
+            directory-form))))
+
+
+    #-(or sbcl cmu lispworks openmcl allegro clisp)
+    (error "list-directory not implemented"))
+
+(defun directory-wildcard (dirname)
+  (make-pathname 
+   :name :wild
+   :type #-clisp :wild #+clisp nil
+   :defaults (pathname-as-directory dirname)))
+
+#+clisp
+(defun clisp-subdirectories-wildcard (wildcard)
+  (make-pathname
+   :directory (append (pathname-directory wildcard) (list :wild))
+   :name nil
+   :type nil
+   :defaults wildcard))
+
+
+(defun directory-pathname-p (p)
+  "Is the given pathname the name of a directory? This function can
+usefully be used to test whether a name returned by LIST-DIRECTORIES
+or passed to the function in WALK-DIRECTORY is the name of a directory
+in the file system since they always return names in `directory normal
+form'."
+  (flet ((component-present-p (value)
+           (and value (not (eql value :unspecific)))))
+    (and 
+     (not (component-present-p (pathname-name p)))
+     (not (component-present-p (pathname-type p)))
+     p)))
+
+
+(defun file-pathname-p (p)
+  (unless (directory-pathname-p p) p))
+
+(defun pathname-as-directory (name)
+  "Return a pathname reperesenting the given pathname in
+`directory normal form', i.e. with all the name elements in the
+directory component and NIL in the name and type components. Can
+not be used on wild pathnames because there's not portable way to
+convert wildcards in the name and type into a single directory
+component. Returns its argument if name and type are both nil or
+:unspecific."
+  (let ((pathname (pathname name)))
+    (when (wild-pathname-p pathname)
+      (error "Can't reliably convert wild pathnames."))
+    (if (not (directory-pathname-p name))
+      (make-pathname 
+       :directory (append (or (pathname-directory pathname) (list :relative))
+                          (list (file-namestring pathname)))
+       :name      nil
+       :type      nil
+       :defaults pathname)
+      pathname)))
+
+(defun pathname-as-file (name)
+  "Return a pathname reperesenting the given pathname in `file form',
+i.e. with the name elements in the name and type component. Can't
+convert wild pathnames because of problems mapping wild directory
+component into name and type components. Returns its argument if
+it is already in file form."
+  (let ((pathname (pathname name)))
+    (when (wild-pathname-p pathname)
+      (error "Can't reliably convert wild pathnames."))
+    (if (directory-pathname-p name)
+      (let* ((directory (pathname-directory pathname))
+             (name-and-type (pathname (first (last directory)))))
+        (make-pathname 
+         :directory (butlast directory)
+         :name (pathname-name name-and-type)
+         :type (pathname-type name-and-type)
+         :defaults pathname))
+      pathname)))
+
+(defun walk-directory (dirname fn &key directories (test (constantly t)))
+  "Walk a directory invoking `fn' on each pathname found. If `test' is
+supplied fn is invoked only on pathnames for which `test' returns
+true. If `directories' is t invokes `test' and `fn' on directory
+pathnames as well."
+  (labels
+      ((walk (name)
+         (cond
+           ((directory-pathname-p name)
+            (when (and directories (funcall test name))
+              (funcall fn name))
+            (dolist (x (list-directory name)) (walk x)))
+           ((funcall test name) (funcall fn name)))))
+    (walk (pathname-as-directory dirname))))
+
+(defun directory-p (name)
+  "Is `name' the name of an existing directory."
+  (let ((truename (file-exists-p name)))
+    (and truename (directory-pathname-p name))))
+
+(defun file-p (name)
+  "Is `name' the name of an existing file, i.e. not a directory."
+  (let ((truename (file-exists-p name)))
+    (and truename (file-pathname-p name))))
+
+

--- a/examples/practical-coalton/practical-common-lisp/LICENSE
+++ b/examples/practical-coalton/practical-common-lisp/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2005, Peter Seibel All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of the Peter Seibel nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This PR ports some of the "practical" chapters from _Practical Common Lisp_ into Coalton. It includes the first two, and I'm working on chapter 23 (the spam filter) which could be a follow-up PR. I think that is a great source to show how to write practical, application style code in Coalton.

To that end, two goals of the style employed are:

- Highlight usage that is likely to show up in writing real applications, such as interop with CL and handling mutable state.
- Avoid some of the more complex areas of the type system, like type classes, monads, and _do_ notation.

I've written some fun side-code in Coalton before, but never a full program, so there might be places where the code could be improved or made more "Coaltony". I had a few places with particular questions for experienced Coalton writers, so I called them out in some comments.