### PR TITLE
Update `thih-coalton`, `thih-coalton/tests`

### DIFF
--- a/examples/thih/src/thih.lisp
+++ b/examples/thih/src/thih.lisp
@@ -9,19 +9,12 @@
   (define-type Id
     (Id String))
 
-  (define (id->string id)
-    (match id
-      ((Id s) s)))
+  (define (id->string (Id str))
+    str)
 
   (define-instance (Eq Id)
-    (define (== x y)
-      (== (get-id x)
-          (get-id y))))
-
-  (declare get-id (Id -> String))
-  (define (get-id x)
-    (match x
-      ((Id str) str)))
+    (define (== (Id x) (Id y))
+      (== x y)))
 
   (declare enumId (Integer -> Id))
   (define (enumId n)
@@ -72,22 +65,18 @@
     (Tyvar Id Kind))
 
   (define-instance (Eq Tyvar)
-    (define (== x y)
-      (match (Tuple x y)
-        ((Tuple (Tyvar i1 k1) (Tyvar i2 k2))
-         (and (== i1 i2)
-              (== k1 k2))))))
+    (define (== (Tyvar i1 k1) (Tyvar i2 k2))
+      (and (== i1 i2)
+           (== k1 k2))))
 
 
   (define-type Tycon
     (Tycon Id Kind))
 
   (define-instance (Eq Tycon)
-    (define (== x y)
-      (match (Tuple x y)
-        ((Tuple (Tycon i1 k1) (Tycon i2 k2))
-         (and (== i1 i2)
-              (== k1 k2))))))
+    (define (== (Tycon i1 k1) (Tycon i2 k2))
+      (and (== i1 i2)
+           (== k1 k2))))
 
 
   (define tUnit (TCon (Tycon (Id "()") Star)))
@@ -121,14 +110,12 @@
     (kind (:t -> Kind)))
 
   (define-instance (HasKind Tyvar)
-    (define (kind t)
-      (match t
-        ((Tyvar _ k) k))))
+    (define (kind (Tyvar _ k))
+      k))
 
   (define-instance (HasKind Tycon)
-    (define (kind t)
-      (match t
-        ((Tycon _ k) k))))
+    (define (kind (Tycon _ k))
+      k))
 
   (define-instance (HasKind Type)
     (define (kind t)
@@ -279,43 +266,32 @@
     (Qual (List Pred) :t))
 
   (define-instance (Eq :t => Eq (Qual :t))
-    (define (== x y)
-      (match (Tuple x y)
-        ((Tuple (Qual xs t1) (Qual ys t2))
-         (and (== xs ys)
-              (== t1 t2))))))
+    (define (== (Qual xs t1) (Qual ys t2))
+      (and (== xs ys)
+           (== t1 t2))))
 
   (define-instance (Types :t => Types (Qual :t))
-    (define (apply s q)
-      (match q
-        ((Qual ps t)
-         (Qual (apply s ps)
-               (apply s t)))))
-    (define (tv q)
-      (match q
-        ((Qual ps t)
-         (list:union (tv ps) (tv t))))))
-
+    (define (apply s (Qual ps t))
+      (Qual (apply s ps)
+            (apply s t)))
+    
+    (define (tv (Qual ps t))
+      (list:union (tv ps) (tv t))))
 
   (define-type Pred
     (IsIn Id Type))
 
   (define-instance (Eq Pred)
-    (define (== x y)
-      (match (Tuple x y)
-        ((Tuple (IsIn id1 t1) (IsIn id2 t2))
-         (and (== id1 id2)
-              (== t1 t2))))))
+    (define (== (IsIn id1 t1) (IsIn id2 t2))
+      (and (== id1 id2)
+           (== t1 t2))))
 
   (define-instance (Types Pred)
-    (define (apply s p)
-      (match p
-        ((IsIn i t)
-         (IsIn i (apply s t)))))
-    (define (tv p)
-      (match p
-        ((IsIn _ t)
-         (tv t)))))
+    (define (apply s (IsIn i t))
+      (IsIn i (apply s t)))
+    
+    (define (tv (IsIn _ t))
+      (tv t)))
 
 
   (declare mguPred (Pred -> Pred -> (Optional Subst)))
