### PR TITLE
Method Parser tests

### DIFF
--- a/tests/parser-test-files/bad-files/parse-method.1.coal
+++ b/tests/parser-test-files/bad-files/parse-method.1.coal
@@ -1,0 +1,4 @@
+(package test)
+
+(define-class (Greetable :a)
+  (Greet :a Unit))

--- a/tests/parser-test-files/bad-files/parse-method.1.error
+++ b/tests/parser-test-files/bad-files/parse-method.1.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:4:12
+   |
+ 3 |  (define-class (Greetable :a)
+   |                -------------- in this class definition
+ 4 |    (Greet :a Unit))
+   |              ^^^^ unexpected trailing form

--- a/tests/parser-test-files/bad-files/parse-method.2.coal
+++ b/tests/parser-test-files/bad-files/parse-method.2.coal
@@ -1,0 +1,4 @@
+(package test)
+
+(define-class (Oops :a)
+  (Ouch "This method stubbed its toe" :a Unit))

--- a/tests/parser-test-files/bad-files/parse-method.2.error
+++ b/tests/parser-test-files/bad-files/parse-method.2.error
@@ -1,0 +1,7 @@
+error: Malformed method definition
+  --> test:4:41
+   |
+ 3 |  (define-class (Oops :a)
+   |                --------- in this class definition
+ 4 |    (Ouch "This method stubbed its toe" :a Unit))
+   |                                           ^^^^ unexpected trailing form


### PR DESCRIPTION
Add tests described in #1132 that indicate presence of trailing forms.

Closes #1133 