### PR TITLE
Make references to operators and operands consistent

### DIFF
--- a/src/codegen/ast-subsitutions.lisp
+++ b/src/codegen/ast-subsitutions.lisp
@@ -55,23 +55,23 @@
              (values node))
     (make-node-application
      :type (node-type node)
-     :rator (apply-ast-substitution subs (node-application-rator node))
-     :rands (apply-ast-substitution subs (node-application-rands node))))
+     :operator (apply-ast-substitution subs (node-application-operator node))
+     :operands (apply-ast-substitution subs (node-application-operands node))))
 
   (:method (subs (node node-direct-application))
     (declare (type ast-substitution-list subs)
              (values node))
 
-    (when (find (node-direct-application-rator node) subs :key #'ast-substitution-from)
+    (when (find (node-direct-application-operator node) subs :key #'ast-substitution-from)
       (util:coalton-bug
        "Failure to apply ast substitution on variable ~A to node-direct-application"
-       (node-direct-application-rator node)))
+       (node-direct-application-operator node)))
 
     (make-node-direct-application
      :type (node-type node)
-     :rator-type (node-direct-application-rator-type node)
-     :rator (node-direct-application-rator node)
-     :rands (apply-ast-substitution subs (node-direct-application-rands node))))
+     :operator-type (node-direct-application-operator-type node)
+     :operator (node-direct-application-operator node)
+     :operands (apply-ast-substitution subs (node-direct-application-operands node))))
 
   (:method (subs (node node-abstraction))
     (declare (type ast-substitution-list subs)

--- a/src/codegen/monomorphize.lisp
+++ b/src/codegen/monomorphize.lisp
@@ -27,7 +27,7 @@
 ;;;; version of a function. Valid candidates have at least two
 ;;;; arguments, at least one argument must not be '@@unpropagated, and
 ;;;; they must have at least one unpropagated argument.
-;;;; 
+;;;;
 ;;;; Valid candidates can have unknown typeclass dictionaries as long
 ;;;; as at least one argument is a valid dictionary. Candidates are
 ;;;; each given a unique name, used as the name of their recompiled
@@ -110,13 +110,13 @@ constant values could be."
 
     ((and
       (node-direct-application-p node)
-      (tc:lookup-instance-by-codegen-sym env (node-direct-application-rator node) :no-error t))
+      (tc:lookup-instance-by-codegen-sym env (node-direct-application-operator node) :no-error t))
      t) 
 
     ((and
       (node-application-p node)
-      (node-variable-p (node-application-rator node))
-      (tc:lookup-instance-by-codegen-sym env (node-variable-value (node-application-rator node)) :no-error t))
+      (node-variable-p (node-application-operator node))
+      (tc:lookup-instance-by-codegen-sym env (node-variable-value (node-application-operator node)) :no-error t))
      t)
 
     (t
@@ -271,8 +271,8 @@ recompilation, and also maintains a stack of uncompiled candidates."
                              :type (tc:make-function-type*
                                     (util:drop num-remaining (tc:function-type-arguments new-type))
                                     (tc:function-return-type new-type))
-                             :rator subexpr
-                             :rands (loop :for name :in remaing-names
+                             :operator subexpr
+                             :operands (loop :for name :in remaing-names
                                           :for ty :in remaining-types
                                           :collect (make-node-variable
                                                     :type ty
@@ -321,8 +321,8 @@ propigate dictionaries that have been moved by the hoister."
            (type package package)
            (type tc:environment env))
   (labels ((validate-candidate (node &key bound-variables &allow-other-keys)
-             (let ((name (node-rator-name node))
-                   (rands (node-rands node)))
+             (let ((name (node-operator-name node))
+                   (operands (node-operands node)))
 
                (unless name
                  (return-from validate-candidate nil))
@@ -330,8 +330,8 @@ propigate dictionaries that have been moved by the hoister."
                (let ((candidate
                        (valid-candidate-p
                         name
-                        (loop :for rand :in rands
-                              :collect (resolve-var rand resolve-table))
+                        (loop :for operand :in operands
+                              :collect (resolve-var operand resolve-table))
                         bound-variables
                         env)))
 
@@ -359,16 +359,16 @@ propigate dictionaries that have been moved by the hoister."
            (values node &optional))
 
   (labels ((apply-candidate (node &key bound-variables &allow-other-keys)
-             (let ((name (node-rator-name node))
-                   (rands (node-rands node)))
+             (let ((name (node-operator-name node))
+                   (operands (node-operands node)))
 
                (unless name
                  (return-from apply-candidate nil))
 
                (let ((candidate (valid-candidate-p
                                  name
-                                 (loop :for rand :in rands
-                                       :collect (resolve-var rand resolve-table))
+                                 (loop :for operand :in operands
+                                       :collect (resolve-var operand resolve-table))
                                  bound-variables
                                  env)))
 
@@ -377,12 +377,12 @@ propigate dictionaries that have been moved by the hoister."
 
                  (let* ((function-name (candidate-manager-get candidate-manager candidate))
 
-                        (new-type (node-rator-type node))
+                        (new-type (node-operator-type node))
 
                         (arg-tys nil) 
 
                         (args (loop
-                                :for arg :in (node-rands node)
+                                :for arg :in (node-operands node)
                                 :for candidate-arg :in (compile-candidate-args candidate)
 
                                 :when (eq candidate-arg '@@unpropagated)
@@ -398,12 +398,12 @@ propigate dictionaries that have been moved by the hoister."
                         :value function-name)
                        (make-node-application
                         :type (node-type node)
-                        :rator (make-node-variable
+                        :operator (make-node-variable
                                 :type (tc:make-function-type*
                                        (reverse arg-tys)
                                        new-type)
                                 :value function-name)
-                        :rands args)))))))
+                        :operands args)))))))
 
     (traverse
      node

--- a/src/codegen/resolve-instance.lisp
+++ b/src/codegen/resolve-instance.lisp
@@ -77,10 +77,10 @@
           ;; Otherwise create a new dict at runtime
           (make-node-application
            :type (pred-type pred env) 
-           :rator (make-node-variable
+           :operator (make-node-variable
                    :type (tc:make-function-type* arg-types (pred-type pred env))
                    :value (tc:ty-class-instance-codegen-sym instance))
-           :rands subdicts)))))
+           :operands subdicts)))))
 
 
 (defun superclass-accessors (pred ctx-pred env)

--- a/src/codegen/transformations.lisp
+++ b/src/codegen/transformations.lisp
@@ -49,11 +49,11 @@
     (let ((node
             (make-node-application
              :type (node-type node)
-             :rator (traverse (node-application-rator node) funs bound-variables)
-             :rands (mapcar
+             :operator (traverse (node-application-operator node) funs bound-variables)
+             :operands (mapcar
                      (lambda (node)
                        (traverse node funs bound-variables))
-                     (node-application-rands node)))))
+                     (node-application-operands node)))))
       (call-if node :application funs bound-variables)))
 
   (:method ((node node-direct-application) funs bound-variables)
@@ -61,12 +61,12 @@
     (let ((node
             (make-node-direct-application
              :type (node-type node)
-             :rator-type (node-direct-application-rator-type node)
-             :rator (node-direct-application-rator node)
-             :rands (mapcar
+             :operator-type (node-direct-application-operator-type node)
+             :operator (node-direct-application-operator node)
+             :operands (mapcar
                      (lambda (node)
                        (traverse node funs bound-variables))
-                     (node-direct-application-rands node)))))
+                     (node-direct-application-operands node)))))
       (call-if node :direct-application funs bound-variables)))
 
   (:method ((node node-abstraction) funs bound-variables)

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -148,14 +148,14 @@ Returns a `node'.")
         
         (make-node-application
          :type (tc:qualified-ty-type qual-ty)
-         :rator (make-node-variable
+         :operator (make-node-variable
                  :type (tc:make-function-type*
                         (list
                          (pred-type num-pred env)
                          tc:*integer-type*)
                         (tc:qualified-ty-type qual-ty))
                  :value from-int-method)
-         :rands (list
+         :operands (list
                  (resolve-dict num-pred ctx env)
                  (make-node-literal
                   :type tc:*integer-type*
@@ -220,11 +220,11 @@ Returns a `node'.")
       
       (make-node-application
        :type (tc:qualified-ty-type qual-ty)
-       :rator (translate-expression (tc:node-application-rator expr) ctx env)
-       :rands (mapcar
+       :operator (translate-expression (tc:node-application-operator expr) ctx env)
+       :operands (mapcar
                (lambda (expr)
                  (apply-dicts expr ctx env))
-               (tc:node-application-rands expr)))))
+               (tc:node-application-operands expr)))))
 
   (:method ((expr tc:node-body) ctx env)
     (declare (type pred-context ctx)
@@ -647,13 +647,13 @@ Returns a `node'.")
            (into-iter-node
              (make-node-application
               :type optional-pat-arg-ty
-              :rator (make-node-variable
+              :operator (make-node-variable
                       :type (tc:make-function-type*
                              (list (pred-type intoiterator-pred env)
                                    (node-type into-iter-arg))
                              iter-ty)
                       :value into-iter-method)
-              :rands (list
+              :operands (list
                       (resolve-dict intoiterator-pred ctx env)
                       into-iter-arg)))
 
@@ -666,12 +666,12 @@ Returns a `node'.")
            (iter-next-node
              (make-node-application
               :type optional-pat-arg-ty
-              :rator (make-node-variable
+              :operator (make-node-variable
                       :type (tc:make-function-type*
                              (list iter-ty)
                              optional-pat-arg-ty)
                       :value next-method)
-              :rands (list (make-node-variable
+              :operands (list (make-node-variable
                             :type iter-ty
                             :value  into-iter-binding-var-name))))
 
@@ -803,14 +803,14 @@ Returns a `node'.")
 
                            (make-node-application
                             :type (node-type out-node)
-                            :rator (make-node-variable
+                            :operator (make-node-variable
                                     :type (tc:make-function-type* ; (Monad :m => m :a -> (:a -> :m :b) -> :m :b)
                                            (list (pred-type pred env)
                                                  (tc:qualified-ty-type (tc:node-type (tc:node-do-bind-expr elem)))
                                                  callback-ty)
                                            (node-type out-node))
                                     :value bind-symbol)
-                            :rands (list
+                            :operands (list
                                     (resolve-dict pred ctx env)
                                     (translate-expression (tc:node-do-bind-expr elem) ctx env)
                                     (make-node-abstraction
@@ -839,14 +839,14 @@ Returns a `node'.")
 
                            (make-node-application
                             :type (node-type out-node)
-                            :rator (make-node-variable
+                            :operator (make-node-variable
                                     :type (tc:make-function-type* ; (Monad :m => m :a -> (:a -> :m :b) -> :m :b)
                                            (list (pred-type pred env)
                                                  (tc:qualified-ty-type (tc:node-type elem))
                                                  callback-ty)
                                            (node-type out-node))
                                     :value bind-symbol)
-                            :rands (list
+                            :operands (list
                                     (resolve-dict pred ctx env)
                                     (translate-expression elem ctx env)
                                     (make-node-abstraction
@@ -926,8 +926,8 @@ dictionaries applied."
       (t
        (make-node-application
         :type (tc:qualified-ty-type qual-ty)
-        :rator inner-node
-        :rands dicts)))))
+        :operator inner-node
+        :operands dicts)))))
 
 (defun wrap-with-pattern-params (pattern-params inner)
   "Wrap INNER in nested `NODE-MATCH' expressions to pattern match on PATTERN-PARAMS"

--- a/src/codegen/translate-instance.lisp
+++ b/src/codegen/translate-instance.lisp
@@ -86,8 +86,8 @@
            (if (or unqualified-method-definitions superclass-preds)
                (make-node-application
                 :type (pred-type pred env)
-                :rator var-node
-                :rands (append
+                :operator var-node
+                :operands (append
                         (loop :for pred :in superclass-preds
                               :collect (resolve-dict pred ctx env))
                         unqualified-method-definitions))

--- a/src/codegen/typecheck-node.lisp
+++ b/src/codegen/typecheck-node.lisp
@@ -29,12 +29,12 @@
   (:method ((expr node-application) env)
     (declare (type tc:environment env)
              (values tc:ty))
-    (assert (not (null (node-application-rands expr))))
+    (assert (not (null (node-application-operands expr))))
 
-    (let ((type (typecheck-node (node-application-rator expr) env))
+    (let ((type (typecheck-node (node-application-operator expr) env))
 
           (subs nil))
-      (loop :for arg :in (node-application-rands expr)
+      (loop :for arg :in (node-application-operands expr)
             :for arg-ty := (typecheck-node arg env) :do
               (progn
                 (setf subs (tc:unify subs (tc:function-type-from type) arg-ty))
@@ -45,12 +45,12 @@
   (:method ((expr node-direct-application) env)
     (declare (type tc:environment env)
              (values tc:ty))
-    (assert (not (null (node-direct-application-rands expr))))
+    (assert (not (null (node-direct-application-operands expr))))
 
-    (let ((type (node-direct-application-rator-type expr))
+    (let ((type (node-direct-application-operator-type expr))
 
           (subs nil))
-      (loop :for arg :in (node-direct-application-rands expr)
+      (loop :for arg :in (node-direct-application-operands expr)
             :for arg-ty := (typecheck-node arg env) :do
               (progn
                 (setf subs (tc:unify subs (tc:function-type-from type) arg-ty))

--- a/src/parser/collect.lisp
+++ b/src/parser/collect.lisp
@@ -192,8 +192,8 @@ in expressions. May not include all bound variables."
   (:method ((node node-application))
     (declare (values node-variable-list &optional))
     (nconc
-     (collect-variables-generic% (node-application-rator node))
-     (mapcan #'collect-variables-generic% (node-application-rands node))))
+     (collect-variables-generic% (node-application-operator node))
+     (mapcan #'collect-variables-generic% (node-application-operands node))))
 
   (:method ((node node-or))
     (declare (values node-variable-list))

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -91,8 +91,8 @@
    #:node-return-expr                   ; ACCESSOR
    #:node-application                   ; STRUCT
    #:make-node-application              ; CONSTRUCTOR
-   #:node-application-rator             ; ACCESSOR
-   #:node-application-rands             ; ACCESSOR
+   #:node-application-operator             ; ACCESSOR
+   #:node-application-operands             ; ACCESSOR
    #:node-or                            ; STRUCT
    #:make-node-or                       ; CONSTRUCTOR
    #:node-or-nodes                      ; ACCESSOR
@@ -424,8 +424,8 @@ Rebound to NIL parsing an anonymous FN.")
 (defstruct (node-application
             (:include node)
             (:copier nil))
-  (rator (util:required 'rator) :type node      :read-only t)
-  (rands (util:required 'rands) :type node-list :read-only t))
+  (operator (util:required 'operator) :type node      :read-only t)
+  (operands (util:required 'operands) :type node-list :read-only t))
 
 (defstruct (node-or
             (:include node)
@@ -1214,11 +1214,11 @@ Rebound to NIL parsing an anonymous FN.")
 
     (t
      (make-node-application
-      :rator (parse-expression (cst:first form) file)
-      :rands (loop :for rands := (cst:rest form) :then (cst:rest rands)
-                   :while (cst:consp rands)
-                   :for rand := (cst:first rands)
-                   :collect (parse-expression rand file))
+      :operator (parse-expression (cst:first form) file)
+      :operands (loop :for operands := (cst:rest form) :then (cst:rest operands)
+                   :while (cst:consp operands)
+                   :for operand := (cst:first operands)
+                   :collect (parse-expression operand file))
       :source (cst:source form)))))
 
 (defun parse-variable (form file)

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -231,8 +231,8 @@
 
     (values
      (make-node-application
-      :rator (rename-variables-generic% (node-application-rator node) ctx)
-      :rands (rename-variables-generic% (node-application-rands node) ctx)
+      :operator (rename-variables-generic% (node-application-operator node) ctx)
+      :operands (rename-variables-generic% (node-application-operands node) ctx)
       :source (node-source node))
      ctx))
 

--- a/src/testing/coalton-native-test-utils.lisp
+++ b/src/testing/coalton-native-test-utils.lisp
@@ -47,9 +47,9 @@ BODY within a `coalton' expression."
              (cl:or (cl:not (cl:symbolp (cl:first check)))
                     (cl:and (cl:not (cl:macro-function (cl:first check)))
                             (cl:not (cl:eql 'coalton:if (cl:first check))))))
-     (cl:let* ((rator (cl:first check))
-               (rands (cl:rest check))
-               (name-els (cl:loop :for rand :in (cl:cons rator rands) :collect (cl:list (cl:gensym) rand)))
+     (cl:let* ((operator (cl:first check))
+               (operands (cl:rest check))
+               (name-els (cl:loop :for operand :in (cl:cons operator operands) :collect (cl:list (cl:gensym) operand)))
                (names (cl:mapcar #'cl:first name-els)))
        `(progn
           (%register-assertion) 

--- a/src/typechecker/collect.lisp
+++ b/src/typechecker/collect.lisp
@@ -175,8 +175,8 @@ in expressions. May not include all bound variables."
   (:method ((node node-application))
     (declare (values node-variable-list &optional))
     (nconc
-     (collect-variables-generic% (node-application-rator node))
-     (mapcan #'collect-variables-generic% (node-application-rands node))))
+     (collect-variables-generic% (node-application-operator node))
+     (mapcan #'collect-variables-generic% (node-application-operands node))))
 
   (:method ((node node-or))
     (declare (values node-variable-list))

--- a/src/typechecker/expression.lisp
+++ b/src/typechecker/expression.lisp
@@ -90,8 +90,8 @@
    #:node-return-expr                   ; ACCESSOR
    #:node-application                   ; STRUCT
    #:make-node-application              ; CONSTRUCTOR
-   #:node-application-rator             ; ACCESSOR
-   #:node-application-rands             ; ACCESSOR
+   #:node-application-operator          ; ACCESSOR
+   #:node-application-operands          ; ACCESSOR
    #:node-or                            ; STRUCT
    #:make-node-or                       ; CONSTRUCTOR
    #:node-or-nodes                      ; ACCESSOR
@@ -297,8 +297,8 @@
 (defstruct (node-application
             (:include node)
             (:copier nil))
-  (rator (util:required 'rator) :type node      :read-only t)
-  (rands (util:required 'rands) :type node-list :read-only t))
+  (operator (util:required 'operator) :type node      :read-only t)
+  (operands (util:required 'operands) :type node-list :read-only t))
 
 (defstruct (node-or
             (:include node)
@@ -537,8 +537,8 @@
   (make-node-application
    :type (tc:apply-substitution subs (node-type node))
    :source (node-source node)
-   :rator (tc:apply-substitution subs (node-application-rator node))
-   :rands (tc:apply-substitution subs (node-application-rands node))))
+   :operator (tc:apply-substitution subs (node-application-operator node))
+   :operands (tc:apply-substitution subs (node-application-operands node))))
 
 (defmethod tc:apply-substitution (subs (node node-or))
   (declare (type tc:substitution-list subs)

--- a/src/typechecker/traverse.lisp
+++ b/src/typechecker/traverse.lisp
@@ -192,8 +192,8 @@
      (make-node-application
       :type (node-type node)
       :source (node-source node)
-      :rator (traverse (node-application-rator node) block)
-      :rands (traverse (node-application-rands node) block))))
+      :operator (traverse (node-application-operator node) block)
+      :operands (traverse (node-application-operands node) block))))
 
   (:method ((node node-or) block)
     (declare (type traverse-block block)


### PR DESCRIPTION
Replace s/rator/operator/g ; s/rands/operands/g for accessibility and consistency.

(Despite feeling a twinge of being a killjoy, because the naming is mildly amusing.)
