### PR TITLE
print-object method for seq:seq

### DIFF
--- a/library/seq.lisp
+++ b/library/seq.lisp
@@ -562,6 +562,15 @@ It attempts to rebalance with a minimum of array copying."
                           (cl:rest leaf-arrays)
                           :initial-value `(LeafArray ,(cl:funcall make-ary (cl:first leaf-arrays))))))))))
 
+;; This method implementation uses :around because sum types implement
+;; cl:print-object for each representation, to avoid a brittle design
+;; by overwriting them manually, the :around method short-circuits them.
+(cl:defmethod cl:print-object :around ((self seq) stream)
+  (cl:print-unreadable-object (self stream :type cl:nil)
+    (cl:format stream "SEQ~{ ~A~}"
+               (coalton ((the ((Seq :a) -> (List :a)) (fn (seq) (into seq)))
+                         (lisp (Seq :a) () self)))))
+  self)
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/SEQ")


### PR DESCRIPTION
Solves https://github.com/coalton-lang/coalton/issues/1144

```lisp
COALTON-USER> (coalton (coalton-library/seq:make 1 2 3))
#.(SEQ 1 2 3)
```

To avoid the methods defined [here](https://github.com/coalton-lang/coalton/blob/main/src/codegen/codegen-type-definition.lisp#L90) being used, I short-circuited them by using an `:around` method.

Regarding the suggested output `#.(seq:make 1 2 3)`, I replaced `seq:make` with just `seq` to match the implementations for Queue and Cell.

There will be nits, I will resolve them tomorrow :)