### PR TITLE
Replace hash tables in environment with alists

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -88,6 +88,7 @@
                              (:file "type-errors")
                              (:file "unify")
                              (:file "fundeps")
+                             (:file "map")
                              (:file "environment")
                              (:file "lisp-type")
                              (:file "context-reduction")
@@ -346,6 +347,9 @@
                (:file "fundep-tests")
                (:file "fundep-fib-test")
                (:file "runtime-tests")
+               (:module "typechecker"
+                :serial t
+                :components ((:file "map-tests")))
                (:file "environment-persist-tests")
                (:file "slice-tests")
                (:file "float-tests")

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -501,7 +501,7 @@
                     (superclass-dict (tc:ty-class-superclass-dict class))
 
                     ;; Map the accessor to a named superclass
-                    (superclass-name (gethash (node-field-name node) (tc:ty-class-superclass-map class)))
+                    (superclass-name (tc:get-value (tc:ty-class-superclass-map class) (node-field-name node)))
 
                     ;; Find the predicate of the accessed superclass
                     (superclass-pred (car (find superclass-name superclass-dict :key #'cdr)))

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -188,7 +188,8 @@ Returns a `node'.")
 
                (struct-entry (tc:lookup-struct env (tc:tycon-name from-ty)))
 
-               (idx (gethash (tc:node-accessor-name expr) (tc:struct-entry-field-idx struct-entry))))
+               (idx (tc:get-value (tc:struct-entry-field-idx struct-entry)
+                                  (tc:node-accessor-name expr))))
 
           (assert idx)
 

--- a/src/codegen/translate-instance.lisp
+++ b/src/codegen/translate-instance.lisp
@@ -49,7 +49,7 @@
          (method-definitions
            (loop :for (method-name . type) :in (tc:ty-class-unqualified-methods class)
                  :for binding := (gethash method-name (tc:toplevel-define-instance-methods instance))
-                 :for codegen-sym := (gethash method-name method-codegen-syms)
+                 :for codegen-sym := (tc:get-value method-codegen-syms method-name)
 
                  :collect (cons codegen-sym (translate-toplevel binding env))))
 

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -427,8 +427,8 @@
                     :type (tc:type-entry-type entry)
                     :tyvars (tc:type-entry-tyvars entry)
                     :fields (tc:struct-entry-fields struct-entry)
-                    :field-docstrings (tc:struct-entry-field-docstrings struct-entry)
-                    :field-tys (tc:struct-entry-field-tys struct-entry)
+                    :field-docstrings (tc:get-table (tc:struct-entry-field-docstrings struct-entry))
+                    :field-tys (tc:get-table (tc:struct-entry-field-tys struct-entry))
                     :instances applicable-instances)
                    output-structs))
 

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -214,7 +214,7 @@
                 :constraints context
                 :predicate predicate
                 :codegen-sym nil
-                :method-codegen-syms (make-hash-table)
+                :method-codegen-syms (tc:make-map :test 'eq)
                 :docstring nil)))
 
       (maybe-write-section stream documentation)

--- a/src/typechecker/accessor.lisp
+++ b/src/typechecker/accessor.lisp
@@ -113,8 +113,8 @@
                      (format nil "type '~S' is not a struct" ty-name))))
 
       (let* ((subs (tc:match struct-ty (accessor-from accessor)))
-             (field-ty (gethash (accessor-field accessor)
-                                (tc:struct-entry-field-tys struct-entry))))
+             (field-ty (tc:get-value (tc:struct-entry-field-tys struct-entry)
+                                      (accessor-field accessor))))
 
         (unless field-ty
           (error 'tc:tc-error

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -261,14 +261,14 @@
                                       (format nil "SUPER-~D" i))))
 
            :for superclass-map
-             := (loop :with table := (make-hash-table :test #'eq)
+             := (loop :with table := (tc:make-map :test 'eq)
                       :for (pred . super-name) :in superclass-dict
                       :for prefixed-name := (alexandria:format-symbol
                                              *package*
                                              "~A-~A"
                                              codegen-sym
                                              super-name)
-                      :do (setf (gethash prefixed-name table) super-name)
+                      :do (setf (tc:get-value table prefixed-name) super-name)
                       :finally (return table))
 
            :for fundeps
@@ -284,10 +284,10 @@
                   :superclasses (partial-class-superclasses partial)
                   :class-variables class-vars
 
-                  :class-variable-map (loop :with table := (make-hash-table :test #'eq)
+                  :class-variable-map (loop :with table := (tc:make-map :test 'eq)
                                             :for var :in class-vars
                                             :for i :from 0
-                                            :do (setf (gethash var table) i)
+                                            :do (setf (tc:get-value table var) i)
                                             :finally (return table))
 
                   :fundeps fundeps

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -110,14 +110,12 @@
              (method-names (mapcar #'car (tc:ty-class-unqualified-methods class)))
 
              (method-codegen-syms
-               (loop :with table := (make-hash-table :test #'eq)
+               (loop :with table := (tc:make-map :test 'eq)
                      :for method-name :in method-names
-                     :do (setf (gethash method-name table)
-                               (alexandria:format-symbol
-                                *package*
-                                "~A-~S"
-                                instance-codegen-sym
-                                method-name))
+                     :do (setf (tc:get-value table method-name)
+                               (alexandria:format-symbol *package* "~A-~S"
+                                                         instance-codegen-sym
+                                                         method-name))
                      :finally (return table)))
 
              (docstring (parser:toplevel-define-instance-docstring instance))
@@ -161,7 +159,7 @@
                          :primary-note (format nil "instance overlaps with ~S" (tc:overlapping-instance-error-inst2 e))))))
 
         (loop :for method-name :in method-names
-              :for method-codegen-sym := (gethash method-name method-codegen-syms) :do
+              :for method-codegen-sym := (tc:get-value method-codegen-syms method-name) :do
                 (setf env (tc:set-method-inline env method-name instance-codegen-sym method-codegen-sym)))
 
         (values instance-entry env)))))

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -235,21 +235,21 @@
   (cond ((typep parsed-type 'parser:toplevel-define-struct)
          (let* ((fields (mapcar #'parser:struct-field-name
                                 (parser:toplevel-define-struct-fields parsed-type)))
-                (field-docstrings (loop :with table := (make-hash-table :test #'equal)
+                (field-docstrings (loop :with table := (tc:make-map)
                                         :for field :in fields
                                         :for docstring :in (mapcar #'parser:struct-field-docstring
                                                                    (parser:toplevel-define-struct-fields parsed-type))
-                                        :do (setf (gethash field table) docstring)
+                                        :do (setf (tc:get-value table field) docstring)
                                         :finally (return table)))
-                (field-tys (loop :with table := (make-hash-table :test #'equal)
+                (field-tys (loop :with table := (tc:make-map)
                                  :for field :in fields
                                  :for ty :in (first (type-definition-constructor-args type))
-                                 :do (setf (gethash field table) ty)
+                                 :do (setf (tc:get-value table field) ty)
                                  :finally (return table)))
-                (field-idx (loop :with table := (make-hash-table :test #'equal)
+                (field-idx (loop :with table := (tc:make-map)
                                  :for field :in fields
                                  :for i :from 0
-                                 :do (setf (gethash field table) i)
+                                 :do (setf (tc:get-value table field) i)
                                  :finally (return table))))
            (setf env (tc:set-struct
                       env

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -2691,7 +2691,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
                      (new-tys (util:project-map
                                new-vars
-                               (tc:ty-class-class-variable-map class)
+                               (tc:get-table (tc:ty-class-class-variable-map class))
                                (tc:ty-predicate-types pred))))
 
                 (loop :for var :in (set-difference

--- a/src/typechecker/map.lisp
+++ b/src/typechecker/map.lisp
@@ -1,0 +1,65 @@
+;;; Environment maps provide readable representations of hash
+;;; table-valued fields present in Coalton environment updates
+;;; in generated Lisp code.
+
+(defpackage #:coalton-impl/typechecker/map
+  (:use
+   #:cl)
+  (:local-nicknames
+   (#:util #:coalton-impl/util))
+  (:export
+   #:environment-map
+   #:make-map
+   #:get-table
+   #:get-value))
+
+(in-package #:coalton-impl/typechecker/map)
+
+(defstruct environment-map
+  "A readable, hash table-backed map."
+  (table (util:required 'table) :type hash-table :read-only t)
+  (test  (util:required 'test)  :type symbol     :read-only t))
+
+(defun make-map (&key initial-contents (test 'equal))
+  "Construct an environment map containing the keys and values of the association list ALIST.
+
+Environment maps have a readable representation as an alist.
+Hash table is initialized using TEST."
+  (let ((table (make-hash-table :test test)))
+    (dolist (cons initial-contents)
+      (alexandria:ensure-gethash (car cons) table (cdr cons)))
+    (make-environment-map :table table
+                          :test test)))
+
+(defmethod make-load-form ((self environment-map) &optional environment)
+  (make-load-form-saving-slots self :environment environment))
+
+(defmethod print-object ((self environment-map) stream)
+  (if *print-readably*
+      (let ((alist (alexandria:hash-table-alist (environment-map-table self))))
+        (write-string "#.(" stream)
+        (write 'make-map :stream stream)
+        (dolist (value `(:initial-contents ',alist :test ',(environment-map-test self)))
+          (write-char #\Space stream)
+          (write value :stream stream))
+        (write-string ")" stream))
+      (call-next-method)))
+
+(declaim (inline get-table))
+(defun get-table (environment-map)
+  "Return the underlying hash table that provides storage for environment map ENVIRONMENT-MAP."
+  (declare (type environment-map environment-map))
+  (environment-map-table environment-map))
+
+(declaim (inline get-value))
+(defun get-value (environment-map key)
+  "Return the value in environment map ENVIRONMENT-MAP associated with KEY."
+  (declare (type environment-map environment-map))
+  (gethash key (environment-map-table environment-map)))
+
+(declaim (inline (setf get-value)))
+(defun (setf get-value) (value environment-map key)
+  "Mutate environment map ENVIRONMENT-MAP to associate KEY with VALUE."
+  (declare (type environment-map environment-map))
+  (setf (gethash key (environment-map-table environment-map)) value)
+  environment-map)

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -114,7 +114,7 @@
                       :for pred-tys := (tc:ty-predicate-types pred)
                       :for class-name := (tc:ty-predicate-class pred)
                       :for class := (tc:lookup-class env class-name)
