### PR TITLE
Remove stray field definition

### DIFF
--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -484,7 +484,7 @@
   (field-tys (util:required 'field-tys) :type hash-table       :read-only t)
 
   ;; Mapping of "field name" -> "field index"
-  (field-idx (util:required 'field-idx) :type hash-table       :read-only t)h)
+  (field-idx (util:required 'field-idx) :type hash-table       :read-only t))
 
 (defmethod make-load-form ((self struct-entry) &optional env)
   (make-load-form-saving-slots self :environment env))


### PR DESCRIPTION
Remove a nonfunctional 'h' field in struct-entry seen in generated environment update code.