### PR TITLE
Generic environment

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -58,6 +58,7 @@
                 :serial t
                 :components ((:file "function-entry")
                              (:file "package")))
+               (:file "environment")
                (:module "typechecker"
                 :serial t
                 :components ((:file "kinds")

--- a/src/codegen/transformations.lisp
+++ b/src/codegen/transformations.lisp
@@ -7,6 +7,7 @@
    #:coalton-impl/algorithm
    #:immutable-map-data)
   (:local-nicknames
+   (#:env #:coalton-impl/environment)
    (#:util #:coalton-impl/util)
    (#:tc #:coalton-impl/typechecker))
   (:export
@@ -240,9 +241,7 @@
   env)
 
 (defun make-function-table (env)
-  (declare (type tc:environment env)
-           (values hash-table))
   (let ((table (make-hash-table)))
-    (fset:do-map (name entry (immutable-map-data (tc:environment-function-environment env)))
+    (env:do-environment (name entry env :function)
       (setf (gethash name table) (tc:function-env-entry-arity entry)))
     table))

--- a/src/debug.lisp
+++ b/src/debug.lisp
@@ -1,191 +1,156 @@
 (defpackage #:coalton-impl/debug
   (:use #:cl)
   (:local-nicknames
-   (#:settings #:coalton-impl/settings)
+   (#:a #:alexandria)
    (#:algo #:coalton-impl/algorithm)
-   (#:tc #:coalton-impl/typechecker)
-   (#:entry #:coalton-impl/entry)))
+   (#:entry #:coalton-impl/entry)
+   (#:env #:coalton-impl/environment)
+   (#:settings #:coalton-impl/settings)
+   (#:tc #:coalton-impl/typechecker)))
+
+;;; Utilities for dumping the contents of Coalton's global environment
+;;;
+;;; Covers values, types, classes, instances and specializations.
 
 (in-package #:coalton-impl/debug)
 
+(defun print-package (stream entry-printer package entries)
+  (format stream "[package ~A]~%~%" (package-name package))
+  ;; Remove qualifications from package symbols
+  (let ((*package* package))
+    (dolist (entry entries)
+      (funcall entry-printer stream entry)
+      (format stream "~%"))
+    (format stream "~%")))
+
+(defun print-one-package (stream env entry-printer ns entry-resolver package)
+  (let ((p (find-package package)))
+    (unless p
+      (error "Invalid package ~A" package))
+    (print-package stream entry-printer p
+                   (env:entries-for-package env ns p
+                                            :entry-resolver entry-resolver))))
+
+(defun print-all-packages (stream env entry-printer ns entry-resolver)
+  (maphash (lambda (package entries)
+             (print-package stream entry-printer package entries))
+           (env:entries-by-package env ns :entry-resolver entry-resolver)))
+
+(defun print-db (printer ns &key package (entry-resolver #'identity)) 
+  "Print namespace NS of the global environment"
+  (let ((env entry:*global-environment*)
+        (stream t))
+    (if package
+        (print-one-package stream env printer ns entry-resolver package)
+        (print-all-packages stream env printer ns entry-resolver))))
+
+;; Coalton environment-specific structure printers
+
+(defun print-class (stream entry)
+  (destructuring-bind (name . entry) entry
+    (declare (ignore name))
+    (tc:with-pprint-variable-context ()
+      (let ((class-pred (tc:ty-class-predicate entry)))
+        (format stream "  [~S (~A :: ~A)]~%"
+                (tc:ty-predicate-class class-pred)
+                (tc:ty-predicate-types class-pred)
+                (mapcar #'tc:kind-of (tc:ty-predicate-types class-pred))))
+      (loop :for (method-name . method-type) :in (tc:ty-class-unqualified-methods entry) :do
+        (format stream "    ~S :: ~A~%" method-name method-type)))))
+
+(defun print-instance (stream entry)
+  (destructuring-bind (entry . instances) entry
+    (unless (null instances)
+      ;; Generate substitutions for class
+      (tc:with-pprint-variable-context ()
+        (let ((class-pred (tc:ty-class-predicate entry)))
+          (format stream "  [~S (~A :: ~A)]~%"
+                  (tc:ty-predicate-class class-pred)
+                  (tc:ty-predicate-types class-pred)
+                  (mapcar #'tc:kind-of (tc:ty-predicate-types class-pred)))))
+      (dolist (instance instances)
+        (format stream "    ")
+        ;; Generate type variable substitutions from instance
+        ;; constraints
+        (tc:with-pprint-variable-context ()
+          (let* ((instance-constraints (tc:ty-class-instance-constraints instance))
+                 (instance-predicate (tc:ty-class-instance-predicate instance)))
+            (case (length instance-constraints)
+              (0
+               (format stream "~A~%" instance-predicate))
+              (1
+               (format stream "~A ~A ~A~%"
+                       (first instance-constraints)
+                       (if settings:*coalton-print-unicode* "⇒" "=>")
+                       instance-predicate))
+              (t
+               (format stream "~A ~A ~A~%"
+                       instance-constraints
+                       (if settings:*coalton-print-unicode* "⇒" "=>")
+                       instance-predicate)))))))))
+
+(defun print-specialization (stream entry env)
+  (destructuring-bind (name . specs) entry
+    (format stream "  ~A :: ~A~%" name (tc:lookup-value-type env name))
+    (dolist (spec specs)
+      (format stream "    ~A :: ~A~%"
+              (tc:specialization-entry-to spec)
+              (tc:specialization-entry-to-ty spec)))
+    (format stream "~%"))
+  (format stream "~%"))
+
+;; Toplevel debug functions
+
 (defun coalton:print-value-db (&optional package)
   "Print the global value environment"
-  (let ((env entry:*global-environment*)
-        (sorted-by-package (make-hash-table)))
-    ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-value-environment env)))
-      (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
-
-    ;; Print out the entries for each package
-    (labels ((print-package (package entries)
-               (format t "[package ~A]~%~%" (package-name package))
-               ;; Remove qualifications from package symbols
-               (let ((*package* package))
-                 (loop :for (name . type) :in entries :do
-                   (format t "  ~A :: ~A~%"
-                           name
-                           type)))
-               (format t "~%")))
-      (if package
-          (let ((p (find-package package)))
-            (unless p
-              (error "Invalid package ~A" package))
-            (print-package p (gethash p sorted-by-package)))
-          (maphash #'print-package sorted-by-package)))))
+  (print-db (lambda (stream entry)
+              (destructuring-bind (name . type) entry
+                (format stream "  ~A :: ~A~%" name type)))
+            :value :package package))
 
 (defun coalton:print-type-db (&optional package)
   "Print the global type environment"
-  (let ((env entry:*global-environment*)
-        (sorted-by-package (make-hash-table)))
-    ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-type-environment env)))
-      (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
-
-    ;; Print out the entries for each package
-
-    (labels ((print-package (package entries)
-               (format t "[package ~A]~%~%" (package-name package))
-               (loop :for (name . entry) :in entries :do
-                 (format t "  ~A :: ~A~%"
-                         name
-                         (tc:kind-of entry)))
-               (format t "~%")))
-      (if package
-          (let ((p (find-package package)))
-            (unless p
-              (error "Invalid package ~A" package))
-            (print-package p (gethash p sorted-by-package)))
-          (maphash #'print-package sorted-by-package)))))
+  (print-db (lambda (stream entry)
+              (destructuring-bind (name . entry) entry
+                (format stream "  ~A :: ~A~%" name (tc:kind-of entry))))
+            :type :package package))
 
 (defun coalton:print-class-db (&optional package)
   "Print the global class environment"
-  (let ((env entry:*global-environment*)
-        (sorted-by-package (make-hash-table)))
-    ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-class-environment env)))
-      (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
-
-    ;; Print out the entries for each package
-
-    (labels ((print-package (package entries)
-               (format t "[package ~A]~%~%" (package-name package))
-               (let ((*package* package))
-                 (loop :for (name . entry) :in entries :do
-                   (tc:with-pprint-variable-context ()
-                     (let ((class-pred (tc:ty-class-predicate entry)))
-                       (format t "  [~S (~A :: ~A)]~%"
-                               (tc:ty-predicate-class class-pred)
-                               (tc:ty-predicate-types class-pred)
-                               (mapcar #'tc:kind-of (tc:ty-predicate-types class-pred))))
-                     (loop :for (method-name . method-type) :in (tc:ty-class-unqualified-methods entry) :do
-                       (format t "    ~S :: ~A~%" method-name method-type)))
-                   (format t "~%")))
-               (format t "~%")))
-      (if package
-          (let ((p (find-package package)))
-            (unless p
-              (error "Invalid package ~A" package))
-            (print-package p (gethash p sorted-by-package)))
-          (maphash #'print-package sorted-by-package)))))
+  (print-db #'print-class :class :package package))
 
 (defun coalton:print-instance-db (&optional package)
   "Print the global instance environment"
-  (let ((env entry:*global-environment*)
-        (sorted-by-package (make-hash-table)))
-    ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-class-environment env)))
-      (push (cons entry (tc:lookup-class-instances env sym :no-error t))
-            (gethash (symbol-package sym) sorted-by-package)))
-
-    ;; Print out the entries for each package
-
-    (labels ((print-package (package entries)
-               (format t "[package ~A]~%~%" (package-name package))
-               (let ((*package* package))
-                 (loop
-                   :for (entry . instances) :in entries
-                   :when (not (null instances))
-                     ;; Generate substitutions for class
-                     :do (tc:with-pprint-variable-context ()
-                           (let* ((class-pred (tc:ty-class-predicate entry)))
-                             (format t "  [~S (~A :: ~A)]~%"
-                                     (tc:ty-predicate-class class-pred)
-                                     (tc:ty-predicate-types class-pred)
-                                     (mapcar #'tc:kind-of (tc:ty-predicate-types class-pred)))))
-
-                         (fset:do-seq (instance instances)
-                           (format t "    ")
-                           ;; Generate type variable substitutions from instance constraints
-                           (tc:with-pprint-variable-context ()
-                             (let* ((instance-constraints (tc:ty-class-instance-constraints instance))
-                                    (instance-predicate (tc:ty-class-instance-predicate instance)))
-                               (cond
-                                 ((= 0 (length instance-constraints))
-                                  (format t "~A~%" instance-predicate))
-                                 ((= 1 (length instance-constraints))
-                                  (format t "~A ~A ~A~%"
-                                          (first instance-constraints)
-                                          (if settings:*coalton-print-unicode* "⇒" "=>")
-                                          instance-predicate))
-                                 (t
-                                  (format t "~A ~A ~A~%"
-                                          instance-constraints
-                                          (if settings:*coalton-print-unicode* "⇒" "=>")
-                                          instance-predicate))))))
-
-                         (format t "~%")))
-               (format t "~%")))
-      (if package
-          (let ((p (find-package package)))
-            (unless p
-              (error "Invalid package ~A" package))
-            (print-package p (gethash p sorted-by-package)))
-          (maphash #'print-package sorted-by-package)))))
+  (let* ((env entry:*global-environment*)
+         (class-instances (lambda (class)
+                            (tc:lookup-class-instances env class :no-error t))))
+    (print-db #'print-instance :class
+              :package package
+              :entry-resolver class-instances)))
 
 (defun coalton:print-specializations (&optional package)
   "Print all specializations"
-  (let ((env entry:*global-environment*)
-        (sorted-by-package (make-hash-table)))
-    (fset:do-map (sym entry (algo:immutable-listmap-data (tc:environment-specialization-environment env)))
-      (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
-
-    (labels ((print-package (package entries)
-               (format t "[package ~A]~%~%" (package-name package))
-               (loop :for (name . specs) :in entries
-                     :do (progn
-                           (format t "  ~A :: ~A~%" name (tc:lookup-value-type env name))
-                           (fset:do-seq (spec specs)
-                             (format t "    ~A :: ~A~%"
-                                     (tc:specialization-entry-to spec)
-                                     (tc:specialization-entry-to-ty spec)))
-                           (format t "~%")))
-               (format t "~%")))
-      (if package
-          (let ((p (find-package package)))
-            (unless p
-              (error "Invalid package ~A" package))
-            (print-package p (gethash p sorted-by-package)))
-          (maphash #'print-package sorted-by-package)))))
+  (print-db (a:rcurry #'print-specialization entry:*global-environment*) :specialization :package package))
 
 (defun coalton:type-of (symbol)
-  "Lookup the type of value SYMBOL in the global environment"
+  "Look up the type of value SYMBOL in the global environment"
   (tc:lookup-value-type entry:*global-environment* symbol))
 
 (defun coalton:kind-of (symbol)
-  "Lookup the kind of type SYMBOL in the global environment"
+  "Look up the kind of type SYMBOL in the global environment"
   (tc:kind-of (coalton-impl/typechecker::type-entry-type (tc:lookup-type entry:*global-environment* symbol))))
 
 (defun coalton:lookup-code (name)
-  "Lookup the compiled code of a given definition"
+  "Look up the compiled code of a given definition"
   (declare (type symbol name))
   (tc:lookup-code entry:*global-environment* name))
 
 (defun coalton:lookup-class (name)
-  "Lookup a given class"
+  "Look up a given class"
   (declare (type symbol name))
   (tc:lookup-class entry:*global-environment* name))
 
 (defun coalton:lookup-fundeps (name)
-  "Lookup the fundep structure for a given class"
+  "Look up the fundep structure for a given class"
   (declare (type symbol name))
   (tc:lookup-fundep-environment entry:*global-environment* name))

--- a/src/doc/package.lisp
+++ b/src/doc/package.lisp
@@ -4,6 +4,7 @@
   (:documentation "Implementation of documentation generation for COALTON. This is a package private to the COALTON system and is not intended for public use.")
   (:use #:cl)
   (:local-nicknames
+   (#:env #:coalton-impl/environment)
    (#:util #:coalton-impl/util)
    (#:settings #:coalton-impl/settings)
    (#:algo #:coalton-impl/algorithm)

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -1,0 +1,148 @@
+(defpackage #:coalton-impl/environment
+  (:use
+   #:cl)
+  (:shadow
+   #:get
+   #:set
+   #:map)
+  (:local-nicknames
+   (#:a #:alexandria))
+  (:export
+   #:do-environment
+   #:empty
+   #:entries-by-package
+   #:entries-for-package
+   #:environment
+   #:exported-symbol-p
+   #:get
+   #:keys
+   #:namespace
+   #:operation
+   #:parent
+   #:set
+   #:set*
+   #:update-entries
+   #:unset))
+
+;;;
+;;; Low-level environment, representing all that Coalton knows about
+;;; types and classes. Definitions are stored in a two-level map,
+;;; where the first level is keyed by major namespace (value, type,
+;;; class, instance, specialization, and so on) and the second by
+;;; symbol, to instances of per-namespace class.
+;;;
+;;; The global map is immutable, and versions are maintained across
+;;; environment records linked by a 'parent' slot.
+;;;
+;;; A global environment is constructed and maintained by propagating
+;;; an initial environment through a compilation unit, and reassigning
+;;; the global environment to the returned environment on success.
+;;;
+;;; The file typechecker/environment.lisp provides higher level
+;;; per-namespace/type set of functions for modifying the environment.
+;;;
+
+(in-package #:coalton-impl/environment)
+
+(defstruct (environment (:conc-name nil))
+  (namespace nil :type symbol)
+  parent
+  operation
+  value)                                ; namespace->k->v
+
+(defmethod print-object ((environment environment) stream)
+  (print-unreadable-object (environment stream :type t :identity t)))
+
+(defun empty ()
+  "Return an empty environment."
+  (make-environment :value (fset:empty-map)))
+
+(declaim (inline get-namespace))
+(defun get-namespace (environment namespace)
+  (or (fset:lookup (value environment) namespace)
+      (fset:empty-map)))
+
+(declaim (inline update-namespace))
+(defun update-namespace (environment namespace f)
+  "Update map-valued NAMESPACE in ENVIRONMENT using function F."
+  (let ((v (value environment)))
+    (fset:with v namespace (funcall f (or (fset:lookup v namespace)
+                                          (fset:empty-map))))))
+
+(defun get (environment namespace name)
+  "Return the entry bound by NAME in NAMESPACE of ENVIRONMENT."
+  (fset:lookup (get-namespace environment namespace) name))
+
+(declaim (inline set))
+(defun set (environment namespace name entry)
+  "Bind NAME to ENTRY in NAMESPACE of ENVIRONMENT."
+  (make-environment :namespace namespace
+                    :parent environment
+                    :operation (list :set name entry)
+                    :value (update-namespace environment namespace
+                                             (a:rcurry #'fset:with name entry))))
+
+(declaim (inline unset))
+(defun unset (environment namespace name)
+  "Unbind NAME in NAMESPACE of ENVIRONMENT."
+  (make-environment :namespace namespace
+                    :parent environment
+                    :operation (list :unset name)
+                    :value (update-namespace environment namespace
+                                             (a:rcurry #'fset:less name))))
+
+(defun set* (environment namespace &rest entries)
+  "Create multiple NAME -> ENTRY bindings in NAMESPACE of ENVIRONMENT."
+  (loop :for (name entry) :on entries :by #'cddr
+        :do (setf environment (set environment namespace name entry)))
+  environment)
+
+(defun keys (environment namespace)
+  "Return the names in NAMESPACE of ENVIRONMENT."
+  (fset:convert 'list (fset:domain (get-namespace environment namespace))))
+
+(defun map (environment namespace f)
+  "Apply 2-ary function F to each name and entry in ENVIRONMENT."
+  (dolist (k (keys environment namespace))
+    (funcall f k (get environment namespace k))))
+
+(defmacro do-environment ((name entry environment namespace) &body body)
+  "For each entry in ENVIRONMENT, bind NAME and ENTRY for the scope of BODY."
+  `(map ,environment ,namespace (lambda (,name ,entry) ,@body)))
+
+(defun update-entries (environment namespace f)
+  "Rewrite NAMESPACE by applying function F to each entry."
+  (reduce (lambda (environment k)
+            (set environment namespace k (funcall f (get environment namespace k))))
+          (keys environment namespace) :initial-value environment))
+
+(defun exported-symbol-p (symbol package)
+  "Test that SYMBOL is exported by PACKAGE."
+  (declare (type symbol symbol))
+  (and (equalp (symbol-package symbol) package)
+       (eql :external (nth-value 1 (find-symbol (symbol-name symbol) package)))))
+
+(defun entries-for-package (environment namespace package
+                            &key (public nil)
+                                 (entry-resolver #'identity))
+  "Return the entries in NAMESPACE of ENVIRONMENT matching PACKAGE."
+  (let ((result nil))
+    (do-environment (sym entry environment namespace)
+      (when (if public
+                (exported-symbol-p sym package)
+                (eql package (symbol-package sym)))
+        (push (cons sym (funcall entry-resolver entry)) result)))
+    result))
+
+(defun entries-by-package (environment namespace
+                           &key (public nil)
+                                (entry-resolver #'identity))
+  "Group the entries in NAMESPACE of ENVIRONMENT by package."
+  (let ((table (make-hash-table)))
+    (do-environment (sym entry environment namespace)
+      (let ((package (symbol-package sym)))
+        (when (or (not public)
+                  (exported-symbol-p sym package))
+          (push (cons sym (funcall entry-resolver entry))
+                (gethash package table)))))
+    table))

--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -61,7 +61,7 @@ Returns (PREDS FOUNDP)"
   (declare (type environment env)
            (type ty-predicate pred)
            (values ty-predicate-list boolean))
-  (fset:do-seq (inst (lookup-class-instances env (ty-predicate-class pred) :no-error t))
+  (dolist (inst (lookup-class-instances env (ty-predicate-class pred) :no-error t))
     (handler-case
         (let* ((subs (predicate-match (ty-class-instance-predicate inst) pred))
                (resulting-preds (mapcar (lambda (p) (apply-substitution subs p))

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -322,10 +322,7 @@
                                 :span (parser:toplevel-define-class-head-src class)
                                 :file file
                                 :message "Invalid fundep redefinition"
-                                :primary-note (format nil "unable to redefine the fudndeps of class ~S." class-name))))
-
-           :when fundeps
-             :do (setf env (tc:initialize-fundep-environment env class-name))
+                                :primary-note (format nil "unable to redefine the fundeps of class ~S." class-name))))
 
            :do (setf env (tc:set-class env class-name class-entry))
 
@@ -376,7 +373,7 @@
 
   (let ((var-names (mapcar #'parser:keyword-src-name (parser:toplevel-define-class-vars class))))
 
-    ;; Ensure fudneps don't have duplicate variables
+    ;; Ensure fundeps don't have duplicate variables
     (labels ((check-duplicate-fundep-variables (vars)
                (check-duplicates
                 vars

--- a/src/typechecker/tc-env.lisp
+++ b/src/typechecker/tc-env.lisp
@@ -4,6 +4,7 @@
    #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/parse-type)
   (:local-nicknames
+   (#:env #:coalton-impl/environment)
    (#:util #:coalton-impl/util)
    (#:error #:coalton-impl/error)
    (#:parser #:coalton-impl/parser)
@@ -30,10 +31,10 @@
 (defstruct (tc-env
             (:predicate nil))
 
-  ;; The main copiler env
+  ;; The main compiler env
   (env      (util:required 'env)          :type tc:environment :read-only t)
 
-  ;; Hash table mappinig variables bound in the current translation unit to types
+  ;; Hash table mapping variables bound in the current translation unit to types
   (ty-table (make-hash-table :test #'eq)  :type hash-table     :read-only t))
 
 (defun tc-env-add-variable (env name)
@@ -67,8 +68,7 @@
                                        (alexandria:hash-table-keys (tc-env-ty-table env)))
                                       (remove-if-not
                                        (lambda (s) (string= (symbol-name s) sym-name))
-                                       (coalton-impl/algorithm::immutable-map-keys
-                                        (tc:environment-value-environment (tc-env-env env)))))))
+                                       (env:keys (tc-env-env env) :value)))))
                        (error 'tc-error
                               :err (coalton-error
                                     :span (parser:node-source var)


### PR DESCRIPTION
Define a functional environment class for the type checker to use. Instead of reifying structures and collections for each partition of the environment (type, value, class, instance, fundep, specialization, name, code, etc.), use fset to build a two-level purely functional map.

A primary motivation is to simplify calculation of environment updates during compilation. Instead of wrapping each environment mutator in a macro that emits a copy of the envrionment-altering invocation, low-level environment set and unset operations can be calculated directly, by unwinding chained environment records back to the original environment record.

This also supports an arrangement where environment updates, generated code, AST info and other debugging artifacts are captured during compilation, rather then emitted all at once, as multiple return values from entry-point.

Generic access also simplifies utilities for dumping environment contents, and may count towards better support for incremental and partially-consistent definitions.

Scattered direct calls to functions in fset are removed.