### PR TITLE
Draft: Adds type constructor docstring support

### DIFF
--- a/examples/small-coalton-programs/src/brainfold.lisp
+++ b/examples/small-coalton-programs/src/brainfold.lisp
@@ -48,9 +48,9 @@
 (coalton-toplevel
 
   (define-struct State
-    (memory (Vector Integer))
-    (pointer (Cell UFix))
-    (print-buffer (Cell String)))
+    (memory (Vector Integer) "The brainfold memory array.")
+    (pointer (Cell UFix) "A pointer to the current register.")
+    (print-buffer (Cell String) "The print buffer."))
   
   ;;
   ;; Generating a Brainfold memory vector

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -632,6 +632,7 @@
     (make-struct-field
      :name (struct-field-name field)
      :type (rename-type-variables-generic% (struct-field-type field) ctx)
+     :docstring (struct-field-docstring field)
      :source (struct-field-source field)))
 
   (:method ((toplevel toplevel-define-struct) ctx)

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -592,6 +592,7 @@
     (make-constructor
      :name (constructor-name ctor)
      :fields (rename-type-variables-generic% (constructor-fields ctor) ctx)
+     :docstring (constructor-docstring ctor)
      :source (constructor-source ctor)))
 
   (:method ((keyword keyword-src) ctx)

--- a/src/parser/types.lisp
+++ b/src/parser/types.lisp
@@ -290,7 +290,8 @@
          (make-tyvar :name (cst:raw form) :source (cst:source form))
          (make-tycon :name (cst:raw form) :source (cst:source form))))
 
-    ((cst:atom form)
+    ((and (cst:atom form)
+          (not (stringp (cst:raw form))))
      (error 'parse-error
             :err (coalton-error
                   :span (cst:source form)

--- a/tests/struct-tests.lisp
+++ b/tests/struct-tests.lisp
@@ -5,13 +5,13 @@
 (deftest test-struct-definition ()
   (check-coalton-types
    "(define-struct Point
-      (x Integer)
+      (x Integer \"The x value.\")
       (y Integer))")
 
   (check-coalton-types
    "(define-type (Point :a)
       (x :a)
-      (y :a))"))
+      (y :a \"The y value.\"))"))
 
 (deftest test-struct-accessors ()
   (check-coalton-types


### PR DESCRIPTION
This adds docstrings for type constructor definitions. 

Currently it's fast and loose:

```
(coalton-toplevel

  (define-type Fish
    (Saltwater "A saltwater fish" String "the name of the fish" UFix "The number of fins")
    (Freshwater "A Freshwater fish" String "the name of the fish")))
```

I think probably the ideal syntax would be:
```
(coalton-toplevel

  (define-type Fish
    (Saltwater (String "Fish Name") (UFix "The number of fins") "A Saltwater fish.")
    (Freshwater (String "Fish Name") (Double-Float "How fresh really?") "A Freshwater fish.")))
```
Or we can limit it to:
```
(coalton-toplevel

  (define-type Fish
    (Saltwater "A saltwater fish" String UFix)
    (Freshwater "A Freshwater fish" String  Double-Float)))
```