### PR TITLE
docstrings and fix type lookup with :no-error

### DIFF
--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -141,6 +141,7 @@ A function bound here will be called with a keyword category, and one or more ad
        ,(codegen-expression (node-abstraction-subexpr node) name env))))
 
 (defun compile-scc (bindings env)
+  "Compile SCC definitions in a translation unit."
   (declare (type binding-list bindings)
            (type tc:environment env))
   (append
@@ -171,7 +172,7 @@ A function bound here will be called with a keyword category, and one or more ad
       (let ((name (car binding)))
         (format t ";; ~a :: ~a~%"
                 name
-                (tc:lookup-value-type env name)))))
+                (tc:lookup-value-type env name :no-error t)))))
 
   ;; Docstrings
   (loop :for (name . node) :in bindings

--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -58,7 +58,7 @@ Enable release mode either by setting the UNIX environment variable COALTON_ENV 
 
 (declaim (type boolean *compile-print-types*))
 (defvar *compile-print-types* nil
-  "Print types of definitions to stdout on compile.")
+  "Print types of definitions to standard output on compile.")
 
 (defvar *coalton-optimize* '(optimize (speed 3) (safety 0)))
 


### PR DESCRIPTION
Looking up the type in the env caused an error with `define-type`, I copied other calls of that function and added `:no-error t`