-                      :for map := (tc:ty-class-class-variable-map class)
+                      :for map := (tc:get-table (tc:ty-class-class-variable-map class))
                       :when (tc:ty-class-fundeps class) :do
                         (loop :for fundep :in (tc:ty-class-fundeps class)
                               :for from-vars := (util:project-map (tc:fundep-from fundep) map pred-tys)

--- a/src/typechecker/stage-1.lisp
+++ b/src/typechecker/stage-1.lisp
@@ -1,6 +1,7 @@
 (uiop:define-package #:coalton-impl/typechecker/stage-1
   (:mix-reexport
    #:coalton-impl/typechecker/base
+   #:coalton-impl/typechecker/map
    #:coalton-impl/typechecker/kinds
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/substitutions

--- a/tests/typechecker/map-tests.lisp
+++ b/tests/typechecker/map-tests.lisp
@@ -1,0 +1,45 @@
+(in-package #:coalton-tests)
+
+(defstruct map-container
+  map)
+
+(defmethod make-load-form ((self map-container) &optional environment)
+  (make-load-form-saving-slots self :environment environment))
+
+(deftest test-print-environment-map ()
+  "Maps with hash table storage survive print, read."
+  (let ((map (tc:make-map :initial-contents '(("key" . "value")))))
+    (with-standard-io-syntax
+      (let* ((obj (make-map-container :map map))
+             (obj-string (with-output-to-string (stream)
+                              (prin1 obj stream)))
+             (obj-roundtrip (with-input-from-string (stream obj-string)
+                                 (read stream))))
+        (is (equalp obj
+                    obj-roundtrip))))))
+
+;; *test-map* is bound when the test below loads a compiled file
+;; containing a map.
+
+(defvar *test-map*)
+
+(deftest test-compile-environment-map ()
+  "Maps with hash table storage survive print, compile-file, load."
+  (let* ((sym (gensym))
+         (map (tc:make-map :initial-contents `(("key" . ,sym))))
+         (obj (make-map-container :map map)))
+    (uiop:with-temporary-file (:stream stream
+                               :pathname input-file
+                               :suffix "lisp"
+                               :direction :output)
+      (with-standard-io-syntax
+        (prin1 `(setf *test-map* ,obj) stream))
+
+      :close-stream
+
+      (uiop:with-temporary-file (:pathname output-file
+                                 :type #+ccl (pathname-type ccl:*.fasl-pathname*)
+                                       #+(not ccl) "fasl")
+        (load (compile-file input-file :output-file output-file :verbose nil :print nil))
+        (is (string-equal sym
+                          (tc:get-value (map-container-map *test-map*) "key")))))))


### PR DESCRIPTION
Hash table instances aren't, by default, printed readably in Allegro and CCL, preventing generation of environment updates in source for coalton when there are classes and structs present.

Convert the few occurrences of these into association lists, which are probably more efficient, since the entry counts are always small.

This emerges from incremental conversion of the standard library to .coal files, in #1129 