### PR TITLE
Fixed define-instance unknown method error message

### DIFF
--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -254,9 +254,10 @@
                              :span (parser:instance-method-definition-source method)
                              :file file
                              :message "Unknown method"
-                             :primary-note (format nil "The method ~S is not part of class ~S"
-                                                   name
-                                                   class-name))))
+                             :primary-note (let ((*package* util:+keyword-package+))
+                                             (format nil "The method ~S is not part of class ~S"
+                                                     name
+                                                     class-name)))))
 
     ;; Ensure each method is defined
     (loop :for name :being :the :hash-keys :of method-table


### PR DESCRIPTION
This fixes issue #1048 

Example: 
```
(defpackage #:cauldron
  (:use #:coalton
        #:coalton-prelude)
  (:export #:bubble
           #:toil
           #:trouble))

(in-package #:cauldron)

(coalton-toplevel

  (define-class (Bubble :a)
    (toil (:a -> :a))
    (trouble (:a -> :a)))

  (define-instance (Bubble UFix)
    (define (toil x)
      (1+ x))
    (define (trouble x)
      (+ x 2))))

(defpackage #:cauldron2
  (:use #:coalton
        #:coalton-prelude
        #:cauldron))

(in-package #:cauldron2)

(coalton-toplevel

  (repr :native :t)
  (define-type ingredient)
  
  (define-instance (Bubble Ingredient)
    (define (toil x)
      (1+ x))
    (define (trouble x)
      (+ x 2))
    (define (double x) ;; undefined class method
      (* x 2))))
```
Compiling the second coalton-toplevel returns:
```
error: Unknown method
  --> COALTON-TOPLEVEL (/private/var/tmp/slime5WJyv6):9:4
    |
 9  |       (DEFINE (DOUBLE X)
    |  _____^
 10 | |       (* X 2))))
    | |______________^ The method CAULDRON2:DOUBLE is not part of class BUBBLE
   [Condition of type SB-INT:COMPILED-PROGRAM-ERROR]
```


