### PR TITLE
Unset structures and functions more cautiously

### DIFF
--- a/src/codegen/transformations.lisp
+++ b/src/codegen/transformations.lisp
@@ -234,9 +234,9 @@
                     (tc:make-function-env-entry
                      :name name
                      :arity arity))))
-    (loop :for name :in toplevel-values
-          :do
-             (setf env (tc:unset-function env name))))
+    (dolist (name toplevel-values)
+      (when (tc:lookup-function env name :no-error t)
+        (setf env (tc:unset-function env name)))))
   env)
 
 (defun make-function-table (env)

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -336,7 +336,8 @@
                                                              :name codegen-sym
                                                              :arity class-arity)))
            :else
-             :do (setf env (tc:unset-function env codegen-sym))
+             :when (tc:lookup-function env codegen-sym :no-error t)
+               :do (setf env (tc:unset-function env codegen-sym))
 
            :do (loop :for method-ty :in method-tys
                      :for method-name :in method-names

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -127,11 +127,12 @@
                 :method-codegen-syms method-codegen-syms
                 :docstring docstring)))
 
-        (if context
-            (setf env (tc:set-function env instance-codegen-sym (tc:make-function-env-entry
-                                                                 :name instance-codegen-sym
-                                                                 :arity (length context))))
-            (setf env (tc:unset-function env instance-codegen-sym)))
+        (cond (context
+               (setf env (tc:set-function env instance-codegen-sym (tc:make-function-env-entry
+                                                                    :name instance-codegen-sym
+                                                                    :arity (length context)))))
+              ((tc:lookup-function env instance-codegen-sym :no-error t)
+               (setf env (tc:unset-function env instance-codegen-sym))))
 
         (when (tc:ty-class-fundeps class)
           (handler-case 

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -223,7 +223,8 @@
                                name
                                (parser:toplevel-define-orig-params define)))
               :else
-                :do (setf env (tc:unset-function-source-parameter-names env name)))
+                :when (tc:lookup-function-source-parameter-names env name)
+                  :do (setf env (tc:unset-function-source-parameter-names env name)))
 
 
         (values


### PR DESCRIPTION
This suppresses ineffectual modifications to the environment in cases where structures and constructors are not being redefined.