### PR TITLE
Initial support for compilation of .coalton files

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -98,7 +98,8 @@
                              (:file "package")))
                (:module "codegen"
                 :serial t
-                :components ((:file "pattern")
+                :components ((:file "base")
+                             (:file "pattern")
                              (:file "ast")
                              (:file "ast-substitutions")
                              (:file "resolve-instance")
@@ -118,6 +119,7 @@
                              (:file "package")))
                (:file "unlock-package" :if-feature :sb-package-locks)
                (:file "entry")
+               (:file "compiler")
                (:file "reader")
                (:file "debug")
                (:file "faux-macros")

--- a/src/codegen/base.lisp
+++ b/src/codegen/base.lisp
@@ -1,0 +1,40 @@
+(defpackage #:coalton-impl/codegen/base
+  (:use
+   #:cl)
+  (:export
+   #:emit
+   #:emit-ast
+   #:emit-comment
+   #:emit-env))
+
+(in-package #:coalton-impl/codegen/base)
+
+;;; protocol: compiler backend
+
+;; These generic functions are the interface to compiler backends.
+;; Implementations are defined in src/compiler.lisp.
+
+(defgeneric emit (stream form)
+  (:documentation "Emit a Lisp form")
+  (:method (stream form)
+    (values)))
+
+(defgeneric emit-ast (stream name type value)
+  (:documentation "Emit an AST entry")
+  (:method (stream name type value)
+    (values)))
+
+(defgeneric emit-comment (stream comment)
+  (:documentation "Emit a comment")
+  (:method (stream comment)
+    (values)))
+
+;; Multiple definitions of the same functions are emitted to the
+;; global environment (via 'set-code') before and during optimization,
+;; so it's currently up to the backend to, e.g., provide logic to emit
+;; only final, optimized versions.
+
+(defgeneric emit-env (stream name args)
+  (:documentation "Emit a global environment update")
+  (:method (stream name args)
+    (values)))

--- a/src/codegen/package.lisp
+++ b/src/codegen/package.lisp
@@ -1,5 +1,17 @@
 (uiop:define-package #:coalton-impl/codegen
   (:import-from
+   #:coalton-impl/codegen/base
+   #:emit
+   #:emit-ast
+   #:emit-comment
+   #:emit-env)
+  (:export
+   #:emit
+   #:emit-ast
+   #:emit-comment
+   #:emit-env)
+
+  (:import-from
    #:coalton-impl/codegen/codegen-expression
    #:codegen-expression)
   (:export

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -1,7 +1,8 @@
 (defpackage #:coalton-impl/codegen/program
   (:use
    #:cl
-   #:coalton-impl/codegen/ast)
+   #:coalton-impl/codegen/ast
+   #:coalton-impl/codegen/base)
   (:import-from
    #:coalton-impl/codegen/translate-expression
    #:translate-toplevel)
@@ -31,7 +32,7 @@
 
 (in-package #:coalton-impl/codegen/program)
 
-(defun compile-translation-unit (translation-unit monomorphize-table env)
+(defun compile-translation-unit (backend translation-unit monomorphize-table env)
   (declare (type tc:translation-unit translation-unit)
            (type hash-table monomorphize-table)
            (type tc:environment env))
@@ -43,11 +44,10 @@
 
                   :for compiled-node := (translate-toplevel define env)
 
-                  :do (when settings:*coalton-dump-ast*
-                        (format t "~A :: ~A~%~A~%~%~%"
-                                name
+                  :do (emit-ast backend name
                                 (tc:lookup-value-type env name)
-                                (tc:binding-value define)))
+                                (tc:binding-value define))
+
                   :collect (cons name compiled-node))
 
             ;; HACK: this load bearing reverse should be replaced with an actual solution
@@ -58,101 +58,91 @@
            (mapcar #'car definitions)))
 
     (multiple-value-bind (definitions env)
-        (optimize-bindings
-         definitions
-         monomorphize-table
-         *package*
-         env)
+        (optimize-bindings definitions monomorphize-table *package* env)
 
       (let ((sccs (node-binding-sccs definitions)))
 
-        (values
-         `(progn
-            ;; Muffle redefinition warnings in SBCL. A corresponding
-            ;; SB-EXT:UNMUFFLE-CONDITIONS appears at the bottom.
-            #+sbcl ,@(when settings:*emit-type-annotations*
-                       (list '(declaim (sb-ext:muffle-conditions sb-kernel:redefinition-warning))))
+        ;; Muffle redefinition warnings in SBCL. A corresponding
+        ;; SB-EXT:UNMUFFLE-CONDITIONS appears at the bottom.
+        #+sbcl
+        (when settings:*emit-type-annotations*
+          (emit backend
+                '(declaim (sb-ext:muffle-conditions sb-kernel:redefinition-warning))))
 
-            ,@(when (tc:translation-unit-types translation-unit)
-                (list
-                 `(eval-when (:compile-toplevel :load-toplevel :execute)
-                    ,@(loop :for type :in (tc:translation-unit-types translation-unit)
-                            :append (codegen-type-definition type env)))))
+        (when (tc:translation-unit-types translation-unit)
+          (emit backend
+                `(eval-when (:compile-toplevel :load-toplevel :execute)
+                   ,@(loop :for type :in (tc:translation-unit-types translation-unit)
+                           :append (codegen-type-definition type env)))))
 
-            ,@(when (tc:translation-unit-classes translation-unit)
-                (list
-                 `(eval-when (:compile-toplevel :load-toplevel :execute)
-                    ,@(codegen-class-definitions
-                       (tc:translation-unit-classes translation-unit)
-                       env))))
+        (when (tc:translation-unit-classes translation-unit)
+          (emit backend
+                `(eval-when (:compile-toplevel :load-toplevel :execute)
+                   ,@(codegen-class-definitions
+                      (tc:translation-unit-classes translation-unit)
+                      env))))
 
-            #+sbcl
-            ,@(when (eq sb-ext:*block-compile-default* :specified)
-                (list
-                 `(declaim (sb-ext:start-block ,@definition-names))))
+        #+sbcl
+        (when (eq sb-ext:*block-compile-default* :specified)
+          (emit backend `(declaim (sb-ext:start-block ,@definition-names))))
 
-            ,@(loop :for scc :in sccs
-                    :for bindings
-                      := (remove-if-not
-                          (lambda (binding)
-                            (find (car binding) scc))
-                          definitions)
-                    :append (compile-scc bindings env))
+        (loop :for scc :in sccs
+              :for bindings
+                := (remove-if-not
+                    (lambda (binding)
+                      (find (car binding) scc))
+                    definitions)
+              :do (compile-scc backend bindings env))
 
-            #+sbcl
-            ,@(when (eq sb-ext:*block-compile-default* :specified)
-                (list
-                 `(declaim (sb-ext:end-block))))
+        #+sbcl
+        (when (eq sb-ext:*block-compile-default* :specified)
+          (emit backend `(declaim (sb-ext:end-block))))
 
-            #+sbcl ,@(when settings:*emit-type-annotations*
-                       (list '(declaim (sb-ext:unmuffle-conditions sb-kernel:redefinition-warning))))
-
-            (values))
-         env)))))
+        #+sbcl
+        (when settings:*emit-type-annotations*
+          (emit backend
+                '(declaim (sb-ext:unmuffle-conditions sb-kernel:redefinition-warning)))))
+      env)))
 
 (defun compile-function (name node env)
   (declare (type symbol name)
            (type node-abstraction node)
            (type tc:environment env))
   (let ((type-decs
-           (when settings:*emit-type-annotations*
-             (append
-              (loop :for name :in (node-abstraction-vars node)
-                    :for i :from 0
-                    :for arg-ty := (nth i (tc:function-type-arguments (node-type node)))
-                    :collect `(type ,(tc:lisp-type arg-ty env) ,name))
-              (list `(values ,(tc:lisp-type (node-type (node-abstraction-subexpr node)) env)
-                             &optional))))))
-
+          (when settings:*emit-type-annotations*
+            (append
+             (loop :for name :in (node-abstraction-vars node)
+                   :for i :from 0
+                   :for arg-ty := (nth i (tc:function-type-arguments (node-type node)))
+                   :collect `(type ,(tc:lisp-type arg-ty env) ,name))
+             (list `(values ,(tc:lisp-type (node-type (node-abstraction-subexpr node)) env)
+                            &optional))))))
     `(defun ,name ,(node-abstraction-vars node)
        (declare (ignorable ,@(node-abstraction-vars node))
                 ,@type-decs)
        ,(codegen-expression (node-abstraction-subexpr node) name env))))
 
-(defun compile-scc (bindings env)
+(defun compile-scc (backend bindings env)
   (declare (type binding-list bindings)
            (type tc:environment env))
-  (append
-   ;; Predeclare symbol macros
-   (loop :for (name . node) :in bindings
-         :collect `(global-lexical:define-global-lexical ,name ,(tc:lisp-type (node-type node) env)))
 
-   ;; Compile functions
-   (loop :for (name . node) :in bindings
-         :if (node-abstraction-p node)
-           :append (list
-                    (compile-function name node env)
-                    `(setf
-                      ,name
-                      ,(rt:construct-function-entry
-                        `#',name (length (node-abstraction-vars node))))))
+  ;; Predeclare symbol macros
+  (loop :for (name . node) :in bindings
+        :do (emit backend
+                  `(global-lexical:define-global-lexical ,name ,(tc:lisp-type (node-type node) env))))
+
+  ;; Compile functions
+  (loop :for (name . node) :in bindings
+        :when (node-abstraction-p node)
+          :do (emit backend (compile-function name node env))
+              (emit backend
+                    `(setf ,name ,(rt:construct-function-entry
+                                   `#',name (length (node-abstraction-vars node))))))
 
   ;; Compile variables
   (loop :for (name . node) :in bindings
-        :if (not (node-abstraction-p node))
-          :collect `(setf
-                      ,name
-                      ,(codegen-expression node nil env)))
+        :unless (node-abstraction-p node)
+          :do (emit backend `(setf ,name ,(codegen-expression node nil env))))
 
   ;; Docstrings
   (loop :for (name . node) :in bindings
@@ -166,11 +156,9 @@
                ((and entry (tc:name-entry-docstring entry))
                 (tc:name-entry-docstring entry))
 
-                (type
-                 (format nil "~A :: ~A" name type)))
-        :append (when (and docstring (not settings:*coalton-skip-update*))
-                  (list `(setf (documentation ',name 'variable)
-                               ,docstring)))
-        :append (when (and entry (node-abstraction-p node) (not settings:*coalton-skip-update*))
-                  (list `(setf (documentation ',name 'function)
-                               ,docstring))))))
+               (type
+                (format nil "~A :: ~A" name type)))
+        :when docstring
+          :do (emit backend `(setf (documentation ',name 'variable) ,docstring))
+        :when (and entry (node-abstraction-p node))
+          :do (emit backend `(setf (documentation ',name 'function) ,docstring))))

--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -1,0 +1,193 @@
+(defpackage #:coalton-impl/compiler
+  (:use
+   #:cl)
+  (:shadow
+   #:compile
+   #:compile-file)
+  (:local-nicknames
+   (#:codegen #:coalton-impl/codegen)
+   (#:util #:coalton-impl/util)
+   (#:error #:coalton-impl/error)
+   (#:parser #:coalton-impl/parser)
+   (#:entry #:coalton-impl/entry))
+  (:export
+   #:codegen-ast-result
+   #:codegen-result
+   #:compile
+   #:compile-toplevel
+   #:generate-ast
+   #:generate-code
+   #:toplevel-result))
+
+;;; Compiler backends and utility entry points
+;;;
+;;; The classes defined below implement the code generator's backend
+;;; protocol (codegen:emit, codegen:emit-env, etc.) in order to
+;;; provide output modes supporting:
+;;;
+;;; - The coalton-toplevel macro
+;;; - Direct compilation of .coalton files
+;;; - Raw code generation
+;;; - AST printing
+
+(in-package #:coalton-impl/compiler)
+
+;;; class: compile-toplevel
+
+;; Emit the environment and code created by the coalton-toplevel
+;; macro.
+;;
+;; The Coalton environment is serialized by quoting arguments that
+;; implement make-load-form: see implementations of make-load-form for
+;; the structures defined in typechecker/environment, codegen/types
+;; and elsewhere
+;;
+;; When files are loaded after compilation, the environment
+;; definitions are immediately replayed -- harmless, but doesn't need
+;; to happen and might justify making load behavior configurable with
+;; a dynamic variable.
+
+(defun %adjustable-array ()
+  "Return a zero length extensible array."
+  (make-array 0 :adjustable t :fill-pointer 0))
+
+(defclass compile-toplevel ()
+  ((env :initform (%adjustable-array))
+   (code :initform (%adjustable-array)))
+  (:documentation
+   "Compiler backend that generates the value of the coalton-toplevel macro."))
+
+;; Emit a compiled lisp form
+
+(defmethod codegen:emit ((backend compile-toplevel) form)
+  (vector-push-extend form (slot-value backend 'code)))
+
+;; Emit an environment entry. Repeated code blocks emitted before
+;; and during optimization are deduplicated at output time.
+
+(defmethod codegen:emit-env ((backend compile-toplevel) name args)
+  (vector-push-extend (cons name args) (slot-value backend 'env)))
+
+(defun code-update-eql (a b)
+  "Compare environment updates, returning t for set-code updates of the same symbol."
+  (and (eql (first a) 'coalton-impl/typechecker/environment:set-code)
+       (eql (first b) 'coalton-impl/typechecker/environment:set-code)
+       (eql (second a)
+            (second b))))
+
+(defun toplevel-result (backend)
+  "Return the result of evaluating a coalton-toplevel form."
+  (with-slots (env code) backend
+    (let ((updates (remove-duplicates (coerce env 'list) :test #'code-update-eql)))
+      `(progn
+         (let ((env entry:*global-environment*))
+           ,@(loop :for (name . args) :in updates
+                   :collect `(setf env (,name env ,@(mapcar #'util:runtime-quote args))))
+           (setf entry:*global-environment* env))
+         ,@(coerce code 'list)))))
+
+;;; class: compile-file
+
+;; Generate lisp source from coalton source. This is similar to
+;; compile-toplevel, but serializes environment updates in a completely
+;; different way, by emitting source forms, rather than load forms
+
+(defclass compile-file ()
+  ((stream :initarg :stream)))
+
+(defmethod codegen:emit ((backend compile-file) form)
+  (with-slots (stream) backend
+    (let ((*package* (find-package :cl))
+          (*print-case* :downcase)
+          (*print-circle* nil))
+      (prin1 form stream)
+      (terpri stream)
+      (terpri stream))))
+
+(defmethod codegen:emit-comment ((backend compile-file) string)
+  (with-slots (stream) backend
+    (format stream "~%;; ~A~%~%" string)))
+
+(defun set-value-type! (name value)
+  (setf entry:*global-environment*
+        (coalton-impl/typechecker:set-value-type entry:*global-environment*
+                                                 name value)))
+
+(defmethod codegen:emit-env ((backend compile-file) name args)
+  (case name
+    (coalton-impl/typechecker::set-value-type
+     (destructuring-bind (name type) args
+       (codegen:emit-comment backend (format nil "env: set-value-type ~A" name))
+       (break)
+       (codegen:emit backend `(set-value-type! ',name ',type))))
+    (t
+     ;; fixme -- source-persistable representation of environment modification
+     (codegen:emit-comment backend (format nil "env: ~A" name))
+     (codegen:emit backend
+                   `(setf entry:*global-environment*
+                          (,name entry:*global-environment*
+                                 ,@(mapcar #'util:runtime-quote args)))))))
+
+;;; class: generate-code
+
+;; Emit generated code, ignoring environment updates, comments, etc.
+
+(defclass generate-code ()
+  ((forms :initform (%adjustable-array))))
+
+(defmethod codegen:emit ((backend generate-code) form)
+  (vector-push-extend form (slot-value backend 'forms)))
+
+(defun codegen-result (backend)
+  (util:runtime-quote (coerce (slot-value backend 'forms) 'list)))
+
+;;; class: generate-ast
+
+;; Emit AST, by emitting printed versions to a stream. Ignores all
+;; other compiler activity.
+
+(defclass generate-ast ()
+  ((stream :initarg :stream)))
+
+(defmethod codegen:emit-ast ((backend generate-ast) name type value)
+  (with-slots (stream) backend
+    (format stream "~A :: ~A~%~A~%~%~%" name type value)))
+
+;;; entry points and helpers
+
+(defun %process-source (stream name backend)
+  "Helper: read and compile Coalton source from STREAM using BACKEND.
+
+NAME provides information on the stream's origin in error messages."
+  (let* ((file (error:make-coalton-file :stream stream
+                                        :name name))
+         (program (parser:read-file stream file)))
+    (entry:emit-prologue backend)
+    (entry:entry-point program backend)))
+
+(defun compile (input-stream output-stream)
+  "Read Coalton source from INPUT-STREAM and write Lisp source to OUTPUT-STREAM."
+  (parser:with-reader-context input-stream
+    (let ((backend (make-instance 'compile-file :stream output-stream)))
+      ;; TODO emit header comment, emit defpackage
+      ;; ... Generated from XXX.coalton on YYYYMMDD
+      ;; ... defpackage ...
+      (setf entry:*global-environment* (%process-source input-stream "string" backend))
+      (values))))
+
+(defun compile-file (input-file output-file)
+  (with-open-file (input-stream input-file
+                          :direction :input
+                          :element-type 'character)
+    (with-open-file (output-stream output-file
+                                   :direction :output
+                                   :element-type 'character
+                                   :if-exists :supersede)
+      (compile input-stream output-stream))))
+
+(defun generate-ast (stream)
+  "Read Coalton source from STREAM and return string representation of ast."
+  (parser:with-reader-context stream
+    (with-output-to-string (ast-stream)
+      (let ((backend (make-instance 'generate-ast :stream ast-stream)))
+        (%process-source stream "string" backend)))))

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -11,16 +11,21 @@
    (#:codegen #:coalton-impl/codegen))
   (:export
    #:*global-environment*
+   #:emit-prologue                      ; FUNCTION
    #:entry-point                        ; FUNCTION
    #:expression-entry-point             ; FUNCTION
-   #:file-entry-point                   ; FUNCTION
    ))
 
 (in-package #:coalton-impl/entry)
 
 (defvar *global-environment* (tc:make-default-environment))
 
-(defun entry-point (program)
+;; This is the compiler entry point. PROGRAM is compiled using the
+;; current value of *global-environment*, environment updates and code
+;; definitions are emitted to BACKEND, and an updated environment is
+;; returned.
+
+(defun entry-point (program backend)
   (declare (type parser:program program))
 
   (let* ((*package* (parser:program-package program))
@@ -29,84 +34,61 @@
 
          (file (parser:program-file program))
 
-         (env *global-environment*)
+         (env *global-environment*))
 
-         (tc:*env-update-log* nil))
-
-    (multiple-value-bind (type-definitions instances env)
-        (tc:toplevel-define-type (parser:program-types program)
-                                 (parser:program-structs program)
-                                 file
-                                 env)
-
-      (multiple-value-bind (class-definitions env)
-          (tc:toplevel-define-class (parser:program-classes program)
+    (tc:with-update-hook (lambda (name args)
+                           (codegen:emit-env backend name args))
+      (multiple-value-bind (type-definitions instances env)
+          (tc:toplevel-define-type (parser:program-types program)
+                                   (parser:program-structs program)
+                                   file
+                                   env)
+        (multiple-value-bind (class-definitions env)
+            (tc:toplevel-define-class (parser:program-classes program)
+                                      file
+                                      env)
+          (multiple-value-bind (ty-instances env)
+              (tc:toplevel-define-instance (append instances (parser:program-instances program)) env file)
+            (multiple-value-bind (toplevel-definitions env)
+                (tc:toplevel-define (parser:program-defines program)
+                                    (parser:program-declares program)
                                     file
                                     env)
+              (multiple-value-bind (toplevel-instances)
+                  (tc:toplevel-typecheck-instance ty-instances
+                                                  (append instances (parser:program-instances program))
+                                                  env
+                                                  file)
+                (setf env (tc:toplevel-specialize (parser:program-specializations program) env file))
+                (let ((monomorphize-table (make-hash-table :test #'eq))
+                      (translation-unit (tc:make-translation-unit :types type-definitions
+                                                                  :definitions toplevel-definitions
+                                                                  :classes class-definitions
+                                                                  :instances toplevel-instances
+                                                                  :package *package*)))
+                  (loop :for define :in (parser:program-defines program)
+                        :when (parser:toplevel-define-monomorphize define)
+                          :do (setf (gethash (parser:node-variable-name (parser:toplevel-define-name define))
+                                             monomorphize-table)
+                                    t))
+                  (loop :for declare :in (parser:program-declares program)
+                        :when (parser:toplevel-declare-monomorphize declare)
+                          :do (setf (gethash (parser:identifier-src-name (parser:toplevel-declare-name declare))
+                                             monomorphize-table)
+                                    t))
+                  (analysis:analyze-translation-unit translation-unit env file)
+                  (codegen:compile-translation-unit backend translation-unit monomorphize-table env))))))))))
 
-        (multiple-value-bind (ty-instances env)
-            (tc:toplevel-define-instance (append instances (parser:program-instances program)) env file)
-
-          (multiple-value-bind (toplevel-definitions env)
-              (tc:toplevel-define (parser:program-defines program)
-                                  (parser:program-declares program)
-                                  file
-                                  env)
-
-            (multiple-value-bind (toplevel-instances)
-                (tc:toplevel-typecheck-instance ty-instances
-                                                (append instances (parser:program-instances program))
-                                                env
-                                                file)
-
-              (setf env (tc:toplevel-specialize (parser:program-specializations program) env file))
-
-              (let ((monomorphize-table (make-hash-table :test #'eq))
-
-                    (translation-unit
-                      (tc:make-translation-unit
-                       :types type-definitions
-                       :definitions toplevel-definitions
-                       :classes class-definitions
-                       :instances toplevel-instances
-                       :package *package*)))
-
-                (loop :for define :in (parser:program-defines program)
-                      :when (parser:toplevel-define-monomorphize define)
-                        :do (setf (gethash (parser:node-variable-name (parser:toplevel-define-name define))
-                                           monomorphize-table)
-                                  t))
-
-                (loop :for declare :in (parser:program-declares program)
-                      :when (parser:toplevel-declare-monomorphize declare)
-                        :do (setf (gethash (parser:identifier-src-name (parser:toplevel-declare-name declare))
-                                           monomorphize-table)
-                                  t))
-
-                (analysis:analyze-translation-unit translation-unit env file)
-
-                (multiple-value-bind (program env)
-                    (codegen:compile-translation-unit translation-unit monomorphize-table env)
-
-                  (values
-                   (if settings:*coalton-skip-update*
-                       program
-                       `(progn
-                          (eval-when (:load-toplevel)
-                            (unless (eq (settings:coalton-release-p) ,(settings:coalton-release-p))
-                              ,(if (settings:coalton-release-p)
-                                   `(error "~A was compiled in release mode but loaded in development."
-                                           ,(or *compile-file-pathname* *load-truename*))
-                                   `(error "~A was compiled in development mode but loaded in release."
-                                           ,(or *compile-file-pathname* *load-truename*)))))
-
-                          (let ((coalton-impl/typechecker/environment::env *global-environment*))
-                            ,@(loop :for elem :in (reverse tc:*env-update-log*)
-                                    :collect elem)
-                            (setf *global-environment* coalton-impl/typechecker/environment::env))
-
-                          ,program))
-                   env))))))))))
+(defun emit-prologue (backend)
+  (codegen:emit backend
+                `(eval-when (:load-toplevel)
+                   (unless (eq (settings:coalton-release-p)
+                               ,(settings:coalton-release-p))
+                     ,(if (settings:coalton-release-p)
+                          `(error "~A was compiled in release mode but loaded in development."
+                                  ,(or *compile-file-pathname* *load-truename*))
+                          `(error "~A was compiled in development mode but loaded in release."
+                                  ,(or *compile-file-pathname* *load-truename*)))))))
 
 (defun expression-entry-point (node file)
   (declare (type parser:node node)
@@ -193,24 +175,3 @@
                              :type :secondary
                              :span (tc:node-source node)
                              :message "Add a type assertion with THE to resolve ambiguity")))))))))))
-
-(defun file-entry-point (filename)
-  (declare (type string filename))
-
-  (with-open-file (file-stream filename :if-does-not-exist :error)
-    (let ((coalton-file (error:make-coalton-file
-                         :stream file-stream
-                         :name filename)))
-      (multiple-value-bind (code env)
-          (entry-point (parser:read-program file-stream coalton-file :mode :file))
-
-        (setf *global-environment* env)
-
-        code))))
-
-(defun debug-file-entry-point (filename)
-  (declare (type string filename))
-
-  (let ((settings:*coalton-skip-update* t)
-        (settings:*emit-type-annotations* nil))
-    (file-entry-point filename)))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -2,6 +2,8 @@
   (:use
    #:cl)
   (:local-nicknames
+   (#:codegen #:coalton-impl/codegen)
+   (#:compiler #:coalton-impl/compiler)
    (#:cst #:concrete-syntax-tree)
    (#:settings #:coalton-impl/settings)
    (#:util #:coalton-impl/util)
@@ -15,6 +17,42 @@
 (defvar *coalton-reader-allowed* t
   "Is the Coalton reader allowed to parse the current input?
 Used to forbid reading while inside quasiquoted forms.")
+
+(defun %process-toplevel (stream collector)
+  "Toplevel macro helper: manage stream handles and setup of coalton-file structure, then parse program from stream, then call compiler entry point."
+  (let ((opened-streams nil))
+    (unwind-protect
+         (let* ((pathname (or *compile-file-truename* *load-truename*))
+                (filename (if pathname (namestring pathname) "<unknown>"))
+                (file-input-stream
+                  (cond
+                    ((or #+sbcl (sb-int:form-tracking-stream-p stream)
+                         nil)
+                     (let ((s (open (pathname stream))))
+                       (push s opened-streams)
+                       s))
+                    (t
+                     stream)))
+                (file (error:make-coalton-file :stream file-input-stream :name filename)))
+           (handler-bind
+               ;; render errors and set highlights
+               ((error:coalton-base-error
+                  (lambda (c)
+                    (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
+                    (error:render-coalton-error c)))
+                (error:coalton-base-warning
+                  (lambda (c)
+                    (error:render-coalton-warning c))))
+             (let ((program (parser:read-program stream file)))
+               (entry:emit-prologue collector)
+               (entry:entry-point program collector))))
+      ;; clean up any opened file streams
+      (dolist (s opened-streams)
+        (close s)))))
+
+;; Implementation of toplevel macros
+
+;; Entry point
 
 (defun read-coalton-toplevel-open-paren (stream char)
   (declare (optimize (debug 2)))
@@ -33,112 +71,17 @@ Used to forbid reading while inside quasiquoted forms.")
               form)))
       (case (cst:raw first-form)
         (coalton:coalton-toplevel
-          (let ((opened-streams nil))
-            (unwind-protect
-                 (let* ((pathname (or *compile-file-truename* *load-truename*))
-                        (filename (if pathname (namestring pathname) "<unknown>"))
-
-                        (file-input-stream
-                          (cond
-                            ((or #+sbcl (sb-int:form-tracking-stream-p stream)
-                                 nil)
-                             (let ((s (open (pathname stream))))
-                               (push s opened-streams)
-                               s))
-                            (t
-                             stream)))
-                        (file (error:make-coalton-file :stream file-input-stream :name filename)))
-
-                   (handler-bind
-                       ;; Render errors and set highlights
-                       ((error:coalton-base-error
-                          (lambda (c)
-                            (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                            (error:render-coalton-error c)))
-                        (error:coalton-base-warning
-                          (lambda (c)
-                            (error:render-coalton-warning c))))
-                     (multiple-value-bind (program env)
-                         (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-                       (setf entry:*global-environment* env)
-                       program)))
-              ;; Clean up any opened file streams
-              (dolist (s opened-streams)
-                (close s)))))
-
+          (let ((collector (make-instance 'compiler:compile-toplevel)))
+            (setf entry:*global-environment* (%process-toplevel stream collector))
+            (compiler:toplevel-result collector)))
         (coalton:coalton-codegen
-          (let ((opened-streams nil))
-            (unwind-protect
-                 (let* ((pathname (or *compile-file-truename* *load-truename*))
-                        (filename (if pathname (namestring pathname) "<unknown>"))
-
-                        (file-input-stream
-                          (cond
-                            ((or #+sbcl (sb-int:form-tracking-stream-p stream)
-                                 nil)
-                             (let ((s (open (pathname stream))))
-                               (push s opened-streams)
-                               s))
-                            (t
-                             stream)))
-                        (file (error:make-coalton-file :stream file-input-stream :name filename)))
-
-                   (handler-bind
-                       ;; Render errors and set highlights
-                       ((error:coalton-base-error
-                          (lambda (c)
-                            (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                            (error:render-coalton-error c)))
-                        (error:coalton-base-warning
-                          (lambda (c)
-                            (error:render-coalton-warning c))))
-                     (let ((settings:*coalton-skip-update* t)
-                           (settings:*emit-type-annotations* nil))
-                       (multiple-value-bind (program env)
-                           (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-                         (declare (ignore env))
-                         `',program))))
-              ;; Clean up any opened file streams
-              (dolist (s opened-streams)
-                (close s)))))
-
+          (let ((collector (make-instance 'compiler:generate-code)))
+            (%process-toplevel stream collector)
+            (compiler:codegen-result collector)))
         (coalton:coalton-codegen-ast
-          (let ((opened-streams nil))
-            (unwind-protect
-                 (let* ((pathname (or *compile-file-truename* *load-truename*))
-                        (filename (if pathname (namestring pathname) "<unknown>"))
-
-                        (file-input-stream
-                          (cond
-                            ((or #+sbcl (sb-int:form-tracking-stream-p stream)
-                                 nil)
-                             (let ((s (open (pathname stream))))
-                               (push s opened-streams)
-                               s))
-                            (t
-                             stream)))
-                        (file (error:make-coalton-file :stream file-input-stream :name filename)))
-
-                   (handler-bind
-                       ;; Render errors and set highlights
-                       ((error:coalton-base-error
-                          (lambda (c)
-                            (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                            (error:render-coalton-error c)))
-                        (error:coalton-base-warning
-                          (lambda (c)
-                            (error:render-coalton-warning c))))
-                     (let ((settings:*coalton-skip-update* t)
-                           (settings:*emit-type-annotations* nil)
-                           (settings:*coalton-dump-ast* t))
-                       (multiple-value-bind (program env)
-                           (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-                         (declare (ignore program env))
-                         nil))))
-              ;; Clean up any opened file streams
-              (dolist (s opened-streams)
-                (close s)))))
-
+          (let ((collector (make-instance 'compiler:generate-ast)))
+            (%process-toplevel stream collector)
+            (values)))
         (coalton:coalton
          (let ((opened-streams nil))
            (unwind-protect
@@ -240,29 +183,28 @@ Used to forbid reading while inside quasiquoted forms.")
                      (let ((*coalton-reader-allowed* t))
                        (funcall (get-macro-character #\, (named-readtables:ensure-readtable :standard)) s c)))))
 
-(defmacro coalton:coalton-toplevel (&body forms)
+;; read-in-mode: a helper that sets up the Coalton reader, prepends a
+;; 'mode' to a Coalton source form, serializes that to a string, then
+;; re-reads it. The mode provides a way to select a branch inside
+;; #'read-coalton-toplevel-open-paren; the write/read thing is a way
+;; of cleanly recording source-code offsets.
+
+(defun read-in-mode (mode-symbol forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
         (*compile-file-truename*
           (pathname (format nil "COALTON-TOPLEVEL (~A)" *compile-file-truename*)))
         (*print-circle* t))
-    (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-toplevel forms)))
+    (with-input-from-string (stream (cl:format cl:nil "~S" (cons mode-symbol forms)))
       (cl:read stream))))
+
+(defmacro coalton:coalton-toplevel (&body forms)
+  (read-in-mode 'coalton:coalton-toplevel forms))
 
 (defmacro coalton:coalton-codegen (&body forms)
-  (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*compile-file-truename*
-          (pathname (format nil "COALTON-TOPLEVEL (~A)" *compile-file-truename*)))
-        (*print-circle* t))
-    (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-codegen forms)))
-      (cl:read stream))))
+  (read-in-mode 'coalton:coalton-codegen forms))
 
 (defmacro coalton:coalton-codegen-ast (&body forms)
-  (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*compile-file-truename*
-          (pathname (format nil "COALTON-TOPLEVEL (~A)" *compile-file-truename*)))
-        (*print-circle* t))
-    (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-codegen-ast forms)))
-      (cl:read stream))))
+  (read-in-mode 'coalton:coalton-codegen-ast forms))
 
 (defmacro coalton:coalton (&rest forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))

--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -9,8 +9,6 @@
    #:coalton-release-p                  ; FUNCTION
    #:*coalton-disable-specialization*   ; VARIABLE
    #:*coalton-print-unicode*            ; VARIABLE
-   #:*coalton-dump-ast*                 ; VARIABLE
-   #:*coalton-skip-update*              ; VARIABLE
    #:*emit-type-annotations*            ; VARIABLE
    #:*coalton-optimize*                 ; VARIABLE
    #:*coalton-optimize-library*         ; VARIABLE
@@ -52,14 +50,6 @@ Enable release mode either by setting the UNIX environment variable COALTON_ENV 
             :test #'string-equal)
   (format t "~&;; COALTON starting with specializations disabled")
   (setf *coalton-disable-specialization* t))
-
-;; Configure the backend to print out the ast of toplevel forms
-(declaim (type boolean *coalton-dump-ast*))
-(defvar *coalton-dump-ast* nil)
-
-;; Configure the backend to remove env updates from the generated code
-(declaim (type boolean *coalton-skip-update*))
-(defvar *coalton-skip-update* nil)
 
 ;; Configure the backend to remove type annotations from the generated code
 (declaim (type boolean *emit-type-annotations*))

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -159,7 +159,9 @@
 
         (loop :for method-name :in method-names
               :for method-codegen-sym := (gethash method-name method-codegen-syms) :do
-                (setf env (tc:set-method-inline env method-name instance-codegen-sym method-codegen-sym)))
+                (setf env (tc:set-method-inline env
+                                                (cons method-name instance-codegen-sym)
+                                                method-codegen-sym)))
 
         (values instance-entry env)))))
 

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -9,7 +9,7 @@
                                      :direction :input
                                      :element-type 'character)
                (parser:with-reader-context stream
-                 (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file))))
+                 (parser:read-file stream (error:make-coalton-file :stream stream :name (namestring file))))))
 
            (parse-error-text (file)
              (with-open-file (stream file
@@ -17,7 +17,7 @@
                                      :element-type 'character)
                (handler-case
                    (parser:with-reader-context stream
-                     (parser:read-program stream (error:make-coalton-file :stream stream :name "test") :mode :file))
+                     (parser:read-file stream (error:make-coalton-file :stream stream :name "test")))
                  (error:coalton-base-error (c)
                    (princ-to-string c))))))
     (dolist (file (test-files "tests/parser/*.bad.coalton"))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -41,12 +41,9 @@
                 (file (error:make-coalton-file :stream stream :name "<test>"))
 
                 (program (parser:with-reader-context stream
-                           (parser:read-program stream file :mode :test))))
+                           (parser:read-program stream file))))
 
-           (multiple-value-bind (program env)
-               (entry:entry-point program)
-             (declare (ignore program))
-             
+           (let ((env (entry:entry-point program nil)))
              (when expected-types
                (loop :for (unparsed-symbol . unparsed-type) :in expected-types
                      :for symbol := (intern (string-upcase unparsed-symbol) *package*)


### PR DESCRIPTION
Define a backend protocol to support multiple output schemes. Instead of collecting and returning code and environment from the compiler entry point, and consing an environment update log, provide functions for incremental output (emit, emit-env), and return only the functionally-updated environment, which caller can keep or discard.

Deduplicate set-code environment updates, which reduces FASL size a bit, about 10% on ARM, and a little more on AMD64.