### PR TITLE
Stronger assertions for runtime lookup of stdlib packages

### DIFF
--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -136,7 +136,7 @@ Returns a `node'.")
     (let ((qual-ty (tc:node-type expr)))
       (assert (null (tc:qualified-ty-predicates qual-ty)))
       
-      (let* ((classes-package (find-package "COALTON-LIBRARY/CLASSES"))
+      (let* ((classes-package (util:find-package "COALTON-LIBRARY/CLASSES"))
 
              (num-class (util:find-symbol "NUM" classes-package))
 
@@ -196,9 +196,7 @@ Returns a `node'.")
               ;; If the struct is a newtype, then return 'id' as the accessor
               (make-node-variable
                :type ty
-               :value (util:find-symbol
-                       "ID"
-                       (find-package "COALTON-LIBRARY/FUNCTIONS")))
+               :value (util:find-symbol "ID" "COALTON-LIBRARY/FUNCTIONS"))
 
               (make-node-variable
                :type ty
@@ -392,10 +390,8 @@ Returns a `node'.")
     (let ((qual-ty (tc:node-type expr)))
       (assert (null (tc:qualified-ty-predicates qual-ty)))
 
-      (let* ((coalton-package (find-package "COALTON"))
+      (let ((unit-value (util:find-symbol "UNIT" "COALTON")))
 
-             (unit-value (util:find-symbol "UNIT" coalton-package)))
-        
         (make-node-return
          :type (tc:qualified-ty-type qual-ty)
          :expr (if (tc:node-return-expr expr)
@@ -409,7 +405,7 @@ Returns a `node'.")
              (type tc:environment env)
              (values node))
 
-    (let* ((coalton-package (find-package "COALTON"))
+    (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
            (false-value (util:find-symbol "FALSE" coalton-package)))
 
@@ -443,7 +439,7 @@ Returns a `node'.")
              (type tc:environment env)
              (values node))
 
-    (let* ((coalton-package (find-package "COALTON"))
+    (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
            (false-value (util:find-symbol "FALSE" coalton-package)))
 
@@ -477,7 +473,7 @@ Returns a `node'.")
              (type tc:environment env)
              (values node))
 
-    (let* ((coalton-package (find-package "COALTON"))
+    (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
            (false-value (util:find-symbol "FALSE" coalton-package))
 
@@ -507,7 +503,7 @@ Returns a `node'.")
              (type tc:environment env)
              (values node))
 
-    (let* ((coalton-package (find-package "COALTON"))
+    (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
            (false-value (util:find-symbol "FALSE" coalton-package))
            (unit-value (util:find-symbol "UNIT" coalton-package)))
@@ -536,7 +532,7 @@ Returns a `node'.")
              (type tc:environment env)
              (values node))
 
-    (let* ((coalton-package (find-package "COALTON"))
+    (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
            (false-value (util:find-symbol "FALSE" coalton-package))
            (unit-value (util:find-symbol "UNIT" coalton-package)))
@@ -593,7 +589,7 @@ Returns a `node'.")
              (pattern-type pat-arg))
 
            (classes-package
-             (find-package "COALTON-LIBRARY/CLASSES"))
+             (util:find-package "COALTON-LIBRARY/CLASSES"))
 
            (some
              (util:find-symbol "SOME" classes-package))
@@ -620,7 +616,7 @@ Returns a `node'.")
              (node-type into-iter-arg))
 
            (iterator-package
-             (find-package "COALTON-LIBRARY/ITERATOR"))
+             (util:find-package "COALTON-LIBRARY/ITERATOR"))
 
            (into-iter-method
              (util:find-symbol "INTO-ITER" iterator-package))
@@ -718,7 +714,7 @@ Returns a `node'.")
              (type tc:environment env)
              (values node))
 
-    (let* ((coalton-package (find-package "COALTON"))
+    (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
            (false-value (util:find-symbol "FALSE" coalton-package))
 
@@ -755,7 +751,7 @@ Returns a `node'.")
              (type tc:environment env)
              (values node))
 
-    (let* ((classes-package (find-package "COALTON-LIBRARY/CLASSES"))
+    (let* ((classes-package (util:find-package "COALTON-LIBRARY/CLASSES"))
 
            (monad-symbol (util:find-symbol "MONAD" classes-package))
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -337,7 +337,7 @@
   (when (parser:toplevel-define-instance-compiler-generated instance)
     (return-from check-instance-valid))
 
-  (let* ((types-package (find-package "COALTON-LIBRARY/TYPES"))
+  (let* ((types-package (util:find-package "COALTON-LIBRARY/TYPES"))
 
          (runtime-repr (util:find-symbol "RUNTIMEREPR" types-package)))
 

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -490,7 +490,7 @@
 
   (let* ((source (type-definition-source type))
 
-         (types-package (find-package "COALTON-LIBRARY/TYPES"))
+         (types-package (util:find-package "COALTON-LIBRARY/TYPES"))
 
          (runtime-repr (util:find-symbol "RUNTIMEREPR" types-package))
 

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -314,9 +314,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-integer-literal tc:substitution-list &optional))
 
-    (let* ((classes-package (find-package "COALTON-LIBRARY/CLASSES"))
-
-           (num (util:find-symbol "NUM" classes-package))
+    (let* ((num (util:find-symbol "NUM" "COALTON-LIBRARY/CLASSES"))
 
            (tvar (tc:make-variable))
 
@@ -1250,12 +1248,9 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-for tc:substitution-list &optional))
 
-    (let* ((iterator-package
-             (find-package "COALTON-LIBRARY/ITERATOR"))
-           
-           (intoiter-symbol
-             (util:find-symbol "INTOITERATOR" iterator-package)))
-      
+    (let ((intoiter-symbol
+            (util:find-symbol "INTOITERATOR" "COALTON-LIBRARY/ITERATOR")))
+
       (multiple-value-bind (pat-ty pat-node subs)
           (infer-pattern-type (parser:node-for-pattern node) (tc:make-variable) subs env file)
 
@@ -1499,9 +1494,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
     (let* (;; m-type is the type of the monad and has kind "* -> *"
            (m-type (tc:make-variable (tc:make-kfun :from tc:+kstar+ :to tc:+kstar+)))
 
-           (classes-package (find-package "COALTON-LIBRARY/CLASSES"))
-
-           (monad-symbol (util:find-symbol "MONAD" classes-package))
+           (monad-symbol (util:find-symbol "MONAD" "COALTON-LIBRARY/CLASSES"))
 
            (preds nil)
            (accessors nil)


### PR DESCRIPTION
Add util:find-package, analogous to util:find-symbol, to make some errors related to failed lookups of required packages and symbols more scrutable.

Before:
```
; caught COMMON-LISP:ERROR:
;   COMMON-LISP:READ error during COMMON-LISP:COMPILE-FILE:
;   
;     The value
;       COMMON-LISP:NIL
;     is not of type
;       PACKAGE
;     when binding COMMON-LISP:PACKAGE
;   
;     (in form starting at line: 20, column: 0, position: 397)
```

After:
```
; caught COMMON-LISP:ERROR:
;   COMMON-LISP:READ error during COMMON-LISP:COMPILE-FILE:
;   
;     Internal coalton bug: Missing required package: "COALTON-LIBRARY/TYPES"
;   
;   If you are seeing this, please file an issue on Github.
;   
;     (in form starting at line: 20, column: 0, position: 397)
```