### PR TITLE
Added CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+
+type: software
+
+message: "If you use this software, please cite it as below."
+
+title: "coalton"
+
+authors:
+  - name: coalton-lang contributors
+
+version: 0.0.1
+
+license: MIT
+
+repository-code: "https://github.com/coalton-lang/coalton"
+
+url: "https://coalton-lang.github.io/"
+
+abstract: "Coalton is an efficient, statically typed functional programming language that supercharges Common Lisp."
+
+
+keywords:
+- functional
+- fp
+- "functional programming"
+- "Common Lisp"
+- Lisp
+- Haskell
+- hindley-milner


### PR DESCRIPTION
This addresses #1059. 

I've added a `CITATION.cff` file, which provides citation information for research users, as well as adding a `cite this repository` option to the sidebar :
<img width="188" alt="Screen Shot 2024-02-26 at 4 24 38 PM" src="https://github.com/coalton-lang/coalton/assets/75645156/001ab8c5-4ce9-4956-913f-75d5c67c71e0">