@@ -338,17 +314,15 @@
     (Class (Tuple (List Id) (List Inst))))
 
   (declare get-class (Class -> (Tuple (List Id) (List Inst))))
-  (define (get-class c)
-    (match c
-      ((Class x) x)))
+  (define (get-class (Class x))
+    x)
 
   (define-type Inst
     (Instance (Qual Pred)))
 
   (declare get-inst (Inst -> (Qual Pred)))
-  (define (get-inst i)
-    (match i
-      ((Instance x) x)))
+  (define (get-inst (Instance x))
+    x)
 
 
   ;; Class Environments
@@ -357,14 +331,12 @@
     (ClassEnv (Id -> (Optional Class)) (List Type)))
 
   (declare classes (ClassEnv -> (Id -> (Optional Class))))
-  (define (classes env)
-    (match env
-      ((ClassEnv cs _) cs)))
+  (define (classes (ClassEnv cs _))
+    cs)
 
   (declare defaults (ClassEnv -> (List Type)))
-  (define (defaults env)
-    (match env
-      ((ClassEnv _ ds) ds)))
+  (define (defaults (ClassEnv _ ds))
+    ds)
 
   (declare super (ClassEnv -> Id -> (List Id)))
   (define (super ce i)
@@ -586,22 +558,15 @@
     (Forall (List Kind) (Qual Type)))
 
   (define-instance (Eq Scheme)
-    (define (== x y)
-      (match (Tuple x y)
-        ((Tuple (Forall ks1 q1)
-                (Forall ks2 q2))
-         (and (== ks1 ks2)
-              (== q1 q2))))))
+    (define (== (Forall ks1 q1) (Forall ks2 q2))
+      (and (== ks1 ks2)
+           (== q1 q2))))
 
   (define-instance (Types Scheme)
-    (define (apply s t)
-      (match t
-        ((Forall ks qt)
-         (Forall ks (apply s qt)))))
-    (define (tv t)
-      (match t
-        ((Forall _ qt)
-         (tv qt)))))
+    (define (apply s (Forall ks qt))
+      (Forall ks (apply s qt)))
+    (define (tv (Forall _ qt))
+      (tv qt)))
 
   (declare quantify ((List Tyvar) -> (Qual Type) -> Scheme))
   (define (quantify vs qt)
@@ -627,21 +592,15 @@
     (Assump Id Scheme))
 
   (define-instance (Eq Assump)
-    (define (== a b)
-      (match (Tuple a b)
-        ((Tuple (Assump id-a scheme-a) (Assump id-b scheme-b))
-         (and (== id-a id-b)
-              (== scheme-a scheme-b))))))
+    (define (== (Assump id-a scheme-a) (Assump id-b scheme-b))
+      (and (== id-a id-b)
+           (== scheme-a scheme-b))))
 
   (define-instance (Types Assump)
-    (define (apply s a)
-      (match a
-        ((Assump i sc)
-         (Assump i (apply s sc)))))
-    (define (tv a)
-      (match a
-        ((Assump _ sc)
-         (tv sc)))))
+    (define (apply s (Assump i sc))
+      (Assump i (apply s sc)))
+    (define (tv (Assump _ sc))
+      (tv sc)))
 
   (declare find (MonadFail :m => (Id -> (List Assump) -> (:m Scheme))))
   (define (find i xs)
@@ -662,9 +621,8 @@
     (TI (Subst -> Integer -> (Tuple3 Subst Integer :a))))
 
   (declare get-ti ((TI :a) -> (Subst -> Integer -> (Tuple3 Subst Integer :a))))
-  (define (get-ti x)
-    (match x
-      ((TI y) y)))
+  (define (get-ti (TI y))
+    y)
 
   (define-instance (Functor TI)
     (define (map f x)
@@ -744,15 +702,13 @@
       (map (inst ts))))
 
   (define-instance (Instantiate :t => Instantiate (Qual :t))
-    (define (inst ts q)
-      (match q
-        ((Qual ps t) (Qual (inst ts ps)
-                           (inst ts t))))))
+    (define (inst ts (Qual ps t))
+      (Qual (inst ts ps)
+            (inst ts t))))
 
   (define-instance (Instantiate Pred)
-    (define (inst ts p)
-      (match p
-        ((IsIn c t) (IsIn c (inst ts t))))))
+    (define (inst ts (IsIn c t))
+      (IsIn c (inst ts t))))
 
 
   ;;
