### PR TITLE
Adds `Signalable` class, for signalling errors

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -3,13 +3,14 @@
    #:coalton)
   (:local-nicknames
    (#:types #:coalton-library/types))
-
   (:export
    #:Addressable #:eq?)
   (:export
    #:Eq #:==
    #:Num #:+ #:- #:* #:fromInt)
   (:export
+   #:Signalable
+   #:error
    #:Tuple
    #:Optional #:Some #:None
    #:Result #:Ok #:Err
@@ -44,6 +45,25 @@
 
 #+coalton-release
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
+
+;;;
+;;; Signaling errors and warnings
+;;;
+
+(coalton-toplevel
+ 
+ ;;
+ ;; Signalling errors on supported types
+ ;;
+ (define-class (Signalable :a)
+   "Signals errors or warnings by calling their respective lisp conditions."
+   (error (:a -> :b)))
+
+  (define-instance (Signalable String)
+    (define (error str)
+      (lisp :a (str)
+        (cl:error str)))))
+
 
 (coalton-toplevel
 
@@ -264,11 +284,6 @@
   ;;
   ;; Unwrappable for fallible unboxing
   ;;
-
-  (declare error (String -> :a))
-  (define (error str)
-    "Signal an error by calling `CL:ERROR`."
-    (lisp :a (str) (cl:error str)))
 
   (define-class (Unwrappable :container)
     "Containers which can be unwrapped to get access to their contents.

--- a/library/ord-tree.lisp
+++ b/library/ord-tree.lisp
@@ -1,13 +1,13 @@
 (coalton-library/utils:defstdlib-package :coalton-library/ord-tree
   (:use
-   :coalton
-   :coalton-library/classes
+   #:coalton
+   #:coalton-library/classes
    #:coalton-library/hash
-   :coalton-library/tuple
-   :coalton-library/functions)
+   #:coalton-library/tuple
+   #:coalton-library/functions)
   (:local-nicknames
-   (#:iter :coalton-library/iterator)
-   (#:cell :coalton-library/cell))
+   (#:iter #:coalton-library/iterator)
+   (#:cell #:coalton-library/cell))
   (:shadow #:empty)
   (:export
    #:Tree #:Empty

--- a/library/result.lisp
+++ b/library/result.lisp
@@ -11,7 +11,8 @@
    #:ok?
    #:err?
    #:map-err
-   #:flatten))
+   #:flatten
+   #:ok-or-error))
 
 (in-package #:coalton-library/result)
 
@@ -52,6 +53,12 @@
       ((Ok x) x)
       ((Err x) x)))
 
+  (declare ok-or-error ((Signalable :err) => (Result :err :a) -> :a))
+  (define (ok-or-error res)
+    (match res
+      ((Ok elt) elt)
+      ((Err r) (error r))))
+  
   ;;
   ;; Instances
   ;;


### PR DESCRIPTION
Currently the function `error` only takes arguments of type `String`. 

This PR allows you to define error behavior for any type without first converting each object to a string first. 

This also allows for error behavior to be specified within one instance definition rather than making scattered formatting functions or repetitive boilerplate lisp format strings. 

**Note** This doesn't break any existing `error` uses, since there is an instance defined for `String`. 

Eventually `warn` might also be useful but I think it's worth thinking a little more about.

Here are some examples:

```
(defpackage #:signalable-demo
  (:use #:coalton
        #:coalton-prelude)
  (:local-nicknames (#:math #:coalton-library/math)
                    (#:result #:coalton-library/result)))

(in-package #:signalable-demo)

(coalton-toplevel

  (define-type InvalidIntError
    (OddError Integer)
    (EvenError Integer))

  (define-instance (Signalable InvalidIntError)
    (define (error x)
      (match x
        ((OddError i)
         (error (lisp String (i)
                  (cl:format cl:nil "Invalid Integer: ~a is Odd." i))))
        ((EvenError i)
         (error (lisp String (i)
                  (cl:format cl:nil "Invalid Integer: ~a is Even." i))))))))

;; Some working use-cases:
(coalton-toplevel

  (define (only-if-even x)
    (if (math:zero? (mod x 2))
        x
        (error (OddError x))))

  (define (evn? x)
    (if (math:zero? (mod x 2))
        (Ok x)
        (Err (OddError x))))
  
  (define (error-if-odd x)
    (result:unwrap-or-error (evn? x))))
```