### PR TITLE
Parser error regression tests

### DIFF
--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -1953,7 +1953,7 @@ consume all attributes")))
                    :file file
                    :highlight :end
                    :message "Malformed functional dependency"
-                   :primary-note "expected one ore more type variables")))
+                   :primary-note "expected one or more type variables")))
 
     (make-fundep
      :left (loop :for var :in left

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -15,7 +15,7 @@
                    (parser:with-reader-context stream
                      (parser:read-program stream (error:make-coalton-file :stream stream :name "test") :mode :file))
                  (error:coalton-base-error (c)
-                   (format nil "~A" c))))))
+                   (princ-to-string c))))))
     (loop :for file :in (test-files "tests/parser/*.bad.coalton")
           :do (let ((error-file (make-pathname :type "error"
                                                :defaults file)))

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -9,17 +9,13 @@
                (parser:with-reader-context stream
                  (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file))))
 
-           (error-string (condition)
-             (with-output-to-string (out)
-               (coalton-impl/error::display-coalton-error out
-                                                          (slot-value condition 'coalton-impl/error::err))))
            (parse-error-text (file)
              (with-open-file (stream file)
                (handler-case
                    (parser:with-reader-context stream
                      (parser:read-program stream (error:make-coalton-file :stream stream :name "test") :mode :file))
                  (error:coalton-base-error (c)
-                   (error-string c))))))
+                   (format nil "~A" c))))))
     (loop :for file :in (test-files "tests/parser/*.bad.coalton")
           :do (let ((error-file (make-pathname :type "error"
                                                :defaults file)))

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -5,27 +5,31 @@
              (directory (merge-pathnames pattern (asdf:system-source-directory "coalton/tests"))))
 
            (parse-file (file)
-             (with-open-file (stream file)
+             (with-open-file (stream file
+                                     :direction :input
+                                     :element-type 'character)
                (parser:with-reader-context stream
                  (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file))))
 
            (parse-error-text (file)
-             (with-open-file (stream file)
+             (with-open-file (stream file
+                                     :direction :input
+                                     :element-type 'character)
                (handler-case
                    (parser:with-reader-context stream
                      (parser:read-program stream (error:make-coalton-file :stream stream :name "test") :mode :file))
                  (error:coalton-base-error (c)
                    (princ-to-string c))))))
-    (loop :for file :in (test-files "tests/parser/*.bad.coalton")
-          :do (let ((error-file (make-pathname :type "error"
-                                               :defaults file)))
-                (cond ((uiop:file-exists-p error-file)
-                       (check-string= (format nil "expected error ~A (A) and generated error (B)" error-file)
-                                      (alexandria:read-file-into-string error-file)
-                                      (parse-error-text file)))
-                      (t
-                       (signals parser:parse-error
-                         (parse-file file))))))
+    (dolist (file (test-files "tests/parser/*.bad.coalton"))
+      (let ((error-file (make-pathname :type "error"
+                                       :defaults file)))
+        (cond ((uiop:file-exists-p error-file)
+               (check-string= (format nil "expected error ~A (A) and generated error (B)" error-file)
+                              (alexandria:read-file-into-string error-file)
+                              (parse-error-text file)))
+              (t
+               (signals parser:parse-error
+                 (parse-file file))))))
 
-    (loop :for file :in (test-files "tests/parser/*.good.coalton")
-          :do (parse-file file))))
+    (dolist (file (test-files "tests/parser/*.good.coalton"))
+      (parse-file file))))

--- a/tests/parser/define-class.1.bad.error
+++ b/tests/parser/define-class.1.bad.error
@@ -1,0 +1,8 @@
+error: Malformed class definition
+  --> test:4:15
+   |
+ 4 |  (define-class (C))
+   |                 ^ expected class type variable(s)
+help: add class type variable `:a`
+ 4 | (define-class (C :a))
+   |                ----

--- a/tests/parser/define-class.10.bad.error
+++ b/tests/parser/define-class.10.bad.error
@@ -1,0 +1,8 @@
+error: Malformed class definition
+  --> test:4:15
+   |
+ 4 |  (define-class ((C) :a))
+   |                 ^^^ unnecessary parentheses
+help: remove unnecessary parentheses
+ 4 | (define-class (C :a))
+   |                -

--- a/tests/parser/define-class.11.bad.error
+++ b/tests/parser/define-class.11.bad.error
@@ -1,0 +1,5 @@
+error: Malformed class definition
+  --> test:4:15
+   |
+ 4 |  (define-class ("C" :a :b))
+   |                 ^^^ expected symbol

--- a/tests/parser/define-class.12.bad.error
+++ b/tests/parser/define-class.12.bad.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:5:3
+   |
+ 4 |  (define-class (C :a)
+   |                ------ in this class definition
+ 5 |    (0.5 (:a -> :a)))
+   |     ^^^ expected symbol

--- a/tests/parser/define-class.13.bad.error
+++ b/tests/parser/define-class.13.bad.error
@@ -1,0 +1,5 @@
+error: Malformed class definition
+  --> test:4:14
+   |
+ 4 |  (define-class (C :a . :b))
+   |                ^^^^^^^^^^^ unexpected dotted list

--- a/tests/parser/define-class.14.bad.error
+++ b/tests/parser/define-class.14.bad.error
@@ -1,0 +1,5 @@
+error: Malformed functional dependency
+  --> test:4:34
+   |
+ 4 |  (define-class (C :a :b (:a -> :b) :c))
+   |                                    ^^ expected a list

--- a/tests/parser/define-class.15.bad.error
+++ b/tests/parser/define-class.15.bad.error
@@ -1,0 +1,5 @@
+error: Malformed functional dependency
+  --> test:4:23
+   |
+ 4 |  (define-class (C :a :b (:a :b . :c)))
+   |                         ^^^^^^^^^^^^ unexpected dotted list

--- a/tests/parser/define-class.16.bad.error
+++ b/tests/parser/define-class.16.bad.error
@@ -1,0 +1,5 @@
+error: Malformed functional dependency
+  --> test:4:33
+   |
+ 4 |  (define-class (C :a :b (:a :b ->)))
+   |                                  ^ expected one or more type variables

--- a/tests/parser/define-class.17.bad.error
+++ b/tests/parser/define-class.17.bad.error
@@ -1,0 +1,5 @@
+error: Malformed functional dependency
+  --> test:4:23
+   |
+ 4 |  (define-class (C :a :b (-> :b :c)))
+   |                         ^^^^^^^^^^ expected one or more type variables

