### PR TITLE
Fail if no input files are selected by tests

### DIFF
--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -1745,15 +1745,13 @@ consume all attributes")))
                  :message "Invalid type variable"
                  :primary-note "expected keyword symbol"
                  :help-notes
-                 (cond
-                   ((eq *package* (symbol-package (cst:raw form)))
-                    (list
-                     (make-coalton-error-help
-                      :span (cst:source form)
-                      :replacement
-                      (lambda (existing)
-                        (concatenate 'string ":" existing))
-                      :message "add `:` to symbol")))))))
+                 (list
+                  (make-coalton-error-help
+                   :span (cst:source form)
+                   :replacement
+                   (lambda (existing)
+                     (concatenate 'string ":" existing))
+                   :message "add `:` to symbol")))))
 
   (make-keyword-src
    :name (cst:raw form)

--- a/tests/parser-test-files/bad-files/define-instance.7.error
+++ b/tests/parser-test-files/bad-files/define-instance.7.error
@@ -1,5 +1,5 @@
 error: Malformed instance definition
-  --> test:4:17
+  --> test:4:16
    |
  4 |  (define-instance)
    |                  ^ expected an instance head

--- a/tests/parser-test-files/bad-files/parse-attribute.5.error
+++ b/tests/parser-test-files/bad-files/parse-attribute.5.error
@@ -1,5 +1,5 @@
 error: Malformed repr :native attribute
-  --> test:4:14
+  --> test:4:13
    |
  4 |  (repr :native)
    |               ^ expected a lisp type

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -2,7 +2,10 @@
 
 (deftest test-parser ()
   (labels ((test-files (pattern)
-             (directory (merge-pathnames pattern (asdf:system-source-directory "coalton/tests"))))
+             (let ((files (directory (merge-pathnames pattern (asdf:system-source-directory "coalton/tests")))))
+               (when (endp files)
+                 (error "No test files match pattern '~A'" pattern))
+               files))
 
            (parse-file (file)
              (with-open-file (stream file
@@ -22,7 +25,7 @@
                      "no errors")
                  (error:coalton-base-error (c)
                    (princ-to-string c))))))
-    (dolist (file (test-files "tests/parser-test-files/bad/*.coal"))
+    (dolist (file (test-files "tests/parser-test-files/bad-files/*.coal"))
       (let ((error-file (make-pathname :type "error"
                                        :defaults file)))
         (cond ((uiop:file-exists-p error-file)
@@ -33,5 +36,5 @@
                (signals parser:parse-error
                  (parse-file file))))))
 
-    (dolist (file (test-files "tests/parser-test-files/good/*.coal"))
+    (dolist (file (test-files "tests/parser-test-files/good-files/*.coal"))
       (parse-file file))))


### PR DESCRIPTION
Parser tests are not enabled because the suite is looking in 'bad', and files are in 'bad-files'.

This reenables tests, and adds a guardrail. At least one assertion will need updating.