@@ -766,7 +722,7 @@
   (define-type Literal
     (LitInt Integer)
     (LitChar Char)
-    ;; NOTE: Rationals are ignored because coalton does not have support
+    (LitRat Fraction)
     (LitStr String))
 
   (declare tiLit (Literal -> (TI (Tuple (List Pred) Type))))
@@ -775,7 +731,9 @@
       ((LitChar _) (pure (Tuple Nil tChar)))
       ((LitInt _)  (do (v <- (newTVar Star))
                        (pure (Tuple (make-list (IsIn (Id "Num") v)) v))))
-      ((LitStr _)  (pure (Tuple Nil tString)))))
+      ((LitStr _)  (pure (Tuple Nil tString)))
+      ((LitRat _) (do (v <- (newTVar Star))
+                      (pure (Tuple (make-list (IsIn (Id "Fractional") v)) v))))))
 
   ;; Patterns
 
@@ -984,9 +942,9 @@
   (declare defaultedPreds (MonadFail :m => (ClassEnv -> (List Tyvar) -> (List Pred) -> (:m (List Pred)))))
   (define defaultedPreds
     (withDefaults (fn (vps _ts) (concat (map (fn (a)
-                                              (match a
-                                                ((Ambiguity _ x) x)))
-                                            vps)))))
+                                               (match a
+                                                 ((Ambiguity _ x) x)))
+                                             vps)))))
 
   (declare defaultSubst (MonadFail :m => (ClassEnv -> (List Tyvar) -> (List Pred) -> (:m Subst))))
   (define defaultSubst
@@ -1131,17 +1089,15 @@
     (Program (List BindGroup)))
 
   (declare tiProgram (ClassEnv -> (List Assump) -> Program -> (List Assump)))
