### PR TITLE
Configurable AST collection

### DIFF
--- a/src/codegen/package.lisp
+++ b/src/codegen/package.lisp
@@ -27,6 +27,8 @@
 
   (:import-from
    #:coalton-impl/codegen/program
-   #:compile-translation-unit)
+   #:compile-translation-unit
+   #:*codegen-hook*)
   (:export
-   #:compile-translation-unit))
+   #:compile-translation-unit
+   #:*codegen-hook*))

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -270,3 +270,15 @@
            (t
             (with-output-to-string (lisp-stream)
               (compile-to-lisp coal-file-name coal-stream lisp-stream)))))))))
+
+(defun get-ast (stream)
+  "Read Coalton source from STREAM and collect AST of toplevel definitions."
+  (parser:with-reader-context stream
+    (let* ((ast nil)
+           (codegen:*codegen-hook* (lambda (op &rest args)
+                                     (when (eql op :ast)
+                                       (push args ast)))))
+      (let ((file (se:make-file :stream stream
+                                :name "<stream>")))
+        (entry-point (parser:read-program stream file :mode :file)))
+      (nreverse ast))))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -4,6 +4,7 @@
   (:local-nicknames
    (#:se #:source-error)
    (#:cst #:concrete-syntax-tree)
+   (#:codegen #:coalton-impl/codegen)
    (#:settings #:coalton-impl/settings)
    (#:util #:coalton-impl/util)
    (#:parser #:coalton-impl/parser)
@@ -85,10 +86,15 @@ Used to forbid reading while inside quasiquoted forms.")
 
         (coalton:coalton-codegen-ast
           (with-coalton-file (file stream)
-            (let ((settings:*emit-type-annotations* nil)
-                  (settings:*coalton-dump-ast* t))
+            (let* ((settings:*emit-type-annotations* nil)
+                   (ast nil)
+                   (codegen:*codegen-hook* (lambda (op &rest args)
+                                             (when (eql op :ast)
+                                               (push args ast)))))
               (entry:entry-point (parser:read-program stream file :mode ':toplevel-macro))
-              nil)))
+              (loop :for (name type value) :in (nreverse ast)
+                    :do (format t "~A :: ~A~%~A~%~%~%" name type value))))
+          nil)
 
         (coalton:coalton
           (with-coalton-file (file stream)

--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -9,7 +9,6 @@
    #:coalton-release-p                  ; FUNCTION
    #:*coalton-disable-specialization*   ; VARIABLE
    #:*coalton-print-unicode*            ; VARIABLE
-   #:*coalton-dump-ast*                 ; VARIABLE
    #:*emit-type-annotations*            ; VARIABLE
    #:*coalton-optimize*                 ; VARIABLE
    #:*coalton-optimize-library*         ; VARIABLE
@@ -51,10 +50,6 @@ Enable release mode either by setting the UNIX environment variable COALTON_ENV 
             :test #'string-equal)
   (format t "~&;; COALTON starting with specializations disabled")
   (setf *coalton-disable-specialization* t))
-
-;; Configure the backend to print out the ast of toplevel forms
-(declaim (type boolean *coalton-dump-ast*))
-(defvar *coalton-dump-ast* nil)
 
 ;; Configure the backend to remove type annotations from the generated code
 (declaim (type boolean *emit-type-annotations*))


### PR DESCRIPTION
Instead of writing AST info to stdout, code generator provides values to an output hook function under control of caller, which can decide what to do with the values.

This is to support returning these structures to Emacs via swank.