### PR TITLE
Docstring support for Class methods

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -57,7 +57,7 @@
  ;;
  (define-class (Signalable :a)
    "Signals errors or warnings by calling their respective lisp conditions."
-   (error (:a -> :b)))
+   (error "Signal an error with a type-specific error string." (:a -> :b)))
 
   (define-instance (Signalable String)
     (define (error str)
@@ -228,13 +228,9 @@
     (empty (:f :a)))
 
   (define-class (Foldable :container)
-    "Types which can be folded into a single element.
-
-`fold` is a left tail recursive fold.
-
-`foldr` is a right non tail recursive fold."
-    (fold ((:accum -> :elt -> :accum) -> :accum -> :container :elt -> :accum))
-    (foldr ((:elt -> :accum -> :accum) -> :accum -> :container :elt -> :accum)))
+    "Types which can be folded into a single element."
+    (fold  "A left tail-recursive fold."       ((:accum -> :elt -> :accum) -> :accum -> :container :elt -> :accum))
+    (foldr "A right non-tail-recursive fold."  ((:elt -> :accum -> :accum) -> :accum -> :container :elt -> :accum)))
 
   (declare mconcat ((Foldable :f) (Monoid :a) => :f :a -> :a))
   (define mconcat

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -39,10 +39,12 @@
 
 (defstruct (documentation-class-entry
             (:include documentation-entry))
-  (context   (util:required 'context)   :type t :read-only t)
-  (predicate (util:required 'predicate) :type t :read-only t)
-  (methods   (util:required 'methods)   :type t :read-only t)
-  (instances (util:required 'instances) :type t :read-only t))
+  (context   (util:required 'context)                   :type t :read-only t)
+  (predicate (util:required 'predicate)                 :type t :read-only t)
+  (methods   (util:required 'methods)                   :type t :read-only t)
+  ;; A list of strings in the same order as the methods slot
+  (method-docstrings (util:required 'method-docstrings) :type t :read-only t)
+  (instances (util:required 'instances)                 :type t :read-only t))
 
 (defun documentation-class-entry-list-p (x)
   (and (every #'documentation-class-entry-p x)
@@ -454,6 +456,7 @@
                          (lambda (binding)
                            (exported-symbol-p (car binding) package t))
                          (tc:ty-class-unqualified-methods e))
+               :method-docstrings (tc:ty-class-method-docstrings e)
                :instances (reverse (fset:convert 'list (tc:lookup-class-instances env (tc:ty-class-name e) :no-error t)))
                :documentation (tc:ty-class-docstring e)
                :location (tc:ty-class-location e)))

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -203,7 +203,7 @@
         (format stream "~%</details>~%~%")))))
 
 (defmethod write-documentation ((backend (eql ':markdown)) stream (object documentation-class-entry))
-  (with-slots (name context predicate methods instances documentation location)
+  (with-slots (name context predicate methods method-docstrings instances documentation location)
       object
 
     (format stream "#### <code>~A</code> <sup><sub>[CLASS]</sub></sup><a name=\"~(~:*~A-class~)\"></a>~%"
@@ -226,10 +226,13 @@
                  :regex "[<>&]")))
 
       (format stream "Methods:~%")
-      (loop :for (name . type) :in methods :do
-        (format stream "- <code>~A :: ~A</code>~%"
+      (loop :for (name . type) :in methods
+            :for docstring     :in method-docstrings :do
+
+        (format stream "- <code>~A :: ~A</code>~@[<br/>~A~]~%"
                 (html-entities:encode-entities (symbol-name name))
-                (to-markdown type))))
+                (to-markdown type)
+                (html-entities:encode-entities docstring))))
 
     (when instances
       (format stream "~%<details>~%")

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -680,6 +680,7 @@
       (make-method-definition
        :name (method-definition-name method)
        :type (rename-type-variables-generic% (method-definition-type method) new-ctx)
+       :docstring (method-definition-docstring method)
        :source (method-definition-source method))))
 
   (:method ((toplevel toplevel-define-class) ctx)

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -296,6 +296,8 @@
                                                                   (parser:method-definition-name method))
 
                                              :collect (cons method-name (tc:quantify nil method-ty)))
+                  :method-docstrings (mapcar #'parser:method-definition-docstring
+                                             (parser:toplevel-define-class-methods class))
                   :codegen-sym codegen-sym
                   :superclass-dict superclass-dict
                   :superclass-map superclass-map

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -67,6 +67,7 @@
    #:ty-class-class-variable-map            ; ACCESSOR
    #:ty-class-fundeps                       ; ACCESSOR
    #:ty-class-unqualified-methods           ; ACCESSOR
+   #:ty-class-method-docstrings             ; ACCESSOR
    #:ty-class-codegen-sym                   ; ACCESSOR
    #:ty-class-superclass-dict               ; ACCESSOR
    #:ty-class-superclass-map                ; ACCESSOR
@@ -531,6 +532,9 @@
   ;; Methods of the class containing the same tyvars in PREDICATE for
   ;; use in pretty printing
   (unqualified-methods (util:required 'unqualified-methods) :type scheme-binding-list :read-only t)
+  ;; Method-docstrings is a list of Strings or Nils, in the same order
+  ;; as the unqualified-methods
+  (method-docstrings   (util:required 'method-docstrings)   :type list                :read-only t)
   (codegen-sym         (util:required 'codegen-sym)         :type symbol              :read-only t)
   (superclass-dict     (util:required 'superclass-dict)     :type list                :read-only t)
   (superclass-map      (util:required 'superclass-map)      :type hash-table          :read-only t)
@@ -564,6 +568,7 @@
                                   (cons (car entry)
                                         (apply-substitution subst-list (cdr entry))))
                                 (ty-class-unqualified-methods class))
+   :method-docstrings (ty-class-method-docstrings class)
    :codegen-sym (ty-class-codegen-sym class)
    :superclass-dict (mapcar (lambda (entry)
                               (cons (apply-substitution subst-list (car entry))

--- a/tests/parser-test-files/good-files/define-class.coal
+++ b/tests/parser-test-files/good-files/define-class.coal
@@ -13,6 +13,18 @@
   (m1 :a)
   (m2 (:a -> :b)))
 
+(define-class (C5 :a)
+  (m3 "Method m3" :a)
+  (m4 (:a -> :b)))
+
+(define-class (C6 :a)
+  (m5 :a)
+  (m6 "Method m6" (:a -> :b)))
+
+(define-class (C7 :a)
+  (m7 "Method m7" :a)
+  (m8 "Method m8" (:a -> :b)))
+
 (define-class (C :a :b (:a -> :b)))
 
 (define-class (C :a :b :c :d (:a :b -> :c :d)))


### PR DESCRIPTION
This adds docstring support for class methods.

```
(coalton-toplevel

  (define-class (Greetable :a)
    (Greet "This method greets." (:a -> Unit))))
```

If approved I'll make a subsequent PR for adding these to the documentation generator.