-  (define (tiProgram ce as bgs)
-    (match bgs
-      ((Program bgs)
-       (runTI
-        (do (seq <- (tiSeq tiBindGroup ce as bgs))
-            (match seq
-              ((Tuple ps as_)
-               (do (s  <- getSubst)
-                   (rs <- (reduce ce (apply s ps)))
-                 (s_ <- (defaultSubst ce Nil rs))
-                 (pure (apply (@@ s_ s) as_))))))))))
+  (define (tiProgram ce as (Program bgs))
+    (runTI
+     (do (seq <- (tiSeq tiBindGroup ce as bgs))
+         (match seq
+           ((Tuple ps as_)
+            (do (s  <- getSubst)
+                (rs <- (reduce ce (apply s ps)))
+              (s_ <- (defaultSubst ce Nil rs))
+              (pure (apply (@@ s_ s) as_))))))))
 
   (declare assumption-list-equal ((List Assump) -> (List Assump) -> Boolean))
   (define (assumption-list-equal a b)

--- a/examples/thih/tests/package.lisp
+++ b/examples/thih/tests/package.lisp
@@ -1,14 +1,25 @@
 ;;;; package.lisp
 
-(fiasco:define-test-package #:thih-coalton-tests
-  (:documentation "Tests for the THIH-COALTON system.")
-  (:use #:cl #:thih-coalton)
-  (:shadowing-import-from
-   #:thih-coalton
-   #:Type)
-  (:shadowing-import-from
-   #:coalton
-   #:make-list
-   #:Nil)
-  (:export
-   #:run-thih-coalton-tests))
+(defpackage #:thih-coalton/tests
+  (:use #:coalton-testing)
+  (:local-nicknames (#:th #:thih-coalton))
+  (:export #:run-tests))
+
+(in-package #:thih-coalton/tests)
+
+(named-readtables:in-readtable coalton:coalton)
+
+(fiasco:define-test-package #:thih-coalton/fiasco-test-package
+    (:documentation "Tests for the THIH-COALTON system."))
+
+(coalton-fiasco-init #:thih-coalton/fiasco-test-package)
+
+(cl:defun run-tests ()
+  (fiasco:run-package-tests
+   :packages '(#:thih-coalton/fiasco-test-package)
+   :interactive cl:t))
+
+
+
+
+

--- a/examples/thih/tests/thih-coalton-tests.lisp
+++ b/examples/thih/tests/thih-coalton-tests.lisp
@@ -1,34 +1,37 @@
-(cl:in-package #:thih-coalton-tests)
+(in-package #:thih-coalton/tests)
 
-(cl:defparameter *initial-env* (coalton-prelude:from-some "Failed to init classenv"
-                                                         (compose
-                                                          addPreludeClasses
-                                                          exampleInsts
-                                                          initialEnv)))
+(named-readtables:in-readtable coalton:coalton)
 
-(deftest test-type-inference ()
-  (is (thih-coalton::assumption-list-equal (tiProgram
-                                            *initial-env*
-                                            Nil
-                                            (Program
-                                             (make-list
-                                              (BindGroup
-                                               Nil
-                                               (make-list
-                                                (make-list
-                                                 (Impl
-                                                  (Id "f")
-                                                  (make-list
-                                                   (Alt
-                                                    (make-list
-                                                     (PVar (Id "x")))
-                                                    (Var (Id "x")))))))))))
+(coalton-toplevel
+  (define *initial-env* (from-some "Failed to init classenv"
+                                   (th:compose
+                                    th:addPreludeClasses
+                                    th:exampleInsts
+                                    th:initialEnv))))
+
+(define-test test-thih-type-inference ()
+  (is (th::assumption-list-equal (th:tiProgram
+                                  *initial-env*
+                                  Nil
+                                  (th:Program
+                                   (make-list
+                                    (th:BindGroup
+                                     Nil
+                                     (make-list
+                                      (make-list
+                                       (th:Impl
+                                        (th:Id "f")
+                                        (make-list
+                                         (th:Alt
+                                          (make-list
+                                           (th:PVar (th:Id "x")))
+                                          (th:Var (th:Id "x")))))))))))
               
-                                           (make-list
-                                            (Assump
-                                             (Id "f")
-                                             (Forall
-                                              (make-list Star)
-                                              (Qual Nil
-                                                    (mkFn (TGen 0)
-                                                          (TGen 0)))))))))
+                                 (make-list
+                                  (th:Assump
+                                   (th:Id "f")
+                                   (th:Forall
+                                    (make-list th:Star)
+                                    (th:Qual Nil
+                                             (th:mkFn (th:TGen 0)
+                                                      (th:TGen 0)))))))))

--- a/examples/thih/tests/utilities.lisp
+++ b/examples/thih/tests/utilities.lisp
@@ -1,8 +1,0 @@
-;;;; utilities.lisp
-
-(in-package #:thih-coalton-tests)
-
-(defun run-thih-coalton-tests ()
-  (run-package-tests
-   :package ':thih-coalton-tests
-   :interactive t))

--- a/examples/thih/thih-coalton.asd
+++ b/examples/thih/thih-coalton.asd
@@ -5,14 +5,16 @@
   :depends-on (#:coalton)
   :pathname "src/"
   :serial t
+  :in-order-to ((test-op (test-op "thih-coalton/tests")))
   :components ((:file "package")
                (:file "thih")))
 
 (asdf:defsystem #:thih-coalton/tests
   :description "Tests for THIH-COALTON"
-  :depends-on (#:thih-coalton #:fiasco)
+  :depends-on (#:thih-coalton #:fiasco #:coalton/testing)
   :pathname "tests/"
   :serial t
   :components ((:file "package")
-               (:file "thih-coalton-tests")
-               (:file "utilities")))
+               (:file "thih-coalton-tests"))
+  :perform (test-op (o s)
+                    (symbol-call '#:thih-coalton/tests '#:run-tests)))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -4,7 +4,7 @@
   (run-package-tests
    :packages '(:coalton-tests
                :quil-coalton-tests
-               :thih-coalton-tests)
+               :thih-coalton/fiasco-test-package)
    :interactive t))
 
 (defun set-equalp (set1 set2)


### PR DESCRIPTION
This primarily removes unnecessary constructor matching, and revamps the thih test suite (according to the style set forth in https://github.com/coalton-lang/coalton/blob/main/docs/intro-to-coalton-testing.md).

