### PR TITLE
fix translate-expression for node-for

### DIFF
--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -129,8 +129,8 @@
       `(loop
          :named ,(break-label label)
          :while ,pred-expr
-         :do
-            (block ,(continue-label label) ,body-expr))))
+         :do (block ,(continue-label label) ,body-expr)
+         :finally (return-from ,(break-label label) coalton:Unit))))
 
   (:method ((expr node-while-let) current-function env)
     (declare (type tc:environment env)
@@ -154,21 +154,23 @@
                  ,(cond ((null bindings) body-expr)
                         (t `(let ,bindings
                               (declare (ignorable ,@(mapcar #'car bindings)))
-                              ,body-expr))))))))
+                              ,body-expr))))
+           :finally (return-from ,(break-label label) coalton:Unit)))))
 
   (:method ((expr node-loop) current-function env)
     (declare (type tc:environment env)
              (type (or null symbol) current-function))
     (let ((body-expr (codegen-expression (node-loop-body expr) current-function env))
           (label (node-loop-label expr)))
-      `(loop :named  ,(break-label label)
+      `(loop :named ,(break-label label)
              :do (block ,(continue-label label)
-                   ,body-expr))))
+                   ,body-expr)
+             :finally (return-from ,(break-label label) coalton:Unit))))
 
   (:method ((expr node-break) current-function env)
     (declare (type tc:environment env)
              (type (or null symbol) current-function))
-    `(return-from ,(break-label (node-break-label expr))))
+    `(return-from ,(break-label (node-break-label expr)) coalton:Unit))
 
   (:method ((expr node-continue) current-function env)
     (declare (type tc:environment env)

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -656,7 +656,7 @@ Returns a `node'.")
              (tc:apply-type-argument
               (tc:make-tycon :name iterator
                              :kind (tc:make-kfun :from tc:+kstar+ :to tc:+kstar+))
-              into-iter-arg-ty))
+              pat-arg-ty))
 
            (intoiterator-pred
              (tc:make-ty-predicate
@@ -666,7 +666,7 @@ Returns a `node'.")
 
            (into-iter-node
              (make-node-application
-              :type optional-pat-arg-ty
+              :type iter-ty
               :rator (make-node-variable
                       :type (tc:make-function-type*
                              (list (pred-type intoiterator-pred env)

--- a/tests/iterator-tests.lisp
+++ b/tests/iterator-tests.lisp
@@ -214,6 +214,17 @@
 	   (iter:flat-map! (fn (x) (iter:into-iter (make-list x (+ x 2))))
 			   (iter:up-to 4))))))
 
+(coalton-toplevel
+  (define (gh1197)
+    ;; A late unification failure occured on this code when run with the
+    ;; inliner. This will fail to compile in that case.
+    (for x in (iter:once 1)
+      (is (== 1 x)))))
+
+(define-test gh1200-for-loop-type-error ()
+  ;; Incidentally, the function for testing gh1197 also tests gh1200.
+  (gh1197))
+
 ;;; FIXME: define more tests
 ;; - vector-iter
 ;; - recursive-iter


### PR DESCRIPTION
This PR fixes two bugs, #1197 and #1200 

#1197 was caused by incorrect types being assigned to the resulting translated `node-for` in `translate-expression`. I think this was just human mistake in constructing a somewhat complicated AST node with lots of sub-nodes. I believe I have it correct, but I'm not 100% confident. (It does pass a new test I added.) Is there a better way to do it?

#1200 was problematic because all looping constructs implicitly returned `cl:nil`, but the type checker unified loops to `Unit`. I've changed all of the loops to just explicitly codegen a `Unit` return.