### PR TITLE
Extract source error code to a separate asdf system

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -42,7 +42,8 @@
                #:eclector
                #:concrete-syntax-tree
                #:eclector-concrete-syntax-tree
-               #:named-readtables)
+               #:named-readtables
+               #:source-error)
   :pathname "src/"
   :serial t
   :components ((:file "package")
@@ -56,7 +57,6 @@
                              (:file "immutable-map")
                              (:file "immutable-listmap")
                              (:file "package")))
-               (:file "error")
                (:module "parser"
                 :serial t
                 :components ((:file "base")

--- a/source-error/source-error.asd
+++ b/source-error/source-error.asd
@@ -1,0 +1,7 @@
+(asdf:defsystem #:source-error
+  :license "MIT"
+  :depends-on (#:alexandria)
+  :pathname "src"
+  :serial t
+  :components ((:file "error")
+               (:file "package")))

--- a/source-error/src/error.lisp
+++ b/source-error/src/error.lisp
@@ -1,181 +1,175 @@
-(defpackage #:coalton-impl/error
-  (:use #:cl)
-  (:local-nicknames
-   (#:util #:coalton-impl/util))
+(defpackage #:source-error/error
+  (:shadow
+   #:file
+   #:file-stream)
+  (:use
+   #:cl)
   (:export
-   #:coalton-internal-condition         ; CONDITION
-   #:coalton-base-error                 ; CONDITION
-   #:coalton-error-err                  ; ACCESSOR
-   #:coalton-error-text                 ; ACCESSOR
-   #:coalton-base-warning               ; CONDITION
-   #:coalton-warning-err                ; ACCESSOR
-   #:render-coalton-error               ; FUNCTION
-   #:render-coalton-warning             ; FUNCTION
-   #:coalton-internal-type-error        ; CONDITION
-   #:coalton-file                       ; TYPE
-   #:coalton-file-stream                ; ACCESSOR
-   #:coalton-file-name                  ; ACCESSOR
-   #:make-coalton-file                  ; FUNCTION
-   #:make-coalton-error-note            ; FUNCTION
-   #:make-coalton-error-help            ; FUNCTION
-   #:make-coalton-error-context         ; FUNCTION
-   #:*coalton-error-context*            ; VARIABLE
-   #:coalton-error                      ; MACRO
-   #:coalton-error-location             ; ACCESSOR
-   #:coalton-error-file                 ; ACCESSOR
-   #:display-coalton-error              ; FUNCTION
+   #:source-base-error                  ; CONDITION
+   #:source-base-error-err              ; ACCESSOR
+   #:source-base-error-text             ; ACCESSOR
+   #:source-base-warning                ; CONDITION
+   #:source-base-warning-err            ; ACCESSOR
+   #:source-base-warning-text           ; ACCESSOR
+   #:render-source-error                ; FUNCTION
+   #:render-source-warning              ; FUNCTION
+   #:file                               ; TYPE
+   #:make-file                          ; CONSTRUCTOR
+   #:file-stream                        ; ACCESSOR
+   #:file-name                          ; ACCESSOR
+   #:make-source-error-note             ; FUNCTION
+   #:make-source-error-help             ; FUNCTION
+   #:make-source-error-context          ; FUNCTION
+   #:*source-error-context*             ; VARIABLE
+   #:source-error                       ; MACRO
+   #:source-error-location              ; ACCESSOR
+   #:source-error-file                  ; ACCESSOR
+   #:display-source-error               ; FUNCTION
+   #:define-source-condition            ; MACRO
    ))
 
-(in-package #:coalton-impl/error)
+(in-package #:source-error/error)
 
-
-(define-condition coalton-internal-condition (error)
-  ()
-  (:documentation "An internal Coalton condition for use in signaling. Internal conditions should always be caught.")
-  (:report (lambda (c s)
-             (declare (ignore c))
-             (format s "Unhandled internal condition.~%~%If you are seeing this, please file an issue on Github."))))
-
-(define-condition coalton-base-error (error)
-  ((err :accessor coalton-error-err
+(define-condition source-base-error (error)
+  ((err :accessor source-base-error-err
         :initarg :err
         :type (or null function))
-   (text :accessor coalton-error-text
+   (text :accessor source-base-error-text
          :initarg :text
          :initform nil
          :type (or null string)))
-  (:documentation "The base type for user-facing errors. Only ERR needs to be specified, and TEXT will be filled when RENDER-COALTON-ERROR is called.")
+  (:documentation "The base type for user-facing errors. Only ERR needs to be specified, and TEXT will be filled when `RENDER-ERROR' is called.")
   (:report (lambda (c s)
-             (if (coalton-error-text c)
-                 (write-string (coalton-error-text c) s)
-                 (display-coalton-error s (coalton-error-err c))))))
+             (if (source-base-error-text c)
+                 (write-string (source-base-error-text c) s)
+                 (display-source-error s (source-base-error-err c))))))
 
-(define-condition coalton-base-warning (style-warning)
-  ((err :accessor coalton-warning-err
+(define-condition source-base-warning (style-warning)
+  ((err :accessor source-base-warning-err
         :initarg :err
         :type (or null function))
-   (text :accessor coalton-warning-text
+   (text :accessor source-base-warning-text
          :initarg :text
          :initform nil
          :type (or null string)))
-    (:documentation "The base type for user-facing warnings. Only ERR needs to be specified, and TEXT will be filled when RENDER-COALTON-WARNING is called.")
+    (:documentation "The base type for user-facing warnings. Only ERR needs to be specified, and TEXT will be filled when `RENDER-WARNING' is called.")
     (:report (lambda (c s)
-             (if (coalton-warning-text c)
-                 (write-string (coalton-warning-text c) s)
-                 (display-coalton-error s (coalton-warning-err c))))))
+             (if (source-base-warning-text c)
+                 (write-string (source-base-warning-text c) s)
+                 (display-source-error s (source-base-warning-err c))))))
 
-(defun render-coalton-error (e)
-  "Render the error object within a COALTON-BASE-ERROR to text, removing the need to keep source file handles open."
-  (declare (type coalton-base-error e))
+(defun render-source-error (e)
+  "Render the error object within a `SOURCE-BASE-ERROR' to text, removing the need to keep source file handles open."
+  (declare (type source-base-error e))
   (let ((*print-escape* nil))
-    (setf (coalton-error-text e)
+    (setf (source-base-error-text e)
           (with-output-to-string (s)
             (print-object e s))
-          (coalton-error-err e)
+          (source-base-error-err e)
           nil)))
 
-(defun render-coalton-warning (w)
-  "Render the error object within a COALTON-BASE-ERROR to text, removing the need to keep source file handles open."
-  (declare (type coalton-base-warning w))
+(defun render-source-warning (w)
+  "Render the error object within a `SOURCE-BASE-ERROR' to text, removing the need to keep source file handles open."
+  (declare (type source-base-warning w))
   (let ((*print-escape* nil))
-    (setf (coalton-warning-text w)
+    (setf (source-base-warning-text w)
           (with-output-to-string (s)
             (print-object w s))
-          (coalton-warning-err w)
+          (source-base-warning-err w)
           nil)))
 
-
-(define-condition coalton-internal-type-error (coalton-internal-condition)
-  ())
-
-;;;
-;;; Error Rendering
-;;;
-
-(defstruct (coalton-error-note
+(defstruct (source-error-note
             (:copier nil))
-  (type    (util:required 'type)    :type (member :primary :secondary) :read-only t)
-  (span    (util:required 'span)    :type (cons integer integer)       :read-only t)
-  (message (util:required 'message) :type string                       :read-only t))
+  (type    nil :type (member :primary :secondary) :read-only t)
+  (span    nil :type (cons integer integer)       :read-only t)
+  (message nil :type string                       :read-only t))
 
-(defun coalton-error-note-list-p (x)
+(defun source-error-note-list-p (x)
   (and (alexandria:proper-list-p x)
-       (every #'coalton-error-note-p x)))
+       (every #'source-error-note-p x)))
 
-(deftype coalton-error-note-list ()
-  '(satisfies coalton-error-note-list-p))
+(deftype source-error-note-list ()
+  '(satisfies source-error-note-list-p))
 
-
-(defstruct (coalton-error-help
+(defstruct (source-error-help
             (:copier nil))
-  (span        (util:required 'span)        :type (cons integer integer)     :read-only t)
-  (replacement (util:required 'replacement) :type (function (string) string) :read-only t)
-  (message     (util:required 'message)     :type string                     :read-only t))
+  (span        nil :type (cons integer integer)     :read-only t)
+  (replacement nil :type (function (string) string) :read-only t)
+  (message     nil :type string                     :read-only t))
 
-(defun coalton-error-help-list-p (x)
+(defun source-error-help-list-p (x)
   (and (alexandria:proper-list-p x)
-       (every #'coalton-error-help-p x)))
+       (every #'source-error-help-p x)))
 
-(deftype coalton-error-help-list ()
-  '(satisfies coalton-error-help-list-p))
+(deftype source-error-help-list ()
+  '(satisfies source-error-help-list-p))
 
-
-(defstruct (coalton-error-context
+(defstruct (source-error-context
             (:copier nil))
-  (message (util:required 'message) :type string :read-only t))
+  (message nil :type string :read-only t))
 
-(defvar *coalton-error-context* nil)
+(defun source-error-context-list-p (x)
+  (and (alexandria:proper-list-p x)
+       (every #'source-error-context-p x)))
 
-(defstruct (coalton-file
+(deftype source-error-context-list ()
+  '(satisfies source-error-context-list-p))
+
+(defvar *source-error-context* nil)
+
+(defstruct (file
             (:copier nil))
-  (stream (util:required 'stream) :type stream :read-only t)
-  (name   (util:required 'name)   :type string :read-only t))
+  (stream nil :type stream :read-only t)
+  (name   nil :type string :read-only t))
 
-(defstruct (coalton-error
+(defstruct (source-error
             (:copier nil))
-  (type            (util:required 'type)     :type (member :error :warn)   :read-only t)
-  (file            (util:required 'file)     :type coalton-file            :read-only t)
-  (location        (util:required 'location) :type integer                 :read-only t)
-  (message         (util:required 'message)  :type string                  :read-only t)
-  (notes           (util:required 'notes)    :type coalton-error-note-list :read-only t)
-  (help-notes      nil                       :type coalton-error-help-list :read-only t)
-  (context         *coalton-error-context*   :type list                    :read-only t))
+  (type       nil :type (member :error :warn)     :read-only t)
+  (file       nil :type file                      :read-only t)
+  (location   nil :type integer                   :read-only t)
+  (message    nil :type string                    :read-only t)
+  (notes      nil :type source-error-note-list    :read-only t)
+  (help-notes nil :type source-error-help-list    :read-only t)
+  (context    nil :type source-error-context-list :read-only t))
 
-(defmacro coalton-error (&key (type :error) span file (highlight :all) message primary-note notes help-notes)
-  `(lambda ()
-     (coalton-error_
-      :type ,type
-      :span ,span
-      :file ,file
-      :highlight ,highlight
-      :message ,message
-      :primary-note ,primary-note
-      :notes ,notes
-      :help-notes ,help-notes)))
+(defmacro source-error (&key (type :error) span file (highlight :all) message primary-note notes help-notes)
+  `(let ((ctx *source-error-context*))
+     (lambda ()
+       (source-error%
+        :type ,type
+        :span ,span
+        :file ,file
+        :highlight ,highlight
+        :message ,message
+        :primary-note ,primary-note
+        :notes ,notes
+        :help-notes ,help-notes
+        :context ctx))))
 
-(defun coalton-error_ (&key
-                         (type :error)
-                         span
-                         file
-                         (highlight :all)
-                         message
-                         primary-note
-                         notes
-                         help-notes)
-  "Construct a COALTON-ERROR with a message and primary note attached to the provided form.
-
-MESSAGE and PRIMARY-NOTE must be supplied string arguments.
-NOTES and HELP-NOTES may optionally be supplied notes and help messages."
+(defun source-error% (&key
+                        (type :error)
+                        span
+                        file
+                        (highlight :all)
+                        message
+                        primary-note
+                        notes
+                        help-notes
+                        context)
+  "Construct a `SOURCE-ERROR' with a message and primary note attached to the provided form."
   (declare (type cons span)
-           (type coalton-file file)
+           (type file file)
            (type (member :all :end) highlight)
-           (type string message primary-note)
-           (type list notes help-notes)
-           (values coalton-error &optional))
+           (type string message)
+           (type string primary-note)
+           (type source-error-note-list notes)
+           (type source-error-help-list help-notes)
+           (type source-error-context-list context)
+           (values source-error))
 
   (let ((start (car span))
         (end (cdr span)))
-    (make-coalton-error
+    (make-source-error
      :type type
      :file file
      :location (ecase highlight
@@ -185,29 +179,30 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
      :notes (list*
              (ecase highlight
                (:all
-                (make-coalton-error-note
+                (make-source-error-note
                  :type :primary
                  :span (cons start end)
                  :message primary-note))
                (:end
-                (make-coalton-error-note
+                (make-source-error-note
                  :type :primary
                  :span (cons (1- end) end)
                  :message primary-note)))
              notes)
-     :help-notes help-notes)))
+     :help-notes help-notes
+     :context context)))
 
-(defstruct (coalton-error-resolved-note
+(defstruct (source-error-resolved-note
             (:copier nil))
-  "A COALTON-ERROR-NOTE with its location resolved in the file's context."
-  (type         (util:required 'type)         :type (member :primary :secondary) :read-only t)
-  (start-line   (util:required 'start-line)   :type integer                      :read-only t)
-  (start-column (util:required 'start-column) :type integer                      :read-only t)
-  (end-line     (util:required 'end-line)     :type integer                      :read-only t)
-  (end-column   (util:required 'end-column)   :type integer                      :read-only t)
-  (message      (util:required 'message)      :type string                       :read-only t))
+  "A `SOURCE-ERROR-NOTE' with its location resolved in the file's context."
+  (type         nil :type (member :primary :secondary) :read-only t)
+  (start-line   nil :type integer                      :read-only t)
+  (start-column nil :type integer                      :read-only t)
+  (end-line     nil :type integer                      :read-only t)
+  (end-column   nil :type integer                      :read-only t)
+  (message      nil :type string                       :read-only t))
 
-(defun display-coalton-error (stream error)
+(defun display-source-error (stream error)
   (declare (type stream stream)
            (type function error))
 
@@ -215,30 +210,30 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
 
          (error (funcall error))
 
-         (file-stream (coalton-file-stream (coalton-error-file error)))
+         (file-stream (file-stream (source-error-file error)))
          (file-stream-pos (file-position file-stream)))
 
     (progn
 
       ;; Print the error message and location
       (multiple-value-bind (line-number line-start-index)
-          (get-line-from-index file-stream (coalton-error-location error))
+          (get-line-from-index file-stream (source-error-location error))
 
         ;; get-line-from-index sometimes returns a line-start-index
         ;; that is 1 larger than (coalton-error-location error),
         ;; resulting in a column number of -1. The following lines
         ;; compensate for that and can be removed if and when that is
         ;; fixed.
-        (let ((column-number (- (coalton-error-location error) line-start-index)))
+        (let ((column-number (- (source-error-location error) line-start-index)))
           (when (< column-number 0)
             (decf line-number)
             (setf column-number (1- (length (get-nth-line file-stream line-number)))))
 
           (format stream
                   "~(~A~): ~A~%  --> ~A:~D:~D~%"
-                  (coalton-error-type error)
-                  (coalton-error-message error)
-                  (coalton-file-name (coalton-error-file error))
+                  (source-error-type error)
+                  (source-error-message error)
+                  (file-name (source-error-file error))
                   line-number
                   column-number)))
 
@@ -253,18 +248,18 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
              ;; Sort notes by start of span
              (sorted-notes
                (stable-sort
-                (coalton-error-notes error)
+                (source-error-notes error)
                 #'<
                 :key (lambda (note)
-                       (car (coalton-error-note-span note)))))
+                       (car (source-error-note-span note)))))
 
              ;; Attach line info to notes and figure out the maximum
              ;; multiline note depth we will need.
              (resolved-notes
                (mapcar
                 (lambda (note)
-                  (let ((start (car (coalton-error-note-span note)))
-                        (end (cdr (coalton-error-note-span note))))
+                  (let ((start (car (source-error-note-span note)))
+                        (end (cdr (source-error-note-span note))))
                     ;; Get line info for the start of the span
                     (multiple-value-bind (start-line start-line-start)
                         (get-line-from-index file-stream start)
@@ -281,24 +276,24 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                           (when (or (< end-line start-line)
                                     (and (= end-line start-line)
                                          (< end-column start-column)))
-                            (util:coalton-bug "Error note contains invalid span ~A:~A to ~A:~A"
-                                              start-line start-column end-line end-column))
+                            (error "Error note contains invalid span ~A:~A to ~A:~A"
+                                   start-line start-column end-line end-column))
 
                           ;; Clear any multiline notes in the stack that we have now passed.
                           (loop :while (and (car multiline-note-stack)
                                             (> start-line
-                                               (coalton-error-resolved-note-end-line
+                                               (source-error-resolved-note-end-line
                                                 (car multiline-note-stack))))
                                 :do (pop multiline-note-stack)
                                     (decf multiline-note-current-depth))
 
-                          (let ((resolved-note (make-coalton-error-resolved-note
-                                                :type (coalton-error-note-type note)
+                          (let ((resolved-note (make-source-error-resolved-note
+                                                :type (source-error-note-type note)
                                                 :start-line start-line
                                                 :start-column start-column
                                                 :end-line end-line
                                                 :end-column end-column
-                                                :message (coalton-error-note-message note))))
+                                                :message (source-error-note-message note))))
 
                             ;; If this is a multiline note then keep track of the current depth.
                             (when (/= end-line start-line)
@@ -314,8 +309,8 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                 sorted-notes))
 
              ;; Get the character width of the last line mentioned.
-             (first-line (coalton-error-resolved-note-start-line (car resolved-notes)))
-             (last-line (reduce #'max resolved-notes :key #'coalton-error-resolved-note-end-line))
+             (first-line (source-error-resolved-note-start-line (car resolved-notes)))
+             (last-line (reduce #'max resolved-notes :key #'source-error-resolved-note-end-line))
              (line-number-width
                (1+ (floor (log last-line 10)))))
 
@@ -343,7 +338,7 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                              '(#\Space)
                              (mapcar
                               (lambda (note)
-                                (>= (coalton-error-resolved-note-end-line note)
+                                (>= (source-error-resolved-note-end-line note)
                                     line-number))
                               multiline-note-stack)))
 
@@ -351,46 +346,46 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                      (print-line-number line-number t)
                      (format stream " ~v@{ ~}~A~%"
                              (- multiline-note-max-depth
-                                multiline-note-current-depth)
+                                 multiline-note-current-depth)
                              (get-nth-line file-stream line-number)))
 
                    (note-highlight-char (note)
-                     (ecase (coalton-error-resolved-note-type note)
+                     (ecase (source-error-resolved-note-type note)
                        (:primary #\^)
                        (:secondary #\-)))
 
                    (print-singleline-note (note)
-                     (print-line-number (coalton-error-resolved-note-start-line note) nil)
+                     (print-line-number (source-error-resolved-note-start-line note) nil)
                      (format stream
                              " ~v{~C~:*~}~v{~C~:*~} ~A~%"
-                             (+ (coalton-error-resolved-note-start-column note)
-                                (- multiline-note-max-depth
-                                   multiline-note-current-depth))
+                             (+ (source-error-resolved-note-start-column note)
+                                 (- multiline-note-max-depth
+                                     multiline-note-current-depth))
                              '(#\Space)
-                             (- (coalton-error-resolved-note-end-column note)
-                                (coalton-error-resolved-note-start-column note))
+                             (- (source-error-resolved-note-end-column note)
+                                 (source-error-resolved-note-start-column note))
                              (list (note-highlight-char note))
-                             (coalton-error-resolved-note-message note)))
+                             (source-error-resolved-note-message note)))
 
                    (print-multiline-note-start (note)
-                     (print-line-number (coalton-error-resolved-note-start-line note) nil)
+                     (print-line-number (source-error-resolved-note-start-line note) nil)
                      (format stream " ~v{~C~:*~}~C~%"
-                             (+ (coalton-error-resolved-note-start-column note)
-                                (- multiline-note-max-depth
-                                   multiline-note-current-depth))
+                             (+ (source-error-resolved-note-start-column note)
+                                 (- multiline-note-max-depth
+                                     multiline-note-current-depth))
                              '(#\_)
                              (note-highlight-char note)))
 
                    (print-multiline-note-end (note)
-                     (print-line-number (coalton-error-resolved-note-start-line note) nil)
+                     (print-line-number (source-error-resolved-note-start-line note) nil)
                      (format stream
                              "~v{~C~:*~}~C ~A~%"
-                             (+ (coalton-error-resolved-note-end-column note)
-                                (- multiline-note-max-depth
-                                   multiline-note-current-depth))
+                             (+ (source-error-resolved-note-end-column note)
+                                 (- multiline-note-max-depth
+                                     multiline-note-current-depth))
                              '(#\_)
                              (note-highlight-char note)
-                             (coalton-error-resolved-note-message note)))
+                             (source-error-resolved-note-message note)))
 
                    (print-finished-multiline-notes-for-line (line-number)
                      ;; Check if there are any multiline notes that need to be printed
@@ -400,11 +395,11 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                            :when (null stack-head)
                              :do (return)
 
-                           :when (= line-number (coalton-error-resolved-note-end-line note))
+                           :when (= line-number (source-error-resolved-note-end-line note))
                              :do (print-multiline-note-end note)
 
                            :when (and (eq note (car multiline-note-stack))
-                                      (>= line-number (coalton-error-resolved-note-end-line note)))
+                                      (>= line-number (source-error-resolved-note-end-line note)))
                              :do (pop multiline-note-stack)
                                  (decf multiline-note-current-depth)))
 
@@ -428,8 +423,8 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
 
                             ;; Print out any intermediate multiline note endings.
                             (loop :for note :in multiline-note-stack
-                                  :when (< current-line (coalton-error-resolved-note-end-line note) line-number)
-                                    :do (print-lines-until (coalton-error-resolved-note-end-line note)))
+                                  :when (< current-line (source-error-resolved-note-end-line note) line-number)
+                                    :do (print-lines-until (source-error-resolved-note-end-line note)))
 
                             (format stream " ...~%")
                             (print-line-contents (1- line-number))
@@ -441,10 +436,10 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
             (loop :for note :in resolved-notes
                   :do (cond
                         ;; For multiline we need to add to the current stack.
-                        ((/= (coalton-error-resolved-note-start-line note)
-                             (coalton-error-resolved-note-end-line note))
+                        ((/= (source-error-resolved-note-start-line note)
+                             (source-error-resolved-note-end-line note))
                          ;; Print lines until this note.
-                         (print-lines-until (coalton-error-resolved-note-start-line note))
+                         (print-lines-until (source-error-resolved-note-start-line note))
 
                          ;; Print out a new row with underlines connecting
                          ;; back to the multiline position.
@@ -456,11 +451,11 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                         ;; For non-multiline just print the note
                         (t
                          ;; Print lines until this note.
-                         (print-lines-until (coalton-error-resolved-note-start-line note))
+                         (print-lines-until (source-error-resolved-note-start-line note))
 
                          (print-singleline-note note)
 
-                         (print-finished-multiline-notes-for-line (coalton-error-resolved-note-start-line note)))))
+                         (print-finished-multiline-notes-for-line (source-error-resolved-note-start-line note)))))
 
             ;; If there are any multiline notes that have not closed out then
             ;; print them.
@@ -468,20 +463,20 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
             (print-finished-multiline-notes-for-line last-line))))
 
       ;; Print help messages
-      (loop :for help :in (coalton-error-help-notes error)
-            :for start := (car (coalton-error-help-span help))
-            :for end := (cdr (coalton-error-help-span help))
+      (loop :for help :in (source-error-help-notes error)
+            :for start := (car (source-error-help-span help))
+            :for end := (cdr (source-error-help-span help))
             :do (multiple-value-bind (start-line start-line-start)
                     (get-line-from-index file-stream start)
                   (multiple-value-bind (end-line end-line-start)
                       (get-line-from-index file-stream (1- end))
 
                     (unless (= start-line end-line)
-                      (util:coalton-bug "multiline help messages not supported yet."))
+                      (error "multiline help messages not supported yet."))
 
                     (let ((line-number-width (1+ (floor (log end-line 10)))))
                       (format stream "help: ~A~%"
-                              (coalton-error-help-message help))
+                              (source-error-help-message help))
 
                       (format stream " ~vD | ~A"
                               line-number-width
@@ -489,7 +484,7 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                               (subseq (get-nth-line file-stream start-line)
                                       0 (- start start-line-start)))
 
-                      (let ((replaced-text (funcall (coalton-error-help-replacement help)
+                      (let ((replaced-text (funcall (source-error-help-replacement help)
                                                     (subseq (get-nth-line file-stream start-line)
                                                             (- start start-line-start)
                                                             (- end end-line-start)))))
@@ -508,8 +503,8 @@ NOTES and HELP-NOTES may optionally be supplied notes and help messages."
                                 '(#\-)))))))
 
       ;; Print error context
-      (loop :for context :in (coalton-error-context error)
-            :do (format stream "note: ~A~%" (coalton-error-context-message context)))
+      (loop :for context :in (source-error-context error)
+            :do (format stream "note: ~A~%" (source-error-context-message context)))
 
       ;; Reset our file position to avoid messing things up.
       (file-position file-stream file-stream-pos))))
@@ -539,20 +534,6 @@ Returns (VALUES LINE-NUM LINE-START-INDEX)"
             :return nil)
     (values line line-start-index)))
 
-(defun get-source-line-info (file form)
-  "Get source information about FORM which can be used in errors.
-
-Returns (VALUES LINE-NUM LINE-START-INDEX LINE-END-INDEX)"
-  (declare (type stream file)
-           (type cst:cst form))
-  (let ((start-index (car (cst:source form)))
-        (end-index   (cdr (cst:source form))))
-    (multiple-value-bind (line-number line-start-index)
-        (get-line-from-index file start-index)
-      (values line-number
-              (- start-index line-start-index)
-              (- end-index   line-start-index)))))
-
 (defun get-nth-line (file index)
   "Get the INDEXth line FILE. This function uses 1 based indexing."
   (declare (type stream file)
@@ -564,4 +545,4 @@ Returns (VALUES LINE-NUM LINE-START-INDEX LINE-END-INDEX)"
         :when (= i index)
           :do (return-from get-nth-line line))
 
-  (util:coalton-bug "Line number ~D out of bounds for file ~A" index file))
+  (error "Line number ~D out of bounds for file ~A" index file))

--- a/source-error/src/package.lisp
+++ b/source-error/src/package.lisp
@@ -1,0 +1,2 @@
+(uiop:define-package #:source-error
+  (:mix-reexport #:source-error/error))

--- a/src/analysis/pattern-exhaustiveness.lisp
+++ b/src/analysis/pattern-exhaustiveness.lisp
@@ -3,8 +3,7 @@
    #:cl)
   (:local-nicknames
    (#:tc #:coalton-impl/typechecker)
-   (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error))
+   (#:util #:coalton-impl/util))
   (:export
    #:non-exhaustive-match-warning
    #:useless-pattern-warning

--- a/src/analysis/underapplied-values.lisp
+++ b/src/analysis/underapplied-values.lisp
@@ -2,8 +2,8 @@
   (:use
    #:cl)
   (:local-nicknames
+   (#:se #:source-error)
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:tc #:coalton-impl/typechecker))
   (:export
    #:find-underapplied-values           ; FUNCTION
@@ -11,7 +11,7 @@
 
 (in-package #:coalton-impl/analysis/underapplied-values)
 
-(define-condition underapplied-value-warning (error:coalton-base-warning)
+(define-condition underapplied-value-warning (se:source-base-warning)
   ())
 
 (defun find-underapplied-values (binding file)
@@ -25,7 +25,7 @@
                   :when (and (typep elem 'tc:node)
                              (tc:function-type-p (tc:qualified-ty-type (tc:node-type elem))))
                     :do (warn 'underapplied-value-warning
-                              :err (error:coalton-error
+                              :err (se:source-error
                                     :type :warn
                                     :file file
                                     :span (tc:node-source elem)

--- a/src/analysis/unused-variables.lisp
+++ b/src/analysis/unused-variables.lisp
@@ -2,8 +2,8 @@
   (:use
    #:cl)
   (:local-nicknames
+   (#:se #:source-error)
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:tc #:coalton-impl/typechecker))
   (:export
    #:find-unused-variables              ; FUNCTION
@@ -12,12 +12,12 @@
 
 (in-package #:coalton-impl/analysis/unused-variables)
 
-(define-condition unused-variable-warning (error:coalton-base-warning)
+(define-condition unused-variable-warning (se:source-base-warning)
   ())
 
 (defun find-unused-variables (binding file)
   (declare (type (or tc:toplevel-define tc:instance-method-definition) binding)
-           (type error:coalton-file file))
+           (type se:file file))
 
   (let ((used-variables (make-hash-table :test #'eq)))
 
@@ -68,7 +68,7 @@
 (defun variable-binding (var used-variables file)
   (declare (type (or tc:node-variable tc:pattern-var) var)
            (type hash-table used-variables)
-           (type error:coalton-file file))
+           (type se:file file))
 
   (destructuring-bind (name . source)
       (etypecase var
@@ -84,7 +84,7 @@
     (unless (char= (aref (symbol-name name) 0) #\_)
         (unless (gethash name used-variables)
           (warn 'unused-variable-warning
-                :err (error:coalton-error
+                :err (se:source-error
                       :type :warn
                       :file file
                       :span source
@@ -92,7 +92,7 @@
                       :primary-note "variable defined here"
                       :help-notes
                       (list
-                       (error:make-coalton-error-help
+                       (se:make-source-error-help
                         :span source
                         :replacement (lambda (name)
                                        (concatenate 'string "_" name))

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -14,7 +14,6 @@
    #:typecheck-node)
   (:local-nicknames
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:tc #:coalton-impl/typechecker))
   (:export
    #:translate-toplevel                   ; FUNCTION

--- a/src/codegen/translate-instance.lisp
+++ b/src/codegen/translate-instance.lisp
@@ -15,8 +15,7 @@
    #:translate-toplevel)
   (:local-nicknames
    (#:util #:coalton-impl/util)
-   (#:tc #:coalton-impl/typechecker)
-   (#:error #:coalton-impl/error))
+   (#:tc #:coalton-impl/typechecker))
   (:export
    #:translate-instance                   ; FUNCTION
    ))

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -2,9 +2,9 @@
   (:use
    #:cl)
   (:local-nicknames
+   (#:se #:source-error)
    (#:settings #:coalton-impl/settings)
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker)
    (#:analysis #:coalton-impl/analysis)
@@ -89,7 +89,7 @@
 
 (defun expression-entry-point (node file)
   (declare (type parser:node node)
-           (type error:coalton-file file))
+           (type se:file file))
 
   (let ((env *global-environment*))
 
@@ -111,7 +111,7 @@
 
           (when accessors
             (error 'tc:tc-error
-                   :err (tc:coalton-error
+                   :err (se:source-error
                          :span (tc:accessor-source (first accessors))
                          :file file
                          :message "Ambiguous accessor"
@@ -150,7 +150,7 @@
                                (tc:ty-scheme-type scheme))))
 
               (error 'tc:tc-error
-                     :err (error:coalton-error
+                     :err (se:source-error
                            :span (tc:node-source node)
                            :file file
                            :message "Unable to codegen"
@@ -168,7 +168,7 @@
                                                  (tc:qualified-ty-predicates qual-type))
                            :notes
                            (list
-                            (error:make-coalton-error-note
+                            (se:make-source-error-note
                              :type :secondary
                              :span (tc:node-source node)
                              :message "Add a type assertion with THE to resolve ambiguity")))))))))))
@@ -228,8 +228,9 @@
   "Read Coalton source from INPUT and write Lisp source to OUTPUT."
   (parser:with-reader-context input
     (with-environment-updates updates
-      (let* ((file (error:make-coalton-file :stream input
-                                            :name name))
+      (let* ((file (se:make-file
+                    :stream input
+                    :name name))
              (program (entry-point (parser:read-program input file :mode :file))))
         (print-form output (make-prologue))
         (print-form output (make-environment-updater updates))

--- a/src/parser/base.lisp
+++ b/src/parser/base.lisp
@@ -5,8 +5,8 @@
    #:parse-error)
   (:local-nicknames
    (#:cst #:concrete-syntax-tree)
-   (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error))
+   (#:se #:source-error)
+   (#:util #:coalton-impl/util))
   (:export
    #:identifier                         ; TYPE
    #:identifierp                        ; FUNCTION
@@ -69,13 +69,13 @@
 (deftype identifier-src-list ()
   '(satisfies identifier-src-list-p))
 
-(define-condition parse-error (error:coalton-base-error)
+(define-condition parse-error (se:source-base-error)
   ())
 
 (defun parse-list (f list_ file)
   (declare (type function f)
            (type cst:cst list_)
-           (type error:coalton-file file)
+           (type se:file file)
            (values list))
 
   (loop :for list := list_ :then (cst:rest list)

--- a/src/parser/binding.lisp
+++ b/src/parser/binding.lisp
@@ -6,7 +6,6 @@
 (defpackage #:coalton-impl/parser/binding
   (:use
    #:cl
-   #:coalton-impl/error
    #:coalton-impl/parser/pattern
    #:coalton-impl/parser/expression
    #:coalton-impl/parser/toplevel)

--- a/src/parser/pattern.lisp
+++ b/src/parser/pattern.lisp
@@ -1,13 +1,13 @@
 (defpackage #:coalton-impl/parser/pattern
   (:use
    #:cl
-   #:coalton-impl/error
    #:coalton-impl/parser/base)
   (:shadowing-import-from
    #:coalton-impl/parser/base
    #:parse-error)
   (:local-nicknames
    (#:cst #:concrete-syntax-tree)
+   (#:se #:source-error)
    (#:util #:coalton-impl/util))
   (:export
    #:pattern                            ; STRUCT
@@ -89,7 +89,7 @@
 
 (defun parse-pattern (form file)
   (declare (type cst:cst form)
-           (type coalton-file file))
+           (type se:file file))
 
   (cond
     ((and (cst:atom form)
@@ -107,7 +107,7 @@
           (identifierp (cst:raw form)))
      (when (string= "_" (symbol-name (cst:raw form)))
        (error 'parse-error
-              :err  (coalton-error
+              :err  (se:source-error
                      :span (cst:source form)
                      :file file
                      :message "Invalid variable"
@@ -119,7 +119,7 @@
 
     ((cst:atom form)
      (error 'parse-error
-            :err (coalton-error
+            :err (se:source-error
                   :span (cst:source form)
                   :file file
                   :message "Invalid pattern"
@@ -127,7 +127,7 @@
 
     ((not (cst:proper-list-p form))
      (error 'parse-error
-            :err (coalton-error
+            :err (se:source-error
                   :span (cst:source form)
                   :file file
                   :message "Invalid match branch"
@@ -136,7 +136,7 @@
     ((not (and (cst:atom (cst:first form))
                (identifierp (cst:raw (cst:first form)))))
      (error 'parse-error
-            :err (coalton-error
+            :err (se:source-error
                   :span (cst:source (cst:first form))
                   :file file
                   :message "Invalid pattern"

--- a/src/parser/reader.lisp
+++ b/src/parser/reader.lisp
@@ -41,7 +41,8 @@
     (lambda ()
       ,@body)
     ,stream
-    nil 'eof
+    nil
+    'eof
     nil))
 
 (defun maybe-read-form (stream &optional (eclector-client eclector.base:*client*))

--- a/src/parser/types.lisp
+++ b/src/parser/types.lisp
@@ -1,13 +1,13 @@
 (defpackage #:coalton-impl/parser/types
   (:use
    #:cl
-   #:coalton-impl/error
    #:coalton-impl/parser/base)
   (:shadowing-import-from
    #:coalton-impl/parser/base
    #:parse-error)
   (:local-nicknames
    (#:cst #:concrete-syntax-tree)
+   (#:se #:source-error)
    (#:util #:coalton-impl/util))
   (:export
    #:ty                                 ; STRUCT
@@ -130,7 +130,7 @@
 
 (defun parse-qualified-type (form file)
   (declare (type cst:cst form)
-           (type coalton-file file))
+           (type se:file file))
 
   (if (cst:atom form)
 
@@ -155,7 +155,7 @@
           ;; (=> T -> T)
           ((and (null left) right)
            (error 'parse-error
-                  :err (coalton-error
+                  :err (se:source-error
                         :span (cst:source (cst:first form))
                         :file file
                         :message "Malformed type"
@@ -168,7 +168,7 @@
                           ;; If there is nothing to the right of C then emit without list
                           ((cst:atom (cst:rest (cst:rest form)))
                            (list
-                            (make-coalton-error-help
+                            (se:make-source-error-help
                              :span (cst:source form)
                              :replacement
                              (lambda (existing)
@@ -176,7 +176,7 @@
                              :message "remove `=>`")))
                           (t
                            (list
-                            (make-coalton-error-help
+                            (se:make-source-error-help
                              :span (cst:source form)
                              :replacement
                              (lambda (existing)
@@ -188,7 +188,7 @@
           ;; (... =>)
           ((null (rest right))
            (error 'parse-error
-                  :err (coalton-error
+                  :err (se:source-error
                         :span (cst:source (cst:second form))
                         :file file
                         :message "Malformed type"
@@ -206,7 +206,7 @@
                  (loop :for pred :in left
                        :unless (cst:consp pred)
                          :do (error 'parse-error
-                                    :err (coalton-error
+                                    :err (se:source-error
                                           :span (cst:source (cst:second form))
                                           :file file
                                           :message "Malformed type predicate"
@@ -225,7 +225,7 @@
 (defun parse-predicate (forms source file)
   (declare (type util:cst-list forms)
            (type cons source)
-           (type coalton-file file)
+           (type se:file file)
            (values ty-predicate))
 
   (assert forms)
@@ -234,14 +234,14 @@
     ;; (T) ... => ....
     ((not (cst:atom (first forms)))
      (error 'parse-error
-            :err (coalton-error
+            :err (se:source-error
                   :span (cst:source (first forms))
                   :file file
                   :message "Malformed type predicate"
                   :primary-note "expected class name"
                   :help-notes
                   (list
-                   (make-coalton-error-help
+                   (se:make-source-error-help
                     :span (cst:source (first forms))
                     :replacement
                     (lambda (existing)
@@ -251,7 +251,7 @@
     ;; "T" ... => ...
     ((not (identifierp (cst:raw (first forms))))
      (error 'parse-error
-            :err (coalton-error
+            :err (se:source-error
                   :span (cst:source (first forms))
                   :file file
                   :message "Malformed type predicate"
@@ -262,7 +262,7 @@
            (name-src (cst:source (first forms))))
        (when (= 1 (length forms))
          (error 'parse-error
-                :err (coalton-error
+                :err (se:source-error
                       :span (cst:source (first forms))
                       :file file
                       :message "Malformed type predicate"
@@ -278,7 +278,7 @@
 
 (defun parse-type (form file)
   (declare (type cst:cst form)
-           (type coalton-file file)
+           (type se:file file)
            (values ty &optional))
 
   (cond
@@ -292,7 +292,7 @@
 
     ((cst:atom form)
      (error 'parse-error
-            :err (coalton-error
+            :err (se:source-error
                   :span (cst:source form)
                   :file file
                   :message "Malformed type"
@@ -301,7 +301,7 @@
     ;; (T)
     ((cst:atom (cst:rest form))
      (error 'parse-error
-            :err (coalton-error
+            :err (se:source-error
                   :span (cst:source form)
                   :file file
                   :message "Malformed type"
@@ -313,7 +313,7 @@
 (defun parse-type-list (forms source file)
   (declare (type util:cst-list forms)
            (type cons source)
-           (type coalton-file file)
+           (type se:file file)
            (values ty &optional))
 
   (assert forms)
@@ -331,7 +331,7 @@
         (cond
           ((and right (null (rest right)))
            (error 'parse-error
-                  :err (coalton-error
+                  :err (se:source-error
                         :span (cst:source (car right))
                         :file file
                         :message "Malformed function type"
@@ -340,7 +340,7 @@
           ;; (-> ...)
           ((and (null left) right)
            (error 'parse-error
-                  :err (coalton-error
+                  :err (se:source-error
                         :span (cst:source (car right))
                         :file file
                         :message "Malformed function type"

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -2,10 +2,10 @@
   (:use
    #:cl)
   (:local-nicknames
+   (#:se #:source-error)
    (#:cst #:concrete-syntax-tree)
    (#:settings #:coalton-impl/settings)
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker)
    (#:entry #:coalton-impl/entry)))
@@ -39,15 +39,15 @@ Used to forbid reading while inside quasiquoted forms.")
                           s))
                        (t
                         ,stream)))
-                   (,file (error:make-coalton-file :stream ,file-input-stream :name ,filename)))
+                   (,file (se:make-file :stream ,file-input-stream :name ,filename)))
               (handler-bind
                   ;; Render errors and set highlights
-                  ((error:coalton-base-error
+                  ((se:source-base-error
                      (lambda (c)
-                       (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                       (error:render-coalton-error c)))
-                   (error:coalton-base-warning
-                     #'error:render-coalton-warning))
+                       (set-highlight-position-for-error stream (funcall (se:source-base-error-err c)))
+                       (se:render-source-error c)))
+                   (se:source-base-warning
+                     #'se:render-source-warning))
                 ,@body))
          ;; Clean up any opened file streams
          (dolist (s ,opened-streams)
@@ -147,7 +147,7 @@ Used to forbid reading while inside quasiquoted forms.")
     (let* ((file-offset
              (- (sb-impl::fd-stream-get-file-position stream)
                 (file-position stream)))
-           (loc (error:coalton-error-location error)))
+           (loc (se:source-error-location error)))
       (setf (sb-impl::fd-stream-misc stream)
             (lambda (stream operation arg1)
               (if (= (sb-impl::%stream-opcode :get-file-position) operation)

--- a/src/typechecker/accessor.lisp
+++ b/src/typechecker/accessor.lisp
@@ -3,8 +3,8 @@
    #:cl
    #:coalton-impl/typechecker/base)
   (:local-nicknames
+   (#:se #:source-error)
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:tc #:coalton-impl/typechecker/stage-1))
   (:export
    #:accessor                           ; STRUCT
@@ -52,7 +52,7 @@
 
 (defun solve-accessors (accessors file env)
   (declare (type accessor-list accessors)
-           (type error:coalton-file file)
+           (type se:file file)
            (type tc:environment env))
 
   (let ((subs nil)
@@ -84,7 +84,7 @@
 
 (defun solve-accessor (accessor file env)
   (declare (type accessor accessor)
-           (type error:coalton-file file)
+           (type se:file file)
            (type tc:environment env)
            (values boolean tc:substitution-list))
 
@@ -104,8 +104,8 @@
            (struct-entry (tc:lookup-struct env ty-name :no-error t)))
 
       (unless struct-entry
-        (error 'tc-error
-               :err (error:coalton-error
+        (error 'tc:tc-error
+               :err (se:source-error
                      :span (accessor-source accessor)
                      :file file
                      :message "Invalid accessor"
@@ -117,8 +117,8 @@
                                 (tc:struct-entry-field-tys struct-entry))))
 
         (unless field-ty
-          (error 'tc-error
-                 :err (error:coalton-error
+          (error 'tc:tc-error
+                 :err (se:source-error
                        :span (accessor-source accessor)
                        :file file
                        :message "Invalid accessor"

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -2,6 +2,7 @@
   (:use
    #:cl
    #:coalton-impl/algorithm
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/type-errors
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/predicate
@@ -21,7 +22,6 @@
    #:+fundep-max-depth+)
   (:local-nicknames
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:parser #:coalton-impl/parser))
   (:export
    #:*update-hook*                          ; VARIABLE
@@ -1264,7 +1264,7 @@
         (progn
           (match (specialization-entry-to-ty elem) ty)
           (return-from lookup-specialization-by-type elem))
-      (error:coalton-internal-type-error (e)
+      (coalton-internal-type-error (e)
         (declare (ignore e))))))
 
 (defun lookup-fundep-environment (env class &key (no-error nil))

--- a/src/typechecker/kinds.lisp
+++ b/src/typechecker/kinds.lisp
@@ -1,10 +1,10 @@
 (defpackage #:coalton-impl/typechecker/kinds
   (:use
-   #:cl)
+   #:cl
+   #:coalton-impl/typechecker/base)
   (:local-nicknames
    (#:util #:coalton-impl/util)
-   (#:settings #:coalton-impl/settings)
-   (#:error #:coalton-impl/error))
+   (#:settings #:coalton-impl/settings))
   (:export
    #:kind                               ; STRUCT
    #:kind-list                          ; TYPE
@@ -307,7 +307,7 @@
 ;;; Conditions
 ;;;
 
-(define-condition kunify-error (error:coalton-internal-type-error)
+(define-condition kunify-error (coalton-internal-type-error)
   ((kind1 :initarg :kind1
           :reader kunify-errror-kind1
           :type kind)

--- a/src/typechecker/partial-type-env.lisp
+++ b/src/typechecker/partial-type-env.lisp
@@ -1,8 +1,8 @@
 (defpackage #:coalton-impl/typechecker/partial-type-env
   (:use
-   #:cl
-   #:coalton-impl/typechecker/base)
+   #:cl)
   (:local-nicknames
+   (#:se #:source-error)
    (#:util #:coalton-impl/util)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker/stage-1))
@@ -44,14 +44,14 @@
   (declare (type partial-type-env env)
            (type symbol var)
            (type cons source)
-           (type coalton-file file)
+           (type se:file file)
            (values tc:tyvar))
 
   (let ((ty (gethash var (partial-type-env-ty-table env))))
 
     (unless ty
-      (error 'tc-error
-             :err (coalton-error
+      (error 'tc:tc-error
+             :err (se:source-error
                    :span source
                    :file file
                    :message "Unknown type variable"
@@ -87,7 +87,7 @@
 (defun partial-type-env-lookup-type (env tycon file)
   (declare (type partial-type-env env)
            (type parser:tycon tycon)
-           (type coalton-file file)
+           (type se:file file)
            (values tc:ty))
   
   (let* ((name (parser:tycon-name tycon))
@@ -100,8 +100,8 @@
     (let ((type-entry (tc:lookup-type (partial-type-env-env env) name :no-error t)))
 
       (unless type-entry
-        (error 'tc-error
-               :err (coalton-error
+        (error 'tc:tc-error
+               :err (se:source-error
                      :span (parser:ty-source tycon)
                      :file file
                      :message "Unknown type"
@@ -123,7 +123,7 @@
 (defun partial-type-env-lookup-class (env pred file)
   (declare (type partial-type-env env)
            (type parser:ty-predicate pred)
-           (type coalton-file file)
+           (type se:file file)
            (values tc:ty-predicate))
 
   (let* ((name (parser:identifier-src-name (parser:ty-predicate-class pred)))
@@ -136,8 +136,8 @@
     (let ((class-entry (tc:lookup-class (partial-type-env-env env) name :no-error t)))
 
       (unless class-entry
-        (error 'tc-error
-               :err (coalton-error
+        (error 'tc:tc-error
+               :err (se:source-error
                      :span (parser:ty-predicate-source pred)
                      :file file
                      :message "Unknown class"

--- a/src/typechecker/stage-1.lisp
+++ b/src/typechecker/stage-1.lisp
@@ -1,5 +1,6 @@
 (uiop:define-package #:coalton-impl/typechecker/stage-1
   (:mix-reexport
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/kinds
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/substitutions

--- a/src/typechecker/substitutions.lisp
+++ b/src/typechecker/substitutions.lisp
@@ -1,10 +1,10 @@
 (defpackage #:coalton-impl/typechecker/substitutions
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/types)
   (:local-nicknames
-   (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error))
+   (#:util #:coalton-impl/util))
   (:export
    #:substitution                       ; STRUCT
    #:make-substitution                  ; CONSTRUCTOR
@@ -34,7 +34,7 @@
 (deftype substitution-list ()
   '(satisfies substitution-list-p))
 
-(define-condition substitution-list-merge-error (error:coalton-internal-type-error)
+(define-condition substitution-list-merge-error (coalton-internal-type-error)
   ())
 
 (defun merge-substitution-lists (s1 s2)

--- a/src/typechecker/type-errors.lisp
+++ b/src/typechecker/type-errors.lisp
@@ -5,8 +5,7 @@
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/predicate)
   (:local-nicknames
-   (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error))
+   (#:util #:coalton-impl/util))
   (:export
    #:unification-error                  ; CONDITION
    #:infinite-type-unification-error    ; CONDITION
@@ -30,7 +29,7 @@
 
 (in-package #:coalton-impl/typechecker/type-errors)
 
-(define-condition unification-error (error:coalton-internal-type-error)
+(define-condition unification-error (coalton-internal-type-error)
   ((type1 :initarg :type1
           :reader unification-error-type1)
    (type2 :initarg :type2
@@ -43,7 +42,7 @@
                (unification-error-type1 c)
                (unification-error-type2 c))))))
 
-(define-condition infinite-type-unification-error (error:coalton-internal-type-error)
+(define-condition infinite-type-unification-error (coalton-internal-type-error)
   ((type :initarg :type
          :reader infinite-type-unification-error-type))
   (:report
@@ -54,7 +53,7 @@
                (infinite-type-unification-error-type c))))))
 
 
-(define-condition kind-mismatch-error (error:coalton-internal-type-error)
+(define-condition kind-mismatch-error (coalton-internal-type-error)
   ((type :initarg :type
          :reader kind-mismatch-error-type)
    (kind :initarg :kind
@@ -68,7 +67,7 @@
                (kind-of (kind-mismatch-error-type c))
                (kind-mismatch-error-kind c))))))
 
-(define-condition type-kind-mismatch-error (error:coalton-internal-type-error)
+(define-condition type-kind-mismatch-error (coalton-internal-type-error)
   ((type1 :initarg :type1
           :reader type-kind-mismatch-error-type1)
    (type2 :initarg :type2
@@ -83,7 +82,7 @@
                (type-kind-mismatch-error-type2 c)
                (kind-of (type-kind-mismatch-error-type2 c)))))))
 
-(define-condition predicate-unification-error (error:coalton-internal-type-error)
+(define-condition predicate-unification-error (coalton-internal-type-error)
   ((pred1 :initarg :pred1
           :reader unification-error-pred1)
    (pred2 :initarg :pred2
@@ -96,7 +95,7 @@
                (unification-error-pred1 c)
                (unification-error-pred2 c))))))
 
-(define-condition ambiguous-constraint (error:coalton-internal-type-error)
+(define-condition ambiguous-constraint (coalton-internal-type-error)
   ((pred :initarg :pred
          :reader ambiguous-constraint-pred))
   (:report
@@ -106,7 +105,7 @@
        (format s "Ambiguous constraint ~S~%"
                (ambiguous-constraint-pred c))))))
 
-(define-condition overlapping-instance-error (error:coalton-internal-type-error)
+(define-condition overlapping-instance-error (coalton-internal-type-error)
   ((inst1 :initarg :inst1
           :reader overlapping-instance-error-inst1)
    (inst2 :initarg :inst2
@@ -119,7 +118,7 @@
                (overlapping-instance-error-inst1 c)
                (overlapping-instance-error-inst2 c))))))
 
-(define-condition fundep-conflict (error:coalton-internal-type-error)
+(define-condition fundep-conflict (coalton-internal-type-error)
   ((new-pred :initarg :new-pred
              :reader fundep-conflict-new-pred
              :type ty-predicate)
@@ -158,7 +157,7 @@
          (format s "instance conflicts previous instance ~S"
                  (fundep-conflict-old-pred c)))))))
 
-(define-condition overlapping-specialization-error (error:coalton-internal-type-error)
+(define-condition overlapping-specialization-error (coalton-internal-type-error)
   ((new :initarg :new
         :reader overlapping-specialization-error-new)
    (existing :initarg :existing

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -5,8 +5,7 @@
    #:coalton-impl/typechecker/kinds)
   (:local-nicknames
    (#:util #:coalton-impl/util)
-   (#:settings #:coalton-impl/settings)
-   (#:error #:coalton-impl/error))
+   (#:settings #:coalton-impl/settings))
   (:export
    #:ty                                 ; STRUCT
    #:ty-list                            ; TYPE
@@ -455,7 +454,7 @@
 ;;; Conditions
 ;;;
 
-(define-condition type-application-error (error:coalton-internal-type-error)
+(define-condition type-application-error (coalton-internal-type-error)
   ((type :initarg :type
          :reader type-application-error-type)
    (argument :initarg :argument

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -1,12 +1,11 @@
 (defpackage #:coalton-impl/typechecker/unify
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/type-errors
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/substitutions
    #:coalton-impl/typechecker/predicate)
-  (:local-nicknames
-   (#:error #:coalton-impl/error))
   (:export
    #:unify                              ; FUNCTION
    #:match                              ; FUNCTION
@@ -103,7 +102,7 @@ apply s type1 == type2")
                                            (apply-substitution subs pred-type2))
                                       subs)))
                 :initial-value nil))
-    (error:coalton-internal-type-error ()
+    (coalton-internal-type-error ()
       (error 'predicate-unification-error :pred1 pred1 :pred2 pred2))))
 
 (defun predicate-match (pred1 pred2 &optional subs)
@@ -129,7 +128,7 @@ apply s type1 == type2")
                                      subs)))
                :initial-value nil)
        subs)
-    (error:coalton-internal-type-error ()
+    (coalton-internal-type-error ()
       (error 'predicate-unification-error :pred1 pred1 :pred2 pred2))))
 
 (defun match-list (list1 list2)

--- a/tests/error-tests.lisp
+++ b/tests/error-tests.lisp
@@ -30,32 +30,32 @@
                   output-stream)
     :close-stream
     (with-open-file (stream program-file)
-      (let* ((f (coalton-impl/error::make-coalton-file :stream stream :name "file"))
+      (let* ((f (se:make-file :stream stream :name "file"))
              (msg (with-output-to-string (output)
                     ;; an annotating error
-                    (coalton-impl/error::display-coalton-error
+                    (se:display-source-error
                      output
-                     (coalton-impl/error::coalton-error
+                     (se:source-error
                       :span '(76 . 321)
                       :file f
                       :message "message"
                       :primary-note "define instance form"
                       :notes (list
-                              (coalton-impl/error:make-coalton-error-note
+                              (se:make-source-error-note
                                :type :secondary
                                :span  '(132 . 319)
                                :message "message 2")
-                              (coalton-impl/error:make-coalton-error-note
+                              (se:make-source-error-note
                                :type :secondary
                                :span  '(140 . 145)
                                :message "message 3")
-                              (coalton-impl/error:make-coalton-error-note
+                              (se:make-source-error-note
                                :type :secondary
                                :span  '(170 . 174)
                                :message "message 4"))
                       :help-notes
                       (list
-                       (coalton-impl/error:make-coalton-error-help
+                       (se:make-source-error-help
                         :span  '(289 . 291)
                         :replacement (lambda (existing)
                                        (concatenate 'string "*" existing "*"))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -5,8 +5,8 @@
   (:use
    #:cl)
   (:local-nicknames
+   (#:se #:source-error)
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker)
    (#:analysis #:coalton-impl/analysis)

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -12,7 +12,7 @@
                                      :direction :input
                                      :element-type 'character)
                (parser:with-reader-context stream
-                 (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file))))
+                 (parser:read-program stream (se:make-file :stream stream :name (namestring file)) :mode :file))))
 
            (parse-error-text (file)
              (with-open-file (stream file
@@ -21,9 +21,9 @@
                (handler-case
                    (parser:with-reader-context stream
                      (entry:entry-point
-                      (parser:read-program stream (error:make-coalton-file :stream stream :name "test") :mode :file))
+                      (parser:read-program stream (se:make-file :stream stream :name "test") :mode :file))
                      "no errors")
-                 (error:coalton-base-error (c)
+                 (se:source-base-error (c)
                    (princ-to-string c))))))
     (dolist (file (test-files "tests/parser-test-files/bad-files/*.coal"))
       (let ((error-file (make-pathname :type "error"

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -38,7 +38,7 @@
     (unwind-protect
          (let* ((stream (make-string-input-stream toplevel-string))
 
-                (file (error:make-coalton-file :stream stream :name "<test>"))
+                (file (se:make-file :stream stream :name "<test>"))
 
                 (program (parser:with-reader-context stream
                            (parser:read-program stream file :mode :test))))
@@ -52,7 +52,7 @@
                      :for symbol := (intern (string-upcase unparsed-symbol) *package*)
 
                      :for stream := (make-string-input-stream unparsed-type)
-                     :for file := (error:make-coalton-file :stream stream :name "<unknown>")
+                     :for file := (se:make-file :stream stream :name "<unknown>")
 
                      :for ast-type := (parser:parse-qualified-type
                                        (eclector.concrete-syntax-tree:read stream)


### PR DESCRIPTION
This makes it easier to reuse the error rendering machinery in other projects. It also enforces a strict seperating between the error system and Coalton proper.