### PR TITLE
iter:optimize-by!

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -172,7 +172,7 @@
                 :serial t
                 :components ((:file "arith")
                              (:file "num")
-                             (:file "bounded") 
+                             (:file "bounded")
                              (:file "conversions")
                              (:file "fraction")
                              (:file "integral")
@@ -183,10 +183,10 @@
                              (:file "dual")))
                (:file "randomaccess")
                (:file "cell")
+               (:file "tuple")
                (:file "iterator")
                (:file "optional")
                (:file "result")
-               (:file "tuple")
                (:file "lisparray")
                (:file "list")
                (:file "vector")
@@ -268,11 +268,11 @@
                (:file "fibonacci")
                (:file "big-float")
                (:module "gabriel-benchmarks"
-                        :serial t
-                        :components ((:file "tak")
-                                     (:file "stak")
-                                     (:file "takl")
-                                     (:file "takr")))))
+                :serial t
+                :components ((:file "tak")
+                             (:file "stak")
+                             (:file "takl")
+                             (:file "takr")))))
 
 ;;; we need to inspect the sbcl version in order to decide which version of the hashtable shim to load,
 ;;; because 2.1.12 includes (or will include) a bugfix that allows a cleaner, more maintainable

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -55,6 +55,9 @@
    #:optimize!
    #:max!
    #:min!
+   #:optimize-by!
+   #:maximize-by!
+   #:minimize-by!
    #:every!
    #:any!
    #:elementwise-match!
@@ -516,6 +519,33 @@ Return `None` if ITER is empty."
   (define (min! iter)
     "Return the most-negative element of ITER, or `None` if ITER is empty."
     (optimize! < iter))
+
+  (declare optimize-by! ((:b -> :b -> Boolean) ->
+                        (:a -> :b) ->
+                        Iterator :a ->
+                        Optional :a))
+  (define (optimize-by! better? f iter)
+    "For an order BETTER? which returns `True` if its first argument is better than its second argument, return the element of ITER where (F ELT) is the best.
+
+Return `None` if ITER is empty."
+    (match (optimize! (fn ((Tuple _ a) (Tuple _ b)) (better? a b))
+                      (pair-with! f iter))
+      ((Some (Tuple result _)) (Some result))
+      ((None) None)))
+
+  (declare maximize-by! (Ord :a => (:elt -> :a) -> Iterator :elt -> Optional :elt))
+  (define (maximize-by! f iter)
+    "For a function F, which maps the iterator, return the element of ITER where (F ELT) is the most-positive.
+
+Return `None' if ITER is empty."
+    (optimize-by! > f iter))
+
+  (declare minimize-by! (Ord :a => (:elt -> :a) -> Iterator :elt -> Optional :elt))
+  (define (minimize-by! f iter)
+    "For a function F, which maps the iterator, return the element of ITER where (F ELT) is the most-negative.
+
+Return `None' if ITER is empty."
+    (optimize-by! < f iter))
 
   (declare every! ((:elt -> Boolean) -> Iterator :elt -> Boolean))
   (define (every! good? iter)

--- a/tests/iterator-tests.lisp
+++ b/tests/iterator-tests.lisp
@@ -32,7 +32,7 @@
 
 (define-test iter-char-range-string-chars ()
   (let ((same? (fn (expected-str range-start range-end)
-                 (iter:and! 
+                 (iter:and!
                   (iter:zip-with!
                    ==
                    (iter:into-iter expected-str)
@@ -117,7 +117,13 @@
                                   (iter:up-to 10)))))
   (is (== (Some (the UFix 0))
           (iter:min! (iter:chain! (iter:down-from 10)
-                                  (iter:up-to 10))))))
+                                  (iter:up-to 10)))))
+  (is (== (Some (the Integer 0))
+          (iter:maximize-by! negate (iter:chain! (iter:up-to 10)
+                                                (iter:down-from 10)))))
+  (is (== (Some (the Integer 10))
+          (iter:minimize-by! negate (iter:chain! (iter:down-from 10)
+                                                (iter:up-through 10))))))
 
 (define-test iter-optimize-string-length ()
   (let ((longer? (fn (long short)


### PR DESCRIPTION
Added `optimizing!`, `maximizing!`, and `minimizing!` to the iterator package, these behave like `optimize!` functions but compare values mapped by `f`.