### PR TITLE
Implement inlining with basic syntactic heuristics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,8 @@ jobs:
         LISP_IMPL: ["sbcl", "allegro", "ccl"]
         COALTON_ENV: ["release", "development"]
         SAFETY: ["0", "3"]
-        DISABLE_SPECIALIZATION: ["1", "0"] 
+        DISABLE_SPECIALIZATION: ["1", "0"]
+        HEURISTIC_INLINING: ["1", "0"]
         exclude:
           # Since we don't have a way of switching safety on allegro or ccl, we can
           # just ignore high safety tests.
@@ -47,6 +48,7 @@ jobs:
         env:
           COALTON_ENV: ${{ matrix.COALTON_ENV }}
           COALTON_DISABLE_SPECIALIZATION: ${{ matrix.DISABLE_SPECIALIZATION }}
+          COALTON_HEURISTIC_INLINING: ${{ matrix.HEURISTIC_INLINING }}
         run: |
           cat <<EOF > run-tests.lisp
           (sb-ext:restrict-compiler-policy 'safety ${{ matrix.SAFETY }})
@@ -61,6 +63,7 @@ jobs:
         env:
           COALTON_ENV: ${{ matrix.COALTON_ENV }}
           COALTON_DISABLE_SPECIALIZATION: ${{ matrix.DISABLE_SPECIALIZATION }}
+          COALTON_HEURISTIC_INLINING: ${{ matrix.HEURISTIC_INLINING }}
         run: |
           cat <<EOF > run-tests.lisp
           (ql:quickload :coalton/tests)
@@ -74,6 +77,7 @@ jobs:
         env:
           COALTON_ENV: ${{ matrix.COALTON_ENV }}
           COALTON_DISABLE_SPECIALIZATION: ${{ matrix.DISABLE_SPECIALIZATION }}
+          COALTON_HEURISTIC_INLINING: ${{ matrix.HEURISTIC_INLINING }}
         run: |
           cat <<EOF > run-tests.lisp
           (ql:quickload :coalton/tests)

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -281,20 +281,6 @@ call to (break)."
       (loop :for (name . node) :in bindings
             :collect (cons name (intersection binding-names (node-variables node))))))))
 