--- a/tests/parser/define-class.18.bad.error
+++ b/tests/parser/define-class.18.bad.error
@@ -1,0 +1,7 @@
+error: Invalid attribute for define-class
+  --> test:4:0
+   |
+ 4 |  (repr :enum)
+   |  ^^^^^^^^^^^^ define-class cannot have attributes
+ 5 |  (define-class (C :a))
+   |                ------ while parsing define-class

--- a/tests/parser/define-class.19.bad.error
+++ b/tests/parser/define-class.19.bad.error
@@ -1,0 +1,5 @@
+error: Malformed class definition
+  --> test:4:31
+   |
+ 4 |  (define-class (Eq :a => (C :a) :b))
+   |                                 ^^ unexpected form

--- a/tests/parser/define-class.2.bad.error
+++ b/tests/parser/define-class.2.bad.error
@@ -1,0 +1,8 @@
+error: Malformed class definition
+  --> test:4:15
+   |
+ 4 |  (define-class (=> C :a :b))
+   |                 ^^ unnecessary `=>`
+help: remove `=>`
+ 4 | (define-class (C :a :b))
+   |               ---------

--- a/tests/parser/define-class.20.bad.error
+++ b/tests/parser/define-class.20.bad.error
@@ -1,0 +1,5 @@
+error: Invalid variable
+  --> test:5:3
+   |
+ 5 |    (.m (:a -> :a)))
+   |     ^^ variables cannot start with '.'

--- a/tests/parser/define-class.3.bad.error
+++ b/tests/parser/define-class.3.bad.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:5:2
+   |
+ 4 |  (define-class (C :a :b)
+   |                --------- in this class definition
+ 5 |    m)
+   |    ^ missing method type

--- a/tests/parser/define-class.4.bad.error
+++ b/tests/parser/define-class.4.bad.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:5:7
+   |
+ 4 |  (define-class (C :a)
+   |                ------ in this class definition
+ 5 |   (m :a :b))
+   |         ^^ unexpected trailing form

--- a/tests/parser/define-class.5.bad.error
+++ b/tests/parser/define-class.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed class definition
+  --> test:4:14
+   |
+ 4 |  (define-class (C :a :b =>))
+   |                ^^^^^^^^^^^^ missing class name

--- a/tests/parser/define-class.6.bad.error
+++ b/tests/parser/define-class.6.bad.error
@@ -1,0 +1,8 @@
+error: Malformed class definition
+  --> test:4:14
+   |
+ 4 |  (define-class C)
+   |                ^ expected class type variable(s)
+help: add class type variable `:a`
+ 4 | (define-class (C :a))
+   |               ------

--- a/tests/parser/define-class.7.bad.error
+++ b/tests/parser/define-class.7.bad.error
@@ -1,0 +1,5 @@
+error: Malformed class definition
+  --> test:4:0
+   |
+ 4 |  (define-class)
+   |  ^^^^^^^^^^^^^^ expected body

--- a/tests/parser/define-class.8.bad.error
+++ b/tests/parser/define-class.8.bad.error
@@ -1,0 +1,8 @@
+error: Malformed class definition
+  --> test:4:15
+   |
+ 4 |  (define-class (=> C))
+   |                 ^^ unnecessary `=>`
+help: remove `=>`
+ 4 | (define-class C)
+   |               -

--- a/tests/parser/define-class.9.bad.error
+++ b/tests/parser/define-class.9.bad.error
@@ -1,0 +1,5 @@
+error: Malformed class definition
+  --> test:4:15
+   |
+ 4 |  (define-class (=>))
+   |                 ^^ unnecessary `=>`

--- a/tests/parser/define-instance.1.bad.error
+++ b/tests/parser/define-instance.1.bad.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:5:2
+   |
+ 4 |  (define-instance (C :a)
+   |                   ------ when parsing instance
+ 5 |    5)
+   |    ^ expected list

--- a/tests/parser/define-instance.10.bad.error
+++ b/tests/parser/define-instance.10.bad.error
@@ -1,0 +1,7 @@
+error: Invalid attribute for define-instance
+  --> test:4:0
+   |
+ 4 |  (repr :enum)
+   |  ^^^^^^^^^^^^ define-instance cannot have attributes
+ 5 |  (define-instance (C :a))
+   |                   ------ while parsing define-instance

--- a/tests/parser/define-instance.11.bad.error
+++ b/tests/parser/define-instance.11.bad.error
@@ -1,0 +1,5 @@
+error: Malformed instance definition
+  --> test:4:40
+   |
+ 4 |  (define-instance (C :a => (C (List :a)) :b))
+   |                                          ^^ unexpected form

--- a/tests/parser/define-instance.2.bad.error
+++ b/tests/parser/define-instance.2.bad.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:5:2
+   |
+ 4 |  (define-instance (C :a)
+   |                   ------ when parsing instance
+ 5 |    (1 2 . 3))
+   |    ^^^^^^^^^ unexpected dotted list

--- a/tests/parser/define-instance.3.bad.error
+++ b/tests/parser/define-instance.3.bad.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:5:3
+   |
+ 4 |  (define-instance (C :a)
+   |                   ------ when parsing instance
+ 5 |    (f x y))
+   |     ^ expected method definition

--- a/tests/parser/define-instance.4.bad.error
+++ b/tests/parser/define-instance.4.bad.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:5:2
+   |
+ 4 |  (define-instance (C :a)
+   |                   ------ when parsing instance
+ 5 |    (define))
+   |    ^^^^^^^^ expected definition name

--- a/tests/parser/define-instance.5.bad.error
+++ b/tests/parser/define-instance.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed instance definition
+  --> test:4:17
+   |
+ 4 |  (define-instance (C :a . :b))
+   |                   ^^^^^^^^^^^ unexpected dotted list

--- a/tests/parser/define-instance.6.bad.error
+++ b/tests/parser/define-instance.6.bad.error
@@ -1,0 +1,5 @@
+error: Malformed instance definition
+  --> test:4:17
+   |
+ 4 |  (define-instance 5)
+   |                   ^ expected a list

--- a/tests/parser/define-instance.7.bad._error
+++ b/tests/parser/define-instance.7.bad._error
@@ -1,0 +1,5 @@
+error: Malformed instance definition
+  --> test:4:17
+   |
+ 4 |  (define-instance)
+   |                  ^ expected an instance head

--- a/tests/parser/define-instance.8.bad.error
+++ b/tests/parser/define-instance.8.bad.error
@@ -1,0 +1,8 @@
+error: Malformed instance head
+  --> test:4:18
+   |
+ 4 |  (define-instance (=> C :a :b))
+   |                    ^^ unexpected `=>`
+help: remove the `=>`
+ 4 | (define-instance ( C :a :b))
+   |                   

