### PR TITLE
coalton-codegen-ast: return a value, like coalton-codegen

### DIFF
--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -92,9 +92,9 @@ Used to forbid reading while inside quasiquoted forms.")
                                              (when (eql op ':AST)
                                                (push args ast)))))
               (entry:entry-point (parser:read-program stream file :mode ':toplevel-macro))
-              (loop :for (name type value) :in (nreverse ast)
-                    :do (format t "~A :: ~A~%~A~%~%~%" name type value))))
-          nil)
+              `',(loop :for (name type value) :in (nreverse ast)
+                       :do (format t "~A :: ~A~%~A~%~%~%" name type value)
+                       :collect (list name type value)))))
 
         (coalton:coalton
           (with-coalton-file (file stream)


### PR DESCRIPTION
Arising from discussion with a Coalton User who asked why codegen-ast doesn't return a value for use in further debugging: have it return a value, like codegen does.