### PR TITLE
lisp-toplevel in coalton files

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -27,7 +27,12 @@
   :version (:read-file-form "VERSION.txt")
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t)
-                          #+sbcl (sb-ext:*block-compile-default* :specified))
+                          #+sbcl (sb-ext:*block-compile-default* :specified)
+                          ;; The lisp-toplevel form is currently
+                          ;; restricted to standard library
+                          ;; implementation by checking for the
+                          ;; presence of this feature.
+                          (*features* (cons ':coalton-lisp-toplevel *features*)))
                       (funcall compile)))
   :defsystem-depends-on (#:coalton-asdf)
   :depends-on (#:coalton-compiler

--- a/library/math/num.lisp
+++ b/library/math/num.lisp
@@ -24,30 +24,33 @@
 #+coalton-release
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
+(coalton-toplevel
+
 ;;;
 ;;; Constants
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defconstant +fixnum-bits+
-    #+sbcl sb-vm:n-fixnum-bits
-    #-sbcl (cl:1+ (cl:floor (cl:log cl:most-positive-fixnum 2))))
-  (cl:defconstant +unsigned-fixnum-bits+
-    (cl:1- +fixnum-bits+)))
+  (lisp-toplevel ()
+
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defconstant +fixnum-bits+
+        #+sbcl sb-vm:n-fixnum-bits
+        #-sbcl (cl:1+ (cl:floor (cl:log cl:most-positive-fixnum 2))))
+      (cl:defconstant +unsigned-fixnum-bits+
+        (cl:1- +fixnum-bits+)))
 
 ;;;
 ;;; Eq Instances
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-eq (type)
-    `(define-instance (Eq ,type)
-       (define (== a b)
-         (lisp Boolean (a b)
-           ;; Use cl:= so that (== 0.0 -0.0) => True
-           (cl:= a b))))))
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-eq (type)
+        `(define-instance (Eq ,type)
+           (define (== a b)
+             (lisp Boolean (a b)
+               ;; Use cl:= so that (== 0.0 -0.0) => True
+               (cl:= a b)))))))
 
-(coalton-toplevel
   (define-eq Integer)
   (define-eq IFix)
   (define-eq UFix)
@@ -60,59 +63,60 @@
   (define-eq I64)
   (define-eq U64)
   (define-eq Single-Float)
-  (define-eq Double-Float))
+  (define-eq Double-Float)
 
 ;;;
 ;;; Ord Instances
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-ord (type)
-    (cl:let ((>-spec (alexandria:format-symbol cl:*package* "~A->" type))
-             (>=-spec (alexandria:format-symbol cl:*package* "~A->=" type))
-             (<-spec (alexandria:format-symbol cl:*package* "~A-< type" type))
-             (<=-spec (alexandria:format-symbol cl:*package* "~A-<=" type)))
+  (lisp-toplevel ()
 
-      ;; Generates the instance and specializations to use more direct
-      ;; comparison functions when possible.
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-ord (type)
+        (cl:let ((>-spec (alexandria:format-symbol cl:*package* "~A->" type))
+                 (>=-spec (alexandria:format-symbol cl:*package* "~A->=" type))
+                 (<-spec (alexandria:format-symbol cl:*package* "~A-< type" type))
+                 (<=-spec (alexandria:format-symbol cl:*package* "~A-<=" type)))
 
-      `(progn
-         (define-instance (Ord ,type)
-           (define (<=> a b)
-             (lisp Ord (a b)
-               (cl:cond
-                 ((cl:< a b)
-                  LT)
-                 ((cl:> a b)
-                  GT)
-                 (cl:t
-                  EQ)))))
+          ;; Generates the instance and specializations to use more direct
+          ;; comparison functions when possible.
 
-         (specialize > ,>-spec (,type -> ,type -> Boolean))
-         (declare ,>-spec (,type -> ,type -> Boolean))
-         (define (,>-spec a b)
-           (lisp Boolean (a b)
-             (to-boolean (cl:> a b))))
+          `(progn
+             (define-instance (Ord ,type)
+               (define (<=> a b)
+                 (lisp Ord (a b)
+                   (cl:cond
+                     ((cl:< a b)
+                      LT)
+                     ((cl:> a b)
+                      GT)
+                     (cl:t
+                      EQ)))))
 
-         (specialize >= ,>=-spec (,type -> ,type -> Boolean))
-         (declare ,>=-spec (,type -> ,type -> Boolean))
-         (define (,>=-spec a b)
-           (lisp Boolean (a b)
-             (to-boolean (cl:>= a b))))
+             (specialize > ,>-spec (,type -> ,type -> Boolean))
+             (declare ,>-spec (,type -> ,type -> Boolean))
+             (define (,>-spec a b)
+               (lisp Boolean (a b)
+                 (to-boolean (cl:> a b))))
 
-         (specialize < ,<-spec (,type -> ,type -> Boolean))
-         (declare ,<-spec (,type -> ,type -> Boolean))
-         (define (,<-spec a b)
-           (lisp Boolean (a b)
-             (to-boolean (cl:< a b))))
+             (specialize >= ,>=-spec (,type -> ,type -> Boolean))
+             (declare ,>=-spec (,type -> ,type -> Boolean))
+             (define (,>=-spec a b)
+               (lisp Boolean (a b)
+                 (to-boolean (cl:>= a b))))
 
-         (specialize <= ,<=-spec (,type -> ,type -> Boolean))
-         (declare ,<=-spec (,type -> ,type -> Boolean))
-         (define (,<=-spec a b)
-           (lisp Boolean (a b)
-             (to-boolean (cl:<= a b))))))))
+             (specialize < ,<-spec (,type -> ,type -> Boolean))
+             (declare ,<-spec (,type -> ,type -> Boolean))
+             (define (,<-spec a b)
+               (lisp Boolean (a b)
+                 (to-boolean (cl:< a b))))
 