--- a/tests/parser/define-instance.9.bad.error
+++ b/tests/parser/define-instance.9.bad.error
@@ -1,0 +1,8 @@
+error: Malformed instance head
+  --> test:4:26
+   |
+ 4 |  (define-instance (C :a :b =>))
+   |                            ^^ unexpected `=>`
+help: remove the `=>`
+ 4 | (define-instance (C :a :b ))
+   |                           

--- a/tests/parser/define-type.1.bad.error
+++ b/tests/parser/define-type.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type definition
+  --> test:4:0
+   |
+ 4 |  (define-type)
+   |  ^^^^^^^^^^^^^ expected body

--- a/tests/parser/define-type.10.bad.error
+++ b/tests/parser/define-type.10.bad.error
@@ -1,0 +1,9 @@
+error: Duplicate repr atttribute
+  --> test:5:0
+   |
+ 4 |  (repr :enum)
+   |  ------------ previous attribute here
+ 5 |  (repr :enum)
+   |  ^^^^^^^^^^^^ repr attribute here
+ 6 |  (define-type T)
+   |               - when parsing define-type

--- a/tests/parser/define-type.11.bad.error
+++ b/tests/parser/define-type.11.bad.error
@@ -1,0 +1,7 @@
+error: Invalid target for monomorphize attribute
+  --> test:4:0
+   |
+ 4 |  (monomorphize)
+   |  ^^^^^^^^^^^^^^ monomorphize must be attached to a define or declare form
+ 5 |  (define-type T)
+   |               - when parsing define-type

--- a/tests/parser/define-type.2.bad._error
+++ b/tests/parser/define-type.2.bad._error
@@ -1,0 +1,8 @@
+error: Invalid type variable
+  --> test:4:16
+   |
+ 4 |  (define-type (T a))
+   |                  ^ expected keyword symbol
+help: add `:` to symbol
+ 4 | (define-type (T :a))
+   |                 --

--- a/tests/parser/define-type.3.bad.error
+++ b/tests/parser/define-type.3.bad.error
@@ -1,0 +1,8 @@
+error: Malformed type definition
+  --> test:4:13
+   |
+ 4 |  (define-type (T))
+   |               ^^^ nullary types should not have parentheses
+help: remove unnecessary parentheses
+ 4 | (define-type T)
+   |              -

--- a/tests/parser/define-type.4.bad.error
+++ b/tests/parser/define-type.4.bad.error
@@ -1,0 +1,7 @@
+error: Malformed constructor
+  --> test:5:3
+   |
+ 4 |  (define-type (T :a)
+   |               ------ in this type definition
+ 5 |    ((T) :a))
+   |     ^^^ expected symbol

--- a/tests/parser/define-type.5.bad.error
+++ b/tests/parser/define-type.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type definition
+  --> test:4:13
+   |
+ 4 |  (define-type "T")
+   |               ^^^ expected symbol

--- a/tests/parser/define-type.6.bad.error
+++ b/tests/parser/define-type.6.bad.error
@@ -1,0 +1,8 @@
+error: Malformed type definition
+  --> test:4:14
+   |
+ 4 |  (define-type ((T) :a))
+   |                ^^^ expected symbol
+help: remove parentheses
+ 4 | (define-type (T) :a)
+   |              ------

--- a/tests/parser/define-type.7.bad.error
+++ b/tests/parser/define-type.7.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type definition
+  --> test:4:14
+   |
+ 4 |  (define-type ("T" :a :b))
+   |                ^^^ expected symbol

--- a/tests/parser/define-type.8.bad.error
+++ b/tests/parser/define-type.8.bad.error
@@ -1,0 +1,5 @@
+error: Invalid type variable
+  --> test:4:16
+   |
+ 4 |  (define-type (T (:a)))
+   |                  ^^^^ expected keyword symbol

--- a/tests/parser/define-type.9.bad.error
+++ b/tests/parser/define-type.9.bad.error
@@ -1,0 +1,7 @@
+error: Malformed constructor
+  --> test:5:2
+   |
+ 4 |  (define-type (T :a)
+   |               ------ in this type definition
+ 5 |    0.5)
+   |    ^^^ expected symbol

--- a/tests/parser/define.1.bad.error
+++ b/tests/parser/define.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed definition
+  --> test:4:0
+   |
+ 4 |  (define)
+   |  ^^^^^^^^ expected define body

--- a/tests/parser/define.2.bad.error
+++ b/tests/parser/define.2.bad.error
@@ -1,0 +1,5 @@
+error: Invalid variable
+  --> test:4:8
+   |
+ 4 |  (define "x" 1.5)
+   |          ^^^ expected identifier

--- a/tests/parser/define.3.bad.error
+++ b/tests/parser/define.3.bad.error
@@ -1,0 +1,9 @@
+error: Duplicate monomorphize attribute
+  --> test:5:0
+   |
+ 4 |  (monomorphize)
+   |  -------------- previous attribute here
+ 5 |  (monomorphize)
+   |  ^^^^^^^^^^^^^^ monomorphize attribute here
+ 6 |  (define f x)
+   |          - when parsing define

--- a/tests/parser/define.4.bad.error
+++ b/tests/parser/define.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed definition
+  --> test:4:0
+   |
+ 4 |  (define x)
+   |  ^^^^^^^^^^ expected value

--- a/tests/parser/define.5.bad.error
+++ b/tests/parser/define.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function definition
+  --> test:4:9
+   |
+ 4 |  (define (0.5 x y) 2)
+   |           ^^^ expected symbol

--- a/tests/parser/define.6.bad.error
+++ b/tests/parser/define.6.bad.error
@@ -1,0 +1,5 @@
+error: Invalid pattern
+  --> test:4:12
+   |
+ 4 |  (define (f (0.5) x) 1)
+   |              ^^^ invalid constructor in pattern

--- a/tests/parser/define.7.bad.error
+++ b/tests/parser/define.7.bad.error
@@ -1,0 +1,7 @@
+error: Invalid target for repr attribute
+  --> test:4:0
+   |
+ 4 |  (repr :enum)
+   |  ^^^^^^^^^^^^ repr must be attached to a define-type
+ 5 |  (define f x)
+   |          - when parsing define

--- a/tests/parser/package.1.bad.error
+++ b/tests/parser/package.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed package declaration
+  --> test:2:1
+   |
+ 2 |  (package)
+   |   ^^^^^^^ missing package name

