### PR TITLE
Adds error-type to Tryinto to allow for non-string errors

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -246,7 +246,7 @@
   ;;
 
   (define-class (Into :a :b)
-    "INTO imples *every* element of `:a` can be represented by an element of `:b`. This conversion might not be bijective (i.e., there may be elements in `:b` that don't correspond to any in `:a`)."
+    "`INTO` imples *every* element of `:a` can be represented by an element of `:b`. This conversion might not be bijective (i.e., there may be elements in `:b` that don't correspond to any in `:a`)."
     (into (:a -> :b)))
 
   (define-class ((Into :a :b) (Into :b :a) => Iso :a :b)
@@ -255,11 +255,9 @@
   (define-instance (Into :a :a)
     (define (into x) x))
 
-  (define-class (TryInto :a :b)
-    "TRY-INTO implies some elements of `:a` can be represented exactly by an element of :b, but sometimes not. If not, an error string is returned."
-    ;; Ideally we'd have an associated-type here instead of locking in
-    ;; on String.
-    (tryInto (:a -> Result String :b)))
+  (define-class (TryInto :a :b :c (:a :b -> :c))
+    "`TRY-INTO` implies some elements of `:a` can be represented exactly by an element of `:b`, but sometimes not. If not, an error of type `:c` is returned."
+    (tryInto (:a -> (Result :c :b))))
 
   (define-instance (Iso :a :a))
 

--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -123,7 +123,7 @@
               (cl:if presentp
                      (Some (Tuple key value))
                      None))))
-      (with-default 0 (tryinto (count table)))))
+      (with-default 0 (the (Result String UFix) (tryinto (count table))))))
 
   (declare keys (Hashtable :key :value -> iter:Iterator :key))
   (define (keys table)
@@ -138,7 +138,7 @@
               (cl:if presentp
                      (Some key)
                      None))))
-      (with-default 0 (tryinto (count table)))))
+      (with-default 0 (the (Result String Ufix) (tryinto (count table))))))
 
   (declare values (Hashtable :key :value -> iter:Iterator :value))
   (define (values table)
@@ -153,7 +153,7 @@
               (cl:if presentp
                      (Some value)
                      None))))
-      (with-default 0 (tryinto (count table))))) 
+      (with-default 0 (the (Result String UFix) (tryinto (count table)))))) 
 
   (declare extend! ((Hash :key) (iter:IntoIterator :container (Tuple :key :value))
                    => Hashtable :key :value -> :container -> Unit))

--- a/library/math/conversions.lisp
+++ b/library/math/conversions.lisp
@@ -91,7 +91,7 @@ Emitted by `define-integer-conversions' only if every element of FROM-TYPE can b
 
 Emitted by `define-integer-conversions' when some elements of FROM-TYPE cannot be represented in TO-TYPE,
 either because FROM-TYPE is signed and TO-TYPE is unsigned, or because FROM-TYPE is wider than TO-TYPE."
-    `(define-instance (TryInto ,from-type ,to-type)
+    `(define-instance (TryInto ,from-type ,to-type String)
        (define tryInto cast-if-inbounds)))
 
   (cl:defun definitely-subtype? (sub super)
@@ -166,7 +166,7 @@ cannot be represented in :TO. These fall into a few categories:
 
 ;; Allow Integer -> {Single,Double}-Float conversions
 (coalton-toplevel
-  (define-instance (TryInto Integer Single-Float)
+  (define-instance (TryInto Integer Single-Float String)
     (define (tryInto x)
       (lisp (Result String Single-Float) (x)
         (cl:let ((y (cl:ignore-errors (cl:coerce x 'cl:single-float))))
@@ -174,7 +174,7 @@ cannot be represented in :TO. These fall into a few categories:
                  (Err "Integer to Single-Float conversion out-of-range")
                  (Ok y))))))
 
-  (define-instance (TryInto Integer Double-Float)
+  (define-instance (TryInto Integer Double-Float String)
     (define (tryInto x)
       (lisp (Result String Double-Float) (x)
         (cl:let ((y (cl:ignore-errors (cl:coerce x 'cl:double-float))))
@@ -184,7 +184,7 @@ cannot be represented in :TO. These fall into a few categories:
 
 (cl:eval-when (:compile-toplevel :load-toplevel)
   (cl:defmacro integer-tryinto-float (integer lisp-float float pow)
-    `(define-instance (TryInto ,integer ,float)
+    `(define-instance (TryInto ,integer ,float String)
        (define (tryInto x)
 	 (lisp (Result String ,float) (x)
            (cl:if (cl:< ,(cl:- (cl:expt 2 pow)) x ,(cl:expt 2 pow))

--- a/library/math/num.lisp
+++ b/library/math/num.lisp
@@ -279,7 +279,7 @@
 
 (cl:eval-when (:compile-toplevel :load-toplevel)
   (cl:defmacro define-float-fraction-conversion (type)
-    `(define-instance (TryInto ,type Fraction)
+    `(define-instance (TryInto ,type Fraction String)
        (define (tryInto x)
          (if (finite? x)
              (Ok (lisp Fraction (x) (cl:rational x)))

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -199,7 +199,7 @@ does not have that suffix."
       (lisp String (z)
         (cl:prin1-to-string z))))
 
-  (define-instance (TryInto String Integer)
+  (define-instance (TryInto String Integer String)
     (define (tryInto s)
       (lisp (Result String Integer) (s)
         (cl:let ((z (cl:ignore-errors (cl:parse-integer s))))


### PR DESCRIPTION
This adds error-types to `Tryinto` so that it can return non-string errors.