-(coalton-toplevel
+             (specialize <= ,<=-spec (,type -> ,type -> Boolean))
+             (declare ,<=-spec (,type -> ,type -> Boolean))
+             (define (,<=-spec a b)
+               (lisp Boolean (a b)
+                 (to-boolean (cl:<= a b)))))))))
+
   (define-ord Integer)
   (define-ord IFix)
   (define-ord UFix)
@@ -125,83 +129,85 @@
   (define-ord I64)
   (define-ord U64)
   (define-ord Single-Float)
-  (define-ord Double-Float))
+  (define-ord Double-Float)
 
 ;;;
 ;;; Overflow checks for signed values
 ;;;
 
-(cl:declaim (cl:inline %unsigned->signed))
-(cl:defun %unsigned->signed (bits x)
-  ;; This is the two's complement conversion of X (interpreted as BITS
-  ;; bits) to a signed integer (as a Lisp object).
-  (cl:-
-   (cl:ldb (cl:byte (cl:1- bits) 0) x)
-   (cl:dpb 0 (cl:byte (cl:1- bits) 0) x)))
+  (lisp-toplevel ()
 
-(cl:defmacro %define-overflow-handler (name bits)
-  `(cl:progn
-     (cl:declaim (cl:inline ,name))
-     (cl:defun ,name (value)
-       (cl:typecase value
-         ((cl:signed-byte ,bits) value)
-         (cl:otherwise
-          (cl:cerror "Continue, wrapping around."
-                     ,(cl:format cl:nil "Signed value overflowed ~D bits." bits))
-          (%unsigned->signed ,bits (cl:mod value ,(cl:expt 2 bits))))))))
+    (cl:declaim (cl:inline %unsigned->signed))
+    (cl:defun %unsigned->signed (bits x)
+      ;; This is the two's complement conversion of X (interpreted as BITS
+      ;; bits) to a signed integer (as a Lisp object).
+      (cl:-
+       (cl:ldb (cl:byte (cl:1- bits) 0) x)
+       (cl:dpb 0 (cl:byte (cl:1- bits) 0) x)))
+
+    (cl:defmacro %define-overflow-handler (name bits)
+      `(cl:progn
+         (cl:declaim (cl:inline ,name))
+         (cl:defun ,name (value)
+           (cl:typecase value
+             ((cl:signed-byte ,bits) value)
+             (cl:otherwise
+              (cl:cerror "Continue, wrapping around."
+                         ,(cl:format cl:nil "Signed value overflowed ~D bits." bits))
+              (%unsigned->signed ,bits (cl:mod value ,(cl:expt 2 bits))))))))
 
 
-(%define-overflow-handler %handle-8bit-overflow 8)
-(%define-overflow-handler %handle-16bit-overflow 16)
-(%define-overflow-handler %handle-32bit-overflow 32)
-(%define-overflow-handler %handle-64bit-overflow 64)
-(%define-overflow-handler %handle-fixnum-overflow #.+fixnum-bits+)
+    (%define-overflow-handler %handle-8bit-overflow 8)
+    (%define-overflow-handler %handle-16bit-overflow 16)
+    (%define-overflow-handler %handle-32bit-overflow 32)
+    (%define-overflow-handler %handle-64bit-overflow 64)
+    (%define-overflow-handler %handle-fixnum-overflow #.+fixnum-bits+)
 
 ;;;
 ;;; Num instances for integers
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-num-checked (type overflow-handler)
-    "Define a `Num' instance for TYPE which signals on overflow."
-    `(define-instance (Num ,type)
-       (define (+ a b)
-         (lisp ,type (a b)
-           (,overflow-handler (cl:+ a b))))
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-num-checked (type overflow-handler)
+        "Define a `Num' instance for TYPE which signals on overflow."
+        `(define-instance (Num ,type)
+           (define (+ a b)
+             (lisp ,type (a b)
+               (,overflow-handler (cl:+ a b))))
 
-       (define (- a b)
-         (lisp ,type (a b)
-           (,overflow-handler (cl:- a b))))
+           (define (- a b)
+             (lisp ,type (a b)
+               (,overflow-handler (cl:- a b))))
 
-       (define (* a b)
-         (lisp ,type (a b)
-           (,overflow-handler (cl:* a b))))
+           (define (* a b)
+             (lisp ,type (a b)
+               (,overflow-handler (cl:* a b))))
 
-       (define (fromInt x)
-         (lisp ,type (x)
-           (,overflow-handler x))))))
+           (define (fromInt x)
+             (lisp ,type (x)
+               (,overflow-handler x))))))
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-num-wrapping (type bits)
-    "Define a `Num' instance for TYPE which wraps on overflow."
-    `(define-instance (Num ,type)
-       (define (+ a b)
-         (lisp ,type (a b)
-           (cl:values (cl:mod (cl:+ a b) ,(cl:expt 2 bits)))))
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-num-wrapping (type bits)
+        "Define a `Num' instance for TYPE which wraps on overflow."
+        `(define-instance (Num ,type)
+           (define (+ a b)
+             (lisp ,type (a b)
+               (cl:values (cl:mod (cl:+ a b) ,(cl:expt 2 bits)))))
 
-       (define (- a b)
-         (lisp ,type (a b)
-           (cl:values (cl:mod (cl:- a b) ,(cl:expt 2 bits)))))
+           (define (- a b)
+             (lisp ,type (a b)
+               (cl:values (cl:mod (cl:- a b) ,(cl:expt 2 bits)))))
 
-       (define (* a b)
-         (lisp ,type (a b)
-           (cl:values (cl:mod (cl:* a b) ,(cl:expt 2 bits)))))
+           (define (* a b)
+             (lisp ,type (a b)
+               (cl:values (cl:mod (cl:* a b) ,(cl:expt 2 bits)))))
 
-       (define (fromInt x)
-         (lisp ,type (x)
-           (cl:values (cl:mod x ,(cl:expt 2 bits))))))))
+           (define (fromInt x)
+             (lisp ,type (x)
+               (cl:values (cl:mod x ,(cl:expt 2 bits)))))))))
 
-(coalton-toplevel
+
   (define-num-checked Integer cl:identity)
 
   (define-num-checked I8 %handle-8bit-overflow)
@@ -214,213 +220,217 @@
   (define-num-wrapping U16 16)
   (define-num-wrapping U32 32)
   (define-num-wrapping U64 64)
-  (define-num-wrapping UFix #.+unsigned-fixnum-bits+))
+  (define-num-wrapping UFix #.+unsigned-fixnum-bits+)
 
 ;;;
 ;;; Num instances for floats
 ;;;
 
-(cl:defun %optional-coerce (z cl-type)
-  "Attempts to coerce Z to an Optional CL-TYPE, returns NONE if failed."
-  (cl:let ((x (cl:ignore-errors
-               (cl:coerce z cl-type))))
-    (cl:if (cl:null x)
-           None
-           (Some x))))
+  (lisp-toplevel ()
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-num-float (type lisp-type)
-    "Define `Num' for TYPE"
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defun %optional-coerce (z cl-type)
+        "Attempts to coerce Z to an Optional CL-TYPE, returns NONE if failed."
+        (cl:let ((x (cl:ignore-errors
+                     (cl:coerce z cl-type))))
+          (cl:if (cl:null x)
+                 None
+                 (Some x))))
 
-    ;;
-    ;; CCL has a tendency to re-enable float traps. The explicit float
-    ;; trap masking keeps the test suite working during interactive
-    ;; development.
-    ;;
-    ;; Allegro appears to have some checks that make some arithmetic
-    ;; functions error on some inputs. The explicit checks in division
-    ;; keep the behavior consistent with IEEE 754.
-    ;;
+      (cl:defmacro define-num-float (type lisp-type)
+        "Define `Num' for TYPE"
 
-    `(define-instance (Num ,type)
-       (define (+ a b)
-         (lisp ,type (a b)
-           (#+(not ccl) cl:progn
-              #+ccl ff:with-float-traps-masked #+ccl cl:t
-              (cl:+ a b))))
+        ;;
+        ;; CCL has a tendency to re-enable float traps. The explicit float
+        ;; trap masking keeps the test suite working during interactive
+        ;; development.
+        ;;
+        ;; Allegro appears to have some checks that make some arithmetic
+        ;; functions error on some inputs. The explicit checks in division
+        ;; keep the behavior consistent with IEEE 754.
+        ;;
 
-       (define (- a b)
-         (lisp ,type (a b)
-           (#+(not ccl) cl:progn
-              #+ccl ff:with-float-traps-masked #+ccl cl:t
-              (cl:- a b))))
+        `(define-instance (Num ,type)
+           (define (+ a b)
+             (lisp ,type (a b)
+               (#+(not ccl) cl:progn
+                  #+ccl ff:with-float-traps-masked #+ccl cl:t
+                  (cl:+ a b))))
 
-       (define (* a b)
-         (lisp ,type (a b)
-           (#+(not ccl) cl:progn
-              #+ccl ff:with-float-traps-masked #+ccl cl:t
-              (cl:* a b))))
+           (define (- a b)
+             (lisp ,type (a b)
+               (#+(not ccl) cl:progn
+                  #+ccl ff:with-float-traps-masked #+ccl cl:t
+                  (cl:- a b))))
 
-       (define (fromInt x)
-         (match (lisp (Optional ,type) (x)
-                  (%optional-coerce x ',lisp-type))
-           ((Some x) x)
-           ((None) (if (< 0 x)
-                       negative-infinity
-                       infinity)))))))
+           (define (* a b)
+             (lisp ,type (a b)
+               (#+(not ccl) cl:progn
+                  #+ccl ff:with-float-traps-masked #+ccl cl:t
+                  (cl:* a b))))
 
-(coalton-toplevel
+           (define (fromInt x)
+             (match (lisp (Optional ,type) (x)
+                      (%optional-coerce x ',lisp-type))
+               ((Some x) x)
+               ((None) (if (< 0 x)
+                           negative-infinity
+                           infinity))))))))
+
   (define-num-float Single-Float cl:single-float)
-  (define-num-float Double-Float cl:double-float))
+  (define-num-float Double-Float cl:double-float)
 
 ;;;
 ;;; Float to `Fraction' conversions
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-float-fraction-conversion (type)
-    `(define-instance (TryInto ,type Fraction String)
-       (define (tryInto x)
-         (if (finite? x)
-             (Ok (lisp Fraction (x) (cl:rational x)))
-             (Err "Could not convert NaN or infinity into a Fraction"))))))
+  (lisp-toplevel ()
 
-(coalton-toplevel
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-float-fraction-conversion (type)
+        `(define-instance (TryInto ,type Fraction String)
+           (define (tryInto x)
+             (if (finite? x)
+                 (Ok (lisp Fraction (x) (cl:rational x)))
+                 (Err "Could not convert NaN or infinity into a Fraction")))))))
+
   (define-float-fraction-conversion Single-Float)
-  (define-float-fraction-conversion Double-Float))
+  (define-float-fraction-conversion Double-Float)
 
 ;;;
 ;;; `Dividable' and `Reciprocable' instances for floata
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-reciprocable-float (type)
-    `(define-instance (Reciprocable ,type)
-       (define (/ x y)
-         (cond
-           #+allegro
-           ((or (nan? x)
-                (nan? y))
-            nan)
+  (lisp-toplevel ()
 
-           #+allegro
-           ((and (== x 0) (== y 0))
-            nan)
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-reciprocable-float (type)
+        `(define-instance (Reciprocable ,type)
+           (define (/ x y)
+             (cond
+               #+allegro
+               ((or (nan? x)
+                    (nan? y))
+                nan)
 
-           #+allegro
-           ((and (positive? x) (== y 0))
-            infinity)
+               #+allegro
+               ((and (== x 0) (== y 0))
+                nan)
 
-           #+allegro
-           ((and (negative? x) (== y 0))
-            negative-infinity)
+               #+allegro
+               ((and (positive? x) (== y 0))
+                infinity)
 
-           (True
-            (lisp ,type (x y)
-              (#+(not ccl) cl:progn
-                 #+ccl ff:with-float-traps-masked #+ccl cl:t
-                 (cl:/ x y))))))
+               #+allegro
+               ((and (negative? x) (== y 0))
+                negative-infinity)
 
-       (define (reciprocal x)
-         (cond
-           #+allegro
-           ((== x 0)
-            infinity)
+               (True
+                (lisp ,type (x y)
+                  (#+(not ccl) cl:progn
+                     #+ccl ff:with-float-traps-masked #+ccl cl:t
+                     (cl:/ x y))))))
 
-           (True
-            (lisp ,type (x)
-              (#+(not ccl) cl:progn
-                 #+ccl ff:with-float-traps-masked #+ccl cl:t
-                 (cl:/ x)))))))))
+           (define (reciprocal x)
+             (cond
+               #+allegro
+               ((== x 0)
+                infinity)
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-dividable-float (type lisp-type)
-    `(define-instance (Dividable Integer ,type)
-       (define (general/ x y)
-         (if (== y 0)
-             (/ (fromInt x) (fromInt y))
-             (match (lisp (Optional ,type) (x y)
-                      (%optional-coerce (cl:/ x y) ',lisp-type))
-               ((Some x) x)
-               ((None) (if (and (> x 0) (> y 0))
-                           infinity
-                           negative-infinity))))))))
+               (True
+                (lisp ,type (x)
+                  (#+(not ccl) cl:progn
+                     #+ccl ff:with-float-traps-masked #+ccl cl:t
+                     (cl:/ x)))))))))
 
-(coalton-toplevel
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-dividable-float (type lisp-type)
+        `(define-instance (Dividable Integer ,type)
+           (define (general/ x y)
+             (if (== y 0)
+                 (/ (fromInt x) (fromInt y))
+                 (match (lisp (Optional ,type) (x y)
+                          (%optional-coerce (cl:/ x y) ',lisp-type))
+                   ((Some x) x)
+                   ((None) (if (and (> x 0) (> y 0))
+                               infinity
+                               negative-infinity)))))))))
+
   (define-reciprocable-float Single-Float)
   (define-reciprocable-float Double-Float)
 
   (define-dividable-float Single-Float cl:single-float)
-  (define-dividable-float Double-Float cl:double-float))
+  (define-dividable-float Double-Float cl:double-float)
 
 ;;;
 ;;; `Bits' instances
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-bits-checked (type handle-overflow)
-    `(define-instance (bits:Bits ,type)
-       (define (bits:and a b)
-         (lisp ,type (a b)
-           (cl:logand a b)))
+  (lisp-toplevel ()
 
-       (define (bits:or a b)
-         (lisp ,type (a b)
-           (cl:logior a b)))
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-bits-checked (type handle-overflow)
+        `(define-instance (bits:Bits ,type)
+           (define (bits:and a b)
+             (lisp ,type (a b)
+               (cl:logand a b)))
 
-       (define (bits:xor a b)
-         (lisp ,type (a b)
-           (cl:logxor a b)))
+           (define (bits:or a b)
+             (lisp ,type (a b)
+               (cl:logior a b)))
 
-       (define (bits:not x)
-         (lisp ,type (x)
-           (cl:lognot x)))
+           (define (bits:xor a b)
+             (lisp ,type (a b)
+               (cl:logxor a b)))
 
-       (define (bits:shift amount bits)
-         (lisp ,type (amount bits)
-           (,handle-overflow (cl:ash bits amount)))))))
+           (define (bits:not x)
+             (lisp ,type (x)
+               (cl:lognot x)))
 
-(cl:declaim (cl:inline unsigned-lognot))
-(cl:defun unsigned-lognot (int n-bits)
-  (cl:declare (cl:type cl:unsigned-byte int)
-              (cl:type cl:unsigned-byte n-bits)
-              (cl:values cl:unsigned-byte))
+           (define (bits:shift amount bits)
+             (lisp ,type (amount bits)
+               (,handle-overflow (cl:ash bits amount)))))))
 
-  (cl:- (cl:ash 1 n-bits) int 1))
+    (cl:declaim (cl:inline unsigned-lognot))
+    (cl:defun unsigned-lognot (int n-bits)
+      (cl:declare (cl:type cl:unsigned-byte int)
+                  (cl:type cl:unsigned-byte n-bits)
+                  (cl:values cl:unsigned-byte))
 
-(cl:declaim (cl:inline handle-unsigned-overflow))
-(cl:defun handle-unsigned-overflow (int n-bits)
-  (cl:declare (cl:type cl:unsigned-byte int)
-              (cl:type cl:unsigned-byte n-bits)
-              (cl:values cl:unsigned-byte))
+      (cl:- (cl:ash 1 n-bits) int 1))
 
-  (cl:logand (cl:1- (cl:ash 1 n-bits)) int))
+    (cl:declaim (cl:inline handle-unsigned-overflow))
+    (cl:defun handle-unsigned-overflow (int n-bits)
+      (cl:declare (cl:type cl:unsigned-byte int)
+                  (cl:type cl:unsigned-byte n-bits)
+                  (cl:values cl:unsigned-byte))
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
-  (cl:defmacro define-bits-wrapping (type width)
-    `(define-instance (bits:Bits ,type)
-       (define (bits:and a b)
-         (lisp ,type (a b)
-           (cl:logand a b)))
+      (cl:logand (cl:1- (cl:ash 1 n-bits)) int))
 
-       (define (bits:or a b)
-         (lisp ,type (a b)
-           (cl:logior a b)))
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-bits-wrapping (type width)
+        `(define-instance (bits:Bits ,type)
+           (define (bits:and a b)
+             (lisp ,type (a b)
+               (cl:logand a b)))
 
-       (define (bits:xor a b)
-         (lisp ,type (a b)
-           (cl:logxor a b)))
+           (define (bits:or a b)
+             (lisp ,type (a b)
+               (cl:logior a b)))
 
-       (define (bits:not x)
-         (lisp ,type (x)
-           (unsigned-lognot x ,width)))
+           (define (bits:xor a b)
+             (lisp ,type (a b)
+               (cl:logxor a b)))
 
-       (define (bits:shift amount bits)
-         (lisp ,type (amount bits)
-           (cl:logand (cl:ash bits amount)
-                      ,(cl:1- (cl:ash 1 width))))))))
+           (define (bits:not x)
+             (lisp ,type (x)
+               (unsigned-lognot x ,width)))
 
-(coalton-toplevel
+           (define (bits:shift amount bits)
+             (lisp ,type (amount bits)
+               (cl:logand (cl:ash bits amount)
+                          ,(cl:1- (cl:ash 1 width)))))))))
+
   (define-bits-checked Integer cl:identity)
 
   (define-bits-checked I8 %handle-8bit-overflow)
@@ -433,35 +443,36 @@
   (define-bits-wrapping U16 16)
   (define-bits-wrapping U32 32)
   (define-bits-wrapping U64 64)
-  (define-bits-wrapping UFix #.+unsigned-fixnum-bits+))
+  (define-bits-wrapping UFix #.+unsigned-fixnum-bits+)
 
+
+  (lisp-toplevel ()
 
 ;;; `Hash' instances
 
-(define-sxhash-hasher Integer)
-(define-sxhash-hasher I8)
-(define-sxhash-hasher I16)
-(define-sxhash-hasher I32)
-(define-sxhash-hasher I64)
-(define-sxhash-hasher U8)
-(define-sxhash-hasher U16)
-(define-sxhash-hasher U32)
-(define-sxhash-hasher U64)
-(define-sxhash-hasher IFix)
-(define-sxhash-hasher UFix)
-(define-sxhash-hasher Single-Float)
-(define-sxhash-hasher Double-Float)
+    (define-sxhash-hasher Integer)
+    (define-sxhash-hasher I8)
+    (define-sxhash-hasher I16)
+    (define-sxhash-hasher I32)
+    (define-sxhash-hasher I64)
+    (define-sxhash-hasher U8)
+    (define-sxhash-hasher U16)
+    (define-sxhash-hasher U32)
+    (define-sxhash-hasher U64)
+    (define-sxhash-hasher IFix)
+    (define-sxhash-hasher UFix)
+    (define-sxhash-hasher Single-Float)
+    (define-sxhash-hasher Double-Float)
 
 ;;;
 ;;; Default instances
 ;;;
 
-(cl:eval-when (:compile-toplevel :load-toplevel)
- (cl:defmacro define-default-num (type)
-   `(define-instance (Default ,type)
-      (define (default) 0))))
+    (cl:eval-when (:compile-toplevel :load-toplevel)
+      (cl:defmacro define-default-num (type)
+        `(define-instance (Default ,type)
+           (define (default) 0)))))
 
-(coalton-toplevel
   (define-default-num I8)
   (define-default-num U8)
   (define-default-num I16)

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -23,6 +23,7 @@
    #:optimize-bindings)
   (:local-nicknames
    (#:util #:coalton-impl/util)
+   (#:parser #:coalton-impl/parser)
    (#:settings #:coalton-impl/settings)
    (#:global-lexical #:coalton-impl/global-lexical)
    (#:rt #:coalton-impl/runtime)
@@ -42,41 +43,116 @@ A function bound here will be called with a keyword category, and one or more ad
 
     Toplevel definitions, after type checking and before compilation.")
 
+;; The following functions control the output order of compiled
+;; definitions and interleaved lisp expressions.
+;;
+;; Toplevel define and instance forms are compiled to 1 or more named,
+;; lisp-source-valued output definitions: when these definitions are
+;; generated, they are associated with the starting source offset of their
+;; toplevel form:
+;;
+;;   toplevel definition:
+;;     #<def .... (300 . 345)>
+;;
+;;   bindings (lisp definitions):
+;;     (300 b1 .. bn)
+;;
+;; Then when compile-definitions emits the full set of output
+;; definitions, any lisp source forms that occurred earlier in the
+;; file are emitted first.
+
+(defun bindings-offset (bindings offsets)
+  "Given a list of binding names, and a name -> offset map, return the earliest binding start offset."
+  (reduce #'min
+          (mapcar (lambda (binding)
+                    (gethash (car binding) offsets 0))
+                  bindings)))
+
+(defun merge-forms (forms-a forms-b &optional merged)
+  "Stably merge two lists of forms.
+
+1. The inputs and output are lists of 2-lists, structured as (OFFSET FORM).
+2. The order of both lists is preserved.
+3. Lists are merged by recursively selecting the head of the list with the lowest offset.
+
+Example:
+
+  (merge-forms '((2 \"b\") (8 \"d\") (1 \"a\"))
+               '((5 \"x\") (7 \"x\")))
+
+    => ((2 \"b\") (5 \"x\") (7 \"x\") (8 \"d\") (1 \"a\"))
+
+(Note that the order of elements in the first list is preserved)"
+  (cond ((endp forms-a)
+         (return-from merge-forms
+           (nreconc merged forms-b)))
+        ((endp forms-b)
+         (return-from merge-forms
+           (nreconc merged forms-a)))
+        ((< (caar forms-a)
+            (caar forms-b))
+         (push (pop forms-a) merged))
+        (t
+         (push (pop forms-b) merged)))
+  (merge-forms forms-a forms-b merged))
+
+(defun compile-definitions (sccs definitions lisp-forms offsets env)
+  "Compile SCCs and generate a final output definition list, merging any present lisp sources."
+  (let ((bindings (loop :for scc :in sccs
+                        :for bindings := (remove-if-not (lambda (binding)
+                                                          (find (car binding) scc))
+                                                        definitions)
+                        :collect (cons (bindings-offset bindings offsets)
+                                       (compile-scc bindings env))))
+        (lisp-forms (mapcar (lambda (lisp-form)
+                              (cons (car (parser:toplevel-lisp-form-source lisp-form))
+                                    (parser:toplevel-lisp-form-body lisp-form)))
+                            lisp-forms)))
+    (mapcan #'cdr (merge-forms bindings lisp-forms))))
+
+(defun definition-bindings (definitions env offsets)
+  "Translate the DEFINITIONS in this TU into bindings, updating an OFFSETS hashtable to record the source offset of each binding's source definition."
+  (loop :for define :in definitions
+        :for offset := (car (tc:toplevel-define-source define))
+        :for name := (tc:node-variable-name (tc:toplevel-define-name define))
+        :for compiled-node := (translate-toplevel define env name)
+
+        :when *codegen-hook*
+          :do (funcall *codegen-hook* ':AST
+                       name
+                       (tc:lookup-value-type env name)
+                       (tc:binding-value define))
+
+        :do (setf (gethash name offsets) offset)
+        :collect (cons name compiled-node)))
+
+(defun instance-bindings (instances env offsets)
+  "Translate the INSTANCES defined by this TU into bindings, updating an OFFSETS hashtable to record the source offset of each binding's source instance."
+  (loop :for instance :in instances
+        :for offset := (car (tc:toplevel-define-instance-source instance))
+        :for instance-bindings := (translate-instance instance env)
+
+        :do (dolist (binding instance-bindings)
+              (setf (gethash (car binding) offsets) offset))
+        :append instance-bindings))
+
 (defun compile-translation-unit (translation-unit monomorphize-table env)
   (declare (type tc:translation-unit translation-unit)
            (type hash-table monomorphize-table)
            (type tc:environment env))
 
-  (let* ((definitions
+  (let* ((offsets (make-hash-table))
+         (definitions
            (append
-            (loop :for define :in (tc:translation-unit-definitions translation-unit)
-                  :for name := (tc:node-variable-name (tc:toplevel-define-name define))
-
-                  :for compiled-node := (translate-toplevel define env name)
-
-                  :do (when *codegen-hook*
-                        (funcall *codegen-hook*
-                                 ':AST
-                                 name
-                                 (tc:lookup-value-type env name)
-                                 (tc:binding-value define)))
-                  :collect (cons name compiled-node))
-
-            ;; HACK: this load bearing reverse should be replaced with an actual solution
-            (loop :for instance :in (reverse (tc:translation-unit-instances translation-unit))
-                  :append (translate-instance instance env))))
-
-         (definition-names
-           (mapcar #'car definitions)))
+            (definition-bindings (tc:translation-unit-definitions translation-unit) env offsets)
+            (instance-bindings (tc:translation-unit-instances translation-unit) env offsets)))
+         (definition-names (mapcar #'car definitions)))
 
     (multiple-value-bind (definitions env)
-        (optimize-bindings
-         definitions
-         monomorphize-table
-         *package*
-         env)
+        (optimize-bindings definitions monomorphize-table *package* env)
 
-      (let ((sccs (node-binding-sccs definitions)))
+      (let ((sccs (node-binding-sccs definitions))
+            (lisp-forms (tc:translation-unit-lisp-forms translation-unit)))
 
         (values
          `(progn
@@ -103,13 +179,7 @@ A function bound here will be called with a keyword category, and one or more ad
                 (list
                  `(declaim (sb-ext:start-block ,@definition-names))))
 
-            ,@(loop :for scc :in sccs
-                    :for bindings
-                      := (remove-if-not
-                          (lambda (binding)
-                            (find (car binding) scc))
-                          definitions)
-                    :append (compile-scc bindings env))
+            ,@(compile-definitions sccs definitions lisp-forms offsets env)
 
             #+sbcl
             ,@(when (eq sb-ext:*block-compile-default* :specified)

--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -45,6 +45,9 @@
 (define-coalton-editor-macro coalton:define-instance (instance &body method-definitions)
   "Define an instance of a type class. (Coalton top-level operator.)")
 
+(define-coalton-editor-macro coalton:lisp-toplevel (options &body lisp-toplevel-forms)
+  "Include lisp forms. (Coalton top-level operator.)")
+
 (define-coalton-editor-macro coalton:specialize (name from-ty to-ty)
   "Declare a specialization for a function. (Coalton top-level operator.)")
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -27,6 +27,7 @@
    #:define-class
    #:define-instance
    #:repr
+   #:lisp-toplevel
    #:monomorphize
    #:specialize
    #:unable-to-codegen)

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -521,6 +521,7 @@
       :defines (rename-variables-generic% (program-defines program) ctx)
       :classes (program-classes program) ; Class type variables are renamed during kind inference
       :instances (rename-variables-generic% (program-instances program) ctx)
+      :lisp-forms (program-lisp-forms program)
       :specializations (program-specializations program) ; Renaming type variables in specializations is not valid
       )
      ctx))

--- a/src/typechecker/translation-unit.lisp
+++ b/src/typechecker/translation-unit.lisp
@@ -8,6 +8,7 @@
    #:coalton-impl/typechecker/define-type
    #:coalton-impl/typechecker/toplevel)
   (:local-nicknames
+   (#:parser #:coalton-impl/parser)
    (#:util #:coalton-impl/util))
   (:export
    #:translation-unit                   ; STRUCT
@@ -15,6 +16,7 @@
    #:translation-unit-types             ; ACCESSOR
    #:translation-unit-definitions       ; ACCESSOR
    #:translation-unit-instances         ; ACCESSOR
+   #:translation-unit-lisp-forms        ; ACCESSOR
    #:translation-unit-classes           ; ACCESSOR
    #:translation-unit-attr-table        ; ACCESSOR
    #:translation-unit-package           ; ACCESSOR
@@ -24,8 +26,9 @@
 (in-package #:coalton-impl/typechecker/translation-unit)
 
 (defstruct translation-unit
-  (types           nil                      :type type-definition-list           :read-only t)
-  (definitions     nil                      :type toplevel-define-list           :read-only t)
-  (instances       nil                      :type toplevel-define-instance-list  :read-only t)
-  (classes         nil                      :type ty-class-list                  :read-only t)
-  (package         (util:required 'package) :type package                        :read-only t))
+  (types       nil                         :type type-definition-list          :read-only t)
+  (definitions nil                         :type toplevel-define-list          :read-only t)
+  (instances   nil                         :type toplevel-define-instance-list :read-only t)
+  (lisp-forms  (util:required 'lisp-forms) :type parser:toplevel-lisp-form-list :read-only t)
+  (classes     nil                         :type ty-class-list                 :read-only t)
+  (package     (util:required 'package)    :type package                       :read-only t))

--- a/tests/parser-test-files/lisp-toplevel-forbid.txt
+++ b/tests/parser-test-files/lisp-toplevel-forbid.txt
@@ -1,0 +1,20 @@
+================================================================================
+Forbid outside of library code
+================================================================================
+
+(package test)
+
+(lisp-toplevel
+  (defvar *x* nil))
+
+--------------------------------------------------------------------------------
+
+error: Invalid lisp-toplevel form
+  --> test:3:0
+   |
+ 3 |    (lisp-toplevel
+   |  __^
+   | | _-
+ 4 | ||   (defvar *x* nil))
+   | ||___________________- when parsing lisp-toplevel
+   | |____________________^ lisp-toplevel is only allowed in library source code. To enable elsewhere, (pushnew :coalton-lisp-toplevel *features*)

--- a/tests/parser-test-files/lisp-toplevel.txt
+++ b/tests/parser-test-files/lisp-toplevel.txt
@@ -1,0 +1,64 @@
+================================================================================
+Empty options
+
+To support future extension, lisp-toplevel expects an empty options list in the
+first poisition.
+================================================================================
+
+(package test)
+
+(lisp-toplevel (x)
+  t)
+
+--------------------------------------------------------------------------------
+
+error: Invalid lisp-toplevel form
+  --> test:3:15
+   |
+ 3 |   (lisp-toplevel (x)
+   |  _-
+   | |                ^^^ lisp-toplevel must be followed by an empty options list
+ 4 | |   t)
+   | |____- when parsing lisp-toplevel
+
+================================================================================
+lisp-toplevel must receive an options list
+================================================================================
+
+(package test)
+
+(lisp-toplevel
+  (defvar *x* nil))
+
+--------------------------------------------------------------------------------
+
+error: Invalid lisp-toplevel form
+  --> test:4:2
+   |
+ 3 |   (lisp-toplevel
+   |  _-
+ 4 | |   (defvar *x* nil))
+   | |   ^^^^^^^^^^^^^^^^ saw 'def' form: in lisp-toplevel, code must be preceded by an empty options list
+   | |___________________- when parsing lisp-toplevel
+
+================================================================================
+lisp-toplevel may not have attributes
+================================================================================
+
+(package test)
+
+(repr :lisp)
+(lisp-toplevel
+  (defvar *x* nil))
+
+--------------------------------------------------------------------------------
+
+error: Invalid lisp-toplevel form
+  --> test:3:0
+   |
+ 3 |   (repr :lisp)
+   |   ^^^^^^^^^^^^ lisp-toplevel cannot have attributes
+ 4 |   (lisp-toplevel
+   |  _-
+ 5 | |   (defvar *x* nil))
+   | |___________________- when parsing lisp-toplevel

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -44,4 +44,7 @@
       (parse-file file))))
 
 (deftest test-parse-package-suite ()
+  (let ((*features* (cons ':coalton-lisp-toplevel *features*)))
+    (run-suite "tests/parser-test-files/lisp-toplevel.txt"))
+  (run-suite "tests/parser-test-files/lisp-toplevel-forbid.txt")
   (run-suite "tests/parser-test-files/package.txt"))


### PR DESCRIPTION
Add lisp-toplevel form.

`lisp-toplevel` may appear at any point in a coalton-toplevel or coalton file context.

During code generation, lisp forms are merged with coalton definitions according to the rule:

1. coalton forms are emitted in scc order
2. every time a coalton form is emitted, all lisp forms lexically preceding that form are emitted first

Convert math/num.lisp from interleaved lisp and coalton-toplevel forms to a single coalton-toplevel form containing multiple lisp-toplevel forms.

This will support direct conversion to .coal by removing the outer coalton-toplevel macro and adding a native package form.