### PR TITLE
Propagate file:span information through toplevel definitions

### DIFF
--- a/coalton-asdf.lisp
+++ b/coalton-asdf.lisp
@@ -12,11 +12,6 @@
 (defmethod perform ((o compile-op) (c coalton-file))
   (let ((coal-file (first (input-files o c)))
         (fasl-file (first (output-files o c))))
-    (with-open-file (stream coal-file
-                            :direction ':INPUT
-                            :element-type 'character
-                            :external-format ':UTF8)
-      (let ((char-stream (coalton-impl/stream:make-char-position-stream stream)))
-        (coalton-impl/entry:compile char-stream (pathname-name coal-file)
-                                    :load nil
-                                    :output-file fasl-file)))))
+      (coalton-impl/entry:compile (source-error:make-source-file coal-file)
+                                  :load nil
+                                  :output-file fasl-file)))

--- a/source-error/src/error.lisp
+++ b/source-error/src/error.lisp
@@ -146,6 +146,18 @@ In the case of source that is copied to a different location during compilation 
            :reader file-offset))
   (:documentation "A source that supplies error context from a FILE."))
 
+(defmethod print-object ((self file-source) stream)
+  (if *print-readably*
+      (format stream "#.(make-instance 'source-error/error::file-source~@[ :name ~s~] :file ~s~:[~; :offset ~s~])"
+              (original-file-name self)
+              (input-file-name self)
+              (< 0 (file-offset self))
+              (file-offset self))
+      (call-next-method)))
+
+(defmethod make-load-form ((self file-source) &optional env)
+  (make-load-form-saving-slots self :environment env))
+
 (defun make-source-file (file &key name (offset 0))
   "Make a source that supplies error context from a FILE.
 

--- a/src/analysis/analysis.lisp
+++ b/src/analysis/analysis.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/analysis/analysis
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/analysis/pattern-exhaustiveness)
   (:import-from
    #:coalton-impl/analysis/unused-variables
@@ -10,6 +11,7 @@
    #:find-underapplied-values)
   (:local-nicknames
    (#:se #:source-error)
+   (#:parser #:coalton-impl/parser)
    (#:util #:coalton-impl/util)
    (#:tc #:coalton-impl/typechecker))
   (:export
@@ -26,93 +28,86 @@
 (define-condition pattern-var-matches-constructor (se:source-base-warning)
   ())
 
-(defun check-pattern-exhaustiveness (pattern env file)
+(defun check-pattern-exhaustiveness (pattern env)
   (declare (type tc:pattern pattern)
-           (type tc:environment env)
-           (type se:file file))
+           (type tc:environment env))
 
   (let ((missing (find-non-matching-value (list (list pattern)) 1 env)))
     (unless (eq t missing)
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :file file
-                   :span (tc:pattern-source pattern)
-                   :message "Non-exhaustive match"
-                   :primary-note (format nil "Missing case ~W"
-                                         (print-pattern (first missing))))))))
+      (tc-error (tc:pattern-source pattern)
+                "Non-exhaustive match"
+                (format nil "Missing case ~W"
+                        (print-pattern (first missing)))))))
 
-(defun analyze-translation-unit (translation-unit env file)
+(defun analyze-translation-unit (translation-unit env)
   "Perform analysis passes on TRANSLATION-UNIT, potentially producing errors or warnings."
   (declare (type tc:translation-unit translation-unit)
-           (type tc:environment env)
-           (type se:file file))
+           (type tc:environment env))
 
   (let ((analysis-traverse-block
           (tc:make-traverse-block
            :match (lambda (node)
                     (let ((patterns (mapcar #'tc:node-match-branch-pattern (tc:node-match-branches node))))
                       (loop :for pattern :in patterns
-                            :do (check-for-var-matching-constructor pattern env file))
-                      
+                            :do (check-for-var-matching-constructor pattern env))
+
                       (let ((exhaustive-or-missing
                               (find-non-matching-value (mapcar #'list patterns) 1 env)))
                         (unless (eq t exhaustive-or-missing)
                           (warn 'non-exhaustive-match-warning
-                                :err (se:source-error
+                                :err (parser:source-error
                                       :type :warn
-                                      :file file
-                                      :span (tc:node-source node)
+                                      :source (tc:node-source node)
                                       :message "Non-exhaustive match"
                                       :primary-note "non-exhaustive match"
                                       :notes (when (first exhaustive-or-missing)
                                                (list
                                                 (se:make-source-error-note
                                                  :type :secondary
-                                                 :span (tc:node-source node)
+                                                 :span (parser:source-location-span (tc:node-source node))
                                                  :message (format nil "Missing case ~W"
                                                                   (print-pattern (first exhaustive-or-missing)))))))))
                         (loop :for pattern :in patterns
                               :unless (useful-pattern-p patterns pattern env) :do
                                 (warn 'useless-pattern-warning
-                                      :err (se:source-error
+                                      :err (parser:source-error
                                             :type :warn
-                                            :file file
-                                            :span (tc:pattern-source pattern)
+                                            :source (tc:pattern-source pattern)
                                             :message "Useless match case"
                                             :primary-note "useless match case"
                                             :notes
                                             (list
                                              (se:make-source-error-note
                                               :type :secondary
-                                              :span (tc:node-source node)
+                                              :span (parser:source-location-span (tc:node-source node))
                                               :message "in this match")))))))
                     node)
            :abstraction (lambda (node)
                           (declare (type tc:node-abstraction node))
                           (loop :for pattern :in (tc:node-abstraction-params node)
-                                :do (check-pattern-exhaustiveness pattern env file))
+                                :do (check-pattern-exhaustiveness pattern env))
                           node)
            :bind (lambda (node)
                    (declare (type tc:node-bind node))
-                   (check-pattern-exhaustiveness (tc:node-bind-pattern node) env file)
+                   (check-pattern-exhaustiveness (tc:node-bind-pattern node) env)
                    node))))
 
     ;; Run analysis on definitions
     (loop :for define :in (tc:translation-unit-definitions translation-unit)
           :do (tc:traverse (tc:toplevel-define-body define) analysis-traverse-block)
-          :do (find-unused-variables define file)
-          :do (find-underapplied-values define file)
+          :do (find-unused-variables define)
+          :do (find-underapplied-values define)
           :do (loop :for pattern :in (tc:binding-parameters define)
-                    :do (check-pattern-exhaustiveness pattern env file)))
+                    :do (check-pattern-exhaustiveness pattern env)))
 
     ;; Run analysis on instance definitions
     (loop :for instance :in (tc:translation-unit-instances translation-unit) :do
       (loop :for method :being :the :hash-value :of (tc:toplevel-define-instance-methods instance)
             :do (tc:traverse (tc:instance-method-definition-body method) analysis-traverse-block)
-            :do (find-underapplied-values method file)
-            :do (find-underapplied-values method file)
+            :do (find-underapplied-values method)
+            :do (find-underapplied-values method)
             :do (loop :for pattern :in (tc:binding-parameters method)
-                      :do (check-pattern-exhaustiveness pattern env file))))))
+                      :do (check-pattern-exhaustiveness pattern env))))))
 
 (defgeneric print-pattern (pat)
   (:method ((pat tc:pattern-constructor))
@@ -121,27 +116,25 @@
   (:method ((pat tc:pattern-wildcard))
     "_"))
 
-(defgeneric check-for-var-matching-constructor (pat env file)
-  (:method ((pat tc:pattern-var) env file)
-    (declare (type tc:environment env)
-             (type se:file file))
+(defgeneric check-for-var-matching-constructor (pat env)
+  (:method ((pat tc:pattern-var) env)
+    (declare (type tc:environment env))
 
     (let ((ctor (tc:lookup-constructor env (tc:pattern-var-orig-name pat) :no-error t)))
       (when ctor
         (warn 'pattern-var-matches-constructor
-              :err (se:source-error
+              :err (parser:source-error
                     :type :warn
-                    :file file
-                    :span (tc:pattern-source pat)
+                    :source (tc:pattern-source pat)
                     :message "Pattern warning"
                     :primary-note "pattern variable matches constructor name")))))
 
-  (:method ((pat tc:pattern-literal) env file)
-    (declare (ignore env file)))
+  (:method ((pat tc:pattern-literal) env)
+    (declare (ignore env)))
 
-  (:method ((pat tc:pattern-wildcard) env file)
-    (declare (ignore env file)))
+  (:method ((pat tc:pattern-wildcard) env)
+    (declare (ignore env)))
 
-  (:method ((pat tc:pattern-constructor) env file)
+  (:method ((pat tc:pattern-constructor) env)
     (loop :for pat :in (tc:pattern-constructor-patterns pat)
-          :do (check-for-var-matching-constructor pat env file))))
+          :do (check-for-var-matching-constructor pat env))))

--- a/src/analysis/pattern-exhaustiveness.lisp
+++ b/src/analysis/pattern-exhaustiveness.lisp
@@ -27,7 +27,7 @@
     (mapcar #'list patterns)
     (list (tc:make-pattern-wildcard
            :type (tc:qualify nil (tc:make-variable))
-           :source (cons nil nil)))
+           :source nil))
     env)))
 
 (defun useful-pattern-p (patterns pattern env)
@@ -161,7 +161,7 @@ CLAUSE is a list representing a row-vector of patterns."
                       (list (append (mapcar (lambda (pattern)
                                               (tc:make-pattern-wildcard
                                                :type (tc:pattern-type pattern)
-                                               :source (cons nil nil)))
+                                               :source nil))
                                             (tc:pattern-constructor-patterns pattern))
                                     (rest row))))))
                   (t
@@ -219,7 +219,7 @@ CLAUSE is a list representing a row-vector of patterns."
      (loop :for i :below n
            :collect (tc:make-pattern-wildcard
                      :type (tc:qualify nil (tc:make-variable))
-                     :source (cons nil nil))))
+                     :source nil)))
     ;; Zero wildcards with a pattern matrix that has zero columns indicates the matrix is exhaustive.
     ((and (zerop n)
           (zerop (length (first pattern-matrix))))
@@ -244,7 +244,7 @@ CLAUSE is a list representing a row-vector of patterns."
                 :unless (eq val t)
                   :do (return (cons (tc:make-pattern-constructor
                                      :type (tc:pattern-type ctor)
-                                     :source (cons nil nil)
+                                     :source nil
                                      :name (tc:pattern-constructor-name ctor)
                                      :patterns (subseq val 0 ctor-arity))
                                     (subseq val ctor-arity (+ ctor-arity n -1))))
@@ -263,7 +263,7 @@ CLAUSE is a list representing a row-vector of patterns."
               ((null first-column-constructors)
                (cons (tc:make-pattern-wildcard
                       :type (tc:qualify nil (tc:make-variable))
-                      :source (cons nil nil))
+                      :source nil)
                      val))
               ;; Or emit a constructor which was not named in this pattern.
               (t
@@ -288,9 +288,9 @@ CLAUSE is a list representing a row-vector of patterns."
     ;; the error generation. Instead we just select the first one.
     (tc:make-pattern-constructor
      :type (tc:pattern-type (first patterns))
-     :source (cons nil nil)
+     :source nil
      :name unnamed-constructor
      :patterns (loop :for i :below (tc:constructor-entry-arity unnamed-constructor-entry)
                      :collect (tc:make-pattern-wildcard
                                :type (tc:qualify nil (tc:make-variable))
-                               :source (cons nil nil))))))
+                               :source nil)))))

