### PR TITLE
Fix monomorphizer underapplication

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -360,4 +360,5 @@
                (:file "seq-tests")
                (:file "unused-variables")
                (:file "pattern-matching-tests")
-               (:file "looping-native-tests")))
+               (:file "looping-native-tests")
+               (:file "monomorphizer-tests")))

--- a/src/codegen/monomorphize.lisp
+++ b/src/codegen/monomorphize.lisp
@@ -281,15 +281,18 @@ recompilation, and also maintains a stack of uncompiled candidates."
               ((< (length (compile-candidate-args candidate)) (length (node-abstraction-vars node)))
                (let* ((remaining-parameters (util:drop (length (compile-candidate-args candidate)) (node-abstraction-vars node))))
 
-                 (tc:apply-substitution
-                  subs
-                  (make-node-abstraction
-                   :vars new-vars
-                   :type (tc:make-function-type* arg-tys new-type)
-                   :subexpr (make-node-abstraction
-                             :type new-type
-                             :vars remaining-parameters
-                             :subexpr subexpr)))))
+                 (let ((inner-abs (make-node-abstraction
+                                   :type new-type
+                                   :vars remaining-parameters
+                                   :subexpr subexpr)))
+                   (if (null new-vars)
+                       (tc:apply-substitution subs inner-abs)
+                       (tc:apply-substitution
+                        subs
+                        (make-node-abstraction
+                         :vars new-vars
+                         :type (tc:make-function-type* arg-tys new-type)
+                         :subexpr inner-abs))))))
 
               (t
                (util:unreachable)))))

--- a/tests/monomorphizer-tests.lisp
+++ b/tests/monomorphizer-tests.lisp
@@ -31,6 +31,19 @@
 
 
 (coalton-toplevel
+  (monomorphize)
+  (declare underapplication-c
+           ((List coalton-library/big-float:Big-Float) -> coalton-library/big-float:Big-Float))
+  (define (underapplication-c xs)
+    (match (list:maximum (append xs (map (fn (x) (* x x)) xs)))
+      ((Some x) x)
+      ((None) 0))))
+
+(define-test test-monomorphizer-under-application-non-inline-method ()
+  (is (== 9 (underapplication-c (make-list -1 -2 -3)))))
+
+
+(coalton-toplevel
   (define (partial-monomorphization-a x y z)
     (== x y)
     (+ 1 z))


### PR DESCRIPTION
The monomorphizer fails when compiling a `COMPILE-CANDIDATE` that meets the following criteria:

- The `NAME` refers to a method.
- The method is underapplied.
- The `ARGS` are only statically known dictionaries and nothing else.
- The method is not inline for the argument dictionaries.

Such a `COMPILE-CANDIDATE` could be found, for example, when `COALTON-LIBRARY/LIST:MAXIMUM` is applied to a `(List Big-Float)` because `COALTON-LIBRARY/LIST:MAXIMUM` implicitly underapplies `>` to `Big-Float`'s instance of `Ord`, which does not inline the `>` method.

This PR fixes this case in the monomorphizer, adds a test for it, and adds the monomorphizer tests to the Coalton test suite. 

`cl-quil/discrete` now builds and passes its tests with [this `(monomorphize)`](https://github.com/quil-lang/quilc/blob/c181970798e398fade1d2b374e7f4d5806d0e897/src/discrete/rz-approx/generate-solution.lisp#L151) added back.