### PR TITLE
Add optional docstring for struct fields

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -354,6 +354,7 @@
                (:file "string-tests")
                (:file "recursive-let-tests")
                (:file "class-tests")
+               (:file "struct-tests")
                (:file "list-tests")
                (:file "red-black-tests")
                (:file "seq-tests")

--- a/examples/small-coalton-programs/src/brainfold.lisp
+++ b/examples/small-coalton-programs/src/brainfold.lisp
@@ -48,9 +48,9 @@
 (coalton-toplevel
 
   (define-struct State
-    (memory (Vector Integer))
-    (pointer (Cell UFix))
-    (print-buffer (Cell String)))
+    (memory "The brainfold memory array." (Vector Integer))
+    (pointer "A pointer to the current register." (Cell UFix))
+    (print-buffer "The print buffer." (Cell String)))
   
   ;;
   ;; Generating a Brainfold memory vector

--- a/library/math/dual.lisp
+++ b/library/math/dual.lisp
@@ -75,11 +75,12 @@ References:
 
 (coalton-toplevel
 
-  (define-type (Dual :t)
+  (define-struct (Dual :t)
     "Representation of a dual number in the form `a + bε` where `a` and `b` are real numbers and `ε` satisfies `ε^2 = 0` and `ε != 0`.
 
 Note: `Eq`, and `Ord` and `Hash` only make use of the primal component."
-    (Dual :t :t))
+    (primal-part "The primal part." :t)
+    (dual-part "The dual part." :t))
 
   (declare primal-part (Dual :t -> :t))
   (define (primal-part (Dual p _))

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -23,11 +23,12 @@
 
 (defstruct (documentation-struct-entry
             (:include documentation-entry))
-  (type      (util:required 'type)      :type tc:ty                     :read-only t)
-  (tyvars    (util:required 'tyvars)    :type tc:tyvar-list             :read-only t)
-  (fields    (util:required 'fields)    :type util:string-list          :read-only t)
-  (field-tys (util:required 'field-tys) :type hash-table                :read-only t)
-  (instances (util:required 'instances) :type tc:ty-class-instance-list :read-only t))
+  (type             (util:required 'type)             :type tc:ty                     :read-only t)
+  (tyvars           (util:required 'tyvars)           :type tc:tyvar-list             :read-only t)
+  (fields           (util:required 'fields)           :type util:string-list          :read-only t)
+  (field-docstrings (util:required 'field-docstrings) :type hash-table                :read-only t)
+  (field-tys        (util:required 'field-tys)        :type hash-table                :read-only t)
+  (instances        (util:required 'instances)        :type tc:ty-class-instance-list :read-only t))
 
 (defun documentation-struct-entry-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -422,6 +423,7 @@
                     :type (tc:type-entry-type entry)
                     :tyvars (tc:type-entry-tyvars entry)
                     :fields (tc:struct-entry-fields struct-entry)
+                    :field-docstrings (tc:struct-entry-field-docstrings struct-entry)
                     :field-tys (tc:struct-entry-field-tys struct-entry)
                     :instances applicable-instances)
                    output-structs))

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -166,7 +166,7 @@
         (format stream "~%</details>~%~%")))))
 
 (defmethod write-documentation ((backend (eql ':markdown)) stream (object documentation-struct-entry))
-  (with-slots (name type tyvars fields field-tys instances documentation)
+  (with-slots (name type tyvars fields field-docstrings field-tys instances documentation)
       object
     (tc:with-pprint-variable-context ()
       (format stream
@@ -177,9 +177,13 @@
 
       (loop :for field :in fields
             :for field-ty := (gethash field field-tys)
-            :do (format stream "- <code>~A :: ~S</code>~%"
+            :for field-docstring := (gethash field field-docstrings)
+            :do (format stream "- <code>~A :: ~S</code>~A~%"
                         field
-                        field-ty))
+                        field-ty
+                        (if field-docstring
+                            (format nil "<br/>~a" field-docstring)
+                            "")))
 
       (when documentation
         (format stream "~%~A~%"

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -632,6 +632,7 @@
     (make-struct-field
      :name (struct-field-name field)
      :type (rename-type-variables-generic% (struct-field-type field) ctx)
+     :docstring (struct-field-docstring field)
      :source (struct-field-source field)))
 
   (:method ((toplevel toplevel-define-struct) ctx)

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -232,6 +232,12 @@
   (cond ((typep parsed-type 'parser:toplevel-define-struct)
          (let* ((fields (mapcar #'parser:struct-field-name
                                 (parser:toplevel-define-struct-fields parsed-type)))
+                (field-docstrings (loop :with table := (make-hash-table :test #'equal)
+                                        :for field :in fields
+                                        :for docstring :in (mapcar #'parser:struct-field-docstring
+                                                                   (parser:toplevel-define-struct-fields parsed-type))
+                                        :do (setf (gethash field table) docstring)
+                                        :finally (return table)))
                 (field-tys (loop :with table := (make-hash-table :test #'equal)
                                  :for field :in fields
                                  :for ty :in (first (type-definition-constructor-args type))
@@ -248,6 +254,7 @@
                       (tc:make-struct-entry
                        :name (type-definition-name type)
                        :fields fields
+                       :field-docstrings field-docstrings
                        :field-tys field-tys
                        :field-idx field-idx)))))
         ((tc:lookup-struct env (type-definition-name type) :no-error t)

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -54,6 +54,7 @@
    #:struct-entry-name                      ; ACCESSOR
    #:struct-entry-fields                    ; ACCESSOR
    #:struct-entry-field-tys                 ; ACCESSOR
+   #:struct-entry-field-docstrings          ; ACCESSOR
    #:struct-entry-field-idx                 ; ACCESSOR`
    #:struct-entry-list                      ; TYPE
    #:struct-environment                     ; STRUCT
@@ -490,15 +491,16 @@
 ;;;
 
 (defstruct struct-entry
-  (name      (util:required 'name)      :type symbol           :read-only t)
-  (fields    (util:required 'fields)    :type util:string-list :read-only t)
+  (name             (util:required 'name)             :type symbol           :read-only t)
+  (fields           (util:required 'fields)           :type util:string-list :read-only t)
 
+  (field-docstrings (util:required 'field-docstrings) :type hash-table       :read-only t)
   ;; Mapping of "field name" -> "field type"
   ;; Type variables are the same as in `type-entry-type'
-  (field-tys (util:required 'field-tys) :type hash-table       :read-only t)
+  (field-tys        (util:required 'field-tys)        :type hash-table       :read-only t)
 
   ;; Mapping of "field name" -> "field index"
-  (field-idx (util:required 'field-idx) :type hash-table       :read-only t))
+  (field-idx        (util:required 'field-idx)        :type hash-table       :read-only t))
 
 (defmethod make-load-form ((self struct-entry) &optional env)
   (make-load-form-saving-slots self :environment env))

--- a/tests/struct-tests.lisp
+++ b/tests/struct-tests.lisp
@@ -5,13 +5,50 @@
 (deftest test-struct-definition ()
   (check-coalton-types
    "(define-struct Point
-      (x Integer)
+      (x \"The x value.\" Integer)
       (y Integer))")
 
   (check-coalton-types
-   "(define-type (Point :a)
+   "(define-struct (Point :a)
       (x :a)
-      (y :a))"))
+      (y \"The y value.\" :a))"))
+
+(deftest test-struct-definition-parse-errors ()
+  (signals parser:parse-error
+    (check-coalton-types
+     "(define-struct Point
+        5
+        (y Integer))"))
+
+  (signals parser:parse-error
+    (check-coalton-types
+     "(define-struct Point
+        (5 Integer)
+        (y Integer))"))
+
+  (signals parser:parse-error
+    (check-coalton-types
+     "(define-struct Point
+        (x)
+        (y Integer))"))
+
+  (signals parser:parse-error
+    (check-coalton-types
+     "(define-struct Point
+        (x \"the x value.\")
+        (y Integer))"))
+
+  (signals parser:parse-error
+    (check-coalton-types
+     "(define-struct Point
+        (x Integer \"the x value\")
+        (y Integer))"))
+
+  (signals parser:parse-error
+    (check-coalton-types
+     "(define-struct Point
+        (x \"the x value\" Integer \"also, it's the x value\")
+        (y Integer))")))
 
 (deftest test-struct-accessors ()
   (check-coalton-types


### PR DESCRIPTION
This adds docstring support for struct fields:

```
(coalton-toplevel

  (define-struct turtle
    (Shell "Does this turtle have a shell?" Boolean)
    (ThirdEye "Is this actually a terrapin?" Boolean)
    (ShellDensity Double-Float))) ;; docstrings aren't required
```

fixes #1118