--- a/src/analysis/underapplied-values.lisp
+++ b/src/analysis/underapplied-values.lisp
@@ -3,6 +3,7 @@
    #:cl)
   (:local-nicknames
    (#:se #:source-error)
+   (#:parser #:coalton-impl/parser)
    (#:util #:coalton-impl/util)
    (#:tc #:coalton-impl/typechecker))
   (:export
@@ -14,7 +15,7 @@
 (define-condition underapplied-value-warning (se:source-base-warning)
   ())
 
-(defun find-underapplied-values (binding file)
+(defun find-underapplied-values (binding)
   (tc:traverse
    (tc:binding-value binding)
    (tc:make-traverse-block
@@ -25,11 +26,9 @@
                   :when (and (typep elem 'tc:node)
                              (tc:function-type-p (tc:qualified-ty-type (tc:node-type elem))))
                     :do (warn 'underapplied-value-warning
-                              :err (se:source-error
+                              :err (parser:source-error
                                     :type :warn
-                                    :file file
-                                    :span (tc:node-source elem)
+                                    :source (tc:node-source elem)
                                     :message "Value may be underapplied"
                                     :primary-note "discard explicitly with (let _ = ...) to ignore this warning")))
-
             node))))

--- a/src/parser/base.lisp
+++ b/src/parser/base.lisp
@@ -24,6 +24,11 @@
    #:parse-error                        ; CONDITION
    #:parse-error-err                    ; ACCESSOR
    #:parse-list                         ; FUNCTION
+   #:source-location
+   #:make-source-location
+   #:source-location-file
+   #:source-location-span
+   #:source-error
    ))
 
 (in-package #:coalton-impl/parser/base)
@@ -31,6 +36,28 @@
 ;;;
 ;;; Shared definitions for source parser
 ;;;
+
+(defstruct source-location
+  (file nil :type se:file              :read-only t)
+  (span nil :type (cons fixnum fixnum) :read-only t))
+
+(defmethod make-load-form ((self source-location) &optional env)
+  (make-load-form-saving-slots self :environment env))
+
+(defun source-location (form file)
+  (make-source-location :file file
+                        :span (cst:source form)))
+
+(defun source-error (&key (type :error) source (highlight :all)
+                             message primary-note notes help-notes)
+  (se:source-error :type type
+                   :span (source-location-span source)
+                    :file (source-location-file source)
+                    :highlight highlight
+                    :message message
+                    :primary-note primary-note
+                    :notes notes
+                    :help-notes help-notes))
 
 (deftype identifier ()
   '(and symbol (not boolean) (not keyword)))
@@ -48,7 +75,7 @@
 (defstruct (keyword-src
             (:copier nil))
   (name   (util:required 'name)   :type keyword :read-only t)
-  (source (util:required 'source) :type cons    :read-only t))
+  (source (util:required 'source) :type source-location    :read-only t))
 
 (defun keyword-src-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -60,7 +87,7 @@
 (defstruct (identifier-src
             (:copier nil))
   (name   (util:required 'name)   :type identifier :read-only t)
-  (source (util:required 'source) :type cons       :read-only t))
+  (source (util:required 'source) :type source-location       :read-only t))
 
 (defun identifier-src-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/parser/binding.lisp
+++ b/src/parser/binding.lisp
@@ -6,9 +6,13 @@
 (defpackage #:coalton-impl/parser/binding
   (:use
    #:cl
+   #:coalton-impl/parser/base
    #:coalton-impl/parser/pattern
    #:coalton-impl/parser/expression
    #:coalton-impl/parser/toplevel)
+  (:shadowing-import-from
+   #:coalton-impl/parser/base
+   #:parse-error)
   (:export
    #:binding-name                       ; FUNCTION
    #:binding-value                      ; FUNCTION
@@ -55,15 +59,15 @@
   (:documentation "Returns the source location of BINDING")
 
   (:method ((binding node-let-binding))
-    (declare (values cons))
+    (declare (values source-location))
     (node-let-binding-source binding))
 
   (:method ((binding toplevel-define))
-    (declare (values cons))
+    (declare (values source-location))
     (toplevel-define-source binding))
 
   (:method ((binding instance-method-definition))
-    (declare (values cons))
+    (declare (values source-location))
     (instance-method-definition-source binding)))
 
 (defgeneric binding-parameters (binding)

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -269,7 +269,7 @@ Rebound to NIL parsing an anonymous FN.")
 (defstruct (node
             (:constructor nil)
             (:copier nil))
-  (source (util:required 'source) :type cons :read-only t))
+  (source (util:required 'source) :type source-location :read-only t))
 
 (defun node-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -312,7 +312,7 @@ Rebound to NIL parsing an anonymous FN.")
             (:copier nil))
   (pattern (util:required 'pattern) :type pattern :read-only t)
   (expr    (util:required 'expr)    :type node    :read-only t)
-  (source  (util:required 'source)  :type cons    :read-only t))
+  (source  (util:required 'source)  :type source-location    :read-only t))
 
 (deftype node-body-element ()
   '(or node node-bind))
@@ -347,9 +347,9 @@ Rebound to NIL parsing an anonymous FN.")
 
 (defstruct (node-let-binding
             (:copier nil))
-  (name   (util:required 'name)   :type node-variable :read-only t)
-  (value  (util:required 'value)  :type node          :read-only t)
-  (source (util:required 'source) :type cons          :read-only t))
+  (name   (util:required 'name)   :type node-variable   :read-only t)
+  (value  (util:required 'value)  :type node            :read-only t)
+  (source (util:required 'source) :type source-location :read-only t))
 
 (defun node-let-binding-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -360,9 +360,9 @@ Rebound to NIL parsing an anonymous FN.")
 
 (defstruct (node-let-declare
             (:copier nil))
-  (name   (util:required 'name)   :type node-variable :read-only t)
-  (type   (util:required 'type)   :type qualified-ty  :read-only t)
-  (source (util:required 'source) :type cons          :read-only t))
+  (name   (util:required 'name)   :type node-variable   :read-only t)
+  (type   (util:required 'type)   :type qualified-ty    :read-only t)
+  (source (util:required 'source) :type source-location :read-only t))
 
 (defun node-let-declare-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -388,9 +388,9 @@ Rebound to NIL parsing an anonymous FN.")
 
 (defstruct (node-match-branch
             (:copier nil))
-  (pattern (util:required 'pattern) :type pattern   :read-only t)
-  (body    (util:required 'body)    :type node-body :read-only t)
-  (source  (util:required 'source)  :type cons      :read-only t))
+  (pattern (util:required 'pattern) :type pattern         :read-only t)
+  (body    (util:required 'body)    :type node-body       :read-only t)
+  (source  (util:required 'source)  :type source-location :read-only t))
 
 (defun node-match-branch-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -458,9 +458,9 @@ Rebound to NIL parsing an anonymous FN.")
 
 (defstruct (node-cond-clause
             (:copier nil))
-  (expr   (util:required 'expr)   :type node      :read-only t)
-  (body   (util:required 'body)   :type node-body :read-only t)
-  (source (util:required 'source) :type cons      :read-only t))
+  (expr   (util:required 'expr)   :type node            :read-only t)
+  (body   (util:required 'body)   :type node-body       :read-only t)
+  (source (util:required 'source) :type source-location :read-only t))
 
 (defun node-cond-clause-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -476,9 +476,9 @@ Rebound to NIL parsing an anonymous FN.")
 
 (defstruct (node-do-bind
             (:copier nil))
-  (pattern (util:required 'name)   :type pattern :read-only t)
-  (expr    (util:required 'expr)   :type node    :read-only t)
-  (source  (util:required 'source) :type cons    :read-only t))
+  (pattern (util:required 'name)   :type pattern         :read-only t)
+  (expr    (util:required 'expr)   :type node            :read-only t)
+  (source  (util:required 'source) :type source-location :read-only t))
 
 (deftype node-do-body-element ()
   '(or node node-bind node-do-bind))
@@ -619,7 +619,7 @@ Rebound to NIL parsing an anonymous FN.")
                       :span (cst:source (cst:second form))
                       :file file
                       :message "Malformed function"
-                      :primary-note "malformed arugment list"
+                      :primary-note "malformed argument list"
                       :help-notes
                       (list
                        (se:make-source-error-help
@@ -639,7 +639,7 @@ Rebound to NIL parsing an anonymous FN.")
          (make-node-abstraction
           :params params
           :body body
-          :source (cst:source form)))))
+          :source (source-location form file)))))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:let (cst:raw (cst:first form))))
@@ -691,7 +691,7 @@ Rebound to NIL parsing an anonymous FN.")
         :bindings bindings
         :declares (nreverse declares)
         :body (parse-body (cst:nthrest 2 form) form file)
-        :source (cst:source form))))
+        :source (source-location form file))))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:lisp (cst:raw (cst:first form))))
@@ -733,7 +733,7 @@ Rebound to NIL parsing an anonymous FN.")
         :vars vars
         :var-names (mapcar #'node-variable-name vars)
         :body (cst:raw (cst:nthrest 3 form))
-        :source (cst:source form))))
+        :source (source-location form file))))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:match (cst:raw (cst:first form))))
@@ -753,13 +753,13 @@ Rebound to NIL parsing an anonymous FN.")
       :branches (loop :for branches := (cst:nthrest 2 form) :then (cst:rest branches)
                       :while (cst:consp branches)
                       :collect (parse-match-branch (cst:first branches) file))
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:progn (cst:raw (cst:first form))))
      (make-node-progn
       :body (parse-body (cst:rest form) form file)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:the (cst:raw (cst:first form))))
@@ -795,7 +795,7 @@ Rebound to NIL parsing an anonymous FN.")
      (make-node-the
       :type (parse-type (cst:second form) file)
       :expr (parse-expression (cst:third form) file)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:return (cst:raw (cst:first form))))
@@ -816,7 +816,7 @@ Rebound to NIL parsing an anonymous FN.")
 
        (make-node-return
         :expr expr
-        :source (cst:source form))))
+        :source (source-location form file))))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:or (cst:raw (cst:first form))))
@@ -834,7 +834,7 @@ Rebound to NIL parsing an anonymous FN.")
                    :while (cst:consp args)
                    :for arg := (cst:first args)
                    :collect (parse-expression arg file))
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:and (cst:raw (cst:first form))))
@@ -852,7 +852,7 @@ Rebound to NIL parsing an anonymous FN.")
                    :while (cst:consp args)
                    :for arg := (cst:first args)
                    :collect (parse-expression arg file))
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:if (cst:raw (cst:first form))))
@@ -896,7 +896,7 @@ Rebound to NIL parsing an anonymous FN.")
       :expr (parse-expression (cst:second form) file)
       :then (parse-expression (cst:third form) file)
       :else (parse-expression (cst:fourth form) file)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:when (cst:raw (cst:first form))))
@@ -912,7 +912,7 @@ Rebound to NIL parsing an anonymous FN.")
      (make-node-when
       :expr (parse-expression (cst:second form) file)
       :body (parse-body (cst:rest (cst:rest form)) form file)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:unless (cst:raw (cst:first form))))
@@ -928,7 +928,7 @@ Rebound to NIL parsing an anonymous FN.")
      (make-node-unless
       :expr (parse-expression (cst:second form) file)
       :body (parse-body (cst:rest (cst:rest form)) form file)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:cond (cst:raw (cst:first form))))
@@ -946,7 +946,7 @@ Rebound to NIL parsing an anonymous FN.")
                      :while (cst:consp clauses)
                      :for clause := (cst:first clauses)
                      :collect (parse-cond-clause clause file))
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:do (cst:raw (cst:first form))))
@@ -980,7 +980,7 @@ Rebound to NIL parsing an anonymous FN.")
                    (cons const:+default-loop-label+ *loop-label-context*))))
 
          (make-node-while
-          :source (cst:source form)
+          :source (source-location form file)
           :label (or label const:+default-loop-label+)
           :expr (parse-expression (cst:first labelled-body) file)
           :body (parse-body (cst:rest labelled-body) form file)))))
@@ -1034,7 +1034,7 @@ Rebound to NIL parsing an anonymous FN.")
                     (list* label const:+default-loop-label+ *loop-label-context*)
                     (cons const:+default-loop-label+ *loop-label-context*))))
          (make-node-while-let
-          :source (cst:source form)
+          :source (source-location form file)
           :label (or label const:+default-loop-label+)
           :pattern (parse-pattern (cst:first labelled-body) file) 
           :expr (parse-expression (cst:third labelled-body) file)
@@ -1057,7 +1057,7 @@ Rebound to NIL parsing an anonymous FN.")
                     (list* label const:+default-loop-label+ *loop-label-context*)
                     (cons const:+default-loop-label+ *loop-label-context*))))
          (make-node-loop
-          :source (cst:source form)
+          :source (source-location form file)
           :label (or label const:+default-loop-label+)
           :body (parse-body labelled-body form file)))))
 
@@ -1091,7 +1091,8 @@ Rebound to NIL parsing an anonymous FN.")
                           :message "Invalid break"
                           :primary-note "break does not appear in an enclosing loop"))))
        
-       (make-node-break :source (cst:source form) :label (or label (car *loop-label-context*)))))
+       (make-node-break :source (source-location form file)
+                        :label (or label (car *loop-label-context*)))))
 
     ((and (cst:atom (cst:first form))
           (eq 'coalton:continue (cst:raw (cst:first form))))
@@ -1123,7 +1124,8 @@ Rebound to NIL parsing an anonymous FN.")
                           :message "Invalid continue"
                           :primary-note "continue does not appear in an enclosing loop"))))
        
-       (make-node-continue :source (cst:source form) :label (or label (car *loop-label-context*)))))
+       (make-node-continue :source (source-location form file)
+                           :label (or label (car *loop-label-context*)))))
     
 
     ((and (cst:atom (cst:first form))
@@ -1177,7 +1179,7 @@ Rebound to NIL parsing an anonymous FN.")
                    (list* label const:+default-loop-label+ *loop-label-context*)
                    (cons const:+default-loop-label+ *loop-label-context*))))
          (make-node-for
-          :source (cst:source form)
+          :source (source-location form file)
           :label (or label const:+default-loop-label+)
           :pattern (parse-pattern (cst:first labelled-body) file) 
           :expr (parse-expression (cst:third labelled-body) file)
@@ -1219,7 +1221,7 @@ Rebound to NIL parsing an anonymous FN.")
                    :while (cst:consp rands)
                    :for rand := (cst:first rands)
                    :collect (parse-expression rand file))
-      :source (cst:source form)))))
+      :source (source-location form file)))))
 
 (defun parse-variable (form file)
   (declare (type cst:cst form)
@@ -1253,12 +1255,11 @@ Rebound to NIL parsing an anonymous FN.")
 
   (make-node-variable
    :name (cst:raw form)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-accessor (form file)
   (declare (type cst:cst form)
            (type se:file file)
-           (ignore file)
            (values node-accessor))
 
   (assert (cst:atom form))
@@ -1267,7 +1268,7 @@ Rebound to NIL parsing an anonymous FN.")
 
   (make-node-accessor
    :name (subseq (symbol-name (cst:raw form)) 1)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-literal (form file)
   (declare (type cst:cst form)
@@ -1280,12 +1281,12 @@ Rebound to NIL parsing an anonymous FN.")
     (integer
      (make-node-integer-literal
       :value (cst:raw form)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     (util:literal-value
      (make-node-literal
       :value (cst:raw form)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     (t
      (error 'parse-error
@@ -1373,7 +1374,7 @@ Rebound to NIL parsing an anonymous FN.")
   (make-node-bind
    :pattern (parse-pattern (cst:second form) file)
    :expr (parse-expression (cst:fourth form) file)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-body-element (form file)
   (declare (type cst:cst form)
@@ -1455,7 +1456,7 @@ Rebound to NIL parsing an anonymous FN.")
   (make-node-let-binding
    :name (parse-variable (cst:first form) file)
    :value (parse-expression (cst:second form) file)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-match-branch (form file)
   (declare (type cst:cst form)
@@ -1491,7 +1492,7 @@ Rebound to NIL parsing an anonymous FN.")
   (make-node-match-branch
    :pattern (parse-pattern (cst:first form) file)
    :body (parse-body (cst:rest form) form file)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-cond-clause (form file)
   (declare (type cst:cst form)
@@ -1517,7 +1518,7 @@ Rebound to NIL parsing an anonymous FN.")
   (make-node-cond-clause
    :expr (parse-expression (cst:first form) file)
    :body (parse-body (cst:rest form) form file)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-do (form file)
   (declare (type cst:cst form)
@@ -1550,7 +1551,7 @@ Rebound to NIL parsing an anonymous FN.")
     (make-node-do
      :nodes nodes
      :last-node last-node
-     :source (cst:source form))))
+     :source (source-location form file))))
 
 (defun do-bind-p (form)
   "Returns t if FORM is in the form of (x <- y+)"
@@ -1592,7 +1593,7 @@ Rebound to NIL parsing an anonymous FN.")
   (make-node-do-bind
    :pattern (parse-pattern (cst:first form) file)
    :expr (parse-expression (cst:third form) file)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-do-body-element (form file)
   (declare (type cst:cst form)
@@ -1669,7 +1670,7 @@ Rebound to NIL parsing an anonymous FN.")
   (make-node-let-declare
    :name (parse-variable (cst:second form) file)
    :type (parse-qualified-type (cst:third form) file)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun take-label (form)
   "Takes form (HEAD . (MAYBEKEYWORD . REST)) and returns two values,

--- a/src/parser/pattern.lisp
+++ b/src/parser/pattern.lisp
@@ -47,7 +47,7 @@
 (defstruct (pattern
             (:constructor nil)
             (:copier nil))
-  (source (util:required 'source) :type cons :read-only t))
+  (source (util:required 'source) :type source-location :read-only t))
 
 (defmethod make-load-form ((self pattern) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -96,12 +96,12 @@
           (typep (cst:raw form) 'util:literal-value))
      (make-pattern-literal
       :value (cst:raw form)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom form)
           (eq (cst:raw form) 'coalton:_))
      (make-pattern-wildcard
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((and (cst:atom form)
           (identifierp (cst:raw form)))
@@ -115,7 +115,7 @@
      (make-pattern-var
       :name (cst:raw form)
       :orig-name (cst:raw form)
-      :source (cst:source form)))
+      :source (source-location form file)))
 
     ((cst:atom form)
      (error 'parse-error
@@ -148,7 +148,7 @@
       :patterns (loop :for patterns := (cst:rest form) :then (cst:rest patterns)
                       :while (cst:consp patterns)
                       :collect (parse-pattern (cst:first patterns) file))
-      :source (cst:source form)))))
+      :source (source-location form file)))))
 
 (defun pattern-variables (pattern)
   (declare (type t pattern)

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -514,7 +514,6 @@
     (values
      (make-program
       :package (program-package program)
-      :file (program-file program)
       :types (rename-type-variables (program-types program))
       :structs (rename-type-variables (program-structs program))
       :declares (program-declares program)

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -482,7 +482,7 @@ If MODE is :macro, a package form is forbidden, and an explicit check is made fo
 
       (loop :do
         (multiple-value-bind (form presentp eofp)
-            (maybe-read-form stream *coalton-eclector-client*)
+            (maybe-read-form stream file *coalton-eclector-client*)
 
           (when (and eofp (eq mode ':macro))
             (error 'parse-error
@@ -525,7 +525,7 @@ consume all attributes"))))
 
     ;; Read the coalton form
     (multiple-value-bind (form presentp)
-        (maybe-read-form stream *coalton-eclector-client*)
+        (maybe-read-form stream file *coalton-eclector-client*)
 
       (unless presentp
         (error 'parse-error
@@ -538,7 +538,7 @@ consume all attributes"))))
 
       ;; Ensure there is only one form
       (multiple-value-bind (form presentp)
-          (maybe-read-form stream *coalton-eclector-client*)
+          (maybe-read-form stream file *coalton-eclector-client*)
 
         (when presentp
           (error 'parse-error
@@ -651,7 +651,7 @@ consume all attributes"))))
                                            "Malformed package declaration"
                                            syntax-error))))
       (multiple-value-bind (form presentp)
-          (maybe-read-form stream *coalton-eclector-client*)
+          (maybe-read-form stream file *coalton-eclector-client*)
         (unless presentp
           (cursor:span-error (cons (- (file-position stream) 2)
                                    (- (file-position stream) 1))

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -127,7 +127,6 @@
    #:program                                     ; STRUCT
    #:make-program                                ; CONSTRUCTOR
    #:program-package                             ; ACCESSOR
-   #:program-file                                ; ACCESSOR
    #:program-types                               ; ACCESSOR
    #:program-structs                             ; ACCESSOR
    #:program-declares                            ; ACCESSOR
@@ -214,7 +213,7 @@
 (defstruct (attribute
             (:constructor nil)
             (:copier nil))
-  (source (util:required 'source) :type cons :read-only t))
+  (source (util:required 'source) :type source-location :read-only t))
 
 (defstruct (attribute-monomorphize
             (:include attribute)))
@@ -230,9 +229,9 @@
 
 (defstruct (constructor
             (:copier nil))
-  (name   (util:required 'name)   :type identifier-src :read-only t)
-  (fields (util:required 'fields) :type ty-list        :read-only t)
-  (source (util:required 'source) :type cons           :read-only t))
+  (name   (util:required 'name)   :type identifier-src  :read-only t)
+  (fields (util:required 'fields) :type ty-list         :read-only t)
+  (source (util:required 'source) :type source-location :read-only t))
 
 (defun constructor-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -247,9 +246,9 @@
   (vars      (util:required 'vars)      :type keyword-src-list         :read-only t)
   (docstring (util:required 'docstring) :type (or null string)         :read-only t)
   (ctors     (util:required 'ctors)     :type constructor-list         :read-only t)
-  (source    (util:required 'source)    :type cons                     :read-only t)
+  (source    (util:required 'source)    :type source-location          :read-only t)
   (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
-  (head-src  (util:required 'head-src)  :type cons                     :read-only t))
+  (head-src  (util:required 'head-src)  :type source-location                     :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-type-list-p (x)
@@ -264,7 +263,7 @@
   (name      (util:required 'name)      :type string           :read-only t)
   (type      (util:required 'type)      :type ty               :read-only t)
   (docstring (util:required 'docstring) :type (or null string) :read-only t)
-  (source    (util:required 'source)    :type cons             :read-only t))
+  (source    (util:required 'source)    :type source-location             :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun struct-field-list-p (x)
@@ -280,9 +279,9 @@
   (vars      (util:required 'vars)      :type keyword-src-list         :read-only t)
   (docstring (util:required 'docstring) :type (or null string)         :read-only t)
   (fields    (util:required 'fields)    :type struct-field-list        :read-only t)
-  (source    (util:required 'source)    :type cons                     :read-only t)
+  (source    (util:required 'source)    :type source-location          :read-only t)
   (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
-  (head-src  (util:required 'head-src)  :type cons                     :read-only t))
+  (head-src  (util:required 'head-src)  :type source-location          :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-struct-list-p (x)
@@ -294,9 +293,9 @@
 
 (defstruct (toplevel-declare
             (:copier nil))
-  (name         (util:required 'name)         :type identifier-src                  :read-only t)
-  (type         (util:required 'type)         :type qualified-ty                    :read-only t)
-  (source       (util:required 'source)       :type cons                            :read-only t)
+  (name         (util:required 'name)         :type identifier-src                   :read-only t)
+  (type         (util:required 'type)         :type qualified-ty                     :read-only t)
+  (source       (util:required 'source)       :type source-location                  :read-only t)
   (monomorphize (util:required 'monomorphize) :type (or null attribute-monomorphize) :read-only nil))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -314,7 +313,7 @@
   (orig-params  (util:required 'orig-params)  :type pattern-list                     :read-only t)
   (docstring    (util:required 'docstring)    :type (or null string)                 :read-only t)
   (body         (util:required 'body)         :type node-body                        :read-only t)
-  (source       (util:required 'source)       :type cons                             :read-only t)
+  (source       (util:required 'source)       :type source-location                  :read-only t)
   (monomorphize (util:required 'monomorphize) :type (or null attribute-monomorphize) :read-only nil))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -329,7 +328,7 @@
             (:copier nil))
   (left   (util:required 'left)   :type keyword-src-list :read-only t)
   (right  (util:required 'right)  :type keyword-src-list :read-only t)
-  (source (util:required 'source) :type cons             :read-only t))
+  (source (util:required 'source) :type source-location  :read-only t))
 
 (defun fundep-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -343,7 +342,7 @@
   (name      (util:required 'name)      :type identifier-src   :read-only t)
   (type      (util:required 'type)      :type qualified-ty     :read-only t)
   (docstring (util:required 'docstring) :type (or string null) :read-only t)
-  (source    (util:required 'source)    :type cons             :read-only t))
+  (source    (util:required 'source)    :type source-location  :read-only t))
 
 (defmethod make-load-form ((self method-definition) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -363,9 +362,9 @@
   (fundeps   (util:required 'fundeps)   :type fundep-list            :read-only t)
   (docstring (util:required 'docstring) :type (or null string)       :read-only t)
   (methods   (util:required 'methods)   :type method-definition-list :read-only t)
-  (source    (util:required 'source)    :type cons                   :read-only t)
+  (source    (util:required 'source)    :type source-location        :read-only t)
   ;; Source information for context, name, and vars
-  (head-src  (util:required 'head-src) :type cons                   :read-only t))
+  (head-src  (util:required 'head-src) :type source-location         :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-class-list-p (x)
@@ -380,7 +379,7 @@
   (name      (util:required 'name)      :type node-variable       :read-only t)
   (params    (util:required 'params)    :type pattern-list        :read-only t)
   (body      (util:required 'body)      :type node-body           :read-only t)
-  (source    (util:required 'source)    :type cons                :read-only t))
+  (source    (util:required 'source)    :type source-location     :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun instance-method-definition-list-p (x)
@@ -396,9 +395,9 @@
   (pred               (util:required 'pred)               :type ty-predicate                    :read-only t)
   (docstring          (util:required 'docstring)          :type (or null string)                :read-only t)
   (methods            (util:required 'methods)            :type instance-method-definition-list :read-only t)
-  (source             (util:required 'source)             :type cons                            :read-only t)
+  (source             (util:required 'source)             :type source-location                 :read-only t)
   ;; Source information for the context and the pred
-  (head-src           (util:required 'head-src)           :type cons                            :read-only t)
+  (head-src           (util:required 'head-src)           :type source-location                 :read-only t)
   (compiler-generated (util:required 'compiler-generated) :type boolean                         :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -414,7 +413,7 @@
   (from   (util:required 'from)   :type node-variable :read-only t)
   (to     (util:required 'to)     :type node-variable :read-only t)
   (type   (util:required 'type)   :type ty            :read-only t)
-  (source (util:required 'source) :type cons          :read-only t))
+  (source (util:required 'source) :type source-location          :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-specialize-list-p (x)
@@ -434,17 +433,15 @@
   (import-from nil                   :type list)
   (export      nil                   :type list))
 
-(defstruct (program
-            (:copier nil))
-  (package         (util:required 'package)         :type (or null toplevel-package)    :read-only t)
-  (file            (util:required 'file)            :type se:file                  :read-only t)
-  (types           (util:required 'types)           :type toplevel-define-type-list     :read-only nil)
-  (structs         (util:required 'structs)         :type toplevel-define-struct-list   :read-only nil)
-  (declares        (util:required 'declares)        :type toplevel-declare-list         :read-only nil)
-  (defines         (util:required 'defines)         :type toplevel-define-list          :read-only nil)
-  (classes         (util:required 'classes)         :type toplevel-define-class-list    :read-only nil)
-  (instances       (util:required 'instances)       :type toplevel-define-instance-list :read-only nil)
-  (specializations (util:required 'specializations) :type toplevel-specialize-list      :read-only nil))
+(defstruct program
+  (package         nil :type (or null toplevel-package)    :read-only t)
+  (types           nil :type toplevel-define-type-list     :read-only nil)
+  (structs         nil :type toplevel-define-struct-list   :read-only nil)
+  (declares        nil :type toplevel-declare-list         :read-only nil)
+  (defines         nil :type toplevel-define-list          :read-only nil)
+  (classes         nil :type toplevel-define-class-list    :read-only nil)
+  (instances       nil :type toplevel-define-instance-list :read-only nil)
+  (specializations nil :type toplevel-specialize-list      :read-only nil))
 
 (defun read-program (stream file &optional mode)
   "Read a PROGRAM from FILE (an instance of source-error:file).
@@ -456,67 +453,56 @@ If MODE is :macro, a package form is forbidden, and an explicit check is made fo
            (type (member :file :macro nil) mode)
            (values program))
 
-  (let* (;; Setup eclector readtable
-         (eclector.readtable:*readtable*
+  (let* ((eclector.readtable:*readtable*
            (eclector.readtable:copy-readtable eclector.readtable:*readtable*))
 
          ;; In mode :file, the value of package is a toplevel-package structure
-         (package nil))
+         (package
+           (when (eq mode ':file)
+             (read-toplevel-package stream file)))
+         (program
+           (make-program :package package))
+         (*package*
+           (program-lisp-package program))
+         (attributes
+           (make-array 0 :adjustable t :fill-pointer t)))
 
-    (when (eq mode ':file)
-      (setf package (read-toplevel-package stream file)))
+    (loop :do
+      (multiple-value-bind (form presentp eofp)
+          (maybe-read-form stream file *coalton-eclector-client*)
 
-    (let* ((program (make-program
-                     :package package
-                     :file file
-                     :types nil
-                     :structs nil
-                     :declares nil
-                     :defines nil
-                     :classes nil
-                     :instances nil
-                     :specializations nil))
-           (*package* (program-lisp-package program))
+        (when (and eofp (eq mode ':macro))
+          (error 'parse-error
+                 :err (se:source-error
+                       :span (cons (- (file-position stream) 2)
+                                   (- (file-position stream) 1))
+                       :file file
+                       :message "Unexpected EOF"
+                       :primary-note "missing close parenthesis")))
 
-           (attributes (make-array 0 :adjustable t :fill-pointer t)))
+        (unless presentp
+          (return))
 
-      (loop :do
-        (multiple-value-bind (form presentp eofp)
-            (maybe-read-form stream file *coalton-eclector-client*)
+        (when (and (parse-toplevel-form form program attributes file)
+                   (plusp (length attributes)))
+          (util:coalton-bug "parse-toplevel-form indicated that a form was parsed but did not consume all attributes"))))
 
-          (when (and eofp (eq mode ':macro))
-            (error 'parse-error
-                   :err (se:source-error
-                         :span (cons (- (file-position stream) 2)
-                                     (- (file-position stream) 1))
-                         :file file
-                         :message "Unexpected EOF"
-                         :primary-note "missing close parenthesis")))
+    (unless (zerop (length attributes))
+      (error 'parse-error
+             :err (se:source-error
+                   :span (cst:source (cdr (aref attributes 0)))
+                   :file file
+                   :message "Orphan attribute"
+                   :primary-note "attribute must be attached to another form")))
 
-          (unless presentp
-            (return))
+    (setf (program-types program) (nreverse (program-types program)))
+    (setf (program-structs program) (nreverse (program-structs program)))
+    (setf (program-declares program) (nreverse (program-declares program)))
+    (setf (program-defines program) (nreverse (program-defines program)))
+    (setf (program-classes program) (nreverse (program-classes program)))
+    (setf (program-specializations program) (nreverse (program-specializations program)))
 
-          (when (and (parse-toplevel-form form program attributes file)
-                     (plusp (length attributes)))
-            (util:coalton-bug "parse-toplevel-form indicated that a form was parsed but did not
-consume all attributes"))))
-
-      (unless (zerop (length attributes))
-        (error 'parse-error
-               :err (se:source-error
-                     :span (cst:source (cdr (aref attributes 0)))
-                     :file file
-                     :message "Orphan attribute"
-                     :primary-note "attribute must be attached to another form")))
-
-      (setf (program-types program) (nreverse (program-types program)))
-      (setf (program-structs program) (nreverse (program-structs program)))
-      (setf (program-declares program) (nreverse (program-declares program)))
-      (setf (program-defines program) (nreverse (program-defines program)))
-      (setf (program-classes program) (nreverse (program-classes program)))
-      (setf (program-specializations program) (nreverse (program-specializations program)))
-
-      program)))
+    program))
 
 (defun read-expression (stream file)
   (let* (;; Setup eclector readtable
@@ -747,7 +733,7 @@ consume all attributes"))))
                                  (list
                                   (se:make-source-error-note
                                    :type :secondary
-                                   :span (node-source (toplevel-define-name define))
+                                   :span (source-location-span (node-source (toplevel-define-name define)))
                                    :message "when parsing define")))))
 
                    (attribute-monomorphize
@@ -766,7 +752,7 @@ consume all attributes"))))
                                      :message "previous attribute here")
                                     (se:make-source-error-note
                                      :type :secondary
-                                     :span (node-source (toplevel-define-name define))
+                                     :span (source-location-span (node-source (toplevel-define-name define)))
                                      :message "when parsing define")))))
 
                     (setf monomorphize attribute)
@@ -850,7 +836,7 @@ consume all attributes"))))
                                      :message "previous attribute here")
                                     (se:make-source-error-note
                                      :type :secondary
-                                     :span (toplevel-define-type-head-src type)
+                                     :span (source-location-span (toplevel-define-type-head-src type))
                                      :message "when parsing define-type")))))
 
                     (setf repr attribute)
@@ -867,7 +853,7 @@ consume all attributes"))))
                                  (list
                                   (se:make-source-error-note
                                    :type :secondary
-                                   :span (toplevel-define-type-head-src type)
+                                   :span (source-location-span (toplevel-define-type-head-src type))
                                    :message "when parsing define-type")))))))
 
        (setf (fill-pointer attributes) 0)
@@ -899,7 +885,7 @@ consume all attributes"))))
                                      :message "previous attribute here")
                                     (se:make-source-error-note
                                      :type :secondary
-                                     :span (toplevel-define-struct-head-src struct) 
+                                     :span (source-location-span (toplevel-define-struct-head-src struct) )
                                      :message "when parsing define-struct")))))
 
                     (unless (eq :transparent (keyword-src-name (attribute-repr-type attribute)))
@@ -913,7 +899,7 @@ consume all attributes"))))
                                    (list
                                     (se:make-source-error-note
                                      :type :secondary
-                                     :span (toplevel-define-struct-head-src struct)
+                                     :span (source-location-span (toplevel-define-struct-head-src struct))
                                      :message "when parsing define-struct")))))
 
                     (setf repr attribute)
@@ -930,7 +916,7 @@ consume all attributes"))))
                                  (list
                                   (se:make-source-error-note
                                    :type :secondary
-                                   :span (identifier-src-source (toplevel-define-struct-name struct))
+                                   :span (source-location-span (identifier-src-source (toplevel-define-struct-name struct)))
                                    :message "when parsing define-type")))))))
 
        (setf (fill-pointer attributes) 0)
@@ -952,7 +938,7 @@ consume all attributes"))))
                       (list
                        (se:make-source-error-note
                         :type :secondary
-                        :span (toplevel-define-class-head-src class)
+                        :span (source-location-span (toplevel-define-class-head-src class))
                         :message "while parsing define-class")))))
 
        (push class (program-classes program))
@@ -972,7 +958,7 @@ consume all attributes"))))
                       (list
                        (se:make-source-error-note
                         :type :secondary
-                        :span (toplevel-define-instance-head-src instance)
+                        :span (source-location-span (toplevel-define-instance-head-src instance))
                         :message "while parsing define-instance")))))
 
 
@@ -1094,7 +1080,7 @@ consume all attributes")))
        :docstring docstring
        :body body
        :monomorphize nil
-       :source (cst:source form)))))
+       :source (source-location form file)))))
 
 (defun parse-declare (form file)
   (declare (type cst:cst form)
@@ -1142,10 +1128,10 @@ consume all attributes")))
   (make-toplevel-declare
    :name (make-identifier-src
           :name (cst:raw (cst:second form))
-          :source (cst:source (cst:second form)))
+          :source (source-location (cst:second form) file))
    :type (parse-qualified-type (cst:third form) file)
    :monomorphize nil
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-define-type (form file)
   (declare (type cst:cst form)
@@ -1180,7 +1166,7 @@ consume all attributes")))
                       :primary-note "expected symbol")))
 
        (setf name (make-identifier-src :name (cst:raw (cst:second form))
-                                       :source (cst:source form))))
+                                       :source (source-location form file))))
 
       (t                                ; (define-type (T ...) ...)
        ;; (define-type ((T) ...) ...)
@@ -1210,7 +1196,7 @@ consume all attributes")))
                       :primary-note "expected symbol")))
 
        (setf name (make-identifier-src :name (cst:raw (cst:first (cst:second form)))
-                                       :source (cst:source (cst:first (cst:second form)))))
+                                       :source (source-location (cst:first (cst:second form)) file)))
 
        ;; (define-type (T) ...)
        (when (cst:atom (cst:rest (cst:second form)))
@@ -1246,8 +1232,8 @@ consume all attributes")))
                   :while (cst:consp constructors_)
                   :collect (parse-constructor (cst:first constructors_) form file))
      :repr nil
-     :source (cst:source form)
-     :head-src (cst:source (cst:second form)))))
+     :source (source-location form file)
+     :head-src (source-location (cst:second form) file))))
 
 (defun parse-define-struct (form file)
   (declare (type cst:cst form)
@@ -1293,9 +1279,9 @@ consume all attributes")))
               #'parse-struct-field
               (cst:nthrest (if docstring 3 2) form)
               file)
-     :source (cst:source form)
+     :source (source-location form file)
      :repr nil
-     :head-src (cst:source (cst:second form)))))
+     :head-src (source-location (cst:second form) file))))
 
 (defun parse-define-class (form file)
   (declare (type cst:cst form)
@@ -1483,12 +1469,14 @@ consume all attributes")))
       (when right
         (if (cst:atom (first left))
             ;; (C1 ... => C2 ...)
-            (setf predicates (list (parse-predicate left (util:cst-source-range left) file)))
+            (setf predicates (list (parse-predicate left (make-source-location :file file
+                                                                               :span (util:cst-source-range left))
+                                                    file)))
 
             ;; ((C1 ...) (C2 ...) ... => C3 ...)
             (setf predicates
                   (loop :for pred :in left
-                        :collect (parse-predicate (cst:listify pred) (cst:source pred) file)))))
+                        :collect (parse-predicate (cst:listify pred) (source-location pred file) file)))))
 
       (when (and (cst:consp (cst:rest (cst:rest form)))
                  (cst:atom (cst:third form))
@@ -1503,14 +1491,14 @@ consume all attributes")))
       (make-toplevel-define-class
        :name (make-identifier-src
               :name name
-              :source (cst:source unparsed-name))
+              :source (source-location unparsed-name file))
        :vars variables
        :preds predicates
        :fundeps fundeps
        :docstring docstring
        :methods methods
-       :source (cst:source form)
-       :head-src (cst:source (cst:second form))))))
+       :source (source-location form file)
+       :head-src (source-location (cst:second form) file)))))
 
 (defun parse-define-instance (form file)
   (declare (type cst:cst form)
@@ -1623,11 +1611,14 @@ consume all attributes")))
 
       (when unparsed-context
         (if (cst:atom (first unparsed-context))
-            (setf context (list (parse-predicate unparsed-context (util:cst-source-range unparsed-context) file)))
+            (setf context (list (parse-predicate unparsed-context
+                                                 (make-source-location :file file
+                                                                       :span (util:cst-source-range unparsed-context))
+                                                 file)))
 
             (setf context
                   (loop :for unparsed :in unparsed-context
-                        :collect (parse-predicate (cst:listify unparsed) (cst:source unparsed) file)))))
+                        :collect (parse-predicate (cst:listify unparsed) (source-location unparsed file) file)))))
 
       (when (and (cst:consp (cst:rest (cst:rest form)))
                  (cst:atom (cst:third form))
@@ -1636,14 +1627,17 @@ consume all attributes")))
 
       (make-toplevel-define-instance
        :context context
-       :pred (parse-predicate unparsed-predicate (util:cst-source-range unparsed-predicate) file)
+       :pred (parse-predicate unparsed-predicate
+                              (make-source-location :file file
+                                                    :span (util:cst-source-range unparsed-predicate))
+                              file)
        :docstring docstring
        :methods (loop :for methods := (cst:nthrest (if docstring 3 2) form) :then (cst:rest methods)
                       :while (cst:consp methods)
                       :for method := (cst:first methods)
                       :collect (parse-instance-method-definition method (cst:second form) file))
-       :source (cst:source form)
-       :head-src (cst:source (cst:second form))
+       :source (source-location form file)
+       :head-src (source-location (cst:second form) file)
        :compiler-generated nil))))
 
 (defun parse-specialize (form file)
@@ -1696,7 +1690,7 @@ consume all attributes")))
    :from (parse-variable (cst:second form) file)
    :to (parse-variable (cst:third form) file)
    :type (parse-type (cst:fourth form) file)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-method (method-form form file)
   (declare (type cst:cst method-form)
@@ -1795,13 +1789,13 @@ consume all attributes")))
     (make-method-definition
      :name (make-identifier-src
             :name (node-variable-name (parse-variable (cst:first method-form) file))
-            :source (cst:source (cst:first method-form)))
+            :source (source-location (cst:first method-form) file))
      :docstring docstring
      :type (parse-qualified-type (if docstring
                                      (cst:third method-form)
                                      (cst:second method-form))
                                  file)
-     :source (cst:source method-form))))
+     :source (source-location method-form file))))
 
 (defun parse-type-variable (form file)
   (declare (type cst:cst form)
@@ -1834,7 +1828,7 @@ consume all attributes")))
 
   (make-keyword-src
    :name (cst:raw form)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-constructor (form enclosing-form file)
   (declare (type cst:cst form enclosing-form)
@@ -1881,11 +1875,10 @@ consume all attributes")))
     (make-constructor
      :name (make-identifier-src
             :name (cst:raw unparsed-name)
-            :source (cst:source unparsed-name))
+            :source (source-location unparsed-name file))
      :fields (loop :for field :in unparsed-fields
                    :collect (parse-type field file))
-     :source (cst:source form))))
-
+     :source (source-location form file))))
 
 (defun parse-argument-list (form file)
   (declare (type cst:cst form)
@@ -1910,7 +1903,7 @@ consume all attributes")))
    (if (cst:null (cst:rest form))
        (list
         (make-pattern-wildcard
-         :source (cst:source form)))
+         :source (source-location form file)))
        (loop :for vars := (cst:rest form) :then (cst:rest vars)
              :while (cst:consp vars)
              :collect (parse-pattern (cst:first vars) file)))))
@@ -1954,7 +1947,7 @@ consume all attributes")))
 
   (make-identifier-src
    :name (cst:raw form)
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-definition-body (form enclosing-form file)
   (declare (type cst:cst form)
@@ -2035,7 +2028,7 @@ consume all attributes")))
        :name name
        :params params
        :body (parse-body (cst:rest (cst:rest form)) form file)
-       :source (cst:source form)))))
+       :source (source-location form file)))))
 
 (defun parse-fundep (form file)
   (declare (type cst:cst form)
@@ -2087,7 +2080,7 @@ consume all attributes")))
                  :collect (parse-type-variable var file))
      :right (loop :for var :in (cdr right)
                   :collect (parse-type-variable var file))
-     :source (cst:source form))))
+     :source (source-location form file))))
 
 
 (defun parse-monomorphize (form file)
@@ -2106,7 +2099,7 @@ consume all attributes")))
                  :primary-note "unexpected form")))
 
   (make-attribute-monomorphize
-   :source (cst:source form)))
+   :source (source-location form file)))
 
 (defun parse-repr (form file)
   (declare (type cst:cst form)
@@ -2148,7 +2141,7 @@ consume all attributes")))
           (make-attribute-repr
            :type type
            :arg (cst:third form)
-           :source (cst:source form)))
+           :source (source-location form file)))
 
         (progn ;; other reprs do not have an argument
           (when (cst:consp (cst:rest (cst:rest form)))
@@ -2174,7 +2167,7 @@ consume all attributes")))
           (make-attribute-repr
            :type type
            :arg nil
-           :source (cst:source form))))))
+           :source (source-location form file))))))
 
 (defun parse-struct-field (form file)
   (declare (type cst:cst form)
@@ -2240,4 +2233,4 @@ consume all attributes")))
      :type (parse-type (cst:first rest-field)
                        file)
      :docstring docstring
-     :source (cst:source form))))
+     :source (source-location form file))))

--- a/src/parser/type-definition.lisp
+++ b/src/parser/type-definition.lisp
@@ -53,11 +53,11 @@
 
 (defgeneric type-definition-source (def)
   (:method ((def toplevel-define-type))
-    (declare (values cons))
+    (declare (values source-location))
     (toplevel-define-type-source def))
 
   (:method ((def toplevel-define-struct))
-    (declare (values cons))
+    (declare (values source-location))
     (toplevel-define-struct-source def)))
 
 (defgeneric type-definition-vars (def)
@@ -107,11 +107,11 @@
 
 (defgeneric type-definition-ctor-source (ctor)
   (:method ((ctor constructor))
-    (declare (values cons))
+    (declare (values source-location))
     (constructor-source ctor))
 
   (:method ((ctor toplevel-define-struct))
-    (declare (values cons))
+    (declare (values source-location))
     (toplevel-define-struct-source ctor)))
 
 (defgeneric type-definition-ctor-field-types (ctor)

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -59,7 +59,7 @@ Used to forbid reading while inside quasiquoted forms.")
           nil)
 
         (coalton:coalton
-         (entry:expression-entry-point (parser:read-expression stream file) file))
+         (entry:expression-entry-point (parser:read-expression stream file)))
 
         ;; Fall back to reading the list manually
         (t

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -17,43 +17,6 @@
   "Is the Coalton reader allowed to parse the current input?
 Used to forbid reading while inside quasiquoted forms.")
 
-
-
-(defmacro with-coalton-file ((file stream) &body body)
-  "Given a stream STREAM, bind a COALTON-IMPL/ERROR:COALTON-FILE instance to the symbol FILE and execute BODY. In the event of a Coalton compiler error or warning, render the error message (which may rely on operations on STREAM)."
-  (let ((opened-streams (gensym))
-        (pathname (gensym))
-        (filename (gensym))
-        (file-input-stream (gensym)))
-    `(let ((,opened-streams nil))
-       (unwind-protect
-            (let* ((,pathname (or *compile-file-truename* *load-truename*))
-                   (,filename (if ,pathname (namestring ,pathname) "<unknown>"))
-                   ;; Ensure that coalton-file has a reference to an
-                   ;; FD-STREAM, so that stream positioning works.
-                   (,file-input-stream
-                     (cond
-                       ((or #+sbcl (sb-int:form-tracking-stream-p ,stream)
-                            nil)
-                        (let ((s (open (pathname ,stream))))
-                          (push s ,opened-streams)
-                          s))
-                       (t
-                        ,stream)))
-                   (,file (se:make-file :stream ,file-input-stream :name ,filename)))
-              (handler-bind
-                  ;; Render errors and set highlights
-                  ((se:source-base-error
-                     (lambda (c)
-                       (set-highlight-position-for-error stream (funcall (se:source-base-error-err c)))
-                       (se:render-source-error c)))
-                   (se:source-base-warning
-                     #'se:render-source-warning))
-                ,@body))
-         ;; Clean up any opened file streams
-         (dolist (s ,opened-streams)
-           (close s))))))
-
 (defun read-coalton-toplevel-open-paren (stream char)
   (declare (optimize (debug 2)))
 
@@ -62,43 +25,41 @@ Used to forbid reading while inside quasiquoted forms.")
       (funcall (get-macro-character #\( (named-readtables:ensure-readtable :standard)) stream char)))
 
   (parser:with-reader-context stream
-    (let ((first-form
-            (multiple-value-bind (form presentp)
-                (parser:maybe-read-form stream)
-              (unless presentp
-                (return-from read-coalton-toplevel-open-paren
-                  nil))
-              form)))
+    (let* ((file
+             (se:make-source-file *compile-file-truename*
+                                  :offset (file-position stream)))
+           (first-form
+             (multiple-value-bind (form presentp)
+                 (parser:maybe-read-form stream file)
+               (unless presentp
+                 (return-from read-coalton-toplevel-open-paren
+                   nil))
+               form)))
       (case (cst:raw first-form)
         (coalton:coalton-toplevel
-          (with-coalton-file (file stream)
-            (entry:compile-coalton-toplevel (parser:read-program stream file ':macro))))
+          (entry:compile-coalton-toplevel (parser:read-program stream file ':macro)))
 
         (coalton:coalton-codegen
-          (with-coalton-file (file stream)
-            (let ((settings:*emit-type-annotations* nil))
-              `',(entry:entry-point (parser:read-program stream file ':macro)))))
+          (let ((settings:*emit-type-annotations* nil))
+            `',(entry:entry-point (parser:read-program stream file ':macro))))
 
         (coalton:coalton-codegen-types
-          (with-coalton-file (file stream)
-            (let ((settings:*emit-type-annotations* t))
-              `',(entry:entry-point (parser:read-program stream file ':macro)))))
+          (let ((settings:*emit-type-annotations* t))
+            `',(entry:entry-point (parser:read-program stream file ':macro))))
 
         (coalton:coalton-codegen-ast
-          (with-coalton-file (file stream)
-            (let* ((settings:*emit-type-annotations* nil)
-                   (ast nil)
-                   (codegen:*codegen-hook* (lambda (op &rest args)
-                                             (when (eql op ':AST)
-                                               (push args ast)))))
-              (entry:entry-point (parser:read-program stream file ':macro))
-              (loop :for (name type value) :in (nreverse ast)
-                    :do (format t "~A :: ~A~%~A~%~%~%" name type value))))
+          (let* ((settings:*emit-type-annotations* nil)
+                 (ast nil)
+                 (codegen:*codegen-hook* (lambda (op &rest args)
+                                           (when (eql op ':AST)
+                                             (push args ast)))))
+            (entry:entry-point (parser:read-program stream file ':macro))
+            (loop :for (name type value) :in (nreverse ast)
+                  :do (format t "~A :: ~A~%~A~%~%~%" name type value)))
           nil)
 
         (coalton:coalton
-          (with-coalton-file (file stream)
-            (entry:expression-entry-point (parser:read-expression stream file) file)))
+         (entry:expression-entry-point (parser:read-expression stream file) file))
 
         ;; Fall back to reading the list manually
         (t
@@ -107,7 +68,7 @@ Used to forbid reading while inside quasiquoted forms.")
            (loop :do
              (handler-case
                  (multiple-value-bind (form presentp)
-                     (parser:maybe-read-form stream)
+                     (parser:maybe-read-form stream file)
 
                    (cond
                      ((and (not presentp)
@@ -119,7 +80,7 @@ Used to forbid reading while inside quasiquoted forms.")
                         (nreverse collected-forms)))
 
                      (dotted-context
-                      (when (nth-value 1 (parser:maybe-read-form stream))
+                      (when (nth-value 1 (parser:maybe-read-form stream file))
                         (error "Invalid dotted list"))
 
                       (return-from read-coalton-toplevel-open-paren
@@ -132,33 +93,6 @@ Used to forbid reading while inside quasiquoted forms.")
                    (error "Invalid dotted list"))
                  (setf dotted-context t)
                  (eclector.reader:recover c))))))))))
-
-(defun set-highlight-position-for-error (stream error)
-  "Set the highlight position within the editor using implementation specific magic."
-  #+sbcl
-  ;; We need some way of setting FILE-POSITION so that
-  ;; when Slime grabs the location of the error it
-  ;; highlights the correct form.
-  ;;
-  ;; In SBCL, we can't unread more than ~512
-  ;; characters due to limitations with ANSI streams,
-  ;; which breaks our old method of unreading
-  ;; characters until the file position is
-  ;; correct. Instead, we now patch in our own
-  ;; version of FILE-POSITION.
-  ;;
-  ;; This is a massive hack and might start breaking
-  ;; with future changes in SBCL.
-  (when (typep stream 'sb-impl::form-tracking-stream)
-    (let* ((file-offset
-             (- (sb-impl::fd-stream-get-file-position stream)
-                (file-position stream)))
-           (loc (se:source-error-location error)))
-      (setf (sb-impl::fd-stream-misc stream)
-            (lambda (stream operation arg1)
-              (if (= (sb-impl::%stream-opcode :get-file-position) operation)
-                  (+ file-offset loc 1)
-                  (sb-impl::tracking-stream-misc stream operation arg1)))))))
 
 (named-readtables:defreadtable coalton:coalton
   (:merge :standard)

--- a/src/typechecker/accessor.lisp
+++ b/src/typechecker/accessor.lisp
@@ -3,9 +3,10 @@
    #:cl
    #:coalton-impl/typechecker/base)
   (:local-nicknames
+   (#:parser #:coalton-impl/parser)
    (#:se #:source-error)
-   (#:util #:coalton-impl/util)
-   (#:tc #:coalton-impl/typechecker/stage-1))
+   (#:tc #:coalton-impl/typechecker/stage-1)
+   (#:util #:coalton-impl/util))
   (:export
    #:accessor                           ; STRUCT
    #:make-accessor                      ; CONSTRUCTOR
@@ -22,10 +23,10 @@
 
 (defstruct (accessor
             (:copier nil))
-  (from   (util:required 'from)   :type tc:ty  :read-only t)
-  (to     (util:required 'to)     :type tc:ty  :read-only t)
-  (field  (util:required 'field)  :type string :read-only t)
-  (source (util:required 'source) :type cons   :read-only t))
+  (from   (util:required 'from)   :type tc:ty                  :read-only t)
+  (to     (util:required 'to)     :type tc:ty                  :read-only t)
+  (field  (util:required 'field)  :type string                 :read-only t)
+  (source (util:required 'source) :type parser:source-location :read-only t))
 
 (defun accessor-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -50,9 +51,8 @@
     (t
      (util:unreachable))))
 
-(defun solve-accessors (accessors file env)
+(defun solve-accessors (accessors env)
   (declare (type accessor-list accessors)
-           (type se:file file)
            (type tc:environment env))
 
   (let ((subs nil)
@@ -65,7 +65,7 @@
 
           :do (loop :for accessor :in accessors
                     :do (multiple-value-bind (matchp subs_)
-                            (solve-accessor accessor file env)
+                            (solve-accessor accessor env)
                           (when matchp
                             (push accessor solved-accessors))
                           (setf subs (tc:compose-substitution-lists subs subs_))))
@@ -82,9 +82,8 @@
 
     (values accessors subs)))
 
-(defun solve-accessor (accessor file env)
+(defun solve-accessor (accessor env)
   (declare (type accessor accessor)
-           (type se:file file)
            (type tc:environment env)
            (values boolean tc:substitution-list))
 
@@ -104,27 +103,19 @@
            (struct-entry (tc:lookup-struct env ty-name :no-error t)))
 
       (unless struct-entry
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (accessor-source accessor)
-                     :file file
-                     :message "Invalid accessor"
-                     :primary-note
-                     (format nil "type '~S' is not a struct" ty-name))))
+        (tc-error (accessor-source accessor)
+                  "Invalid accessor"
+                  (format nil "type '~S' is not a struct" ty-name)))
 
       (let ((subs (tc:match struct-ty (accessor-from accessor)))
             (field (tc:get-field struct-entry (accessor-field accessor) :no-error t)))
 
         (unless field
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (accessor-source accessor)
-                       :file file
-                       :message "Invalid accessor"
-                       :primary-note
-                       (format nil "struct '~S' does not have the field '~A'"
-                               ty-name
-                               (accessor-field accessor)))))
+          (tc-error (accessor-source accessor)
+                    "Invalid accessor"
+                    (format nil "struct '~S' does not have the field '~A'"
+                            ty-name
+                            (accessor-field accessor))))
 
         ;; the order of unification matters here
         (setf subs (tc:unify subs (accessor-to accessor)

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/typechecker/define-class
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/parse-type
    #:coalton-impl/typechecker/partial-type-env)
   (:import-from
@@ -40,25 +41,22 @@
 ;;; Entrypoint
 ;;;
 
-(defun toplevel-define-class (classes file env)
+(defun toplevel-define-class (classes env)
   (declare (type parser:toplevel-define-class-list classes)
-           (type se:file file)
            (type tc:environment env)
            (values tc:ty-class-list tc:environment))
 
   ;; Check that all class names are in the current package
-  (check-package
-   classes
-   (alexandria:compose #'parser:identifier-src-name #'parser:toplevel-define-class-name)
-   #'parser:toplevel-define-class-head-src
-   file)
+  (check-package classes (alexandria:compose #'parser:identifier-src-name
+                                             #'parser:toplevel-define-class-name)
+                 #'parser:toplevel-define-class-head-src)
 
   ;; Check that all methods are in the current package
-  (check-package
-   (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-class-methods) classes)
-   (alexandria:compose #'parser:identifier-src-name #'parser:method-definition-name)
-   #'parser:method-definition-source
-   file)
+  (check-package (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-class-methods)
+                         classes)
+                 (alexandria:compose #'parser:identifier-src-name
+                                     #'parser:method-definition-name)
+                 #'parser:method-definition-source)
 
   ;; Check for duplicate class definitions
   (check-duplicates
@@ -67,16 +65,15 @@
    #'parser:toplevel-define-class-source
    (lambda (first second)
      (error 'tc:tc-error
-            :err (se:source-error
-                  :span (parser:toplevel-define-class-head-src first)
-                  :file file
+            :err (parser:source-error
+                  :source (parser:toplevel-define-class-head-src first)
                   :message "Duplicate class definition"
                   :primary-note "first definition here"
                   :notes
                   (list
                    (se:make-source-error-note
                     :type :primary
-                    :span (parser:toplevel-define-class-head-src second)
+                    :span (parser:source-location-span (parser:toplevel-define-class-head-src second))
                     :message "second definition here"))))))
 
   ;; Check for duplicate method definitions
@@ -86,16 +83,15 @@
    #'parser:method-definition-source
    (lambda (first second)
      (error 'tc:tc-error
-            :err (se:source-error
-                  :span (parser:method-definition-source first)
-                  :file file
+            :err (parser:source-error
+                  :source (parser:method-definition-source first)
                   :message "Duplicate method definition"
                   :primary-note "first definition here"
                   :notes
                   (list
                    (se:make-source-error-note
                     :type :primary
-                    :span (parser:method-definition-source second)
+                    :span (parser:source-location-span (parser:method-definition-source second))
                     :message "second definition here"))))))
 
   (loop :for class :in classes :do
@@ -106,16 +102,15 @@
      #'parser:keyword-src-source
      (lambda (first second)
        (error 'tc:tc-error
-              :err (se:source-error
-                    :span (parser:keyword-src-source first)
-                    :file file
+              :err (parser:source-error
+                    :source (parser:keyword-src-source first)
                     :message "Duplicate class variable"
                     :primary-note "first usage here"
                     :notes
                     (list
                      (se:make-source-error-note
                       :type :primary
-                      :span (parser:keyword-src-source second)
+                      :span (parser:source-location-span (parser:keyword-src-source second))
                       :message "second usage here")))))))
 
   (let* ((class-table
@@ -167,27 +162,25 @@
            ;; Classes cannot have cyclic superclasses
            :when (intersection superclass-names scc-names :test #'eq)
              :do (error 'tc:tc-error
-                        :err (se:source-error
-                              :span (parser:toplevel-define-class-head-src (first scc))
-                              :file file
+                        :err (parser:source-error
+                              :source (parser:toplevel-define-class-head-src (first scc))
                               :message "Cyclic superclasses"
                               :primary-note "in class defined here"
                               :notes (loop :for class :in (rest scc)
                                            :collect (se:make-source-error-note
                                                      :type :primary
-                                                     :span (parser:toplevel-define-class-head-src class)
+                                                     :span (parser:source-location-span (parser:toplevel-define-class-head-src class))
                                                      :message "in class defined here"))))
 
            :append (multiple-value-bind (classes env_)
-                       (infer-class-scc-kinds scc env file)
+                       (infer-class-scc-kinds scc env)
                      (setf env env_)
                      classes))
      env)))
 
-(defun infer-class-scc-kinds (classes env file)
+(defun infer-class-scc-kinds (classes env)
   (declare (type parser:toplevel-define-class-list classes)
            (type tc:environment env)
-           (type se:file file)
            (values tc:ty-class-list tc:environment))
 
   (let* ((renamed-classes (parser:rename-type-variables classes))
@@ -219,7 +212,7 @@
          (partial-classes
            (loop :for class :in renamed-classes
                  :collect (multiple-value-bind (partial-class ksubs_)
-                              (infer-class-kinds class partial-env ksubs file)
+                              (infer-class-kinds class partial-env ksubs)
                             (setf ksubs ksubs_)
                             partial-class))))
 
@@ -321,13 +314,9 @@
            ;; Fundeps cannot be redefined
            :when (and prev-class (not (equalp (tc:ty-class-fundeps prev-class)
                                               fundeps))) 
-             :do (progn
-                   (error 'tc:tc-error
-                          :err (se:source-error
-                                :span (parser:toplevel-define-class-head-src class)
-                                :file file
-                                :message "Invalid fundep redefinition"
-                                :primary-note (format nil "unable to redefine the fudndeps of class ~S." class-name))))
+             :do (tc-error (parser:toplevel-define-class-head-src class)
+                           "Invalid fundep redefinition"
+                           (format nil "unable to redefine the fudndeps of class ~S." class-name))
 
            :when fundeps
              :do (setf env (tc:initialize-fundep-environment env class-name))
@@ -372,11 +361,10 @@
      env)))
 
 
-(defun infer-class-kinds (class env ksubs file)
+(defun infer-class-kinds (class env ksubs)
   (declare (type parser:toplevel-define-class class)
            (type partial-type-env env)
            (type tc:ksubstitution-list ksubs)
-           (type se:file file)
            (values partial-class tc:ksubstitution-list))
 
   (let ((var-names (mapcar #'parser:keyword-src-name (parser:toplevel-define-class-vars class))))
@@ -389,16 +377,15 @@
                 #'parser:keyword-src-source
                 (lambda (first second)
                   (error 'tc:tc-error
-                         :err (se:source-error
-                               :span (parser:keyword-src-source first)
-                               :file file
+                         :err (parser:source-error
+                               :source (parser:keyword-src-source first)
                                :message "Duplicate variable in function dependency"
                                :primary-note "first usage here"
                                :notes
                                (list
                                 (se:make-source-error-note
                                  :type :primary
-                                 :span (parser:keyword-src-source second)
+                                 :span (parser:source-location-span (parser:keyword-src-source second))
                                  :message "second usage here"))))))))
       (loop :for fundep :in (parser:toplevel-define-class-fundeps class)
             :do (check-duplicate-fundep-variables (parser:fundep-left fundep))
@@ -408,13 +395,10 @@
     (labels ((check-fundep-variables (vars)
                (loop :for var :in vars
                      :unless (find (parser:keyword-src-name var) var-names :test #'eq)
-                       :do (error 'tc:tc-error
-                                  :err (se:source-error
-                                        :span (parser:keyword-src-source var)
-                                        :file file
-                                        :message "Unkown type variable"
-                                        :primary-note (format nil "unknown type variable ~S"
-                                                              (parser:keyword-src-name var)))))))
+                       :do (tc-error (parser:keyword-src-source var)
+                                     "Unkown type variable"
+                                     (format nil "unknown type variable ~S"
+                                             (parser:keyword-src-name var))))))
       (loop :for fundep :in (parser:toplevel-define-class-fundeps class)
             :do (check-fundep-variables (parser:fundep-left fundep))
             :do (check-fundep-variables (parser:fundep-right fundep))))
@@ -431,10 +415,10 @@
            (preds
              (loop :for pred :in (parser:toplevel-define-class-preds class)
                    :collect (multiple-value-bind (pred ksubs_)
-                                (infer-predicate-kinds pred ksubs env file)
+                                (infer-predicate-kinds pred ksubs env)
                               (setf ksubs ksubs_)
                               pred)))
-           
+
            ;; Parse each of the methods
            (method-tys
              (loop :for method :in (parser:toplevel-define-class-methods class)
@@ -451,12 +435,9 @@
 
                    ;; Ensure that methods are not ambiguous
                    :unless (subsetp var-names (tc:closure tyvars fundeps) :test #'eq)
-                     :do (error 'tc:tc-error
-                                :err (se:source-error
-                                      :span (parser:method-definition-source method)
-                                      :file file
-                                      :message "Amgigious method"
-                                      :primary-note "the method is ambiguous"))
+                     :do (tc-error (parser:method-definition-source method)
+                                   "Amgigious method"
+                                   "the method is ambiguous")
 
                          ;; Ensure that the type variables in each
                          ;; pred are not a subset of the class
@@ -467,23 +448,18 @@
                                              :test #'eq)
 
                              :when (subsetp tyvars var-names)
-                               :do (error 'tc:tc-error
-                                          :err (se:source-error
-                                                :span (parser:ty-predicate-source pred)
-                                                :file file
-                                                :message "Invalid method predicate"
-                                                :primary-note "method predicate contains only class variables")))
-                      
+                               :do (tc-error (parser:ty-predicate-source pred)
+                                             "Invalid method predicate"
+                                             "method predicate contains only class variables"))
+
                    :do (loop :for tyvar :in new-tyvars
                              :do (partial-type-env-add-var env tyvar))
 
                    :collect (multiple-value-bind (ty ksubs_)
-                                (infer-type-kinds ty tc:+kstar+ ksubs env file)
+                                (infer-type-kinds ty tc:+kstar+ ksubs env)
                               (setf ksubs ksubs_)
                               ty))))
 
-      (values
-       (make-partial-class
-        :superclasses preds
-        :method-tys method-tys)
-       ksubs))))
+      (values (make-partial-class :superclasses preds
+                                  :method-tys method-tys)
+              ksubs))))

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -1,11 +1,9 @@
 (defpackage #:coalton-impl/typechecker/define-instance
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/expression
    #:coalton-impl/typechecker/toplevel)
-  (:import-from
-   #:coalton-impl/typechecker/base
-   #:check-duplicates)
   (:import-from
    #:coalton-impl/typechecker/partial-type-env
    #:make-partial-type-env
@@ -30,40 +28,37 @@
 
 (in-package #:coalton-impl/typechecker/define-instance)
 
-(defun toplevel-define-instance (instances env file)
+(defun toplevel-define-instance (instances env)
   (declare (type parser:toplevel-define-instance-list instances)
            (type tc:environment env)
-           (type se:file file)
            (values tc:ty-class-instance-list tc:environment))
 
   (values
    (loop :for instance :in instances
          :collect (multiple-value-bind (instance env_)
-                      (define-instance-in-environment instance env file)
+                      (define-instance-in-environment instance env)
                     (setf env env_)
                     instance))
 
    env))
 
-(defun toplevel-typecheck-instance (instances unparsed-instances env file)
+(defun toplevel-typecheck-instance (instances unparsed-instances env)
   (declare (type tc:ty-class-instance-list instances)
            (type parser:toplevel-define-instance-list unparsed-instances)
            (type tc:environment env)
-           (type se:file file)
            (values toplevel-define-instance-list))
 
   (loop :for instance :in instances
         :for unparsed-instance :in unparsed-instances
-        :collect (typecheck-instance instance unparsed-instance env file)))
+        :collect (typecheck-instance instance unparsed-instance env)))
 
-(defun define-instance-in-environment (instance env file)
+(defun define-instance-in-environment (instance env)
   (declare (type parser:toplevel-define-instance instance)
            (type tc:environment env)
-           (type se:file file)
            (values tc:ty-class-instance tc:environment))
 
-  (check-for-orphan-instance instance file)
-  (check-instance-valid instance file)
+  (check-for-orphan-instance instance)
+  (check-instance-valid instance)
 
   (let* ((unparsed-pred (parser:toplevel-define-instance-pred instance))
 
@@ -78,13 +73,13 @@
     (let* ((ksubs nil)
 
            (pred (multiple-value-bind (pred ksubs_)
-                     (infer-predicate-kinds unparsed-pred ksubs partial-env file)
+                     (infer-predicate-kinds unparsed-pred ksubs partial-env)
                    (setf ksubs ksubs_)
                    pred))
 
            (context (loop :for pred :in unparsed-context
                           :collect (multiple-value-bind (pred ksubs_)
-                                       (infer-predicate-kinds pred ksubs partial-env file)
+                                       (infer-predicate-kinds pred ksubs partial-env)
                                      (setf ksubs ksubs_)
                                      pred)))
 
@@ -140,24 +135,18 @@
           (handler-case 
               (setf env (tc:update-instance-fundeps env pred))
             (tc:fundep-conflict (e)
-              (error 'tc:tc-error
-                     :err (se:source-error
-                           :span (parser:toplevel-define-instance-head-src instance)
-                           :file file
-                           :message "Instance fundep conflict"
-                           :primary-note (let ((*print-escape* nil))
-                                           (with-output-to-string (s)
-                                             (print-object e s))))))))
+              (tc-error (parser:toplevel-define-instance-head-src instance)
+                        "Instance fundep conflict"
+                        (let ((*print-escape* nil))
+                          (with-output-to-string (s)
+                            (print-object e s)))))))
 
         (handler-case
             (setf env (tc:add-instance env class-name instance-entry))
           (tc:overlapping-instance-error (e)
-            (error 'tc:tc-error
-                   :err (se:source-error
-                         :span (parser:toplevel-define-instance-head-src instance)
-                         :file file
-                         :message "Overlapping instance"
-                         :primary-note (format nil "instance overlaps with ~S" (tc:overlapping-instance-error-inst2 e))))))
+            (tc-error (parser:toplevel-define-instance-head-src instance)
+                      "Overlapping instance"
+                      (format nil "instance overlaps with ~S" (tc:overlapping-instance-error-inst2 e)))))
 
         (loop :for method-name :in method-names
               :for method-codegen-sym := (tc:get-value method-codegen-syms method-name) :do
@@ -165,11 +154,10 @@
 
         (values instance-entry env)))))
 
-(defun typecheck-instance (instance unparsed-instance env file)
+(defun typecheck-instance (instance unparsed-instance env)
   (declare (type tc:ty-class-instance instance)
            (type parser:toplevel-define-instance unparsed-instance)
-           (type tc:environment env)
-           (type se:file file))
+           (type tc:environment env))
 
   (let* ((pred (tc:ty-class-instance-predicate instance))
 
@@ -202,13 +190,9 @@
                     env
                     superclass
                     :no-error t)
-                   (error 'tc:tc-error
-                          :err (se:source-error
-                                :span (parser:toplevel-define-instance-head-src unparsed-instance)
-                                :file file
-                                :message "Instance missing context"
-                                :primary-note (format nil "No instance for ~S"
-                                                      superclass))))
+                   (tc-error (parser:toplevel-define-instance-head-src unparsed-instance)
+                             "Instance missing context"
+                             (format nil "No instance for ~S" superclass)))
 
           :for additional-context
             := (tc:apply-substitution
@@ -219,49 +203,38 @@
 
           :do (loop :for pred :in additional-context
                     :do (unless (tc:entail env context pred)
-                          (error 'tc:tc-error
-                                 :err (se:source-error
-                                       :span (parser:toplevel-define-instance-head-src unparsed-instance)
-                                       :file file
-                                       :message "Instance missing context"
-                                       :primary-note
-                                       (format nil
-                                               "No instance for ~S arising from constraints of superclasses ~S"
-                                               pred
-                                               superclass))))))
+                          (tc-error (parser:toplevel-define-instance-head-src unparsed-instance)
+                                     "Instance missing context"
+                                     (format nil
+                                             "No instance for ~S arising from constraints of superclasses ~S"
+                                             pred
+                                             superclass)))))
 
     (check-duplicates
      (parser:toplevel-define-instance-methods unparsed-instance)
      (alexandria:compose #'parser:node-variable-name #'parser:instance-method-definition-name)
      #'parser:instance-method-definition-source
      (lambda (first second)
-       (error 'tc:tc-error
-              :err (se:source-error
-                    :span (parser:instance-method-definition-source first)
-                    :file file
-                    :message "Duplicate method definition"
-                    :primary-note "first definition here"
-                    :notes
-                    (list
-                     (se:make-source-error-note
-                      :type :primary
-                      :span (parser:instance-method-definition-source second)
-                      :message "second definition here"))))))
+       (tc-error (parser:instance-method-definition-source first)
+                 "Duplicate method definition"
+                 "first definition here"
+                 (list
+                  (se:make-source-error-note
+                   :type :primary
+                   :span (parser:source-location-span (parser:instance-method-definition-source second))
+                   :message "second definition here")))))
 
     ;; Ensure each method is part for the class
     (loop :for method :in (parser:toplevel-define-instance-methods unparsed-instance)
           :for name := (parser:node-variable-name (parser:instance-method-definition-name method))
 
           :unless (gethash name method-table)
-            :do (error 'tc:tc-error
-                       :err (se:source-error
-                             :span (parser:instance-method-definition-source method)
-                             :file file
-                             :message "Unknown method"
-                             :primary-note (let ((*package* util:+keyword-package+))
-                                             (format nil "The method ~S is not part of class ~S"
-                                                     name
-                                                     class-name)))))
+            :do (tc-error (parser:instance-method-definition-source method)
+                          "Unknown method"
+                          (let ((*package* util:+keyword-package+))
+                            (format nil "The method ~S is not part of class ~S"
+                                    name
+                                    class-name))))
 
     ;; Ensure each method is defined
     (loop :for name :being :the :hash-keys :of method-table
@@ -269,13 +242,9 @@
                                :key (alexandria:compose #'parser:node-variable-name
                                                         #'parser:instance-method-definition-name))
           :unless method
-            :do (error 'tc:tc-error
-                       :err (se:source-error
-                             :span (parser:toplevel-define-instance-source unparsed-instance)
-                             :file file
-                             :message "Missing method"
-                             :primary-note (format nil "The method ~S is not defined"
-                                                   name))))
+            :do (tc-error (parser:toplevel-define-instance-source unparsed-instance)
+                          "Missing method"
+                          (format nil "The method ~S is not defined" name)))
 
     (let* ((methods (loop :with table := (make-hash-table :test #'eq)
 
@@ -300,8 +269,7 @@
                                                            instance-method-scheme
                                                            (parser:instance-method-definition-source method)
                                                            nil
-                                                           (make-tc-env :env env)
-                                                           file)
+                                                           (make-tc-env :env env))
 
                                 ;; Deferred predicates should always be null
                                 (unless (null preds)
@@ -329,9 +297,8 @@
        :source (parser:toplevel-define-instance-source unparsed-instance)
        :head-src (parser:toplevel-define-instance-head-src unparsed-instance)))))
 
-(defun check-instance-valid (instance file)
-  (declare (type parser:toplevel-define-instance instance)
-           (type se:file file))
+(defun check-instance-valid (instance)
+  (declare (type parser:toplevel-define-instance instance))
 
   ;; Instance validation is disabled for compiler generated instances
   (when (parser:toplevel-define-instance-compiler-generated instance)
@@ -347,18 +314,13 @@
 
 
     (when (eq (parser:identifier-src-name (parser:ty-predicate-class (parser:toplevel-define-instance-pred instance))) runtime-repr)
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:toplevel-define-instance-head-src instance)
-                   :file file
-                   :message "Invalid instance"
-                   :primary-note "RuntimeRepr instances cannot be written manually")))))
+      (tc-error (parser:toplevel-define-instance-head-src instance)
+                "Invalid instance"
+                "RuntimeRepr instances cannot be written manually"))))
 
-(defun check-for-orphan-instance (instance file)
-  (declare (type parser:toplevel-define-instance instance) 
-           (type se:file file)
+(defun check-for-orphan-instance (instance)
+  (declare (type parser:toplevel-define-instance instance)
            (values null))
-
 
   ;; Stage-1 packages skip the orphan instance check
   (when (find *package* (list (find-package "COALTON-LIBRARY/TYPES")
@@ -386,7 +348,7 @@
                               (find-package "COALTON-LIBRARY/LIST")
                               (find-package "COALTON-LIBRARY/RESULT")))
     (return-from check-for-orphan-instance))
-  
+
   (let ((instance-syms
           (cons
            (parser:identifier-src-name (parser:ty-predicate-class (parser:toplevel-define-instance-pred instance)))
@@ -394,9 +356,6 @@
                  :append (mapcar #'parser:tycon-name (parser:collect-referenced-types type))))))
 
     (unless (find *package* instance-syms :key #'symbol-package)
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:toplevel-define-instance-head-src instance)
-                   :file file
-                   :message "Invalid orphan instance"
-                   :primary-note "instances must be defined in the same package as their class or reference one or more types in their defining package")))))
+      (tc-error (parser:toplevel-define-instance-head-src instance)
+                "Invalid orphan instance"
+                "instances must be defined in the same package as their class or reference one or more types in their defining package"))))

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -7,6 +7,7 @@
 (defpackage #:coalton-impl/typechecker/define-type
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/parse-type
    #:coalton-impl/typechecker/partial-type-env)
   (:import-from
@@ -52,12 +53,12 @@
   (constructor-args  (util:required 'constructor-args)  :type list                      :read-only t)
 
   (docstring         (util:required 'docstring)         :type (or null string)          :read-only t)
-  (source            (util:required 'source)            :type cons                      :read-only t))
+  (source            (util:required 'source)            :type parser:source-location                      :read-only t))
 
 (defstruct field-definition
   (name   (util:required 'name)   :type symbol :read-only t)
   (type   (util:required 'type)   :type tc:ty  :read-only t)
-  (source (util:required 'source) :type cons   :read-only t))
+  (source (util:required 'source) :type parser:source-location   :read-only t))
 
 (defun type-definition-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -66,26 +67,26 @@
 (deftype type-definition-list ()
   '(satisfies type-definition-list-p))
 
-(defun toplevel-define-type (types structs file env)
+(defun toplevel-define-type (types structs env)
   (declare (type parser:toplevel-define-type-list types)
            (type parser:toplevel-define-struct-list structs)
-           (type se:file file)
            (type tc:environment env)
            (values type-definition-list parser:toplevel-define-instance-list tc:environment))
 
   ;; Ensure that all types are defined in the current package
-  (check-package
-   (append types structs)
-   (alexandria:compose #'parser:identifier-src-name #'parser:type-definition-name)
-   (alexandria:compose #'parser:identifier-src-source #'parser:type-definition-name)
-   file)
+  (check-package (append types structs)
+                 (alexandria:compose #'parser:identifier-src-name
+                                     #'parser:type-definition-name)
+                 (alexandria:compose #'parser:identifier-src-source
+                                     #'parser:type-definition-name))
 
   ;; Ensure that all constructors are defined in the current package
-  (check-package
-   (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-type-ctors) types)
-   (alexandria:compose #'parser:identifier-src-name #'parser:constructor-name)
-   (alexandria:compose #'parser:identifier-src-source #'parser:constructor-name)
-   file)
+  (check-package (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-type-ctors)
+                         types)
+                 (alexandria:compose #'parser:identifier-src-name
+                                     #'parser:constructor-name)
+                 (alexandria:compose #'parser:identifier-src-source
+                                     #'parser:constructor-name))
 
   ;; Ensure that there are no duplicate type definitions
   (check-duplicates
@@ -94,17 +95,15 @@
    #'parser:type-definition-source
    (lambda (first second)
      (error 'tc:tc-error
-            :err (se:source-error
-                  :span (parser:type-definition-source first)
-                  :file file
+            :err (parser:source-error
+                  :source (parser:type-definition-source first)
                   :message "Duplicate type definitions"
                   :primary-note "first definition here"
-                  :notes
-                  (list
-                   (se:make-source-error-note
-                    :type :primary
-                    :span (parser:type-definition-source second)
-                    :message "second definition here"))))))
+                  :notes (list (se:make-source-error-note
+                                :type :primary
+                                :span (parser:source-location-span
+                                       (parser:type-definition-source second))
+                                :message "second definition here"))))))
 
   ;; Ensure that there are no duplicate constructors
   ;; NOTE: structs define a constructor with the same name
@@ -115,16 +114,14 @@
    #'parser:type-definition-ctor-source
    (lambda (first second)
      (error 'tc:tc-error
-            :err (se:source-error
-                  :span (parser:type-definition-ctor-source first)
-                  :file file
+            :err (parser:source-error
+                  :source (parser:type-definition-ctor-source first)
                   :message "Duplicate constructor definitions"
                   :primary-note "first definition here"
-                  :notes
-                  (list (se:make-source-error-note
-                         :type :primary
-                         :span (parser:type-definition-ctor-source second)
-                         :message "second definition here"))))))
+                  :notes (list (se:make-source-error-note
+                                :type :primary
+                                :span (parser:source-location-span (parser:type-definition-ctor-source second))
+                                :message "second definition here"))))))
 
   ;; Ensure that no type has duplicate type variables
   (loop :for type :in (append types structs)
@@ -134,15 +131,14 @@
              #'parser:keyword-src-source
              (lambda (first second)
                (error 'tc:tc-error
-                      :err (se:source-error
-                            :span (parser:keyword-src-source first)
-                            :file file
+                      :err (parser:source-error
+                            :source (parser:keyword-src-source first)
                             :message "Duplicate type variable definitions"
                             :primary-note "first definition here"
                             :notes
                             (list (se:make-source-error-note
                                    :type :primary
-                                   :span (parser:keyword-src-source second)
+                                   :span (parser:source-location-span (parser:keyword-src-source second))
                                    :message "second definition here")))))))
 
   (let* ((type-names (mapcar (alexandria:compose #'parser:identifier-src-name
@@ -193,7 +189,7 @@
                      :do (partial-type-env-add-type partial-env name ty))
 
            :append  (multiple-value-bind (type-definitions instances_ ksubs)
-                        (infer-define-type-scc-kinds scc partial-env file)
+                        (infer-define-type-scc-kinds scc partial-env)
                       (setf instances (append instances instances_))
                       (loop :for type :in type-definitions
 
@@ -309,10 +305,10 @@
 
   env)
 
-(defun infer-define-type-scc-kinds (types env file)
+
+(defun infer-define-type-scc-kinds (types env)
   (declare (type parser:type-definition-list types)
            (type partial-type-env env)
-           (type se:file file)
            (values type-definition-list parser:toplevel-define-instance-list))
 
   (let ((ksubs nil)
@@ -326,11 +322,11 @@
                     :for ctor-name := (parser:identifier-src-name (parser:type-definition-ctor-name ctor))
                     :for fields := (loop :for field :in (parser:type-definition-ctor-field-types ctor)
                                          :collect (multiple-value-bind (type ksubs_)
-                                                      (infer-type-kinds field tc:+kstar+ ksubs env file)
+                                                      (infer-type-kinds field tc:+kstar+ ksubs env)
                                                     (setf ksubs ksubs_)
                                                     type))
                     :do (setf (gethash ctor-name ctor-table) fields)))
-    
+
     ;; Redefine types with final inferred kinds in the environment
     (loop :for type :in types
           :for name := (parser:identifier-src-name (parser:type-definition-name type))
@@ -352,8 +348,7 @@
                                       (partial-type-env-lookup-var
                                        env
                                        (parser:keyword-src-name var)
-                                       (parser:keyword-src-source var)
-                                       file))
+                                       (parser:keyword-src-source var)))
                                     (parser:type-definition-vars type)))
 
              :for repr := (parser:type-definition-repr type)
@@ -381,33 +376,23 @@
              :when (eq repr-type :enum)
                :do (loop :for ctor :in (parser:toplevel-define-type-ctors type)
                          :unless (endp (parser:constructor-fields ctor))
-                           :do (error 'tc:tc-error
-                                      :err (se:source-error
-                                            :span (parser:ty-source (first (parser:constructor-fields ctor)))
-                                            :file file
-                                            :message "Invalid repr :enum attribute"
-                                            :primary-note "constructors of repr :enum types cannot have fields")))
+                           :do (tc-error (parser:ty-source (first (parser:constructor-fields ctor)))
+                                         "Invalid repr :enum attribute"
+                                         "constructors of repr :enum types cannot have fields"))
 
                    ;; Check that repr :transparent types have a single constructor
              :when (eq repr-type :transparent)
                :do (unless (= 1 (length (parser:type-definition-ctors type)))
-                     (error 'tc:tc-error
-                            :err (se:source-error
-                                  :span (parser:toplevel-define-type-source type)
-                                  :file file
-                                  :message "Invalid repr :transparent attribute"
-                                  :primary-note "repr :transparent types must have a single constructor")))
+                     (tc-error (parser:toplevel-define-type-source type)
+                               "Invalid repr :transparent attribute"
+                               "repr :transparent types must have a single constructor"))
 
-                   
                    ;; Check that the single constructor of a repr :transparent type has a single field
              :when (eq repr-type :transparent)
                :do (unless (= 1 (length (parser:type-definition-ctor-field-types (first (parser:type-definition-ctors type)))))
-                     (error 'tc:tc-error
-                            :err (se:source-error
-                                  :span (parser:type-definition-ctor-source (first (parser:type-definition-ctors type)))
-                                  :file file
-                                  :message "Invalid repr :transparent attribute"
-                                  :primary-note "constructors of repr :transparent types must have a single field")))
+                     (tc-error (parser:type-definition-ctor-source (first (parser:type-definition-ctors type)))
+                               "Invalid repr :transparent attribute"
+                               "constructors of repr :transparent types must have a single field"))
 
              :collect (let* ((ctors
                                (loop :for ctor :in (parser:type-definition-ctors type)
@@ -476,24 +461,24 @@
 (defun make-runtime-repr-instance (type)
   (declare (type type-definition type))
 
-  (let* ((source (type-definition-source type))
-
-         (types-package (util:find-package "COALTON-LIBRARY/TYPES"))
-
-         (runtime-repr (util:find-symbol "RUNTIMEREPR" types-package))
-
-         (runtime-repr-method (util:find-symbol "RUNTIME-REPR" types-package))
-
-         (lisp-type (util:find-symbol "LISPTYPE" types-package))
-
-         (tvars (loop :for i :below (tc:kind-arity (tc:tycon-kind (type-definition-type type)))
-                      :collect (parser:make-tyvar
-                                :source source
-                                :name (alexandria:format-symbol util:+keyword-package+ "~d" i))))
-
-         (ty (parser:make-tycon
-              :source source
-              :name (type-definition-name type))))
+  (let* ((source
+           (type-definition-source type))
+         (types-package
+           (util:find-package "COALTON-LIBRARY/TYPES"))
+         (runtime-repr
+           (util:find-symbol "RUNTIMEREPR" types-package))
+         (runtime-repr-method
+           (util:find-symbol "RUNTIME-REPR" types-package))
+         (lisp-type
+           (util:find-symbol "LISPTYPE" types-package))
+         (tvars
+           (loop :for i :below (tc:kind-arity (tc:tycon-kind (type-definition-type type)))
+                 :collect (parser:make-tyvar
+                           :source source
+                           :name (alexandria:format-symbol util:+keyword-package+ "~d" i))))
+         (ty
+           (parser:make-tycon :source source
+                              :name (type-definition-name type))))
 
     (loop :for tvar :in tvars
           :do (setf ty (parser:make-tapp

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -16,6 +16,7 @@
 (defpackage #:coalton-impl/typechecker/define
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/parse-type
    #:coalton-impl/typechecker/pattern
    #:coalton-impl/typechecker/expression
@@ -23,10 +24,6 @@
    #:coalton-impl/typechecker/toplevel
    #:coalton-impl/typechecker/accessor
    #:coalton-impl/typechecker/tc-env)
-  (:import-from
-   #:coalton-impl/typechecker/base
-   #:check-duplicates
-   #:check-package)
   (:local-nicknames
    (#:se #:source-error)
    (#:util #:coalton-impl/util)
@@ -46,7 +43,7 @@
 (defparameter *return-status* :toplevel)
 
 (deftype node-return-info ()
-  '(cons cons tc:ty))
+  '(cons parser:source-location tc:ty))
 
 (defun node-return-info-p (x)
   (typep x 'node-return-info))
@@ -61,63 +58,50 @@
 (declaim (type node-return-info-list *returns*))
 (defparameter *returns* nil)
 
-(defun error-ambiguous-pred (pred file)
-  (declare (type tc:ty-predicate pred)
-           (type se:file file))
+(defun error-ambiguous-pred (pred)
+  (declare (type tc:ty-predicate pred))
 
   (unless (tc:ty-predicate-source pred)
     (util:coalton-bug "Predicate ~S does not have source information" pred))
 
-  (error 'tc:tc-error
-         :err (se:source-error
-               :span (tc:ty-predicate-source pred)
-               :file file
-               :message "Ambiguous predicate"
-               :primary-note (format nil "Ambiguous predicate ~S" pred))))
+  (tc-error (tc:ty-predicate-source pred)
+            "Ambiguous predicate"
+            (format nil "Ambiguous predicate ~S" pred)))
 
-(defun error-unknown-pred (pred file)
-  (declare (type tc:ty-predicate pred)
-           (type se:file file))
+(defun error-unknown-pred (pred)
+  (declare (type tc:ty-predicate pred))
 
   (unless (tc:ty-predicate-source pred)
     (util:coalton-bug "Predicate ~S does not have source information" pred))
 
-  (error 'tc:tc-error
-         :err (se:source-error
-               :message "Unknown instance"
-               :span (tc:ty-predicate-source pred)
-               :file file
-               :primary-note (format nil "Unknown instance ~S" pred))))
+  (tc-error (tc:ty-predicate-source pred)
+            "Unknown instance"
+            (format nil "Unknown instance ~S" pred)))
 
-
-(defun standard-expression-type-mismatch-error (node file subs expected-type ty)
+(defun standard-expression-type-mismatch-error (node subs expected-type ty)
   "Utility for signalling a type-mismatch error in INFER-EXPRESSION-TYPE"
-  (error 'tc:tc-error
-         :err (se:source-error
-               :span (parser:node-source node)
-               :file file
-               :message "Type mismatch"
-               :primary-note (format nil "Expected type '~S' but got '~S'"
-                                     (tc:apply-substitution subs expected-type)
-                                     (tc:apply-substitution subs ty)))))
+  (tc-error (parser:node-source node)
+            "Type mismatch"
+            (format nil "Expected type '~S' but got '~S'"
+                    (tc:apply-substitution subs expected-type)
+                    (tc:apply-substitution subs ty))))
 ;;;
 ;;; Entrypoint
 ;;;
 
-(defun toplevel-define (defines declares file env)
+(defun toplevel-define (defines declares env)
   "Entrypoint for typechecking a group of parsed defines and declares."
   (declare (type parser:toplevel-define-list defines)
            (type parser:toplevel-declare-list declares)
-           (type se:file file)
            (type tc:environment env)
            (values toplevel-define-list tc:environment))
 
   ;; Ensure that all defines are in the current package
-  (check-package
-   defines
-   (alexandria:compose #'parser:node-variable-name #'parser:toplevel-define-name)
-   (alexandria:compose #'parser:node-source #'parser:toplevel-define-name)
-   file)
+  (check-package defines
+                 (alexandria:compose #'parser:node-variable-name
+                                     #'parser:toplevel-define-name)
+                 (alexandria:compose #'parser:node-source
+                                     #'parser:toplevel-define-name))
 
   ;; Ensure that there are no duplicate definitions
   (check-duplicates
@@ -125,18 +109,14 @@
    (alexandria:compose #'parser:node-variable-name #'parser:toplevel-define-name)
    #'parser:toplevel-define-source
    (lambda (first second)
-     (error 'tc:tc-error
-            :err (se:source-error
-                  :span (parser:node-source (parser:toplevel-define-name first))
-                  :file file
-                  :message "Duplicate definition"
-                  :primary-note "first definition here"
-                  :notes
-                  (list
-                   (se:make-source-error-note
-                    :type :primary
-                    :span (parser:node-source (parser:toplevel-define-name second))
-                    :message "second definition here"))))))
+     (tc-error (parser:node-source (parser:toplevel-define-name first))
+               "Duplicate definition"
+               "first definition here"
+               (list
+                (se:make-source-error-note
+                 :type :primary
+                 :span (parser:source-location-span (parser:node-source (parser:toplevel-define-name second)))
+                 :message "second definition here")))))
 
   ;; Ensure that there are no duplicate declarations
   (check-duplicates
@@ -144,18 +124,14 @@
    (alexandria:compose #'parser:identifier-src-name #'parser:toplevel-declare-name)
    #'parser:toplevel-define-source
    (lambda (first second)
-     (error 'tc:tc-error
-            :err (se:source-error
-                  :span (parser:identifier-src-source (parser:toplevel-declare-name first))
-                  :file file
-                  :message "Duplicate declaration"
-                  :primary-note "first declaration here"
-                  :notes
-                  (list
-                   (se:make-source-error-note
-                    :type :primary
-                    :span (parser:identifier-src-source (parser:toplevel-declare-name second))
-                    :message "second declaration here"))))))
+     (tc-error (parser:identifier-src-source (parser:toplevel-declare-name first))
+               "Duplicate declaration"
+               "first declaration here"
+               (list
+                (se:make-source-error-note
+                 :type :primary
+                 :span (parser:source-location-span (parser:identifier-src-source (parser:toplevel-declare-name second)))
+                 :message "second declaration here")))))
 
   ;; Ensure that each declaration has an associated definition
   (loop :with def-table
@@ -173,12 +149,9 @@
         :for name := (parser:identifier-src-name (parser:toplevel-declare-name declare))
 
         :unless (gethash name def-table)
-          :do (error 'tc:tc-error
-                     :err (se:source-error
-                           :span (parser:identifier-src-source (parser:toplevel-declare-name declare))
-                           :file file
-                           :message "Orphan declaration"
-                           :primary-note "declaration does not have an associated definition")))
+          :do (tc-error (parser:identifier-src-source (parser:toplevel-declare-name declare))
+                        "Orphan declaration"
+                        "declaration does not have an associated definition"))
 
   (let ((dec-table (make-hash-table :test #'eq))
 
@@ -191,7 +164,7 @@
 
     ;; Infer binding types, returning the typed nodes.
     (multiple-value-bind (preds accessors binding-nodes subs)
-        (infer-bindings-type defines dec-table nil tc-env file)
+        (infer-bindings-type defines dec-table nil tc-env)
       (assert (null preds))
       (assert (null accessors))
 
@@ -218,7 +191,9 @@
                                                    :name name
                                                    :type :value
                                                    :docstring (parser:toplevel-define-docstring define)
-                                                   :location (se:file-name file))))
+                                                   :location (se:file-name
+                                                              (parser:source-location-file
+                                                               (parser:binding-source define))))))
 
               :if (parser:toplevel-define-orig-params define)
                 :do (setf env (tc:set-function-source-parameter-names
@@ -238,17 +213,14 @@
 ;;; Expression Type Inference
 ;;;
 
-
-
-(defgeneric infer-expression-type (node expected-type subs env file)
+(defgeneric infer-expression-type (node expected-type subs env)
   (:documentation "Infer the type of NODE and then unify against EXPECTED-TYPE
 
 Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
-  (:method ((node parser:node-literal) expected-type subs env file)
+  (:method ((node parser:node-literal) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-literal tc:substitution-list &optional))
 
     (let ((ty (etypecase (parser:node-literal-value node)
@@ -273,21 +245,20 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                subs)))
 
         (tc:coalton-internal-type-error ()
-          (standard-expression-type-mismatch-error node file subs expected-type ty)))))
+          (standard-expression-type-mismatch-error node subs expected-type ty)))))
 
-  (:method ((node parser:node-accessor) expected-type subs env file)
+  (:method ((node parser:node-accessor) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-accessor tc:substitution-list))
 
-    (let* ((from-ty (tc:make-variable))
-
-           (to-ty (tc:make-variable))
-
-           (ty (tc:make-function-type from-ty to-ty)))
-
+    (let* ((from-ty
+             (tc:make-variable))
+           (to-ty
+             (tc:make-variable))
+           (ty
+             (tc:make-function-type from-ty to-ty)))
       (handler-case
           (progn
             (setf subs (tc:unify subs ty expected-type))
@@ -307,19 +278,18 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :name (parser:node-accessor-name node))
                subs))))))
 
-  (:method ((node parser:node-integer-literal) expected-type subs env file)
+  (:method ((node parser:node-integer-literal) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-integer-literal tc:substitution-list &optional))
 
-    (let* ((num (util:find-symbol "NUM" "COALTON-LIBRARY/CLASSES"))
-
-           (tvar (tc:make-variable))
-
-           (pred (tc:make-ty-predicate :class num :types (list tvar) :source (parser:node-source node))))
-
+    (let* ((num
+             (util:find-symbol "NUM" "COALTON-LIBRARY/CLASSES"))
+           (tvar
+             (tc:make-variable))
+           (pred
+             (tc:make-ty-predicate :class num :types (list tvar) :source (parser:node-source node))))
       (handler-case
           (progn
             (setf subs (tc:unify subs tvar expected-type))
@@ -334,18 +304,16 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :value (parser:node-integer-literal-value node))
                subs)))
         (tc:coalton-internal-type-error ()
-          (standard-expression-type-mismatch-error node file subs expected-type tvar)))))
+          (standard-expression-type-mismatch-error node subs expected-type tvar)))))
 
-  (:method ((node parser:node-variable) expected-type subs env file)
+  (:method ((node parser:node-variable) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-variable tc:substitution-list &optional))
 
     (multiple-value-bind (ty preds)
-        (tc-env-lookup-value env node file)
-
+        (tc-env-lookup-value env node)
       (handler-case
           (progn
             (setf subs (tc:unify subs ty expected-type))
@@ -362,21 +330,19 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :name (parser:node-variable-name node))
                subs)))
         (tc:coalton-internal-type-error ()
-          (standard-expression-type-mismatch-error node file subs expected-type ty)))))
+          (standard-expression-type-mismatch-error node subs expected-type ty)))))
 
-  (:method ((node parser:node-application) expected-type subs env file)
+  (:method ((node parser:node-application) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-application tc:substitution-list &optional))
 
     (multiple-value-bind (fun-ty preds accessors rator-node subs)
         (infer-expression-type (parser:node-application-rator node)
                                (tc:make-variable)
                                subs
-                               env
-                               file)
+                               env)
 
       (let* ((rands (or (parser:node-application-rands node)
                         (list
@@ -395,8 +361,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                      (infer-expression-type rand
                                                             (tc:function-type-from fun-ty_)
                                                             subs
-                                                            env
-                                                            file)
+                                                            env)
                                    (declare (ignore ty_))
                                    (setf preds (append preds preds_))
                                    (setf accessors (append accessors accessors_))
@@ -418,8 +383,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                        (infer-expression-type rand
                                                               new-from
                                                               subs
-                                                              env
-                                                              file)
+                                                              env)
                                      (declare (ignore ty_))
                                      (setf preds (append preds preds_))
                                      (setf accessors (append accessors accessors_))
@@ -432,75 +396,65 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                 (t
                                  (setf fun-ty (tc:apply-substitution subs fun-ty))
 
-                                 (error 'tc:tc-error
-                                        :err (se:source-error
-                                              :span (parser:node-source node)
-                                              :file file
-                                              :message "Argument error"
-                                              :primary-note (if (null (tc:function-type-arguments fun-ty))
-                                                                (format nil "Unable to call '~S' it is not a function"
-                                                                        fun-ty)
-                                                                (format nil "Function call has ~D arguments but inferred type '~S' only takes ~D"
-                                                                        (length rands)
-                                                                        fun-ty
-                                                                        (length (tc:function-type-arguments fun-ty)))))))))))
+                                 (tc-error (parser:node-source node)
+                                           "Argument error"
+                                           (if (null (tc:function-type-arguments fun-ty))
+                                               (format nil "Unable to call '~S': it is not a function"
+                                                       fun-ty)
+                                               (format nil "Function call has ~D arguments but inferred type '~S' only takes ~D"
+                                                       (length rands)
+                                                       fun-ty
+                                                       (length (tc:function-type-arguments fun-ty))))))))))
 
         (handler-case
             (progn
               (setf subs (tc:unify subs fun-ty_ expected-type))
               (let ((type (tc:apply-substitution subs fun-ty_)))
-                (values
-                 type
-                 preds
-                 accessors
-                 (make-node-application
-                  :type (tc:qualify nil type)
-                  :source (parser:node-source node)
-                  :rator rator-node
-                  :rands rand-nodes)
-                 subs)))
+                (values type
+                        preds
+                        accessors
+                        (make-node-application :type (tc:qualify nil type)
+                                               :source (parser:node-source node)
+                                               :rator rator-node
+                                               :rands rand-nodes)
+                        subs)))
           (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node file subs expected-type fun-ty_))))))
+            (standard-expression-type-mismatch-error node subs expected-type fun-ty_))))))
 
-  (:method ((node parser:node-bind) expected-type subs env file)
+  (:method ((node parser:node-bind) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values null tc:ty-predicate-list accessor-list node-bind tc:substitution-list))
 
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-bind-expr node)
                                (tc:make-variable)
                                subs
-                               env
-                               file)
+                               env)
 
       (multiple-value-bind (pat-ty pat-node subs)
           (infer-pattern-type (parser:node-bind-pattern node)
                               expr-ty   ; unify against expr-ty
                               subs
-                              env
-                              file)
+                              env)
         (declare (ignore pat-ty))
 
-        (values
-         nil                ; return nil as this is always thrown away
-         preds
-         accessors
-         (make-node-bind
-          ;; NOTE: We don't attach type here because NODE-BIND has no
-          ;; meaningful type.
-          :source (parser:node-bind-source node)
-          :pattern pat-node
-          :expr expr-node)
+        (values nil                ; return nil as this is always thrown away
+                preds
+                accessors
+                (make-node-bind
+                 ;; NOTE: We don't attach type here because NODE-BIND has no
+                 ;; meaningful type.
+                 :source (parser:node-bind-source node)
+                 :pattern pat-node
+                 :expr expr-node)
          subs))))
 
-  (:method ((node parser:node-body) expected-type subs env file)
+  (:method ((node parser:node-body) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-body tc:substitution-list))
 
     (let* ((preds nil)
@@ -510,7 +464,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
            (body-nodes
              (loop :for node_ :in (parser:node-body-nodes node)
                    :collect (multiple-value-bind (node_ty_ preds_ accessors_ node_ subs_)
-                                (infer-expression-type node_ (tc:make-variable) subs env file)
+                                (infer-expression-type node_ (tc:make-variable) subs env)
                               (declare (ignore node_ty_))
                               (setf subs subs_)
                               (setf preds (append preds preds_))
@@ -518,7 +472,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                               node_))))
 
       (multiple-value-bind (ty preds_ accessors_ last-node subs)
-          (infer-expression-type (parser:node-body-last-node node) expected-type subs env file)
+          (infer-expression-type (parser:node-body-last-node node) expected-type subs env)
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
 
@@ -531,11 +485,10 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
           :last-node last-node)
          subs))))
 
-  (:method ((node parser:node-abstraction) expected-type subs env file)
+  (:method ((node parser:node-abstraction) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-abstraction tc:substitution-list &optional))
 
     (check-duplicates
@@ -543,18 +496,13 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
      #'parser:pattern-var-name
      #'parser:pattern-source
      (lambda (first second)
-       (error 'tc:tc-error
-              :err (se:source-error
-                    :span (parser:node-source first)
-                    :file file
-                    :message "Duplicate parameters name"
-                    :primary-note "first parameter here"
-                    :notes
-                    (list
-                     (se:make-source-error-note
-                      :type :primary
-                      :span (parser:node-source second)
-                      :message "second parameter here"))))))
+       (tc-error (parser:node-source first)
+                 "Duplicate parameters name"
+                 "first parameter here"
+                 (list (se:make-source-error-note
+                        :type :primary
+                        :span (parser:source-location-span (parser:node-source second))
+                        :message "second parameter here")))))
 
     (let* (;; Setup return environment
            (*return-status* :lambda)
@@ -574,7 +522,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  (loop :for pattern :in (parser:node-abstraction-params node)
                        :for ty :in arg-tys
                        :collect (multiple-value-bind (ty_ pattern subs_)
-                                    (infer-pattern-type pattern ty subs env file)
+                                    (infer-pattern-type pattern ty subs env)
                                   (declare (ignore ty_))
                                   (setf subs subs_)
                                   pattern)))))
@@ -583,8 +531,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
           (infer-expression-type (parser:node-abstraction-body node)
                                  (tc:make-variable)
                                  subs
-                                 env
-                                 file)
+                                 env)
 
         ;; Ensure that all early returns unify
         (loop :with returns := (reverse *returns*)
@@ -593,40 +540,34 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
               :do (handler-case
                       (setf subs (tc:unify subs ty1 ty2))
                     (tc:coalton-internal-type-error ()
-                      (error 'tc:tc-error
-                             :err (se:source-error
-                                   :span s1
-                                   :file file
-                                   :message "Return type mismatch"
-                                   :primary-note (format nil "First return is of type '~S'"
-                                                         (tc:apply-substitution subs ty1))
-                                   :notes
-                                   (list
-                                    (se:make-source-error-note
-                                     :type :primary
-                                     :span s2
-                                     :message (format nil "Second return is of type '~S'"
-                                                      (tc:apply-substitution subs ty2)))))))))
+                      (tc-error s1
+                                "Return type mismatch"
+                                (format nil "First return is of type '~S'"
+                                        (tc:apply-substitution subs ty1))
+                                (list
+                                 (se:make-source-error-note
+                                  :type :primary
+                                  :span (parser:source-location-span s2)
+                                  :message (format nil "Second return is of type '~S'"
+                                                   (tc:apply-substitution subs ty2))))))))
 
         ;; Unify the function's inferred type with one of the early returns.
         (when *returns*
           (handler-case
               (setf subs (tc:unify subs (cdr (first *returns*)) body-ty))
             (tc:coalton-internal-type-error ()
-              (error 'tc:tc-error
-                     :err (se:source-error
-                           :span (car (first *returns*))
-                           :file file
-                           :message "Return type mismatch"
-                           :primary-note (format nil "First return is of type '~S'"
-                                                 (tc:apply-substitution subs (cdr (first *returns*))))
-                           :notes
-                           (list
-                            (se:make-source-error-note
-                             :type :primary
-                             :span (parser:node-source (parser:node-body-last-node (parser:node-abstraction-body node)))
-                             :message (format nil "Second return is of type '~S'"
-                                              (tc:apply-substitution subs body-ty)))))))))
+              (tc-error (car (first *returns*))
+                        "Return type mismatch"
+                        (format nil "First return is of type '~S'"
+                                (tc:apply-substitution subs (cdr (first *returns*))))
+                        (list
+                         (se:make-source-error-note
+                          :type :primary
+                          :span (parser:source-location-span
+                                 (parser:node-source
+                                  (parser:node-body-last-node (parser:node-abstraction-body node))))
+                          :message (format nil "Second return is of type '~S'"
+                                           (tc:apply-substitution subs body-ty))))))))
 
         (let ((ty (tc:make-function-type* arg-tys body-ty)))
           (handler-case
@@ -644,13 +585,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                     :body body-node)
                    subs)))
             (tc:coalton-internal-type-error ()
-              (standard-expression-type-mismatch-error node file subs expected-type ty)))))))
+              (standard-expression-type-mismatch-error node subs expected-type ty)))))))
 
-  (:method ((node parser:node-let) expected-type subs env file)
+  (:method ((node parser:node-let) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-let tc:substitution-list))
 
     ;; Ensure that there are no duplicate let bindings
@@ -659,28 +599,22 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
      (alexandria:compose #'parser:node-variable-name #'parser:node-let-binding-name)
      #'parser:node-let-binding-source
      (lambda (first second)
-       (error 'tc:tc-error
-              :err (se:source-error
-                    :span (parser:node-let-binding-source first)
-                    :file file
-                    :message "Duplicate definition in let"
-                    :primary-note "first definition here"
-                    :notes
-                    (list
-                     (se:make-source-error-note
-                      :type :primary
-                      :span (parser:node-let-binding-source second)
-                      :message "second definition here"))))))
+       (tc-error (parser:node-let-binding-source first)
+                 "Duplicate definition in let"
+                 "first definition here"
+                 (list (se:make-source-error-note
+                        :type :primary
+                        :span (parser:source-location-span (parser:node-let-binding-source second))
+                        :message "second definition here")))))
 
     (multiple-value-bind (preds accessors binding-nodes subs)
-        (infer-let-bindings (parser:node-let-bindings node) (parser:node-let-declares node) subs env file)
+        (infer-let-bindings (parser:node-let-bindings node) (parser:node-let-declares node) subs env)
 
       (multiple-value-bind (ty preds_ accessors_ body-node subs)
           (infer-expression-type (parser:node-let-body node)
                                  expected-type ; pass through expected type
                                  subs
-                                 env
-                                 file)
+                                 env)
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
 
@@ -695,14 +629,13 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
           :body body-node)
          subs))))
 
-  (:method ((node parser:node-lisp) expected-type subs env file)
+  (:method ((node parser:node-lisp) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-lisp tc:substitution-list &optional))
 
-    (let ((declared-ty (parse-type (parser:node-lisp-type node) (tc-env-env env) file)))
+    (let ((declared-ty (parse-type (parser:node-lisp-type node) (tc-env-env env))))
 
       (handler-case
           (progn
@@ -712,7 +645,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                   (var-nodes
                     (mapcar (lambda (var)
                               (make-node-variable
-                               :type (tc:qualify nil (tc-env-lookup-value env var file))
+                               :type (tc:qualify nil (tc-env-lookup-value env var))
                                :source (parser:node-source var)
                                :name (parser:node-variable-name var)))
                             (parser:node-lisp-vars node))))
@@ -728,13 +661,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :body (parser:node-lisp-body node))
                subs)))
         (tc:coalton-internal-type-error ()
-          (standard-expression-type-mismatch-error node file subs expected-type declared-ty)))))
+          (standard-expression-type-mismatch-error node subs expected-type declared-ty)))))
 
-  (:method ((node parser:node-match) expected-type subs env file)
+  (:method ((node parser:node-match) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-match tc:substitution-list &optional))
 
     ;; Infer the type of the expression being cased on
@@ -742,15 +674,14 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         (infer-expression-type (parser:node-match-expr node)
                                (tc:make-variable)
                                subs
-                               env
-                               file)
+                               env)
 
       (let* (;; Infer the type of each pattern, unifying against expr-ty
              (pat-nodes
                (loop :for branch :in (parser:node-match-branches node)
                      :for pattern := (parser:node-match-branch-pattern branch)
                      :collect (multiple-value-bind (pat-ty pat-node subs_)
-                                  (infer-pattern-type pattern expr-ty subs env file)
+                                  (infer-pattern-type pattern expr-ty subs env)
                                 (declare (ignore pat-ty))
                                 (setf subs subs_)
                                 pat-node)))
@@ -762,7 +693,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                (loop :for branch :in (parser:node-match-branches node)
                      :for body := (parser:node-match-branch-body branch)
                      :collect (multiple-value-bind (body-ty preds_ accessors_ body-node subs_)
-                                  (infer-expression-type body ret-ty subs env file)
+                                  (infer-expression-type body ret-ty subs env)
                                 (declare (ignore body-ty))
                                 (setf subs subs_)
                                 (setf preds (append preds preds_))
@@ -793,21 +724,19 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                   :branches branch-nodes)
                  subs)))
           (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node file subs expr-node ret-ty))))))
+            (standard-expression-type-mismatch-error node subs expr-node ret-ty))))))
 
-  (:method ((node parser:node-progn) expected-type subs env file)
+  (:method ((node parser:node-progn) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-progn tc:substitution-list))
 
     (multiple-value-bind (body-ty preds accessors body-node subs)
         (infer-expression-type (parser:node-progn-body node)
                                expected-type
                                subs
-                               env
-                               file)
+                               env)
       (values
        body-ty
        preds
@@ -818,21 +747,19 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         :body body-node)
        subs)))
 
-  (:method ((node parser:node-the) expected-type subs env file)
+  (:method ((node parser:node-the) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node tc:substitution-list &optional))
 
-    (let ((declared-ty (parse-type (parser:node-the-type node) (tc-env-env env) file)))
+    (let ((declared-ty (parse-type (parser:node-the-type node) (tc-env-env env))))
 
       (multiple-value-bind (expr-ty preds accessors expr-node subs)
           (infer-expression-type (parser:node-the-expr node)
                                  (tc:make-variable)
                                  subs
-                                 env
-                                 file)
+                                 env)
 
         ;; Ensure subs are applied
         (setf expr-ty (tc:apply-substitution subs expr-ty))
@@ -841,27 +768,21 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         (handler-case
             (setf subs (tc:unify subs declared-ty expr-ty))
           (tc:coalton-internal-type-error ()
-            (error 'tc:tc-error
-                   :err (se:source-error
-                         :span (parser:node-source node)
-                         :file file
-                         :message "Type mismatch"
-                         :primary-note (format nil "Declared type '~S' does not match inferred type '~S'"
-                                               (tc:apply-substitution subs declared-ty)
-                                               (tc:apply-substitution subs expr-ty))))))
+            (tc-error (parser:node-source node)
+                      "Type mismatch"
+                      (format nil "Declared type '~S' does not match inferred type '~S'"
+                              (tc:apply-substitution subs declared-ty)
+                              (tc:apply-substitution subs expr-ty)))))
 
         ;; Check that declared-ty is not more specific than expr-ty
         (handler-case
             (tc:match expr-ty declared-ty)
           (tc:coalton-internal-type-error ()
-            (error 'tc:tc-error
-                   :err (se:source-error
-                         :span (parser:node-source node)
-                         :file file
-                         :message "Declared type too general"
-                         :primary-note (format nil "Declared type '~S' is more general than inferred type '~S'"
-                                               (tc:apply-substitution subs declared-ty)
-                                               (tc:apply-substitution subs expr-ty))))))
+            (tc-error (parser:node-source node)
+                      "Declared type too general"
+                      (format nil "Declared type '~S' is more general than inferred type '~S'"
+                              (tc:apply-substitution subs declared-ty)
+                              (tc:apply-substitution subs expr-ty)))))
 
         ;; SAFETY: If declared-ty and expr-ty unify, and expr-ty is
         ;; more general than declared-ty then matching should be
@@ -878,32 +799,25 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                expr-node
                subs))
           (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node file subs expected-type expr-ty))))))
+            (standard-expression-type-mismatch-error node subs expected-type expr-ty))))))
 
-  (:method ((node parser:node-return) expected-type subs env file)
+  (:method ((node parser:node-return) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-return tc:substitution-list))
 
     ;; Returns must be inside a lambda
     (when (eq *return-status* :toplevel)
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source node)
-                   :file file
-                   :message "Unexpected return"
-                   :primary-note "returns must be inside a lambda")))
+      (tc-error (parser:node-source node)
+                "Unexpected return"
+                "returns must be inside a lambda"))
 
     ;; Returns cannot be in a do expression
     (when (eq *return-status* :do)
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source node)
-                   :file file
-                   :message "Invalid return"
-                   :primary-note "returns cannot be in a do expression")))
+      (tc-error (parser:node-source node)
+                "Invalid return"
+                "returns cannot be in a do expression"))
 
     (multiple-value-bind (ty preds accessors expr-node subs)
         (infer-expression-type (or (parser:node-return-expr node)
@@ -913,8 +827,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                     :name 'coalton:Unit))
                                (tc:make-variable)
                                subs
-                               env
-                               file)
+                               env)
 
       ;; Add node the the list of returns
       (push (cons (parser:node-source node) ty) *returns*)
@@ -929,11 +842,10 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         :expr expr-node)
        subs)))
 
-  (:method ((node parser:node-or) expected-type subs env file)
+  (:method ((node parser:node-or) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-or tc:substitution-list))
 
     (let* ((preds nil)
@@ -945,8 +857,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                 (infer-expression-type node_
                                                        tc:*boolean-type*
                                                        subs
-                                                       env
-                                                       file)
+                                                       env)
                               (declare (ignore node_ty_))
                               (setf subs subs_)
                               (setf preds (append preds preds_))
@@ -966,20 +877,16 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
               :nodes body-nodes)
              subs))
         (tc:coalton-internal-type-error ()
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:node-source node)
-                       :file file
-                       :message "Type mismatch"
-                       :primary-note (format nil "Expected type '~S' but 'or' evaluates to '~S'"
-                                             (tc:apply-substitution subs expected-type)
-                                             tc:*boolean-type*)))))))
+          (tc-error (parser:node-source node)
+                    "Type mismatch"
+                    (format nil "Expected type '~S' but 'or' evaluates to '~S'"
+                            (tc:apply-substitution subs expected-type)
+                            tc:*boolean-type*))))))
 
-  (:method ((node parser:node-and) expected-type subs env file)
+  (:method ((node parser:node-and) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-and tc:substitution-list))
 
     (let* ((preds nil)
@@ -991,8 +898,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                 (infer-expression-type node_
                                                        tc:*boolean-type*
                                                        subs
-                                                       env
-                                                       file)
+                                                       env)
                               (declare (ignore node_ty_))
                               (setf subs subs_)
                               (setf preds (append preds preds_))
@@ -1012,36 +918,30 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
               :nodes body-nodes)
              subs))
         (tc:coalton-internal-type-error ()
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:node-source node)
-                       :file file
-                       :message "Type mismatch"
-                       :primary-note (format nil "Expected type '~S' but 'and' evaluates to '~S'"
-                                             (tc:apply-substitution subs expected-type)
-                                             tc:*boolean-type*)))))))
+          (tc-error (parser:node-source node)
+                    "Type mismatch"
+                    (format nil "Expected type '~S' but 'and' evaluates to '~S'"
+                            (tc:apply-substitution subs expected-type)
+                            tc:*boolean-type*))))))
 
-  (:method ((node parser:node-if) expected-type subs env file)
+  (:method ((node parser:node-if) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-if tc:substitution-list &optional))
 
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-if-expr node)
                                tc:*boolean-type* ; unify predicate against boolean
                                subs
-                               env
-                               file)
+                               env)
       (declare (ignore expr-ty))
 
       (multiple-value-bind (then-ty preds_ accessors_ then-node subs)
           (infer-expression-type (parser:node-if-then node)
                                  expected-type
                                  subs
-                                 env
-                                 file)
+                                 env)
         (declare (ignore then-ty))
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
@@ -1050,8 +950,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
             (infer-expression-type (parser:node-if-else node)
                                    expected-type
                                    subs
-                                   env
-                                   file)
+                                   env)
           (setf preds (append preds preds_))
           (setf accessors (append accessors accessors_))
 
@@ -1069,29 +968,26 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                   :else else-node)
                  subs))
             (tc:coalton-internal-type-error ()
-              (standard-expression-type-mismatch-error node file subs expr-node else-ty)))))))
+              (standard-expression-type-mismatch-error node subs expr-node else-ty)))))))
 
-  (:method ((node parser:node-when) expected-type subs env file)
+  (:method ((node parser:node-when) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-when tc:substitution-list &optional))
 
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-when-expr node)
                                tc:*boolean-type*
                                subs
-                               env
-                               file)
+                               env)
       (declare (ignore expr-ty))
 
       (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
           (infer-expression-type (parser:node-when-body node)
                                  tc:*unit-type*
                                  subs
-                                 env
-                                 file)
+                                 env)
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
 
@@ -1109,29 +1005,26 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :body body-node)
                subs))
           (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node file subs expected-type body-ty))))))
+            (standard-expression-type-mismatch-error node subs expected-type body-ty))))))
 
-  (:method ((node parser:node-unless) expected-type subs env file)
+  (:method ((node parser:node-unless) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-unless tc:substitution-list &optional))
 
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-unless-expr node)
                                tc:*boolean-type*
                                subs
-                               env
-                               file)
+                               env)
       (declare (ignore expr-ty))
 
       (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
           (infer-expression-type (parser:node-unless-body node)
                                  tc:*unit-type*
                                  subs
-                                 env
-                                 file)
+                                 env)
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
 
@@ -1149,29 +1042,26 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :body body-node)
                subs))
           (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node file subs expected-type body-ty))))))
+            (standard-expression-type-mismatch-error node subs expected-type body-ty))))))
 
 
-  (:method ((node parser:node-while) expected-type subs env file)
+  (:method ((node parser:node-while) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-while tc:substitution-list &optional))
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-while-expr node)
                                tc:*boolean-type*
                                subs
-                               env
-                               file)
+                               env)
       (declare (ignore expr-ty))
 
       (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
           (infer-expression-type (parser:node-while-body node)
                                  (tc:make-variable)
                                  subs
-                                 env
-                                 file)
+                                 env)
         (declare (ignore body-ty))
 
         (setf preds (append preds preds_))
@@ -1192,32 +1082,29 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :body body-node)
                subs))
           (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node file subs expected-type tc:*unit-type*))))))
+            (standard-expression-type-mismatch-error node subs expected-type tc:*unit-type*))))))
 
-  (:method ((node parser:node-while-let) expected-type subs env file)
+  (:method ((node parser:node-while-let) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-while-let tc:substitution-list &optional))
 
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-while-let-expr node)
                                (tc:make-variable) 
                                subs
-                               env
-                               file)
+                               env)
 
       (multiple-value-bind (pat-ty pat-node subs)
-          (infer-pattern-type (parser:node-while-let-pattern node) expr-ty subs env file)
+          (infer-pattern-type (parser:node-while-let-pattern node) expr-ty subs env)
         (declare (ignore pat-ty))
         
         (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
             (infer-expression-type (parser:node-while-let-body node)
                                    (tc:make-variable)
                                    subs
-                                   env
-                                   file)
+                                   env)
           (declare (ignore body-ty))
           (setf preds (append preds preds_))
           (setf accessors (append accessors accessors_))
@@ -1238,27 +1125,26 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                   :body body-node)
                  subs))
             (tc:coalton-internal-type-error ()
-              (standard-expression-type-mismatch-error node file subs expected-type tc:*unit-type*)))))))
+              (standard-expression-type-mismatch-error node subs expected-type tc:*unit-type*)))))))
 
 
-  (:method ((node parser:node-for) expected-type subs env file)
+  (:method ((node parser:node-for) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-for tc:substitution-list &optional))
 
     (let ((intoiter-symbol
             (util:find-symbol "INTOITERATOR" "COALTON-LIBRARY/ITERATOR")))
 
       (multiple-value-bind (pat-ty pat-node subs)
-          (infer-pattern-type (parser:node-for-pattern node) (tc:make-variable) subs env file)
+          (infer-pattern-type (parser:node-for-pattern node) (tc:make-variable) subs env)
 
         (multiple-value-bind (expr-ty preds accessors expr-node subs)
-            (infer-expression-type (parser:node-for-expr node) (tc:make-variable) subs env file)
+            (infer-expression-type (parser:node-for-expr node) (tc:make-variable) subs env)
 
           (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
-              (infer-expression-type (parser:node-for-body node) (tc:make-variable) subs env file)
+              (infer-expression-type (parser:node-for-body node) (tc:make-variable) subs env)
 
             (declare (ignore body-ty))
 
@@ -1286,21 +1172,19 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                     :body body-node)
                    subs))
               (tc:coalton-internal-type-error ()
-                (standard-expression-type-mismatch-error node file subs expected-type tc:*unit-type*))))))))
+                (standard-expression-type-mismatch-error node subs expected-type tc:*unit-type*))))))))
 
-  (:method ((node parser:node-loop) expected-type subs env file)
+  (:method ((node parser:node-loop) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-loop tc:substitution-list &optional))
 
     (multiple-value-bind (body-ty preds accessors body-node subs)
         (infer-expression-type (parser:node-loop-body node)
                                (tc:make-variable)
                                subs
-                               env
-                               file)
+                               env)
       (declare (ignore body-ty))
       (handler-case
           (progn 
@@ -1316,13 +1200,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
               :body body-node)
              subs))
         (tc:coalton-internal-type-error ()
-          (standard-expression-type-mismatch-error node file subs expected-type tc:*unit-type* )))))
+          (standard-expression-type-mismatch-error node subs expected-type tc:*unit-type* )))))
 
-  (:method ((node parser:node-break) expected-type subs env file)
+  (:method ((node parser:node-break) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-break tc:substitution-list &optional))
     (handler-case
         (progn
@@ -1337,13 +1220,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
             :label (parser:node-break-label node))
            subs))
       (tc:coalton-internal-type-error ()
-        (standard-expression-type-mismatch-error node file subs expected-type tc:*unit-type*))))
+        (standard-expression-type-mismatch-error node subs expected-type tc:*unit-type*))))
 
-  (:method ((node parser:node-continue) expected-type subs env file)
+  (:method ((node parser:node-continue) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-continue tc:substitution-list &optional))
     (handler-case
         (progn
@@ -1358,30 +1240,27 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
             :label (parser:node-continue-label node))
            subs))
       (tc:coalton-internal-type-error ()
-        (standard-expression-type-mismatch-error node file subs expected-type tc:*unit-type*))))
+        (standard-expression-type-mismatch-error node subs expected-type tc:*unit-type*))))
 
 
-  (:method ((node parser:node-cond-clause) expected-type subs env file)
+  (:method ((node parser:node-cond-clause) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-cond-clause tc:substitution-list))
 
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-cond-clause-expr node)
                                tc:*boolean-type*
                                subs
-                               env
-                               file)
+                               env)
       (declare (ignore expr-ty))
 
       (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
           (infer-expression-type (parser:node-cond-clause-body node)
                                  expected-type ; unify against expected-type
                                  subs
-                                 env
-                                 file)
+                                 env)
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
 
@@ -1396,11 +1275,10 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
             :body body-node)
            subs)))))
 
-  (:method ((node parser:node-cond) expected-type subs env file)
+  (:method ((node parser:node-cond) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-cond tc:substitution-list &optional))
 
     (let* ((preds nil)
@@ -1414,8 +1292,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                 (infer-expression-type clause
                                                        ret-ty
                                                        subs
-                                                       env
-                                                       file)
+                                                       env)
                               (declare (ignore clause-ty))
                               (setf subs subs_)
                               (setf preds (append preds preds_))
@@ -1436,13 +1313,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :clauses clause-nodes)
                subs)))
         (tc:coalton-internal-type-error ()
-          (standard-expression-type-mismatch-error node file subs expected-type ret-ty)))))
+          (standard-expression-type-mismatch-error node subs expected-type ret-ty)))))
 
-  (:method ((node parser:node-do-bind) expected-type subs env file)
+  (:method ((node parser:node-do-bind) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-do-bind tc:substitution-list))
 
     (let ((*return-status* :do))
@@ -1451,15 +1327,13 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
           (infer-expression-type (parser:node-do-bind-expr node)
                                  expected-type ; unify here so that expr-ty is in the form "m a"
                                  subs
-                                 env
-                                 file)
+                                 env)
 
         (multiple-value-bind (ty_ pattern subs)
             (infer-pattern-type (parser:node-do-bind-pattern node)
                                 (tc:tapp-to (tc:apply-substitution subs expr-ty)) ; this should never fail
                                 subs
-                                env
-                                file)
+                                env)
           (declare (ignore ty_))
 
           (handler-case
@@ -1475,20 +1349,16 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                   :source (parser:node-do-bind-source node))
                  subs))
             (tc:coalton-internal-type-error ()
-              (error 'tc:tc-error
-                     :err (se:source-error
-                           :span (parser:node-do-bind-source node)
-                           :file file
-                           :message "Type mismatch"
-                           :primary-note (format nil "Expected type '~S' but got '~S'"
-                                                 (tc:apply-substitution subs expected-type)
-                                                 (tc:apply-substitution subs expr-ty))))))))))
+              (tc-error (parser:node-do-bind-source node)
+                        "Type mismatch"
+                        (format nil "Expected type '~S' but got '~S'"
+                                (tc:apply-substitution subs expected-type)
+                                (tc:apply-substitution subs expr-ty)))))))))
 
-  (:method ((node parser:node-do) expected-type subs env file)
+  (:method ((node parser:node-do) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty tc:ty-predicate-list accessor-list node-do tc:substitution-list))
 
     (let* (;; m-type is the type of the monad and has kind "* -> *"
@@ -1512,8 +1382,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                                            :from m-type
                                                            :to (tc:make-variable))
                                                           subs
-                                                          env
-                                                          file)
+                                                          env)
                                  (declare (ignore ty_))
                                  (setf preds (append preds preds_))
                                  (setf accessors (append accessors accessors_))
@@ -1526,8 +1395,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                    (infer-expression-type elem
                                                           (tc:make-variable)
                                                           subs
-                                                          env
-                                                          file)
+                                                          env)
                                  (declare (ignore ty_))
                                  (setf preds (append preds preds_))
                                  (setf accessors (append accessors accessors_))
@@ -1542,25 +1410,19 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                                            :from m-type
                                                            :to (tc:make-variable))
                                                           subs
-                                                          env
-                                                          file)
+                                                          env)
                                  (declare (ignore ty_))
                                  (setf preds (append preds preds_))
                                  (setf accessors (append accessors accessors_))
                                  (setf subs subs_)
                                  node_))))))
 
-      
-
       (multiple-value-bind (ty preds_ accessors_ last-node subs)
-          (infer-expression-type
-           (parser:node-do-last-node node)
-           (tc:make-tapp
-            :from m-type
-            :to (tc:make-variable))
-           subs
-           env
-           file)
+          (infer-expression-type (parser:node-do-last-node node)
+                                 (tc:make-tapp :from m-type
+                                               :to (tc:make-variable))
+                                 subs
+                                 env)
 
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
@@ -1584,28 +1446,24 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :last-node last-node) 
                subs))
           (tc:coalton-internal-type-error ()
-            (error 'tc:tc-error
-                   :err (se:source-error
-                         :span (parser:node-source node)
-                         :file file
-                         :message "Type mismatch"
-                         :primary-note (format nil "Expected type '~S' but do expression has type '~S'"
-                                               (tc:apply-substitution subs expected-type)
-                                               (tc:apply-substitution subs ty))))))))))
+            (tc-error (parser:node-source node)
+                      "Type mismatch"
+                      (format nil "Expected type '~S' but do expression has type '~S'"
+                              (tc:apply-substitution subs expected-type)
+                              (tc:apply-substitution subs ty)))))))))
 
 ;;;
 ;;; Pattern Type Inference
 ;;;
 
-(defgeneric infer-pattern-type (pat expected-type subs env file)
+(defgeneric infer-pattern-type (pat expected-type subs env)
   (:documentation "Infer the type of pattern PAT and then unify against EXPECTED-TYPE.
 
 Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
-  (:method ((pat parser:pattern-var) expected-type subs env file)
+  (:method ((pat parser:pattern-var) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty pattern-var tc:substitution-list))
 
     (let ((ty (tc-env-add-variable env (parser:pattern-var-name pat))))
@@ -1623,11 +1481,10 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
           :orig-name (parser:pattern-var-orig-name pat))
          subs))))
 
-  (:method ((pat parser:pattern-literal) expected-type subs env file)
+  (:method ((pat parser:pattern-literal) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty pattern-literal tc:substitution-list))
 
     (let ((ty (etypecase (parser:pattern-literal-value pat)
@@ -1650,20 +1507,16 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                 :value (parser:pattern-literal-value pat))
                subs)))
         (tc:coalton-internal-type-error ()
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:pattern-source pat)
-                       :file file
-                       :message "Type mismatch"
-                       :primary-note (format nil "Expected type '~S' but pattern literal has type '~S'"
-                                             (tc:apply-substitution subs expected-type)
-                                             (tc:apply-substitution subs ty))))))))
+          (tc-error (parser:pattern-source pat)
+                    "Type mismatch"
+                    (format nil "Expected type '~S' but pattern literal has type '~S'"
+                            (tc:apply-substitution subs expected-type)
+                            (tc:apply-substitution subs ty)))))))
 
-  (:method ((pat parser:pattern-wildcard) expected-type subs env file)
+  (:method ((pat parser:pattern-wildcard) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty pattern-wildcard tc:substitution-list))
 
     (values
@@ -1673,56 +1526,43 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
       :source (parser:pattern-source pat))
      subs))
 
-  (:method ((pat parser:pattern-constructor) expected-type subs env file)
+  (:method ((pat parser:pattern-constructor) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (type se:file file)
              (values tc:ty pattern-constructor tc:substitution-list))
 
     (let ((ctor (tc:lookup-constructor (tc-env-env env) (parser:pattern-constructor-name pat) :no-error t)))
 
-      (check-duplicates
-       (parser:pattern-variables pat)
-       #'parser:pattern-var-name
-       #'parser:pattern-source
-       (lambda (first second)
-         (error 'tc:tc-error
-                :err (se:source-error
-                      :span (parser:pattern-source first) 
-                      :file file
-                      :message "Duplicate pattern variable"
-                      :primary-note "first definition here"
-                      :notes
-                      (list
-                       (se:make-source-error-note
-                        :type :primary
-                        :span (parser:pattern-source second) 
-                        :message "second definition here"))))))
+      (check-duplicates (parser:pattern-variables pat)
+                        #'parser:pattern-var-name
+                        #'parser:pattern-source
+                        (lambda (first second)
+                          (tc-error (parser:pattern-source first)
+                                    "Duplicate pattern variable"
+                                    "first definition here"
+                                    (list
+                                     (se:make-source-error-note
+                                      :type :primary
+                                      :span (parser:source-location-span (parser:pattern-source second))
+                                      :message "second definition here")))))
 
       (unless ctor
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (parser:pattern-source pat)
-                     :file file
-                     :message "Unknown constructor"
-                     :primary-note "constructor is not known")))
+        (tc-error (parser:pattern-source pat)
+                  "Unknown constructor"
+                  "constructor is not known"))
 
-
-      (let ((arity (tc:constructor-entry-arity ctor))
-
-            (num-args (length (parser:pattern-constructor-patterns pat))))
-
+      (let ((arity
+              (tc:constructor-entry-arity ctor))
+            (num-args
+              (length (parser:pattern-constructor-patterns pat))))
         (unless (= arity num-args)
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:pattern-source pat)
-                       :file file
-                       :message "Argument mismatch"
-                       :primary-note (format nil "Constructor ~A takes ~D arguments but is given ~D"
-                                             (parser:pattern-constructor-name pat)
-                                             arity
-                                             num-args))))
+          (tc-error (parser:pattern-source pat)
+                    "Argument mismatch"
+                    (format nil "Constructor ~A takes ~D arguments but is given ~D"
+                            (parser:pattern-constructor-name pat)
+                            arity
+                            num-args)))
 
         (let* ((ctor-ty (tc:qualified-ty-type ;; NOTE: Constructors cannot have predicates
                          (tc:fresh-inst
@@ -1734,7 +1574,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                  (loop :for arg :in (parser:pattern-constructor-patterns pat)
                        :for arg-ty :in (tc:function-type-arguments ctor-ty)
                        :collect (multiple-value-bind (ty_ node_ subs_)
-                                    (infer-pattern-type arg arg-ty subs env file)
+                                    (infer-pattern-type arg arg-ty subs env)
                                   (declare (ignore ty_))
                                   (setf subs subs_)
                                   node_))))
@@ -1752,73 +1592,62 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                     :patterns pattern-nodes)
                    subs)))
             (tc:coalton-internal-type-error ()
-              (error 'tc:tc-error
-                     :err (se:source-error
-                           :span (parser:pattern-source pat)
-                           :file file
-                           :message "Type mismatch"
-                           :primary-note (format nil "Expected type '~S' but pattern has type '~S'"
-                                                 (tc:apply-substitution subs expected-type)
-                                                 (tc:apply-substitution subs pat-ty)))))))))))
+              (tc-error (parser:pattern-source pat)
+                        "Type mismatch"
+                        (format nil "Expected type '~S' but pattern has type '~S'"
+                                (tc:apply-substitution subs expected-type)
+                                (tc:apply-substitution subs pat-ty))))))))))
 
 ;;;
 ;;; Binding Group Type Inference
 ;;;
 
-(defun infer-let-bindings (bindings declares subs env file)
+(defun infer-let-bindings (bindings declares subs env)
   (declare (type parser:node-let-binding-list bindings)
            (type parser:node-let-declare-list declares)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type se:file file)
            (values tc:ty-predicate-list accessor-list (or toplevel-define-list node-let-binding-list) tc:substitution-list &optional))
 
-  (let ((def-table (make-hash-table :test #'eq))
-
-        (dec-table (make-hash-table :test #'eq)))
-
+  (let ((def-table
+          (make-hash-table :test #'eq))
+        (dec-table
+          (make-hash-table :test #'eq)))
     ;; Ensure that there are no duplicate definitions
     (loop :for binding :in bindings
           :for name := (parser:node-variable-name (parser:node-let-binding-name binding))
 
           :if (gethash name def-table)
-            :do (error 'tc:tc-error
-                       :err (se:source-error
-                             :span (parser:node-source (parser:node-let-binding-name binding))
-                             :file file
-                             :message "Duplicate binding in let"
-                             :primary-note "second definition here"
-                             :notes
-                             (list
-                              (se:make-source-error-note
-                               :type :primary
-                               :span (parser:node-source
-                                      (parser:node-let-binding-name
-                                       (gethash name def-table)))
-                               :message "first definition here"))))
+            :do (tc-error (parser:node-source (parser:node-let-binding-name binding))
+                          "Duplicate binding in let"
+                          "second definition here"
+                          (list
+                           (se:make-source-error-note
+                            :type :primary
+                            :span (parser:source-location-span
+                                   (parser:node-source
+                                    (parser:node-let-binding-name
+                                     (gethash name def-table))))
+                            :message "first definition here")))
           :else
             :do (setf (gethash name def-table) binding))
-
 
     ;; Ensure that there are no duplicate declarations
     (loop :for declare :in declares
           :for name := (parser:node-variable-name (parser:node-let-declare-name declare))
 
           :if (gethash name dec-table)
-            :do (error 'tc:tc-error
-                       :err (se:source-error
-                             :span (parser:node-source (parser:node-let-declare-name declare))
-                             :file file
-                             :message "Duplicate declaration in let"
-                             :primary-note "second declaration here"
-                             :notes
-                             (list
-                              (se:make-source-error-note
-                               :type :primary
-                               :span (parser:node-source
-                                      (parser:node-let-declare-name
-                                       (gethash name dec-table)))
-                               :message "first declaration here"))))
+            :do (tc-error (parser:node-source (parser:node-let-declare-name declare))
+                          "Duplicate declaration in let"
+                          "second declaration here"
+                          (list
+                           (se:make-source-error-note
+                            :type :primary
+                            :span (parser:source-location-span
+                                   (parser:node-source
+                                    (parser:node-let-declare-name
+                                     (gethash name dec-table))))
+                            :message "first declaration here")))
           :else
             :do (setf (gethash name dec-table) declare))
 
@@ -1827,12 +1656,9 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
           :for name := (parser:node-variable-name (parser:node-let-declare-name declare))
 
           :unless (gethash name def-table)
-            :do (error 'tc:tc-error
-                       :err (se:source-error
-                             :span (parser:node-source (parser:node-let-declare-name declare))
-                             :file file
-                             :message "Orphan declare in let"
-                             :primary-note "declaration does not have an associated definition")))
+            :do (tc-error (parser:node-source (parser:node-let-declare-name declare))
+                          "Orphan declare in let"
+                          "declaration does not have an associated definition"))
 
     (let ((dec-table
             (loop :with table := (make-hash-table :test #'eq)
@@ -1841,15 +1667,14 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                   :do (setf (gethash name table) (parser:node-let-declare-type declare))
                   :finally (return table))))
 
-      (infer-bindings-type bindings dec-table subs env file))))
+      (infer-bindings-type bindings dec-table subs env))))
 
 
-(defun infer-bindings-type (bindings dec-table subs env file)
+(defun infer-bindings-type (bindings dec-table subs env)
   (declare (type list bindings)
            (type hash-table dec-table)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type se:file file)
            (values tc:ty-predicate-list accessor-list (or toplevel-define-list node-let-binding-list) tc:substitution-list))
   ;;
   ;; Binding type inference has several steps.
@@ -1862,7 +1687,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
   (loop :for name :being :the :hash-keys :of dec-table
         :for unparsed-ty :being :the :hash-values :of dec-table
 
-        :for scheme := (parse-ty-scheme unparsed-ty (tc-env-env env) file)
+        :for scheme := (parse-ty-scheme unparsed-ty (tc-env-env env))
         :do (tc-env-add-definition env name scheme))
 
   ;; Split apart explicit and implicit bindings
@@ -1907,7 +1732,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                    := (loop :for name :in scc
                             :collect (gethash name impl-bindings))
                  :append (multiple-value-bind (preds_ nodes subs_)
-                             (infer-impls-binding-type bindings subs env file)
+                             (infer-impls-binding-type bindings subs env)
                            (setf subs subs_)
                            (setf preds (append preds preds_))
                            nodes)))
@@ -1921,36 +1746,32 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                  :for scheme := (gethash name (tc-env-ty-table env))
 
                  :collect (multiple-value-bind (preds_ node_ subs_)
-                              (infer-expl-binding-type
-                               binding
-                               scheme
-                               (parser:node-source (parser:binding-name binding))
-                               subs
-                               env
-                               file)
+                              (infer-expl-binding-type binding
+                                                       scheme
+                                                       (parser:node-source
+                                                        (parser:binding-name binding))
+                                                       subs
+                                                       env)
                             (setf subs subs_)
                             (setf preds (append preds preds_))
                             node_))))
+    (values preds
+            nil
+            (append impl-binding-nodes expl-binding-nodes)
+            subs)))
 
-    (values
-     preds
-     nil
-     (append impl-binding-nodes expl-binding-nodes)
-     subs)))
-
-(defun infer-expl-binding-type (binding declared-ty source subs env file)
+(defun infer-expl-binding-type (binding declared-ty source subs env)
   "Infer the type of BINDING and then ensure it matches DECLARED-TY."
   (declare (type (or parser:toplevel-define parser:node-let-binding parser:instance-method-definition) binding)
            (type tc:ty-scheme declared-ty)
-           (type cons source)
+           (type parser:source-location source)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type se:file file)
            (values tc:ty-predicate-list (or toplevel-define node-let-binding instance-method-definition) tc:substitution-list &optional))
   
   ;; HACK: recursive scc checking on instances is too strict
   (unless (typep binding 'parser:instance-method-definition)
-    (check-for-invalid-recursive-scc (list binding) (tc-env-env env) file))
+    (check-for-invalid-recursive-scc (list binding) (tc-env-env env)))
 
   (let* ((name (parser:node-variable-name (parser:binding-name binding)))
 
@@ -1965,24 +1786,20 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
          binding
          fresh-type                     ; unify against declared type
          subs
-         env
-         file)
+         env)
 
       (tc:apply-substitution subs env)
 
       (setf accessors (tc:apply-substitution subs accessors))
-      
+
       (multiple-value-bind (accessors subs_)
-          (solve-accessors accessors file (tc-env-env env))
+          (solve-accessors accessors (tc-env-env env))
         (setf subs (tc:compose-substitution-lists subs subs_))
 
         (when accessors
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (accessor-source (first accessors))
-                       :file file
-                       :message "Ambiguous accessor"
-                       :primary-note "accessor is ambiguous")))
+          (tc-error (accessor-source (first accessors))
+                    "Ambiguous accessor"
+                    "accessor is ambiguous"))
 
         (let* ((expr-type (tc:apply-substitution subs fresh-type))
                (expr-preds (tc:apply-substitution subs fresh-preds))
@@ -2038,7 +1855,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                             retained-preds)
 
                          (tc:ambiguous-constraint (e)
-                           (error-ambiguous-pred (tc:ambiguous-constraint-pred e) file))))
+                           (error-ambiguous-pred (tc:ambiguous-constraint-pred e)))))
 
                      ;; Defaultable predicates are not retained
                      (retained-preds
@@ -2058,39 +1875,35 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
                 ;; Toplevel bindings cannot defer predicates
                 (when (and (parser:binding-toplevel-p binding) deferred-preds)
-                  (error-unknown-pred (first deferred-preds) file))
+                  (error-unknown-pred (first deferred-preds)))
 
                 ;; Check that the declared and inferred schemes match
                 (unless (equalp declared-ty output-scheme)
-                  (error 'tc:tc-error
-                         :err (se:source-error
-                               :message "Declared type is too general"
-                               :span source
-                               :file file
-                               :primary-note (format nil "Declared type ~S is more general than inferred type ~S."
-                                                     declared-ty
-                                                     output-scheme))))
+                  (tc-error source
+                            "Declared type is too general"
+                            (format nil "Declared type ~S is more general than inferred type ~S."
+                                    declared-ty
+                                    output-scheme)))
 
                 ;; Check for undeclared predicates
                 (when (not (null retained-preds))
-                  (error 'tc:tc-error
-                         :err (se:source-error
-                               :message "Explicit type is missing inferred predicate"
-                               :span source
-                               :file file
-                               :primary-note (format nil "Declared type ~S is missing inferred predicate ~S"
-                                                     output-qual-type
-                                                     (first retained-preds)))))
+                  (tc-error source
+                            "Explicit type is missing inferred predicate"
+                            (format nil "Declared type ~S is missing inferred predicate ~S"
+                                    output-qual-type
+                                    (first retained-preds))))
 
-                (values
-                 deferred-preds
-                 (attach-explicit-binding-type (tc:apply-substitution subs binding-node) (tc:apply-substitution subs fresh-qual-type))
-                 subs)))))))))
+                (values deferred-preds
+                        (attach-explicit-binding-type (tc:apply-substitution subs binding-node)
+                                                      (tc:apply-substitution subs fresh-qual-type))
+                        subs)))))))))
 
-(defun check-for-invalid-recursive-scc (bindings env file)
-  (declare (type (or parser:toplevel-define-list parser:node-let-binding-list parser:instance-method-definition-list) bindings)
-           (type tc:environment env)
-           (type se:file file))
+(defun check-for-invalid-recursive-scc (bindings env)
+  (declare (type (or parser:toplevel-define-list
+                     parser:node-let-binding-list
+                     parser:instance-method-definition-list)
+                 bindings)
+           (type tc:environment env))
 
   (assert bindings)
 
@@ -2105,17 +1918,14 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     (let ((first-fn (find-if #'parser:binding-function-p bindings)))
       (assert first-fn)
 
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source (parser:binding-name first-fn))
-                   :file file
-                   :message "Invalid recursive bindings"
-                   :primary-note "function can not be defined recursively with variables"
-                   :notes (loop :for binding :in (remove first-fn bindings :test #'eq)
-                                :collect (se:make-source-error-note
-                                          :type :secondary
-                                          :span (parser:node-source (parser:binding-name binding))
-                                          :message "with definition"))))))
+      (tc-error (parser:node-source (parser:binding-name first-fn))
+                "Invalid recursive bindings"
+                "function can not be defined recursively with variables"
+                (loop :for binding :in (remove first-fn bindings :test #'eq)
+                      :collect (se:make-source-error-note
+                                :type :secondary
+                                :span (parser:source-location-span (parser:node-source (parser:binding-name binding)))
+                                :message "with definition")))))
 
   ;; If there is a single non-recursive binding then it is valid
   (when (and (= 1 (length bindings))
@@ -2127,17 +1937,14 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
   ;; Toplevel bindings cannot be recursive values
   (when (parser:binding-toplevel-p (first bindings))
-    (error 'tc:tc-error
-           :err (se:source-error
-                 :span (parser:node-source (parser:binding-name (first bindings)))
-                 :file file
-                 :message "Invalid recursive bindings"
-                 :primary-note "invalid recursive variable bindings"
-                 :notes (loop :for binding :in (rest bindings)
-                              :collect (se:make-source-error-note
-                                        :type :secondary
-                                        :span (parser:node-source (parser:binding-name binding))
-                                        :message "with definition")))))
+    (tc-error (parser:node-source (parser:binding-name (first bindings)))
+              "Invalid recursive bindings"
+              "invalid recursive variable bindings"
+              (loop :for binding :in (rest bindings)
+                    :collect (se:make-source-error-note
+                              :type :secondary
+                              :span (parser:source-location-span (parser:node-source (parser:binding-name binding)))
+                              :message "with definition"))))
 
   (let ((binding-names (mapcar (alexandria:compose #'parser:node-variable-name
                                                    #'parser:binding-name)
@@ -2195,27 +2002,23 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
       (when (every (alexandria:compose #'valid-recursive-constructor-call-p #'parser:binding-value) bindings)
         (return-from check-for-invalid-recursive-scc))
 
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source (parser:binding-name (first bindings)))
-                   :file file
-                   :message "Invalid recursive bindings"
-                   :primary-note "invalid recursive variable bindings"
-                   :notes (loop :for binding :in (rest bindings)
-                                :collect (se:make-source-error-note
-                                          :type :secondary
-                                          :span (parser:node-source (parser:binding-name binding))
-                                          :message "with definition")))))))
+      (tc-error (parser:node-source (parser:binding-name (first bindings)))
+                "Invalid recursive bindings"
+                "invalid recursive variable bindings"
+                (loop :for binding :in (rest bindings)
+                      :collect (se:make-source-error-note
+                                :type :secondary
+                                :span (parser:source-location-span (parser:node-source (parser:binding-name binding)))
+                                :message "with definition"))))))
 
-(defun infer-impls-binding-type (bindings subs env file)
+(defun infer-impls-binding-type (bindings subs env)
   "Infer the type's of BINDINGS and then qualify those types into schemes."
   (declare (type (or parser:toplevel-define-list parser:node-let-binding-list) bindings)
            (type tc:substitution-list subs)
            (type tc-env env)
-           (type se:file file)
            (values tc:ty-predicate-list (or toplevel-define-list node-let-binding-list) tc:substitution-list &optional))
 
-  (check-for-invalid-recursive-scc bindings (tc-env-env env) file)
+  (check-for-invalid-recursive-scc bindings (tc-env-env env))
 
   (let* (;; track variables bound before typechecking
          (bound-variables (tc-env-bound-variables env))
@@ -2237,7 +2040,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                  :for node := (parser:binding-value binding)
 
                  :collect (multiple-value-bind (preds_ accessors_ node_ subs_)
-                              (infer-binding-type binding ty subs env file)
+                              (infer-binding-type binding ty subs env)
                             (setf subs subs_)
                             (setf preds (append preds preds_))
                             (setf accessors (append accessors accessors_))
@@ -2248,24 +2051,22 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     (setf accessors (tc:apply-substitution subs accessors))
 
     (multiple-value-bind (accessors subs_)
-        (solve-accessors accessors file (tc-env-env env))
+        (solve-accessors accessors (tc-env-env env))
       (setf subs (tc:compose-substitution-lists subs subs_))
 
       (when accessors
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (accessor-source (first accessors))
-                     :file file
-                     :message "Ambiguous accessor"
-                     :primary-note "accessor is ambiguous")))
+        (tc-error (accessor-source (first accessors))
+                  "Ambiguous accessor"
+                  "accessor is ambiguous"))
 
-      (let* ((expr-tys (tc:apply-substitution subs expr-tys))
-
-             (env-tvars (tc-env-bindings-variables env bound-variables))
-
-             (expr-tvars (remove-duplicates (tc:type-variables expr-tys) :test #'eq))
-
-             (local-tvars (set-difference expr-tvars env-tvars :test #'eq)))
+      (let* ((expr-tys
+               (tc:apply-substitution subs expr-tys))
+             (env-tvars
+               (tc-env-bindings-variables env bound-variables))
+             (expr-tvars
+               (remove-duplicates (tc:type-variables expr-tys) :test #'eq))
+             (local-tvars
+               (set-difference expr-tvars env-tvars :test #'eq)))
 
         ;; Generate additional substitutions from fundeps
         (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) preds subs)))
@@ -2280,7 +2081,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
           (let* ((defaultable-preds (handler-case
                                         (tc:default-preds (tc-env-env env) (append env-tvars local-tvars) retained-preds)
                                       (tc:coalton-internal-type-error (e)
-                                        (error-ambiguous-pred (tc:ambiguous-constraint-pred e) file))))
+                                        (error-ambiguous-pred (tc:ambiguous-constraint-pred e)))))
 
                  (retained-preds (set-difference retained-preds defaultable-preds :test #'eq))
 
@@ -2330,7 +2131,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                         :do (tc-env-replace-type env name scheme))
 
                   (when (and (parser:binding-toplevel-p (first bindings)) deferred-preds)
-                    (error-unknown-pred (first deferred-preds) file))
+                    (error-unknown-pred (first deferred-preds)))
 
                   (values
                    deferred-preds
@@ -2366,7 +2167,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                         :do (tc-env-replace-type env name scheme))
 
                   (when (and (parser:binding-toplevel-p (first bindings)) deferred-preds)
-                    (error-ambiguous-pred (first deferred-preds) file))
+                    (error-ambiguous-pred (first deferred-preds)))
 
                   (values
                    deferred-preds
@@ -2377,12 +2178,11 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                                    rewrite-table))
                    subs)))))))))
 
-(defun infer-binding-type (binding expected-type subs env file)
+(defun infer-binding-type (binding expected-type subs env)
   "Infer the type of BINDING then unify against EXPECTED-TYPE. Adds BINDING's parameters to the environment."
   (declare (type (or parser:toplevel-define parser:node-let-binding parser:instance-method-definition) binding)
            (type tc:ty expected-type)
            (type tc:substitution-list subs)
-           (type se:file file)
            (values tc:ty-predicate-list accessor-list (or toplevel-define node-let-binding instance-method-definition) tc:substitution-list))
 
   (check-duplicates
@@ -2390,18 +2190,14 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
    #'parser:pattern-var-name
    #'parser:pattern-source
    (lambda (first second)
-     (error 'tc:tc-error
-            :err (se:source-error
-                  :span (parser:node-source first)
-                  :file file
-                  :message "Duplicate parameters name"
-                  :primary-note "first parameter here"
-                  :notes
-                  (list
-                   (se:make-source-error-note
-                    :type :primary
-                    :span (parser:node-source second)
-                    :message "second parameter here"))))))
+     (tc-error (parser:node-source first)
+               "Duplicate parameters name"
+               "first parameter here"
+               (list (se:make-source-error-note
+                      :type :primary
+                      :span (parser:source-location-span
+                             (parser:node-source second))
+                      :message "second parameter here")))))
 
   (let* ((param-tys (loop :with args := (tc:function-type-arguments expected-type)
                           :for pattern :in (parser:binding-parameters binding)
@@ -2415,7 +2211,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
          (params (loop :for pattern :in (parser:binding-parameters binding)
                        :for ty :in param-tys
                        :collect (multiple-value-bind (ty_ pattern subs_)
-                                    (infer-pattern-type pattern ty subs env file)
+                                    (infer-pattern-type pattern ty subs env)
                                   (declare (ignore ty_))
                                   (setf subs subs_)
                                   pattern)))
@@ -2436,8 +2232,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                      (infer-expression-type (parser:binding-value binding)
                                             ret-ty
                                             subs
-                                            env
-                                            file)
+                                            env)
                    (declare (ignore ty_))
                    (setf subs subs_)
                    (setf preds preds_)
@@ -2450,40 +2245,33 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                          :do (handler-case
                                  (setf subs (tc:unify subs ty1 ty2))
                                (tc:coalton-internal-type-error ()
-                                 (error 'tc:tc-error
-                                        :err (se:source-error
-                                              :span s1
-                                              :file file
-                                              :message "Return type mismatch"
-                                              :primary-note (format nil "First return is of type '~S'"
-                                                                    (tc:apply-substitution subs ty1))
-                                              :notes
-                                              (list
-                                               (se:make-source-error-note
-                                                :type :primary
-                                                :span s2
-                                                :message (format nil "Second return is of type '~S'"
-                                                                 (tc:apply-substitution subs ty2)))))))))
+                                 (tc-error s1
+                                           "Return type mismatch"
+                                            (format nil "First return is of type '~S'"
+                                                    (tc:apply-substitution subs ty1))
+                                            (list
+                                             (se:make-source-error-note
+                                              :type :primary
+                                              :span (parser:source-location-span s2)
+                                              :message (format nil "Second return is of type '~S'"
+                                                               (tc:apply-substitution subs ty2))))))))
 
                    ;; Unify the function's inferred type with one of the early returns.
                    (when *returns*
                      (handler-case
                          (setf subs (tc:unify subs (cdr (first *returns*)) ret-ty))
                        (tc:coalton-internal-type-error ()
-                         (error 'tc:tc-error
-                                :err (se:source-error
-                                      :span (car (first *returns*))
-                                      :file file
-                                      :message "Return type mismatch"
-                                      :primary-note (format nil "First return is of type '~S'"
-                                                            (tc:apply-substitution subs (cdr (first *returns*))))
-                                      :notes
-                                      (list
-                                       (se:make-source-error-note
-                                        :type :primary
-                                        :span (parser:node-source (parser:binding-last-node binding))
-                                        :message (format nil "Second return is of type '~S'"
-                                                         (tc:apply-substitution subs ret-ty)))))))))
+                         (tc-error (car (first *returns*))
+                                   "Return type mismatch"
+                                   (format nil "First return is of type '~S'"
+                                           (tc:apply-substitution subs (cdr (first *returns*))))
+                                   (list
+                                    (se:make-source-error-note
+                                     :type :primary
+                                     :span (parser:source-location-span
+                                            (parser:node-source (parser:binding-last-node binding)))
+                                     :message (format nil "Second return is of type '~S'"
+                                                      (tc:apply-substitution subs ret-ty))))))))
 
                    value-node))
 
@@ -2492,8 +2280,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                    (infer-expression-type (parser:binding-value binding)
                                           ret-ty
                                           subs
-                                          env
-                                          file)
+                                          env)
                  (declare (ignore ty_))
                  (setf subs subs_)
                  (setf preds preds_)
@@ -2520,14 +2307,11 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                typed-binding
                subs)))
         (tc:coalton-internal-type-error ()
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:binding-source binding)
-                       :file file
-                       :message "Type mismatch"
-                       :primary-note (format nil "Expected type '~S' but got type '~S'"
-                                             (tc:apply-substitution subs expected-type)
-                                             (tc:apply-substitution subs ty)))))))))
+          (tc-error (parser:binding-source binding)
+                    "Type mismatch"
+                    (format nil "Expected type '~S' but got type '~S'"
+                            (tc:apply-substitution subs expected-type)
+                            (tc:apply-substitution subs ty))))))))
 
 ;;;
 ;;; Helpers

--- a/src/typechecker/expression.lisp
+++ b/src/typechecker/expression.lisp
@@ -170,7 +170,7 @@
             (:constructor nil)
             (:copier nil))
   (type   (util:required 'type)   :type tc:qualified-ty :read-only t)
-  (source (util:required 'source) :type cons            :read-only t))
+  (source (util:required 'source) :type parser:source-location            :read-only t))
 
 (defun node-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -210,7 +210,7 @@
             (:copier nil))
   (pattern (util:required 'pattern) :type pattern :read-only t)
   (expr    (util:required 'expr)    :type node    :read-only t)
-  (source  (util:required 'source)  :type cons    :read-only t))
+  (source  (util:required 'source)  :type parser:source-location    :read-only t))
 
 (deftype node-body-element ()
   '(or node node-bind))
@@ -240,7 +240,7 @@
             (:copier nil))
   (name   (util:required 'name)   :type node-variable :read-only t)
   (value  (util:required 'value)  :type node          :read-only t)
-  (source (util:required 'source) :type cons          :read-only t))
+  (source (util:required 'source) :type parser:source-location          :read-only t))
 
 (defun node-let-binding-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -266,7 +266,7 @@
             (:copier nil))
   (pattern    (util:required 'pattern) :type pattern   :read-only t)
   (body       (util:required 'body)    :type node-body :read-only t)
-  (source     (util:required 'source)  :type cons      :read-only t))
+  (source     (util:required 'source)  :type parser:source-location      :read-only t))
 
 (defun node-match-branch-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -372,7 +372,7 @@
             (:copier nil))
   (expr   (util:required 'expr)   :type node      :read-only t)
   (body   (util:required 'body)   :type node-body :read-only t)
-  (source (util:required 'source) :type cons      :read-only t))
+  (source (util:required 'source) :type parser:source-location      :read-only t))
 
 (defun node-cond-clause-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -390,7 +390,7 @@
             (:copier nil))
   (pattern (util:required 'pattern) :type pattern :read-only t)
   (expr    (util:required 'expr)    :type node    :read-only t)
-  (source  (util:required 'source)  :type cons    :read-only t))
+  (source  (util:required 'source)  :type parser:source-location    :read-only t))
 
 (deftype node-do-body-element ()
   '(or node node-bind node-do-bind))

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -9,6 +9,7 @@
 (defpackage #:coalton-impl/typechecker/parse-type
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/partial-type-env)
   (:local-nicknames
    (#:se #:source-error)
@@ -29,10 +30,9 @@
 ;;; Entrypoints
 ;;;
 
-(defun parse-type (ty env file)
+(defun parse-type (ty env)
   (declare (type parser:ty ty)
            (type tc:environment env)
-           (type se:file file)
            (values tc:ty &optional))
 
   (let ((tvars (parser:collect-type-variables ty))
@@ -47,17 +47,15 @@
         (infer-type-kinds ty
                           tc:+kstar+
                           nil
-                          partial-env
-                          file)
+                          partial-env)
 
       (setf ty (tc:apply-ksubstitution ksubs ty))
       (setf ksubs (tc:kind-monomorphize-subs (tc:kind-variables ty) ksubs))
       (tc:apply-ksubstitution ksubs ty))))
 
-(defun parse-qualified-type (unparsed-ty env file)
+(defun parse-qualified-type (unparsed-ty env)
   (declare (type parser:qualified-ty unparsed-ty)
            (type tc:environment env)
-           (type se:file file)
            (values tc:qualified-ty &optional))
 
   (let ((tvars (parser:collect-type-variables unparsed-ty))
@@ -69,7 +67,7 @@
           :do (partial-type-env-add-var partial-env tvar-name))
 
     (multiple-value-bind (qual-ty ksubs)
-        (infer-type-kinds unparsed-ty tc:+kstar+ nil partial-env file)
+        (infer-type-kinds unparsed-ty tc:+kstar+ nil partial-env)
 
       (setf qual-ty (tc:apply-ksubstitution ksubs qual-ty))
       (setf ksubs (tc:kind-monomorphize-subs (tc:kind-variables qual-ty) ksubs))
@@ -80,28 +78,24 @@
 
              (ty (tc:qualified-ty-type qual-ty)))
 
-        (check-for-ambiguous-variables preds ty unparsed-ty file env)
-        (check-for-reducable-context preds unparsed-ty file env)
+        (check-for-ambiguous-variables preds ty unparsed-ty env)
+        (check-for-reducible-context preds unparsed-ty env)
 
         qual-ty))))
 
-(defun parse-ty-scheme (ty env file)
+(defun parse-ty-scheme (ty env)
   (declare (type parser:qualified-ty ty)
            (type tc:environment env)
-           (type se:file file)
            (values tc:ty-scheme &optional))
 
-  (let* ((qual-ty (parse-qualified-type ty env file))
-
+  (let* ((qual-ty (parse-qualified-type ty env))
          (tvars (tc:type-variables qual-ty)))
-
     (tc:quantify tvars qual-ty)))
 
-(defun check-for-ambiguous-variables (preds type qual-ty file env)
+(defun check-for-ambiguous-variables (preds type qual-ty env)
   (declare (type tc:ty-predicate-list preds)
            (type tc:ty type)
            (type parser:qualified-ty qual-ty)
-           (type se:file file)
            (type tc:environment env))
 
   (let* ((old-unambiguous-vars (tc:type-variables type))
@@ -130,35 +124,27 @@
 
     (unless (subsetp (tc:type-variables preds) unambiguous-vars :test #'equalp)
       (let* ((ambiguous-vars (set-difference (tc:type-variables preds) unambiguous-vars :test #'equalp))
-
              (single-variable (= 1 (length ambiguous-vars))))
+        (tc-error (parser:qualified-ty-source qual-ty)
+                  "Invalid qualified type"
+                  (format nil "The type ~A ~{~S ~}ambiguous in the type ~S"
+                          (if single-variable
+                              "variable is"
+                              "variables are")
+                          ambiguous-vars
+                          (tc:make-qualified-ty :predicates preds
+                                                :type type)))))))
 
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (parser:qualified-ty-source qual-ty)
-                     :file file
-                     :message "Invalid qualified type"
-                     :primary-note (format nil "The type ~A ~{~S ~}ambiguous in the type ~S"
-                                           (if single-variable
-                                               "variable is"
-                                               "variables are")
-                                           ambiguous-vars
-                                           (tc:make-qualified-ty
-                                            :predicates preds
-                                            :type type))))))))
-
-(defun check-for-reducable-context (preds qual-ty file env)
+(defun check-for-reducible-context (preds qual-ty env)
   (declare (type tc:ty-predicate-list preds)
            (type parser:qualified-ty qual-ty)
-           (type se:file file)
            (type tc:environment env))
   (let ((reduced-preds (tc:reduce-context env preds nil)))
     (unless (null (set-exclusive-or preds reduced-preds :test #'tc:type-predicate=))
       (warn 'se:source-base-warning
-            :err (se:source-error
+            :err (parser:source-error
                   :type :warn
-                  :span (parser:qualified-ty-source qual-ty)
-                  :file file
+                  :source (parser:qualified-ty-source qual-ty)
                   :message "Declared context can be reduced"
                   :primary-note (if (null reduced-preds)
                                     "declared predicates are redundant"
@@ -169,17 +155,14 @@
 ;;; Kind Inference
 ;;;
 
-(defgeneric infer-type-kinds (type expected-kind ksubs env file)
-  (:method ((type parser:tyvar) expected-kind ksubs env file)
+(defgeneric infer-type-kinds (type expected-kind ksubs env)
+  (:method ((type parser:tyvar) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
-             (type tc:ksubstitution-list ksubs)
-             (type se:file file))
+             (type tc:ksubstitution-list ksubs))
     (let* ((tvar (partial-type-env-lookup-var
                   env
                   (parser:tyvar-name type)
-                  (parser:ty-source type)
-                  file))
-
+                  (parser:ty-source type)))
            (kvar (tc:kind-of tvar)))
 
       (setf kvar (tc:apply-ksubstitution ksubs kvar))
@@ -189,50 +172,41 @@
             (setf ksubs (tc:kunify kvar expected-kind ksubs))
             (values (tc:apply-ksubstitution ksubs tvar) ksubs))
         (tc:coalton-internal-type-error ()
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:ty-source type)
-                       :file file
-                       :message "Kind mismatch"
-                       :primary-note (format nil "Expected kind '~S' but variable is of kind '~S'"
-                                             expected-kind
-                                             kvar)))))))
+          (tc-error (parser:ty-source type)
+                    "Kind mismatch"
+                    (format nil "Expected kind '~S' but variable is of kind '~S'"
+                            expected-kind
+                            kvar))))))
 
-  (:method ((type parser:tycon) expected-kind ksubs env file)
+  (:method ((type parser:tycon) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type se:file file)
              (values tc:ty tc:ksubstitution-list))
 
-    (let ((type_ (partial-type-env-lookup-type env type file)))
+    (let ((type_ (partial-type-env-lookup-type env type)))
       (handler-case
           (progn
             (setf ksubs (tc:kunify (tc:kind-of type_) expected-kind ksubs))
             (values (tc:apply-ksubstitution ksubs type_) ksubs))
         (tc:coalton-internal-type-error ()
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:ty-source type)
-                       :file file
-                       :message "Kind mismatch"
-                       :primary-note (format nil "Expected kind '~S' but got kind '~S'"
-                                             expected-kind
-                                             (tc:kind-of type_))))))))
+          (tc-error (parser:ty-source type)
+                    "Kind mismatch"
+                    (format nil "Expected kind '~S' but got kind '~S'"
+                            expected-kind
+                            (tc:kind-of type_)))))))
 
-  (:method ((type parser:tapp) expected-kind ksubs env file)
+  (:method ((type parser:tapp) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type se:file file)
              (values tc:ty tc:ksubstitution-list &optional))
 
     (let ((fun-kind (tc:make-kvariable))
-
           (arg-kind (tc:make-kvariable)))
 
       (multiple-value-bind (fun-ty ksubs)
-          (infer-type-kinds (parser:tapp-from type) fun-kind ksubs env file)
+          (infer-type-kinds (parser:tapp-from type) fun-kind ksubs env)
 
         (setf fun-kind (tc:apply-ksubstitution ksubs fun-kind))
 
@@ -242,95 +216,76 @@
           (setf arg-kind (tc:apply-ksubstitution ksubs arg-kind)))
 
         (multiple-value-bind (arg-ty ksubs)
-            (infer-type-kinds (parser:tapp-to type) arg-kind ksubs env file)
+            (infer-type-kinds (parser:tapp-to type) arg-kind ksubs env)
 
           (handler-case
               (progn
-                (setf ksubs (tc:kunify fun-kind (tc:make-kfun :from arg-kind :to expected-kind) ksubs)) 
+                (setf ksubs (tc:kunify fun-kind (tc:make-kfun :from arg-kind
+                                                              :to expected-kind)
+                                       ksubs))
                 (values
                  (tc:apply-type-argument fun-ty arg-ty :ksubs ksubs)
                  ksubs))
             (tc:coalton-internal-type-error ()
-              (error 'tc:tc-error
-                     :err (se:source-error
-                           :span (parser:ty-source (parser:tapp-from type))
-                           :file file
-                           :message "Kind mismatch"
-                           :primary-note (format nil "Expected kind '~S' but got kind '~S'"
-                                                 (tc:make-kfun
-                                                  :from (tc:apply-ksubstitution ksubs arg-kind)
-                                                  :to (tc:apply-ksubstitution ksubs expected-kind))
-                                                 (tc:apply-ksubstitution ksubs fun-kind))))))))))
+              (tc-error (parser:ty-source (parser:tapp-from type))
+                        "Kind mismatch"
+                        (format nil "Expected kind '~S' but got kind '~S'"
+                                (tc:make-kfun
+                                 :from (tc:apply-ksubstitution ksubs arg-kind)
+                                 :to (tc:apply-ksubstitution ksubs expected-kind))
+                                (tc:apply-ksubstitution ksubs fun-kind)))))))))
 
-  (:method ((type parser:qualified-ty) expected-kind ksubs env file)
+  (:method ((type parser:qualified-ty) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type se:file file)
              (values tc:qualified-ty tc:ksubstitution-list))
-    
+
     ;; CCL >:(
     (assert (equalp expected-kind tc:+kstar+))
 
     (let ((preds (loop :for pred :in (parser:qualified-ty-predicates type)
                        :collect (multiple-value-bind (pred ksubs_)
-                                    (infer-predicate-kinds
-                                     pred
-                                     ksubs
-                                     env
-                                     file)
+                                    (infer-predicate-kinds pred ksubs env)
                                   (setf ksubs ksubs_)
                                   pred))))
 
       (multiple-value-bind (ty ksubs)
-          (infer-type-kinds (parser:qualified-ty-type type)
-                            tc:+kstar+
-                            ksubs
-                            env
-                            file)
+          (infer-type-kinds (parser:qualified-ty-type type) tc:+kstar+ ksubs
+                            env)
+        (values (tc:make-qualified-ty :predicates preds
+                                      :type ty)
+                ksubs)))))
 
-        (values
-         (tc:make-qualified-ty
-          :predicates preds
-          :type ty)
-         ksubs)))))
-
-(defun infer-predicate-kinds (pred ksubs env file)
+(defun infer-predicate-kinds (pred ksubs env)
   (declare (type parser:ty-predicate pred)
            (type tc:ksubstitution-list ksubs)
            (type partial-type-env env)
-           (type se:file file)
            (values tc:ty-predicate tc:ksubstitution-list))
 
-  (let* ((class-name (parser:identifier-src-name (parser:ty-predicate-class pred)))
-
-         (class-pred (partial-type-env-lookup-class env pred file))
-
-         (class-arity (length (tc:ty-predicate-types class-pred))))
+  (let* ((class-name
+           (parser:identifier-src-name (parser:ty-predicate-class pred)))
+         (class-pred
+           (partial-type-env-lookup-class env pred))
+         (class-arity
+           (length (tc:ty-predicate-types class-pred))))
 
     ;; Check that pred has the correct number of arguments
     (unless (= class-arity (length (parser:ty-predicate-types pred)))
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:ty-predicate-source pred)
-                   :file file
-                   :message "Predicate arity mismatch"
-                   :primary-note (format nil "Expected ~D arguments but received ~D"
-                                         class-arity
-                                         (length (parser:ty-predicate-types pred))))))
+      (tc-error (parser:ty-predicate-source pred)
+                "Predicate arity mismatch"
+                (format nil "Expected ~D arguments but received ~D"
+                        class-arity
+                        (length (parser:ty-predicate-types pred)))))
 
     (let ((types (loop :for ty :in (parser:ty-predicate-types pred)
                        :for class-ty :in (tc:ty-predicate-types class-pred)
                        :collect (multiple-value-bind (ty ksubs_)
-                                    (infer-type-kinds ty
-                                                      (tc:kind-of class-ty)
+                                    (infer-type-kinds ty (tc:kind-of class-ty)
                                                       ksubs
-                                                      env
-                                                      file)
+                                                      env)
                                   (setf ksubs ksubs_)
                                   ty))))
-      (values
-       (tc:make-ty-predicate
-        :class class-name
-        :types types)
+      (values (tc:make-ty-predicate :class class-name
+                                    :types types)
        ksubs))))

--- a/src/typechecker/partial-type-env.lisp
+++ b/src/typechecker/partial-type-env.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/typechecker/partial-type-env
   (:use
-   #:cl)
+   #:cl
+   #:coalton-impl/typechecker/base)
   (:local-nicknames
    (#:se #:source-error)
    (#:util #:coalton-impl/util)
@@ -31,33 +32,24 @@
             (:copier nil))
   (env         (util:required 'env)         :type tc:environment :read-only t)
   (ty-table    (make-hash-table :test #'eq) :type hash-table     :read-only t)
-  (class-table (make-hash-table :test #'eq) :type hash-table :read-only t))
+  (class-table (make-hash-table :test #'eq) :type hash-table     :read-only t))
 
 (defun partial-type-env-add-var (env var)
   (declare (type partial-type-env env)
            (type symbol var)
            (values tc:tyvar))
-
   (setf (gethash var (partial-type-env-ty-table env)) (tc:make-variable (tc:make-kvariable))))
 
-(defun partial-type-env-lookup-var (env var source file)
+(defun partial-type-env-lookup-var (env var source)
   (declare (type partial-type-env env)
            (type symbol var)
-           (type cons source)
-           (type se:file file)
+           (type parser:source-location source)
            (values tc:tyvar))
-
   (let ((ty (gethash var (partial-type-env-ty-table env))))
-
     (unless ty
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span source
-                   :file file
-                   :message "Unknown type variable"
-                   :primary-note (format nil "Unknown type variable ~S"
-                                         var))))
-
+      (tc-error source
+                "Unknown type variable"
+                (format nil "Unknown type variable ~S" var)))
     ty))
 
 (defun partial-type-env-add-type (env name type)
@@ -84,12 +76,11 @@
   (setf (gethash name (partial-type-env-ty-table env)) type)
   nil)
 
-(defun partial-type-env-lookup-type (env tycon file)
+(defun partial-type-env-lookup-type (env tycon)
   (declare (type partial-type-env env)
            (type parser:tycon tycon)
-           (type se:file file)
            (values tc:ty))
-  
+
   (let* ((name (parser:tycon-name tycon))
 
          (partial (gethash name (partial-type-env-ty-table env))))
@@ -100,12 +91,9 @@
     (let ((type-entry (tc:lookup-type (partial-type-env-env env) name :no-error t)))
 
       (unless type-entry
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (parser:ty-source tycon)
-                     :file file
-                     :message "Unknown type"
-                     :primary-note (format nil "unknown type ~S" (parser:tycon-name tycon)))))
+        (tc-error (parser:ty-source tycon)
+                  "Unknown type"
+                  (format nil "unknown type ~S" (parser:tycon-name tycon))))
 
       (tc:type-entry-type type-entry))))
 
@@ -120,10 +108,9 @@
   (setf (gethash (tc:ty-predicate-class pred) (partial-type-env-class-table env)) pred)
   nil)
 
-(defun partial-type-env-lookup-class (env pred file)
+(defun partial-type-env-lookup-class (env pred)
   (declare (type partial-type-env env)
            (type parser:ty-predicate pred)
-           (type se:file file)
            (values tc:ty-predicate))
 
   (let* ((name (parser:identifier-src-name (parser:ty-predicate-class pred)))
@@ -136,13 +123,10 @@
     (let ((class-entry (tc:lookup-class (partial-type-env-env env) name :no-error t)))
 
       (unless class-entry
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (parser:ty-predicate-source pred)
-                     :file file
-                     :message "Unknown class"
-                     :primary-note (format nil "unknown class ~S"
-                                           (parser:identifier-src-name
-                                            (parser:ty-predicate-class pred))))))
+        (tc-error (parser:ty-predicate-source pred)
+                  "Unknown class"
+                  (format nil "unknown class ~S"
+                          (parser:identifier-src-name
+                           (parser:ty-predicate-class pred)))))
 
       (tc:ty-class-predicate class-entry))))

--- a/src/typechecker/pattern.lisp
+++ b/src/typechecker/pattern.lisp
@@ -41,7 +41,7 @@
             (:constructor nil)
             (:copier nil))
   (type   (util:required 'type)   :type tc:qualified-ty :read-only t)
-  (source (util:required 'source) :type cons            :read-only t))
+  (source (util:required 'source) :type (or parser:source-location null) :read-only t))
 
 (defun pattern-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -5,6 +5,7 @@
    #:coalton-impl/typechecker/types
    #:coalton-impl/typechecker/substitutions)
   (:local-nicknames
+   (#:parser #:coalton-impl/parser)
    (#:util #:coalton-impl/util)
    (#:settings #:coalton-impl/settings))
   (:export
@@ -35,9 +36,9 @@
 
 (defstruct ty-predicate
   "A type predicate indicating that TYPE is of the CLASS"
-  (class (util:required 'class) :type symbol         :read-only t)
-  (types (util:required 'types) :type ty-list        :read-only t)
-  (source nil                   :type (or cons null) :read-only t))
+  (class (util:required 'class) :type symbol                           :read-only t)
+  (types (util:required 'types) :type ty-list                          :read-only t)
+  (source nil                   :type (or parser:source-location null) :read-only t))
 
 (defmethod make-load-form ((self ty-predicate) &optional env)
   (make-load-form-saving-slots self :environment env))

--- a/src/typechecker/specialize.lisp
+++ b/src/typechecker/specialize.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/typechecker/specialize
   (:use
    #:cl
+   #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/parse-type)
   (:local-nicknames
    (#:se #:source-error)
@@ -12,22 +13,20 @@
 
 (in-package #:coalton-impl/typechecker/specialize)
 
-(defun toplevel-specialize (specializations env file)
+(defun toplevel-specialize (specializations env)
 
   (declare (type parser:toplevel-specialize-list specializations)
            (type tc:environment env)
-           (type se:file file)
            (values tc:environment))
 
   (loop :for spec :in specializations :do
-    (setf env (process-specialize spec env file)))
+    (setf env (process-specialize spec env)))
 
   env)
 
-(defun process-specialize (specialize env file)
+(defun process-specialize (specialize env)
   (declare (type parser:toplevel-specialize specialize)
            (type tc:environment env)
-           (type se:file file)
            (values tc:environment &optional))
 
   (let* ((from-name (parser:node-variable-name (parser:toplevel-specialize-from specialize)))
@@ -39,88 +38,60 @@
          (from-name-entry (tc:lookup-name env from-name :no-error t))
          (to-name-entry (tc:lookup-name env to-name :no-error t))
 
-         (type (parse-type (parser:toplevel-specialize-type specialize) env file))
+         (type (parse-type (parser:toplevel-specialize-type specialize) env))
          (scheme (tc:quantify (tc:type-variables type)
                               (tc:qualify nil type))))
 
     (unless from-ty
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source (parser:toplevel-specialize-from specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note "unknown function or variable")))
+      (tc-error (parser:node-source (parser:toplevel-specialize-from specialize))
+                "Invalid specialization"
+                "unknown function or variable"))
     (unless to-ty
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source (parser:toplevel-specialize-to specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note "unknown function or variable")))
+      (tc-error (parser:node-source (parser:toplevel-specialize-to specialize))
+                "Invalid specialization"
+                "unknown function or variable"))
 
     (unless (eq :value (tc:name-entry-type from-name-entry))
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source (parser:toplevel-specialize-from specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry)))))
+      (tc-error (parser:node-source (parser:toplevel-specialize-from specialize))
+                "Invalid specialization"
+                (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry))))
     (unless (eq :value (tc:name-entry-type to-name-entry))
-      (error 'tc:tc-error
-             :err (se:source-error
-                   :span (parser:node-source (parser:toplevel-specialize-to specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry)))))
+      (tc-error (parser:node-source (parser:toplevel-specialize-to specialize))
+                "Invalid specialization"
+                (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry))))
 
     (let ((from-qual-ty (tc:fresh-inst from-ty))
           (to-qual-ty (tc:fresh-inst to-ty)))
 
       (when (null (tc:qualified-ty-predicates from-qual-ty))
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (parser:node-source (parser:toplevel-specialize-from specialize))
-                     :file file
-                     :message "Invalid specialization"
-                     :primary-note "must be a function or variable with class constraints")))
+        (tc-error (parser:node-source (parser:toplevel-specialize-from specialize))
+                  "Invalid specialization"
+                  "must be a function or variable with class constraints"))
 
       (unless (equalp to-ty scheme)
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (parser:toplevel-specialize-source specialize)
-                     :file file
-                     :message "Invalid specialization"
-                     :primary-note (format nil "function ~S does not match declared type" to-name))))
+        (tc-error (parser:toplevel-specialize-source specialize)
+                  "Invalid specialization"
+                  (format nil "function ~S does not match declared type" to-name)))
 
       (when (equalp from-ty to-ty)
-        (error 'tc:tc-error
-               :err (se:source-error
-                     :span (parser:toplevel-specialize-source specialize)
-                     :file file
-                     :message "Invalid specialization"
-                     :primary-note "specialize must result in a more specific type")))
+        (tc-error (parser:toplevel-specialize-source specialize)
+                  "Invalid specialization"
+                  "specialize must result in a more specific type"))
 
       (handler-case
           (tc:match (tc:qualified-ty-type from-qual-ty) (tc:qualified-ty-type to-qual-ty))
         (tc:coalton-internal-type-error ()
-          (error 'tc:tc-error
-                 :err (se:source-error
-                       :span (parser:toplevel-specialize-source specialize)
-                       :file file
-                       :message "Invalid specialization"
-                       :primary-note "cannot specialize to declared type"))))
+          (tc-error (parser:toplevel-specialize-source specialize)
+                    "Invalid specialization"
+                    "cannot specialize to declared type")))
 
-      (let ((entry (tc:make-specialization-entry
-                    :from from-name
-                    :to to-name
-                    :to-ty type)))
-
+      (let ((entry (tc:make-specialization-entry :from from-name
+                                                 :to to-name
+                                                 :to-ty type)))
         (handler-case
             (tc:add-specialization env entry)
           (tc:overlapping-specialization-error (c)
-            (error 'tc:tc-error
-                   :err (se:source-error
-                         :span (parser:toplevel-specialize-source specialize)
-                         :file file
-                         :message "Overlapping specialization"
-                         :primary-note (format nil "overlaps with specialization ~S" (tc:overlapping-specialization-error-existing c))))))))))
+            (tc-error (parser:toplevel-specialize-source specialize)
+                      "Overlapping specialization"
+                       (format nil "overlaps with specialization ~S"
+                               (tc:overlapping-specialization-error-existing c)))))))))

--- a/src/typechecker/toplevel.lisp
+++ b/src/typechecker/toplevel.lisp
@@ -43,10 +43,10 @@
 
 (defstruct (toplevel-define
             (:copier nil))
-  (name    (util:required 'name)   :type node-variable :read-only t)
-  (params  (util:required 'params) :type pattern-list  :read-only t)
-  (body    (util:required 'body)   :type node-body     :read-only t)
-  (source  (util:required 'source) :type cons          :read-only t))
+  (name    (util:required 'name)   :type node-variable          :read-only t)
+  (params  (util:required 'params) :type pattern-list           :read-only t)
+  (body    (util:required 'body)   :type node-body              :read-only t)
+  (source  (util:required 'source) :type parser:source-location :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-list-p (x)
@@ -71,7 +71,7 @@
   (name    (util:required 'name)    :type node-variable :read-only t)
   (params  (util:required 'params)  :type pattern-list  :read-only t)
   (body    (util:required 'body)    :type node-body     :read-only t)
-  (source  (util:required 'source)  :type cons          :read-only t))
+  (source  (util:required 'source)  :type parser:source-location          :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun instance-method-definition-list-p (x)
@@ -96,8 +96,8 @@
   (context  (util:required 'context)  :type tc:ty-predicate-list :read-only t)
   (pred     (util:required 'pred)     :type tc:ty-predicate      :read-only t)
   (methods  (util:required 'methods)  :type hash-table           :read-only t)
-  (source   (util:required 'source)   :type cons                 :read-only t)
-  (head-src (util:required 'head-src) :type cons                 :read-only t))
+  (source   (util:required 'source)   :type parser:source-location                 :read-only t)
+  (head-src (util:required 'head-src) :type parser:source-location                 :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-instance-list-p (x)

--- a/tests/entry-tests.lisp
+++ b/tests/entry-tests.lisp
@@ -11,12 +11,12 @@
 
 (deftest test-compile-to-lisp ()
   "Test that the Coalton compiler compiles a test file into something that looks like Lisp source."
-  (with-open-file (input (compile-test-file) :direction ':input)
-    (let ((source-form-types (mapcar #'first
-                                     (source-forms (entry:codegen input "test")))))
-      (dolist (expect-type '(defpackage in-package defun eval-when let setf))
-        (is (position expect-type source-form-types)
-            "Missing expected ~A form in generated code" expect-type)))))
+  (let* ((file (source-error:make-source-file (compile-test-file)))
+         (source-form-types (mapcar #'first
+                                    (source-forms (entry:codegen file)))))
+    (dolist (expect-type '(defpackage in-package defun eval-when let setf))
+      (is (position expect-type source-form-types)
+          "Missing expected ~A form in generated code" expect-type))))
 
 (deftest test-compile-to-fasl ()
   "Test that the Coalton compiler compiles a test file into a working .fasl that persists environment updates."
@@ -27,8 +27,8 @@
     (let ((fact (test-sym)))
       (fmakunbound fact)
       (setf entry:*global-environment* (tc:unset-function entry:*global-environment* fact)))
-    (with-open-file (stream (compile-test-file))
-      (entry:compile stream "test" :load t)
+    (let ((file (se:make-source-file (compile-test-file) :name "test")))
+      (entry:compile file :load t)
       (let ((fact (test-sym)))
         (is (fboundp fact)
             "Test function was bound as side effect of loading fasl")

--- a/tests/error-tests.lisp
+++ b/tests/error-tests.lisp
@@ -29,39 +29,38 @@
 "
                   output-stream)
     :close-stream
-    (with-open-file (stream program-file)
-      (let* ((f (se:make-file :stream stream :name "file"))
-             (msg (with-output-to-string (output)
-                    ;; an annotating error
-                    (se:display-source-error
-                     output
-                     (se:source-error
-                      :span '(76 . 321)
-                      :file f
-                      :message "message"
-                      :primary-note "define instance form"
-                      :notes (list
-                              (se:make-source-error-note
-                               :type :secondary
-                               :span  '(132 . 319)
-                               :message "message 2")
-                              (se:make-source-error-note
-                               :type :secondary
-                               :span  '(140 . 145)
-                               :message "message 3")
-                              (se:make-source-error-note
-                               :type :secondary
-                               :span  '(170 . 174)
-                               :message "message 4"))
-                      :help-notes
-                      (list
-                       (se:make-source-error-help
-                        :span  '(289 . 291)
-                        :replacement (lambda (existing)
-                                       (concatenate 'string "*" existing "*"))
-                        :message "message 5")))))))
-        ;; output text
-        (is (string= msg "error: message
+    (let* ((f (se:make-source-file program-file :name "file"))
+           (msg (with-output-to-string (output)
+                  ;; an annotating error
+                  (se:display-source-error
+                   output
+                   (se:source-error
+                    :span '(76 . 321)
+                    :file f
+                    :message "message"
+                    :primary-note "define instance form"
+                    :notes (list
+                            (se:make-source-error-note
+                             :type :secondary
+                             :span  '(132 . 319)
+                             :message "message 2")
+                            (se:make-source-error-note
+                             :type :secondary
+                             :span  '(140 . 145)
+                             :message "message 3")
+                            (se:make-source-error-note
+                             :type :secondary
+                             :span  '(170 . 174)
+                             :message "message 4"))
+                    :help-notes
+                    (list
+                     (se:make-source-error-help
+                      :span  '(289 . 291)
+                      :replacement (lambda (existing)
+                                     (concatenate 'string "*" existing "*"))
+                      :message "message 5")))))))
+      ;; output text
+      (is (string= msg "error: message
   --> file:9:2
     |
  9  |      (define-instance (Eq Kind)
@@ -81,4 +80,4 @@
 help: message 5
  16 |               (*==* a2 b2)))
     |                ----
-"))))))
+")))))

--- a/tests/parser-test-files/bad-files/parse-fn.3.error
+++ b/tests/parser-test-files/bad-files/parse-fn.3.error
@@ -2,7 +2,7 @@ error: Malformed function
   --> test:4:14
    |
  4 |  (define f (fn x 1))
-   |                ^ malformed arugment list
+   |                ^ malformed argument list
 help: add parentheses
  4 | (define f (fn (x) 1))
    |               ---

--- a/tests/parser-test-files/package.txt
+++ b/tests/parser-test-files/package.txt
@@ -75,3 +75,20 @@ error: Malformed package declaration
    |
  2 |    (import (something as)))
    |                         ^ missing package nickname
+
+================================================================================
+Unterminated package form
+================================================================================
+
+(package test
+  (import (something as s))
+
+--------------------------------------------------------------------------------
+
+error: Unterminated form
+  --> test:1:0
+   |
+ 1 |   (package test
+   |  _^
+ 2 | |   (import (something as s))
+   | |___________________________^ Missing close parenthesis for form starting at offset 0

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -8,24 +8,19 @@
                files))
 
            (parse-file (file)
-             (with-open-file (stream file
-                                     :direction :input
-                                     :element-type 'character
-                                     :external-format :utf-8)
-               (let ((stream (stream:make-char-position-stream stream)))
-                 (parser:with-reader-context stream
-                   (parser:read-program stream (se:make-file :stream stream :name (namestring file)) ':file)))))
+             (let ((source (source-error:make-source-file file :name "test")))
+               (with-open-stream (stream (source-error:file-stream source))
+                 (let ((stream (stream:make-char-position-stream stream)))
+                   (parser:with-reader-context stream
+                     (parser:read-program stream source ':file))))))
 
            (parse-error-text (file)
-             (with-open-file (stream file
-                                     :direction :input
-                                     :element-type 'character
-                                     :external-format :utf-8)
-               (let ((stream (stream:make-char-position-stream stream)))
+             (let ((source (source-error:make-source-file file :name "test")))
+               (with-open-stream (stream (source-error:file-stream source))
                  (handler-case
                      (parser:with-reader-context stream
                        (entry:entry-point
-                        (parser:read-program stream (se:make-file :stream stream :name "test") ':file))
+                        (parser:read-program stream source ':file))
                        "no errors")
                    (se:source-base-error (c)
                      (princ-to-string c)))))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -53,7 +53,7 @@
                                  (let* ((ast-type (parser:parse-qualified-type
                                                    (eclector.concrete-syntax-tree:read stream)
                                                    file))
-                                        (parsed-type (tc:parse-ty-scheme ast-type env file)))
+                                        (parsed-type (tc:parse-ty-scheme ast-type env)))
                                    (is (equalp
                                         (tc:lookup-value-type env symbol)
                                         parsed-type))))))))))


### PR DESCRIPTION
Most AST types have a `source` field of type `(cons integer integer)` that indicates the character span of the source form associated with the parsed object.

In order to support runtime lookup of source definitions, change the type of `source` to `source-location`, which contains both a span and a filename.

This is stacked on #1209 and left in draft state while that change is considered.