--- a/tests/parser/package.2.bad.error
+++ b/tests/parser/package.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed package declaration
+  --> test:2:9
+   |
+ 2 |  (package 5)
+   |           ^ package name must be a symbol

--- a/tests/parser/package.3.bad.error
+++ b/tests/parser/package.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed package declaration
+  --> test:2:1
+   |
+ 2 |  (pancake test)
+   |   ^^^^^^^ package declarations must start with `package`

--- a/tests/parser/package.4.bad.error
+++ b/tests/parser/package.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed package declaration
+  --> test:2:22
+   |
+ 2 |  (package test-package 1)
+   |                        ^ unexpected forms

--- a/tests/parser/parse-and.1.bad.error
+++ b/tests/parser/parse-and.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed and expression
+  --> test:4:15
+   |
+ 4 |  (define x (and))
+   |                ^ expected one or more arguments

--- a/tests/parser/parse-attribute.1.bad.error
+++ b/tests/parser/parse-attribute.1.bad.error
@@ -1,0 +1,5 @@
+error: Orphan attribute
+  --> test:4:0
+   |
+ 4 |  (repr :enum)
+   |  ^^^^^^^^^^^^ attribute must be attached to another form

--- a/tests/parser/parse-attribute.2.bad.error
+++ b/tests/parser/parse-attribute.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed monomophize attribute
+  --> test:4:0
+   |
+ 4 |  (monomorphize 5)
+   |  ^^^^^^^^^^^^^^^^ unexpected form

--- a/tests/parser/parse-attribute.3.bad.error
+++ b/tests/parser/parse-attribute.3.bad.error
@@ -1,0 +1,5 @@
+error: Invalid type variable
+  --> test:4:6
+   |
+ 4 |  (repr (:enum))
+   |        ^^^^^^^ expected keyword symbol

--- a/tests/parser/parse-attribute.4.bad.error
+++ b/tests/parser/parse-attribute.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed repr attribute
+  --> test:4:12
+   |
+ 4 |  (repr :enum 5)
+   |              ^ unexpected form

--- a/tests/parser/parse-attribute.5.bad._error
+++ b/tests/parser/parse-attribute.5.bad._error
@@ -1,0 +1,5 @@
+error: Malformed repr :native attribute
+  --> test:4:14
+   |
+ 4 |  (repr :native)
+   |               ^ expected a lisp type

--- a/tests/parser/parse-attribute.6.bad.error
+++ b/tests/parser/parse-attribute.6.bad.error
@@ -1,0 +1,5 @@
+error: Malformed repr :native attribute
+  --> test:4:6
+   |
+ 4 |  (repr :native :native :native)
+   |        ^^^^^^^ unexpected form

--- a/tests/parser/parse-attribute.7.bad.error
+++ b/tests/parser/parse-attribute.7.bad.error
@@ -1,0 +1,5 @@
+error: Unknown repr attribute
+  --> test:4:6
+   |
+ 4 |  (repr :hello)
+   |        ^^^^^^ expected one of :lisp, :transparent, :enum, or :native

--- a/tests/parser/parse-body.1.bad.error
+++ b/tests/parser/parse-body.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function
+  --> test:4:17
+   |
+ 4 |  (define x (progn))
+   |                  ^ expected body

--- a/tests/parser/parse-body.2.bad.error
+++ b/tests/parser/parse-body.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed expression
+  --> test:4:10
+   |
+ 4 |  (define x (progn 1 2 . 3))
+   |            ^^^^^^^^^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-body.3.bad.error
+++ b/tests/parser/parse-body.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed body expression
+  --> test:6:4
+   |
+ 6 |      (let x = 5 . 5)
+   |      ^^^^^^^^^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-body.4.bad.error
+++ b/tests/parser/parse-body.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed body expression
+  --> test:6:4
+   |
+ 6 |      (let x = 5)))
+   |      ^^^^^^^^^^^ body forms cannot be terminated by a shorthand let

--- a/tests/parser/parse-body.5.bad.error
+++ b/tests/parser/parse-body.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed shorthand let
+  --> test:6:15
+   |
+ 6 |      (let x = 1 2)
+   |                 ^ unexpected trailing form

--- a/tests/parser/parse-break.1.bad.error
+++ b/tests/parser/parse-break.1.bad.error
@@ -1,0 +1,5 @@
+error: Invalid break
+  --> test:4:10
+   |
+ 4 |  (define f (break))
+   |            ^^^^^^^ break does not appear in an enclosing loop

--- a/tests/parser/parse-break.2.bad.error
+++ b/tests/parser/parse-break.2.bad.error
@@ -1,0 +1,5 @@
+error: Invalid label in break
+  --> test:5:24
+   |
+ 5 |    (while :x True (break :y)))
+   |                          ^^ label not found in any enclosing loop

--- a/tests/parser/parse-break.3.bad.error
+++ b/tests/parser/parse-break.3.bad.error
@@ -1,0 +1,5 @@
+error: Invalid label in break
+  --> test:5:39
+   |
+ 5 |    (while :x True (return (fn () (break :x)))))
+   |                                         ^^ label not found in any enclosing loop

--- a/tests/parser/parse-break.4.bad.error
+++ b/tests/parser/parse-break.4.bad.error
@@ -1,0 +1,5 @@
+error: Invalid break
+  --> test:5:29
+   |
+ 5 |    (while True (return (fn () (break)))))
+   |                               ^^^^^^^ break does not appear in an enclosing loop

--- a/tests/parser/parse-cond.1.bad.error
+++ b/tests/parser/parse-cond.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed cond expression
+  --> test:4:16
+   |
+ 4 |  (define x (cond))
+   |                 ^ expected one or more clauses

--- a/tests/parser/parse-cond.2.bad.error
+++ b/tests/parser/parse-cond.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed cond clause
+  --> test:4:16
+   |
+ 4 |  (define x (cond 1))
+   |                  ^ expected list

--- a/tests/parser/parse-cond.3.bad.error
+++ b/tests/parser/parse-cond.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed cond clause
+  --> test:4:16
+   |
+ 4 |  (define x (cond (1 2 . 3)))
+   |                  ^^^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-cond.4.bad.error
+++ b/tests/parser/parse-cond.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function
+  --> test:4:19
+   |
+ 4 |  (define x (cond (y)))
+   |                    ^ expected body

--- a/tests/parser/parse-continue.1.bad.error
+++ b/tests/parser/parse-continue.1.bad.error
@@ -1,0 +1,5 @@
+error: Invalid continue
+  --> test:4:10
+   |
+ 4 |  (define f (continue))
+   |            ^^^^^^^^^^ continue does not appear in an enclosing loop