-(defun node-application-symbol-rator (node)
-  "Returns the name of the function being called if it is known"
-  (declare (type (or node-application node-direct-application) node)
-           (values (or null parser:identifier)))
-  (etypecase node
-    (node-direct-application
-     (node-direct-application-rator node))
-
-    (node-application
-     (unless (node-variable-p (node-application-rator node))
-       (return-from node-application-symbol-rator))
-
-     (node-variable-value (node-application-rator node)))))
-
 (defun node-rands (node)
   (declare (type (or node-application node-direct-application))
            (values node-list))
@@ -306,6 +292,7 @@ call to (break)."
      (node-application-rands node))))
 
 (defun node-rator-name (node)
+  "Returns the name of the function being called if it is known"
   (declare (type (or node-application node-direct-application))
            (values (or null parser:identifier)))
   (etypecase node

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -321,12 +321,19 @@
      (list
       (action (:after node-application) #'rewrite-application)))))
 
+(defun aggressive-heuristic (node)
+  "This will probably inline more than is optimal."
+  (and (<= (count-applications node)
+           8)
+       (<= (count-nodes node)
+           32)))
+
 (defun heuristic-inline-applications (node
                                       env
                                       &key
-                                        (max-depth  0)
-                                        (max-unroll 0)
-                                        (heuristic  (constantly nil)))
+                                        (max-depth  16)
+                                        (max-unroll 4)
+                                        (heuristic  #'aggressive-heuristic))
   "Recursively inline function calls in `node`, using the environment
 `env` to look up the function bodies to substitute. The traversal
 keeps a call stack and will not continue past the specified
@@ -389,14 +396,10 @@ requires direct constructor calls."
       (make-traverse-let-action-skipping-cons-bindings))
      nil)))
 
-(defun aggressive-heuristic (node)
-  (and (<= (count-applications node)
-           4)
-       (<= (count-nodes node)
-           32)))
-
 (defun inline-applications (node env)
-  (heuristic-inline-applications node env))
+  (if settings:*coalton-heuristic-inlining*
+      (heuristic-inline-applications node env)
+      node))
 
 (defun inline-methods (node env)
   (declare (type node node)

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -30,6 +30,7 @@
    #:action
    #:count-applications
    #:count-nodes
+   #:make-traverse-let-action-skipping-cons-bindings
    #:*traverse*
    #:traverse
    #:traverse-with-binding-list)
@@ -334,8 +335,9 @@ the function already appears more than `max-unroll` times in the call
 stack. Otherwise, if a function's code can be found in `env` and the
 `heuristic` returns true, then the body will be inlined.
 
-Currently, this may break recursive data let expressions, since the
-codegen requires direct constructor calls."
+Special logic prevents inlining `coalton:Cons` in let bindings to
+avoid breaking recursive data let expressions, since the codegen
+requires direct constructor calls."
   (declare (type node           node)
            (type tc:environment env)
            (type (integer 0)    max-depth)
@@ -383,7 +385,8 @@ codegen requires direct constructor calls."
      node
      (list
       (action (:after node-application) #'try-inline)
-      (action (:after node-direct-application) #'try-inline))
+      (action (:after node-direct-application) #'try-inline)
+      (make-traverse-let-action-skipping-cons-bindings))
      nil)))
 
 (defun aggressive-heuristic (node)

--- a/src/codegen/traverse.lisp
+++ b/src/codegen/traverse.lisp
@@ -7,6 +7,8 @@
    (#:util #:coalton-impl/util))
   (:export
    #:action
+   #:count-applications
+   #:count-nodes
    #:traverse
    #:traverse-with-binding-list))
 
@@ -72,13 +74,13 @@ and `body` are again used to generate a lambda function."
      (assert (< 1 (length args)))
      `(make-action ',when ',type
                    (lambda (,@args)
-                     (declare (type ,(first args) ,type)
-                              (type ,(second args) function))
+                     (declare (type ,type ,(first args))
+                              (type function ,(second args)))
                      ,@body)))
     (t
      `(make-action ',when ',type
                    (lambda (,@args)
-                     (declare (type ,(first args) ,type))
+                     (declare (type ,type ,(first args)))
                      ,@body)))))
 
 (defun action-list-p (x)
@@ -353,6 +355,25 @@ gets called."
          (incf counter)
          (values))
        )))
+    counter))
+
+(defun count-applications (node)
+  "Count the number of function application nodes in the AST
+corresponding to `node`."
+  (declare (type node node)
+           (values (integer 0) &optional))
+  (let ((counter 0))
+    (traverse
+     node
+     (list
+      (action (:after node-application _node)
+        (declare (ignore _node))
+        (incf counter)
+        (values))
+      (action (:after node-direct-application _node)
+        (declare (ignore _node))
+        (incf counter)
+        (values))))
     counter))
 
 (defun print-node-traversal-order (node)

--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -8,6 +8,7 @@
   (:export
    #:coalton-release-p                  ; FUNCTION
    #:*coalton-disable-specialization*   ; VARIABLE
+   #:*coalton-heuristic-inlining*       ; VARIABLE
    #:*coalton-print-unicode*            ; VARIABLE
    #:*emit-type-annotations*            ; VARIABLE
    #:*coalton-optimize*                 ; VARIABLE
@@ -49,8 +50,17 @@ Enable release mode either by setting the UNIX environment variable COALTON_ENV 
 (when (find (uiop:getenv "COALTON_DISABLE_SPECIALIZATION")
             '("t" "true" "1")
             :test #'string-equal)
-  (format t "~&;; COALTON starting with specializations disabled")
+  (format t "~&;; COALTON starting with specializations disabled~%")
   (setf *coalton-disable-specialization* t))
+
+(declaim (type boolean *coalton-heuristic-inlining*))
+(defvar *coalton-heuristic-inlining* nil)
+
+(when (find (uiop:getenv "COALTON_HEURISTIC_INLINING")
+            '("t" "true" "1")
+            :test #'string-equal)
+  (format t "~&;; COALTON starting with heuristic inlining enabled~%")
+  (setf *coalton-heuristic-inlining* t))
 
 ;; Configure the backend to remove type annotations from the generated code
 (declaim (type boolean *emit-type-annotations*))


### PR DESCRIPTION
This PR implements an inlining pass based on the work of @digikar99 ( https://github.com/coalton-lang/coalton/pull/1029 ). The updated `traverse` is used to allow passing a call stack, which enables separate bounds on recursive function unrolling and inlining depth. Heuristics are assumed to be simple syntactic functions of a function body for now.