### PR TITLE
don't enforce a default float format

### DIFF
--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -517,10 +517,7 @@ consume all attributes"))))
 (defun read-expression (stream file)
   (let* (;; Setup eclector readtable
          (eclector.readtable:*readtable*
-           (eclector.readtable:copy-readtable eclector.readtable:*readtable*))
-
-         ;; Read unspecified floats as double floats
-         (*read-default-float-format* 'double-float))
+           (eclector.readtable:copy-readtable eclector.readtable:*readtable*)))
 
     ;; Read the coalton form
     (multiple-value-bind (form presentp)


### PR DESCRIPTION
Does this address #1073?

Eclector reader setup is resetting \*read-default-float-format\*.