--- a/tests/parser/parse-continue.2.bad.error
+++ b/tests/parser/parse-continue.2.bad.error
@@ -1,0 +1,5 @@
+error: Invalid argument in continue
+  --> test:6:4
+   |
+ 6 |      (continue notakeyword)))
+   |      ^^^^^^^^^^^^^^^^^^^^^^ expected a keyword

--- a/tests/parser/parse-continue.3.bad.error
+++ b/tests/parser/parse-continue.3.bad.error
@@ -1,0 +1,5 @@
+error: Invalid label in continue
+  --> test:6:14
+   |
+ 6 |      (continue :not-foo)))
+   |                ^^^^^^^^ label not found in any enclosing loop

--- a/tests/parser/parse-continue.4.bad.error
+++ b/tests/parser/parse-continue.4.bad.error
@@ -1,0 +1,5 @@
+error: Invalid continue
+  --> test:6:28
+   |
+ 6 |      (let ((continuer (fn () (continue))))
+   |                              ^^^^^^^^^^ continue does not appear in an enclosing loop

--- a/tests/parser/parse-continue.5.bad.error
+++ b/tests/parser/parse-continue.5.bad.error
@@ -1,0 +1,5 @@
+error: Invalid label in continue
+  --> test:6:42
+   |
+ 6 |          (let ((continuer (fn () (continue :blech))))
+   |                                            ^^^^^^ label not found in any enclosing loop

--- a/tests/parser/parse-declare.1.bad.error
+++ b/tests/parser/parse-declare.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed declaration
+  --> test:4:0
+   |
+ 4 |  (declare)
+   |  ^^^^^^^^^ expected body

--- a/tests/parser/parse-declare.2.bad.error
+++ b/tests/parser/parse-declare.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed declaration
+  --> test:4:0
+   |
+ 4 |  (declare x)
+   |  ^^^^^^^^^^^ expected declared type

--- a/tests/parser/parse-declare.3.bad.error
+++ b/tests/parser/parse-declare.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed declaration
+  --> test:4:20
+   |
+ 4 |  (declare x (T -> T) z)
+   |                      ^ unexpected trailing form

--- a/tests/parser/parse-declare.4.bad.error
+++ b/tests/parser/parse-declare.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed declaration
+  --> test:4:9
+   |
+ 4 |  (declare "x" 5)
+   |           ^^^ expected symbol

--- a/tests/parser/parse-declare.5.bad.error
+++ b/tests/parser/parse-declare.5.bad.error
@@ -1,0 +1,7 @@
+error: Invalid target for repr attribute
+  --> test:4:0
+   |
+ 4 |  (repr :enum)
+   |  ^^^^^^^^^^^^ repr must be attached to a define-type
+ 5 |  (declare x T)
+   |  ------------- when parsing declare

--- a/tests/parser/parse-declare.6.bad.error
+++ b/tests/parser/parse-declare.6.bad.error
@@ -1,0 +1,9 @@
+error: Duplicate monomorphize attribute
+  --> test:5:0
+   |
+ 4 |  (monomorphize)
+   |  -------------- previous attribute here
+ 5 |  (monomorphize)
+   |  ^^^^^^^^^^^^^^ monomorphize attribute here
+ 6 |  (declare f T)
+   |  ------------- when parsing declare

--- a/tests/parser/parse-do.1.bad.error
+++ b/tests/parser/parse-do.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed bind form
+  --> test:6:13
+   |
+ 6 |      (x <- mx y)
+   |               ^ unexpected trailing form

--- a/tests/parser/parse-do.2.bad.error
+++ b/tests/parser/parse-do.2.bad.error
@@ -1,0 +1,6 @@
+error: Malformed do expression
+  --> test:5:6
+   |
+ 5 |    (do (x <- mx)))
+   |     -- when parsing do expression
+   |        ^^^^^^^^^ do expression cannot be terminated by a bind

--- a/tests/parser/parse-do.3.bad.error
+++ b/tests/parser/parse-do.3.bad.error
@@ -1,0 +1,6 @@
+error: Malformed do expression
+  --> test:5:6
+   |
+ 5 |    (do (let x = 5)))
+   |     -- when parsing do expression
+   |        ^^^^^^^^^^^ do expressions cannot be terminated by a shorthand let

--- a/tests/parser/parse-do.4.bad.error
+++ b/tests/parser/parse-do.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed do expression
+  --> test:4:14
+   |
+ 4 |  (define x (do))
+   |               ^ expected one or more forms

--- a/tests/parser/parse-expression.1.bad.error
+++ b/tests/parser/parse-expression.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed expression
+  --> test:4:10
+   |
+ 4 |  (define x ())
+   |            ^^ unexpected `nil` or `()`

