### PR TITLE
Define types for struct fields and class methods

### DIFF
--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -188,8 +188,8 @@ Returns a `node'.")
 
                (struct-entry (tc:lookup-struct env (tc:tycon-name from-ty)))
 
-               (idx (tc:get-value (tc:struct-entry-field-idx struct-entry)
-                                  (tc:node-accessor-name expr))))
+               (idx (tc:struct-field-index (tc:get-field struct-entry
+                                                         (tc:node-accessor-name expr)))))
 
           (assert idx)
 

--- a/src/codegen/translate-instance.lisp
+++ b/src/codegen/translate-instance.lisp
@@ -47,16 +47,19 @@
                  :collect (pred-type pred env)))
 
          (method-definitions
-           (loop :for (method-name . type) :in (tc:ty-class-unqualified-methods class)
+           (loop :for method :in (tc:ty-class-unqualified-methods class)
+                 :for method-name := (tc:ty-class-method-name method)
                  :for binding := (gethash method-name (tc:toplevel-define-instance-methods instance))
                  :for codegen-sym := (tc:get-value method-codegen-syms method-name)
 
                  :collect (cons codegen-sym (translate-toplevel binding env))))
 
          (unqualified-method-definitions
-           (loop :for (method-name . type) :in (tc:ty-class-unqualified-methods class)
+           (loop :for method :in (tc:ty-class-unqualified-methods class)
+                 :for method-name := (tc:ty-class-method-name method)
+                 :for method-type := (tc:ty-class-method-type method)
                  :for binding := (gethash method-name (tc:toplevel-define-instance-methods instance))
-                 :collect (translate-toplevel (tc:attach-explicit-binding-type binding (tc:fresh-inst type))
+                 :collect (translate-toplevel (tc:attach-explicit-binding-type binding (tc:fresh-inst method-type))
                                               env
                                               :extra-context ctx)))
 
@@ -113,4 +116,3 @@
           :do (typecheck-node node env))
 
     bindings))
- 

--- a/src/debug.lisp
+++ b/src/debug.lisp
@@ -77,8 +77,10 @@
                                (tc:ty-predicate-class class-pred)
                                (tc:ty-predicate-types class-pred)
                                (mapcar #'tc:kind-of (tc:ty-predicate-types class-pred))))
-                     (loop :for (method-name . method-type) :in (tc:ty-class-unqualified-methods entry) :do
-                       (format t "    ~S :: ~A~%" method-name method-type)))
+                     (loop :for method :in (tc:ty-class-unqualified-methods entry) :do
+                       (format t "    ~S :: ~A~%"
+                               (tc:ty-class-method-name method)
+                               (tc:ty-class-method-type method))))
                    (format t "~%")))
                (format t "~%")))
       (if package

--- a/src/doc/generate-documentation.lisp
+++ b/src/doc/generate-documentation.lisp
@@ -25,9 +25,7 @@
             (:include documentation-entry))
   (type             (util:required 'type)             :type tc:ty                     :read-only t)
   (tyvars           (util:required 'tyvars)           :type tc:tyvar-list             :read-only t)
-  (fields           (util:required 'fields)           :type util:string-list          :read-only t)
-  (field-docstrings (util:required 'field-docstrings) :type hash-table                :read-only t)
-  (field-tys        (util:required 'field-tys)        :type hash-table                :read-only t)
+  (fields           (util:required 'fields)           :type tc:struct-field-list      :read-only t)
   (instances        (util:required 'instances)        :type tc:ty-class-instance-list :read-only t))
 
 (defun documentation-struct-entry-list-p (x)
@@ -42,8 +40,6 @@
   (context   (util:required 'context)                   :type t :read-only t)
   (predicate (util:required 'predicate)                 :type t :read-only t)
   (methods   (util:required 'methods)                   :type t :read-only t)
-  ;; A list of strings in the same order as the methods slot
-  (method-docstrings (util:required 'method-docstrings) :type t :read-only t)
   (instances (util:required 'instances)                 :type t :read-only t))
 
 (defun documentation-class-entry-list-p (x)
@@ -427,8 +423,6 @@
                     :type (tc:type-entry-type entry)
                     :tyvars (tc:type-entry-tyvars entry)
                     :fields (tc:struct-entry-fields struct-entry)
-                    :field-docstrings (tc:get-table (tc:struct-entry-field-docstrings struct-entry))
-                    :field-tys (tc:get-table (tc:struct-entry-field-tys struct-entry))
                     :instances applicable-instances)
                    output-structs))
 
@@ -455,10 +449,9 @@
                :predicate (tc:ty-class-predicate e)
                ;; Only include exported methods from our packages
                :methods (remove-if-not
-                         (lambda (binding)
-                           (exported-symbol-p (car binding) package t))
+                         (lambda (method)
+                           (exported-symbol-p (tc:ty-class-method-name method) package t))
                          (tc:ty-class-unqualified-methods e))
-               :method-docstrings (tc:ty-class-method-docstrings e)
                :instances (reverse (fset:convert 'list (tc:lookup-class-instances env (tc:ty-class-name e) :no-error t)))
                :documentation (tc:ty-class-docstring e)
                :location (tc:ty-class-location e)))

--- a/src/typechecker/accessor.lisp
+++ b/src/typechecker/accessor.lisp
@@ -112,11 +112,10 @@
                      :primary-note
                      (format nil "type '~S' is not a struct" ty-name))))
 
-      (let* ((subs (tc:match struct-ty (accessor-from accessor)))
-             (field-ty (tc:get-value (tc:struct-entry-field-tys struct-entry)
-                                      (accessor-field accessor))))
+      (let ((subs (tc:match struct-ty (accessor-from accessor)))
+            (field (tc:get-field struct-entry (accessor-field accessor) :no-error t)))
 
-        (unless field-ty
+        (unless field
           (error 'tc:tc-error
                  :err (se:source-error
                        :span (accessor-source accessor)
@@ -128,7 +127,8 @@
                                (accessor-field accessor)))))
 
         ;; the order of unification matters here
-        (setf subs (tc:unify subs (accessor-to accessor) field-ty))
+        (setf subs (tc:unify subs (accessor-to accessor)
+                             (tc:struct-field-type field)))
 
         (values t subs)))))
 

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -298,9 +298,9 @@
                                              :for method-name := (parser:identifier-src-name
                                                                   (parser:method-definition-name method))
 
-                                             :collect (cons method-name (tc:quantify nil method-ty)))
-                  :method-docstrings (mapcar #'parser:method-definition-docstring
-                                             (parser:toplevel-define-class-methods class))
+                                             :collect (tc:make-ty-class-method :name method-name
+                                                                               :type (tc:quantify nil method-ty)
+                                                                               :docstring (parser:method-definition-docstring method)))
                   :codegen-sym codegen-sym
                   :superclass-dict superclass-dict
                   :superclass-map superclass-map

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -107,7 +107,8 @@
                     (let ((*print-escape* t))
                       (tc:pprint-predicate s pred))))))
 
-             (method-names (mapcar #'car (tc:ty-class-unqualified-methods class)))
+             (method-names (mapcar #'tc:ty-class-method-name
+                                   (tc:ty-class-unqualified-methods class)))
 
              (method-codegen-syms
                (loop :with table := (tc:make-map :test 'eq)
@@ -186,8 +187,9 @@
          ;; HACK: these should *not* be stored as schemes
          (method-table
            (loop :with table := (make-hash-table :test #'eq)
-                 :for (name . scheme) :in (tc:ty-class-unqualified-methods class)
-                 :do (setf (gethash name table) scheme)
+                 :for method :in (tc:ty-class-unqualified-methods class)
+                 :do (setf (gethash (tc:ty-class-method-name method) table)
+                           (tc:ty-class-method-type method))
                  :finally (return table))))
 
     ;; Check for superclasses and check the context of superinstances


### PR DESCRIPTION
Refactor: make modeling of structs and classes more consistent by combining parallel slots into structures.

- replace 3 parallel hashtables in struct-entry with list of struct-field (name, type, index, docstring)
- replace parallel lists of (name . type) and docstring in ty-class with list of ty-class-method (name, type, docstring)