### PR TITLE
Restore coalton-codegen-types

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -18,6 +18,7 @@
    #:coalton-toplevel
    #:coalton-codegen
    #:coalton-codegen-ast
+   #:coalton-codegen-types
    #:coalton
    #:declare
    #:define


### PR DESCRIPTION
Add `coalton-codegen-types` macro, to emit code including Lisp type declarations.

Closes #1017