--- a/tests/parser/parse-expression.2.bad.error
+++ b/tests/parser/parse-expression.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed expression
+  --> test:4:10
+   |
+ 4 |  (define x (f . x))
+   |            ^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-expression.3.bad.error
+++ b/tests/parser/parse-expression.3.bad.error
@@ -1,0 +1,5 @@
+error: Invalid literal
+  --> test:4:10
+   |
+ 4 |  (define x #C(1 2))
+   |            ^^^^^^^ unknown literal type

--- a/tests/parser/parse-expression.4.bad.error
+++ b/tests/parser/parse-expression.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed expression
+  --> test:4:10
+   |
+ 4 |  (define x (f . 3))
+   |            ^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-fn.1.bad.error
+++ b/tests/parser/parse-fn.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function
+  --> test:4:14
+   |
+ 4 |  (define f (fn))
+   |               ^ expected function arguments

--- a/tests/parser/parse-fn.2.bad.error
+++ b/tests/parser/parse-fn.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function
+  --> test:4:17
+   |
+ 4 |  (define f (fn ()))
+   |                  ^ expected function body

--- a/tests/parser/parse-fn.3.bad.error
+++ b/tests/parser/parse-fn.3.bad.error
@@ -1,0 +1,8 @@
+error: Malformed function
+  --> test:4:14
+   |
+ 4 |  (define f (fn x 1))
+   |                ^ malformed arugment list
+help: add parentheses
+ 4 | (define f (fn (x) 1))
+   |               ---

--- a/tests/parser/parse-for.1.bad.error
+++ b/tests/parser/parse-for.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed for expression
+  --> test:4:15
+   |
+ 4 |  (define f (for))
+   |                ^ expected pattern

--- a/tests/parser/parse-for.2.bad.error
+++ b/tests/parser/parse-for.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed for expression
+  --> test:4:17
+   |
+ 4 |  (define f (for x))
+   |                  ^ expected in

--- a/tests/parser/parse-for.3.bad.error
+++ b/tests/parser/parse-for.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed for expression
+  --> test:4:19
+   |
+ 4 |  (define f (for x y))
+   |                    ^ expected in

--- a/tests/parser/parse-for.4.bad.error
+++ b/tests/parser/parse-for.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed for expression
+  --> test:4:25
+   |
+ 4 |  (define f (for x in iter))
+   |                          ^ expected body

--- a/tests/parser/parse-for.5.bad.error
+++ b/tests/parser/parse-for.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed for expression
+  --> test:4:32
+   |
+ 4 |  (define f (for :label x in iter))
+   |                                 ^ expected body

--- a/tests/parser/parse-if.1.bad.error
+++ b/tests/parser/parse-if.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed if expression
+  --> test:4:14
+   |
+ 4 |  (define x (if))
+   |               ^ expected a predicate

--- a/tests/parser/parse-if.2.bad.error
+++ b/tests/parser/parse-if.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed if expression
+  --> test:4:16
+   |
+ 4 |  (define x (if 1))
+   |                 ^ expected a form

--- a/tests/parser/parse-if.3.bad.error
+++ b/tests/parser/parse-if.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed if expression
+  --> test:4:18
+   |
+ 4 |  (define x (if 1 2))
+   |                   ^ expected a form

--- a/tests/parser/parse-if.4.bad.error
+++ b/tests/parser/parse-if.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed if expression
+  --> test:4:21
+   |
+ 4 |  (define x (if 1 2 3 4))
+   |                      ^ unexpected trailing form

--- a/tests/parser/parse-let.1.bad.error
+++ b/tests/parser/parse-let.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed let
+  --> test:4:15
+   |
+ 4 |  (define f (let))
+   |                ^ expected let binding list

--- a/tests/parser/parse-let.2.bad.error
+++ b/tests/parser/parse-let.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed let
+  --> test:4:18
+   |
+ 4 |  (define f (let ()))
+   |                   ^ expected let body

--- a/tests/parser/parse-let.3.bad.error
+++ b/tests/parser/parse-let.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed let
+  --> test:4:15
+   |
+ 4 |  (define f (let x 5))
+   |                 ^ expected binding list

--- a/tests/parser/parse-let.4.bad.error
+++ b/tests/parser/parse-let.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed let binding
+  --> test:5:8
+   |
+ 5 |    (let ((y 2 . 3))
+   |          ^^^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-let.5.bad.error
+++ b/tests/parser/parse-let.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed let binding
+  --> test:5:10
+   |
+ 5 |   (let ((x)) 5))
+   |           ^ let bindings must have a value

--- a/tests/parser/parse-let.6.bad.error
+++ b/tests/parser/parse-let.6.bad.error
@@ -1,0 +1,5 @@
+error: Malformed let binding
+  --> test:5:8
+   |
+ 5 |    (let (x) 5))
+   |          ^ expected list

--- a/tests/parser/parse-let.7.bad.error
+++ b/tests/parser/parse-let.7.bad.error
@@ -1,0 +1,5 @@
+error: Malformed let binding
+  --> test:5:13
+   |
+ 5 |    (let ((x y z)) 5))
+   |               ^ unexpected trailing form

--- a/tests/parser/parse-let.8.bad.error
+++ b/tests/parser/parse-let.8.bad.error
@@ -1,0 +1,5 @@
+error: Malformed declare
+  --> test:5:28
+   |
+ 5 |    (let ((declare x (T -> T) 5))
+   |                              ^ unexpected form

--- a/tests/parser/parse-let.9.bad.error
+++ b/tests/parser/parse-let.9.bad.error
@@ -1,0 +1,5 @@
+error: Invalid variable
+  --> test:5:17
+   |
+ 5 |    (let ((declare 5 (T -> T)))
+   |                   ^ expected identifier

--- a/tests/parser/parse-lisp.1.bad.error
+++ b/tests/parser/parse-lisp.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed lisp expression
+  --> test:4:16
+   |
+ 4 |  (define f (lisp))
+   |                 ^ expected expression type

--- a/tests/parser/parse-lisp.2.bad.error
+++ b/tests/parser/parse-lisp.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed lisp expression
+  --> test:4:25
+   |
+ 4 |  (define f (lisp (T -> T)))
+   |                          ^ expected binding list

--- a/tests/parser/parse-lisp.3.bad.error
+++ b/tests/parser/parse-lisp.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed lisp expression
+  --> test:4:10
+   |
+ 4 |  (define f (lisp (T -> T) (x y)))
+   |            ^^^^^^^^^^^^^^^^^^^^^ expected body

--- a/tests/parser/parse-loop.1.bad.error
+++ b/tests/parser/parse-loop.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed loop expression
+  --> test:4:16
+   |
+ 4 |  (define f (loop))
+   |                 ^ expected a loop body

--- a/tests/parser/parse-loop.2.bad.error
+++ b/tests/parser/parse-loop.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed loop expression
+  --> test:4:24
+   |
+ 4 |  (define f (loop :alabel))
+   |                         ^ expected a loop body

--- a/tests/parser/parse-match.1.bad.error
+++ b/tests/parser/parse-match.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed match expression
+  --> test:4:17
+   |
+ 4 |  (define f (match))
+   |                  ^ expected expression

--- a/tests/parser/parse-match.2.bad.error
+++ b/tests/parser/parse-match.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed match branch
+  --> test:6:7
+   |
+ 6 |      (y)))
+   |        ^ expected body

--- a/tests/parser/parse-match.3.bad.error
+++ b/tests/parser/parse-match.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed match branch
+  --> test:6:4
+   |
+ 6 |      5))
+   |      ^ expected list

--- a/tests/parser/parse-match.4.bad.error
+++ b/tests/parser/parse-match.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed match branch
+  --> test:6:4
+   |
+ 6 |      (x y . z)))
+   |      ^^^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-or.1.bad.error
+++ b/tests/parser/parse-or.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed or expression
+  --> test:4:14
+   |
+ 4 |  (define x (or))
+   |               ^ expected one or more arguments

