### PR TITLE
Typechecker base definitions

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -60,7 +60,8 @@
                              (:file "package")))
                (:module "typechecker"
                 :serial t
-                :components ((:file "kinds")
+                :components ((:file "base")
+                             (:file "kinds")
                              (:file "types")
                              (:file "substitutions")
                              (:file "predicate")
@@ -72,7 +73,6 @@
                              (:file "lisp-type")
                              (:file "context-reduction")
                              (:file "stage-1")
-                             (:file "base")
                              (:file "pattern")
                              (:file "expression")
                              (:file "traverse")

--- a/src/parser/base.lisp
+++ b/src/parser/base.lisp
@@ -29,7 +29,7 @@
 (in-package #:coalton-impl/parser/base)
 
 ;;;
-;;; Shared Definitions
+;;; Shared definitions for source parser
 ;;;
 
 (deftype identifier ()

--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -12,7 +12,6 @@
    #:*coalton-dump-ast*                 ; VARIABLE
    #:*coalton-skip-update*              ; VARIABLE
    #:*emit-type-annotations*            ; VARIABLE
-   #:*coalton-stage-1-complete*         ; VARIABLE
    #:*coalton-optimize*                 ; VARIABLE
    #:*coalton-optimize-library*         ; VARIABLE
    ))

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -100,7 +100,7 @@
                 *package*
                 "INSTANCE/~A"
                 (with-output-to-string (s)
-                  (tc:with-pprint-variable-context ()
+                  (with-pprint-variable-context ()
                     (let ((*print-escape* t))
                       (tc:pprint-predicate s pred))))))
 

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/typechecker/scheme
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/kinds
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/substitutions

--- a/src/typechecker/type-errors.lisp
+++ b/src/typechecker/type-errors.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/typechecker/type-errors
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/predicate)
   (:local-nicknames


### PR DESCRIPTION
Following the convention of parser/base, place typechecker/base first in load order, and move basic pretty printing support there. This is motivated by the desire to clarify internal typechecker dependencies, and to provide a place to define typechecker-related defgenerics before early kind and type definitions.