### PR TITLE
Integer literal folding (part 2)

### DIFF
--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -37,6 +37,8 @@
    #:*unit-type*                        ; VARIABLE
    #:*char-type*                        ; VARIABLE
    #:*integer-type*                     ; VARIABLE
+   #:*ifix-type*                        ; VARIABLE
+   #:*ufix-type*                        ; VARIABLE
    #:*single-float-type*                ; VARIABLE
    #:*double-float-type*                ; VARIABLE
    #:*string-type*                      ; VARIABLE
@@ -80,7 +82,7 @@
 (deftype ty-list ()
   '(satisfies ty-list-p))
 
-(defstruct (tyvar (:include ty)) 
+(defstruct (tyvar (:include ty))
   (id   (util:required 'id)   :type fixnum :read-only t)
   (kind (util:required 'kind) :type kind   :read-only t))
 
@@ -200,6 +202,8 @@
 (defvar *unit-type*         (make-tycon :name 'coalton:Unit         :kind +kstar+))
 (defvar *char-type*         (make-tycon :name 'coalton:Char         :kind +kstar+))
 (defvar *integer-type*      (make-tycon :name 'coalton:Integer      :kind +kstar+))
+(defvar *ifix-type*         (make-tycon :name 'coalton:IFix         :kind +kstar+))
+(defvar *ufix-type*         (make-tycon :name 'coalton:UFix         :kind +kstar+))
 (defvar *single-float-type* (make-tycon :name 'coalton:Single-Float :kind +kstar+))
 (defvar *double-float-type* (make-tycon :name 'coalton:Double-Float :kind +kstar+))
 (defvar *string-type*       (make-tycon :name 'coalton:String       :kind +kstar+))


### PR DESCRIPTION
I have an ugly cond block that optimizes `translate-expression` on type `tc:node-integer-literal` for inferred types other than regular ints.

In the following example, `1` expands to `1.0` instead of `(from-int 1)`, essentially just doing that work at comptime in the expression translator.

```lisp
COALTON-USER> (coalton-codegen 
                (declare adder (Single-Float -> Single-Float))
                (define (adder x) (+ 1 x)))
(COMMON-LISP:PROGN
 (COALTON-IMPL/GLOBAL-LEXICAL:DEFINE-GLOBAL-LEXICAL ADDER
                                                    COALTON-IMPL/RUNTIME/FUNCTION-ENTRY:FUNCTION-ENTRY)
 (COMMON-LISP:DEFUN ADDER (X-310)
   (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE X-310))
   (COALTON-LIBRARY/MATH/NUM::|INSTANCE/NUM SINGLE-FLOAT-COALTON-LIBRARY/CLASSES:+|
    1.0 X-310))
 (COMMON-LISP:SETF ADDER (COALTON-IMPL/RUNTIME/FUNCTION-ENTRY::F1 #'ADDER))
 (COMMON-LISP:SETF (COMMON-LISP:DOCUMENTATION 'ADDER 'COMMON-LISP:VARIABLE)
                     "ADDER :: (SINGLE-FLOAT → SINGLE-FLOAT)")
 (COMMON-LISP:SETF (COMMON-LISP:DOCUMENTATION 'ADDER 'COMMON-LISP:FUNCTION)
                     "ADDER :: (SINGLE-FLOAT → SINGLE-FLOAT)")
 (COMMON-LISP:VALUES))
```

Repeatedly checking `tc:tycon-p` is not great but I struggled to create clean control flow here...