--- a/tests/parser/parse-pattern.1.bad.error
+++ b/tests/parser/parse-pattern.1.bad.error
@@ -1,0 +1,5 @@
+error: Invalid pattern
+  --> test:5:7
+   |
+ 5 |    (let #C(1 2) = x)
+   |         ^^^^^^^ unknown pattern literal

--- a/tests/parser/parse-pattern.2.bad.error
+++ b/tests/parser/parse-pattern.2.bad.error
@@ -1,0 +1,5 @@
+error: Invalid match branch
+  --> test:5:7
+   |
+ 5 |    (let (x y . z) = g)
+   |         ^^^^^^^^^ unexpected dotted list

--- a/tests/parser/parse-pattern.3.bad.error
+++ b/tests/parser/parse-pattern.3.bad.error
@@ -1,0 +1,5 @@
+error: Invalid pattern
+  --> test:5:8
+   |
+ 5 |    (let (5 x y) = g)
+   |          ^ invalid constructor in pattern

--- a/tests/parser/parse-return.1.bad.error
+++ b/tests/parser/parse-return.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed return expression
+  --> test:4:20
+   |
+ 4 |  (define x (return y z))
+   |                      ^ unexpected trailing form

--- a/tests/parser/parse-the.1.bad.error
+++ b/tests/parser/parse-the.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed the expression
+  --> test:4:15
+   |
+ 4 |  (define x (the))
+   |                ^ expected type

--- a/tests/parser/parse-the.2.bad.error
+++ b/tests/parser/parse-the.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed the expression
+  --> test:4:24
+   |
+ 4 |  (define x (the (T -> T)))
+   |                         ^ expected value

--- a/tests/parser/parse-the.3.bad.error
+++ b/tests/parser/parse-the.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed the expression
+  --> test:4:26
+   |
+ 4 |  (define x (the (T -> T) y z))
+   |                            ^ unexpected trailing form

--- a/tests/parser/parse-toplevel.1.bad.error
+++ b/tests/parser/parse-toplevel.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed toplevel form
+  --> test:4:1
+   |
+ 4 |  ((define) x 5)
+   |   ^^^^^^^^ unexpected list

--- a/tests/parser/parse-toplevel.2.bad.error
+++ b/tests/parser/parse-toplevel.2.bad.error
@@ -1,0 +1,5 @@
+error: Invalid toplevel form
+  --> test:4:1
+   |
+ 4 |  (unknown)
+   |   ^^^^^^^ unknown toplevel form

--- a/tests/parser/parse-type.1.bad.error
+++ b/tests/parser/parse-type.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type
+  --> test:4:17
+   |
+ 4 |  (declare f (T -> (G)))
+   |                   ^^^ unexpected nullary type

--- a/tests/parser/parse-type.10.bad.error
+++ b/tests/parser/parse-type.10.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type
+  --> test:4:17
+   |
+ 4 |  (declare f (T -> "T"))
+   |                   ^^^ expected identifier

--- a/tests/parser/parse-type.11.bad.error
+++ b/tests/parser/parse-type.11.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function type
+  --> test:4:12
+   |
+ 4 |  (declare f (-> T))
+   |              ^^ invalid function syntax

--- a/tests/parser/parse-type.12.bad.error
+++ b/tests/parser/parse-type.12.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function type
+  --> test:4:14
+   |
+ 4 |  (declare f (T ->))
+   |                ^^ missing return type

--- a/tests/parser/parse-type.13.bad.error
+++ b/tests/parser/parse-type.13.bad.error
@@ -1,0 +1,8 @@
+error: Malformed type
+  --> test:4:12
+   |
+ 4 |  (declare f (=> T))
+   |              ^^ unnecessary `=>`
+help: remove `=>`
+ 4 | (declare f T)
+   |            -

--- a/tests/parser/parse-type.2.bad.error
+++ b/tests/parser/parse-type.2.bad.error
@@ -1,0 +1,8 @@
+error: Malformed type
+  --> test:4:12
+   |
+ 4 |  (declare f (=> T -> T))
+   |              ^^ unnecessary `=>`
+help: remove `=>`
+ 4 | (declare f (T -> T))
+   |            --------

--- a/tests/parser/parse-type.3.bad.error
+++ b/tests/parser/parse-type.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type
+  --> test:4:14
+   |
+ 4 |  (declare f (T :a =>))
+   |                ^^ missing type after `=>`

--- a/tests/parser/parse-type.4.bad.error
+++ b/tests/parser/parse-type.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type predicate
+  --> test:4:12
+   |
+ 4 |  (declare f (T => T -> T))
+   |              ^ expected predicate

--- a/tests/parser/parse-type.5.bad.error
+++ b/tests/parser/parse-type.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type predicate
+  --> test:4:12
+   |
+ 4 |  (declare f ("T" :a => T))
+   |              ^^^ expected identifier

--- a/tests/parser/parse-type.6.bad.error
+++ b/tests/parser/parse-type.6.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type
+  --> test:4:12
+   |
+ 4 |  (declare f (=>))
+   |              ^^ unnecessary `=>`

--- a/tests/parser/parse-type.7.bad.error
+++ b/tests/parser/parse-type.7.bad.error
@@ -1,0 +1,8 @@
+error: Malformed type
+  --> test:4:12
+   |
+ 4 |  (declare f (=> T -> T))
+   |              ^^ unnecessary `=>`
+help: remove `=>`
+ 4 | (declare f (T -> T))
+   |            --------

--- a/tests/parser/parse-type.8.bad.error
+++ b/tests/parser/parse-type.8.bad.error
@@ -1,0 +1,5 @@
+error: Malformed type predicate
+  --> test:4:19
+   |
+ 4 |  (declare f ((T :a) T => T -> T))
+   |                     ^ expected predicate

--- a/tests/parser/parse-type.9.bad.error
+++ b/tests/parser/parse-type.9.bad.error
@@ -1,0 +1,8 @@
+error: Malformed type predicate
+  --> test:4:20
+   |
+ 4 |  (declare f ((T :a) ((T) :a) => T -> T))
+   |                      ^^^ expected class name
+help: remove parentheses
+ 4 | (declare f ((T :a) (T :a) => T -> T))
+   |                     -

--- a/tests/parser/parse-unless.1.bad.error
+++ b/tests/parser/parse-unless.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed unless expression
+  --> test:4:18
+   |
+ 4 |  (define x (unless))
+   |                   ^ expected a predicate

--- a/tests/parser/parse-unless.2.bad.error
+++ b/tests/parser/parse-unless.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function
+  --> test:4:20
+   |
+ 4 |  (define x (unless 1))
+   |                     ^ expected body

--- a/tests/parser/parse-when.1.bad.error
+++ b/tests/parser/parse-when.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed when expression
+  --> test:4:16
+   |
+ 4 |  (define f (when))
+   |                 ^ expected a predicate

--- a/tests/parser/parse-when.2.bad.error
+++ b/tests/parser/parse-when.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed function
+  --> test:4:18
+   |
+ 4 |  (define x (when 1))
+   |                   ^ expected body

--- a/tests/parser/parse-while-let.1.bad.error
+++ b/tests/parser/parse-while-let.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:21
+   |
+ 4 |  (define f (while-let))
+   |                      ^ expected pattern

--- a/tests/parser/parse-while-let.2.bad.error
+++ b/tests/parser/parse-while-let.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:30
+   |
+ 4 |  (define f (while-let (Some x)))
+   |                               ^ expected =

--- a/tests/parser/parse-while-let.3.bad.error
+++ b/tests/parser/parse-while-let.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:32
+   |
+ 4 |  (define f (while-let (Some x) z))
+   |                                 ^ expected =

--- a/tests/parser/parse-while-let.4.bad.error
+++ b/tests/parser/parse-while-let.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:38
+   |
+ 4 |  (define f (while-let (Some x) = (moo)))
+   |                                       ^ expected body

--- a/tests/parser/parse-while-let.5.bad.error
+++ b/tests/parser/parse-while-let.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:45
+   |
+ 4 |  (define f (while-let :label (Some x) = (moo)))
+   |                                              ^ expected body

--- a/tests/parser/parse-while-let.6.bad.error
+++ b/tests/parser/parse-while-let.6.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:28
+   |
+ 4 |  (define f (while-let :label))
+   |                             ^ expected pattern

--- a/tests/parser/parse-while-let.7.bad.error
+++ b/tests/parser/parse-while-let.7.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:32
+   |
+ 4 |  (define f (while-let :label foo))
+   |                                 ^ expected =

--- a/tests/parser/parse-while-let.8.bad.error
+++ b/tests/parser/parse-while-let.8.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:37
+   |
+ 4 |  (define f (while-let :label foo nope))
+   |                                      ^ expected =

--- a/tests/parser/parse-while-let.9.bad.error
+++ b/tests/parser/parse-while-let.9.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while-let expression
+  --> test:4:38
+   |
+ 4 |  (define f (while-let :label foo = bar))
+   |                                       ^ expected body

--- a/tests/parser/parse-while.1.bad.error
+++ b/tests/parser/parse-while.1.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while expression
+  --> test:4:17
+   |
+ 4 |  (define f (while))
+   |                  ^ expected condition

--- a/tests/parser/parse-while.2.bad.error
+++ b/tests/parser/parse-while.2.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while expression
+  --> test:4:23
+   |
+ 4 |  (define f (while false))
+   |                        ^ expected body

--- a/tests/parser/parse-while.3.bad.error
+++ b/tests/parser/parse-while.3.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while expression
+  --> test:4:24
+   |
+ 4 |  (define f (while :label))
+   |                         ^ expected condition

--- a/tests/parser/parse-while.4.bad.error
+++ b/tests/parser/parse-while.4.bad.error
@@ -1,0 +1,5 @@
+error: Malformed while expression
+  --> test:4:29
+   |
+ 4 |  (define f (while :label True))
+   |                              ^ expected body

--- a/tests/parser/toplevel-progn.1.bad.error
+++ b/tests/parser/toplevel-progn.1.bad.error
@@ -1,0 +1,10 @@
+error: Invalid attribute for progn
+  --> test:4:0
+   |
+ 4 |   (repr :transparent)
+   |   ^^^^^^^^^^^^^^^^^^^ progn cannot have attributes
+ 5 |   (progn
+   |  _-
+ 6 | |   (define-type T
+ 7 | |     (T Integer)))
+   | |_________________- when parsing progn

--- a/tests/parser/toplevel-progn.2.bad.error
+++ b/tests/parser/toplevel-progn.2.bad.error
@@ -1,0 +1,8 @@
+error: Trailing attributes in progn
+  --> test:5:2
+   |
+ 4 |   (progn
+   |  _-
+ 5 | |   (repr :transparent))
+   | |   ^^^^^^^^^^^^^^^^^^^ progn cannot have trailing attributes
+   | |______________________- when parsing progn

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -15,7 +15,7 @@
   (set-equalp dag1 dag2))
 
 (defun check-string= (context a b)
-  "Fire a test failure assertion if strings A and B differ, reporting the first position at which this is true."
+  "Signal a test failure assertion if strings A and B differ, reporting the first position at which this is true."
   (let ((compare-len (min (length a)
                           (length b))))
     (loop :for i :from 0 :below compare-len

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -23,12 +23,12 @@
                          (aref b i))
             :do (is (string= a b)
                     (format nil "Strings differ at offset ~A of ~A:~%A: ~A~%B: ~A"
-                            context i a b))
-                (return))
+                            i context a b))
+                (return-from check-string=))
     (is (= (length a)
            (length b))
         (format nil "Strings differ at offset ~A of ~A:~%~A~%~A"
-                context compare-len a b))))
+                compare-len context a b))))
 
 (defun check-coalton-types (toplevel-string &rest expected-types)
   (let ((*package* (make-package (or (and fiasco::*current-test*

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -14,6 +14,22 @@
   ;; XXX: This will not check ordering of edges within vertices
   (set-equalp dag1 dag2))
 
+(defun check-string= (context a b)
+  "Fire a test failure assertion if strings A and B differ, reporting the first position at which this is true."
+  (let ((compare-len (min (length a)
+                          (length b))))
+    (loop :for i :from 0 :below compare-len
+          :unless (char= (aref a i)
+                         (aref b i))
+            :do (is (string= a b)
+                    (format nil "Strings differ at offset ~A of ~A:~%A: ~A~%B: ~A"
+                            context i a b))
+                (return))
+    (is (= (length a)
+           (length b))
+        (format nil "Strings differ at offset ~A of ~A:~%~A~%~A"
+                context compare-len a b))))
+
 (defun check-coalton-types (toplevel-string &rest expected-types)
   (let ((*package* (make-package (or (and fiasco::*current-test*
                                           (fiasco::name-of fiasco::*current-test*))


### PR DESCRIPTION
Modify parser-tests to check the literal contents of emitted parser errors.

Provides verification for modifications of error printer in #1066

Three tests are disabled, because the current error printer computes incorrect newline offsets in 2 cases, and drops 1 help message:

tests/parser/define-instance.7.bad._error
tests/parser/define-type.2.bad._error
tests/parser/parse-attribute.5.bad._error