### PR TITLE
Rewrite get-line-from-index

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -43,12 +43,14 @@
                #:concrete-syntax-tree
                #:eclector-concrete-syntax-tree
                #:named-readtables
-               #:source-error)
+               #:source-error
+               #:trivial-gray-streams)
   :pathname "src/"
   :serial t
   :components ((:file "package")
                (:file "settings")
                (:file "utilities")
+               (:file "stream")
                (:file "global-lexical")
                (:file "constants")
                (:module "algorithm"
@@ -333,6 +335,7 @@
   :serial t
   :components ((:file "package")
                (:file "utilities")
+               (:file "stream-tests")
                (:file "tarjan-scc-tests")
                (:file "reader-tests")
                (:file "error-tests")

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -4,6 +4,7 @@
   (:local-nicknames
    (#:se #:source-error)
    (#:settings #:coalton-impl/settings)
+   (#:stream #:coalton-impl/stream)
    (#:util #:coalton-impl/util)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker)
@@ -241,12 +242,13 @@
 
   :DEFAULT Generate Lisp source, and compile immediately to .fasl. If no output file is specified, compiled Lisp code will be written to a temporary file, and that path will be returned.
   :SOURCE  Write compiled Lisp code to console or specified output file."
-  (with-open-file (coal-stream coal-file
+  (with-open-file (stream coal-file
                                :direction ':input
                                :element-type 'character)
-    (let ((coal-file-name (etypecase coal-file
-                            (pathname (pathname-name coal-file))
-                            (string coal-file))))
+    (let* ((coal-stream (stream:make-char-position-stream stream))
+           (coal-file-name (etypecase coal-file
+                             (pathname (pathname-name coal-file))
+                             (string coal-file))))
       (ecase format
         (:default
          (uiop:with-temporary-file (:stream lisp-stream

--- a/src/stream.lisp
+++ b/src/stream.lisp
@@ -1,0 +1,48 @@
+;;; coalton-impl/stream
+;;;
+;;; Classes for working with streams
+
+(defpackage #:coalton-impl/stream
+  (:use
+   #:cl)
+  (:export
+   #:make-char-position-stream))
+
+(in-package #:coalton-impl/stream)
+
+(defclass char-position-stream (trivial-gray-streams:fundamental-character-input-stream)
+  ((stream :initarg :stream
+           :reader inner-stream)
+   (unread :initform nil
+           :accessor unread-characters)
+   (position :initform 0
+             :accessor character-position))
+  (:documentation "A stream that exposes the character offset into an underlying character stream through #'stream-file-position."))
+
+(defmethod trivial-gray-streams:stream-read-char ((stream char-position-stream))
+  (let ((char (cond ((not (null (unread-characters stream)))
+                     (pop (unread-characters stream)))
+                    (t
+                     (read-char (inner-stream stream) nil :eof)))))
+    (unless (eq char :eof)
+      (incf (character-position stream)))
+    char))
+
+(defmethod trivial-gray-streams:stream-read-char-no-hang ((stream char-position-stream))
+  (trivial-gray-streams:stream-read-char stream))
+
+(defmethod trivial-gray-streams:stream-unread-char ((stream char-position-stream) char)
+  (push char (unread-characters stream))
+  (decf (character-position stream)))
+
+(defmethod trivial-gray-streams:stream-file-position ((stream char-position-stream))
+  (character-position stream))
+
+(defmethod (setf trivial-gray-streams:stream-file-position) (position-spec (stream char-position-stream))
+  (file-position (inner-stream stream) 0)
+  (dotimes (i position-spec)
+    (read-char (inner-stream stream)))
+  (setf (character-position stream) position-spec))
+
+(defun make-char-position-stream (stream)
+  (make-instance 'char-position-stream :stream stream))

--- a/tests/entry-tests.lisp
+++ b/tests/entry-tests.lisp
@@ -1,8 +1,7 @@
 (in-package #:coalton-tests)
 
 (defun compile-test-file ()
-  (merge-pathnames "examples/small-coalton-programs/src/classical.coal"
-                   (asdf:system-source-directory "coalton")))
+  (test-file "examples/small-coalton-programs/src/classical.coal"))
 
 (deftest test-compile-to-lisp ()
   "Test that the Coalton compiler compiles a test file into Lisp source."

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -8,6 +8,7 @@
    (#:se #:source-error)
    (#:util #:coalton-impl/util)
    (#:parser #:coalton-impl/parser)
+   (#:stream #:coalton-impl/stream)
    (#:tc #:coalton-impl/typechecker)
    (#:analysis #:coalton-impl/analysis)
    (#:entry #:coalton-impl/entry))

--- a/tests/parser-test-files/bad-files/_define-class.21.error
+++ b/tests/parser-test-files/bad-files/_define-class.21.error
@@ -1,0 +1,5 @@
+error: Invalid variable
+  --> test:5:3
+   |
+ 5 |    (.方法 (:a -> :a)))
+   |     ^^^ variables cannot start with '.'

--- a/tests/parser-test-files/bad-files/_define-class.22.error
+++ b/tests/parser-test-files/bad-files/_define-class.22.error
@@ -1,0 +1,5 @@
+error: Invalid variable
+  --> test:6:3
+   |
+ 6 |    (.方法 (:a -> :a)))
+   |     ^^^ variables cannot start with '.'

--- a/tests/parser-test-files/bad-files/define-class.21.coal
+++ b/tests/parser-test-files/bad-files/define-class.21.coal
@@ -1,0 +1,5 @@
+;; BAD: Define Class
+(package test-package)
+
+(define-class (C :a)
+  (.方法 (:a -> :a)))

--- a/tests/parser-test-files/bad-files/define-class.22.coal
+++ b/tests/parser-test-files/bad-files/define-class.22.coal
@@ -1,0 +1,6 @@
+;; BAD: Define Class
+(package test-package)
+
+(define-class (C :a)
+  (m "非常に重要な方法" (:a -> :a))
+  (.方法 (:a -> :a)))

--- a/tests/parser-test-files/bad-files/define-instance.7.error
+++ b/tests/parser-test-files/bad-files/define-instance.7.error
@@ -1,5 +1,5 @@
 error: Malformed instance definition
-  --> test:4:16
+  --> test:4:17
    |
  4 |  (define-instance)
    |                  ^ expected an instance head

--- a/tests/parser-test-files/bad-files/parse-attribute.5.error
+++ b/tests/parser-test-files/bad-files/parse-attribute.5.error
@@ -1,5 +1,5 @@
 error: Malformed repr :native attribute
-  --> test:4:13
+  --> test:4:14
    |
  4 |  (repr :native)
    |               ^ expected a lisp type

--- a/tests/stream-tests.lisp
+++ b/tests/stream-tests.lisp
@@ -1,0 +1,25 @@
+(in-package #:coalton-tests)
+
+;; Check that wrapping a character input stream with
+;; char-position-stream class allows callers to collect character
+;; offset using 'file-position'. This is for gathering source offsets
+;; that remain copmpatible with the offsets reported for source parsed
+;; from internal strings.
+
+(deftest test-char-position-stream ()
+  (flet ((stream-contents (stream)
+           (loop :for char
+                   := (read-char stream nil nil)
+                 :while char
+                 :collect (cons char (file-position stream)))))
+    (with-open-file (stream (test-file "tests/parser-test-files/bad-files/define-class.21.coal")
+                            :direction ':input
+                            :element-type 'character
+                            :external-format :utf-8)
+      (let* ((char-stream (stream:make-char-position-stream stream))
+             (chars (stream-contents char-stream)))
+        (is (= 86 (length chars))
+            (format nil "File expected length 86 != ~A" (length chars)))
+        (is (equal 72                 ; byte offset would have been 76
+                   (cdr (nth 71 chars)))
+            "Scond kanji is at char offset, not byte offset")))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -91,3 +91,7 @@ Returns (values SOURCE-PATHNAME COMPILED-PATHNAME)."
        ((,muffle #'muffle-warning))
      (compile-and-load-forms '(,@(when package `((cl:in-package ,package)))
                                ,@coalton-code))))
+
+(defun test-file (pathname)
+  "Create a pathname relative to the coalton/test system."
+  (merge-pathnames pathname (asdf:system-source-directory "coalton/tests")))


### PR DESCRIPTION
Allow get-line-from-index to handle character offsets that point to line endings.

- add assertion for requests beyond eof
- rewrite in 'loop'
- remove utf code point calculation: all errors are character index relative
- remove column number patch
- adjust test assertions

This deletes a patch that was introduced in https://github.com/coalton-lang/coalton/pull/1131