### PR TITLE
Add node-block and node-return-from for inlining functions with node-return

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -249,4 +249,5 @@
                (:file "pattern-matching-tests")
                (:file "looping-native-tests")
                (:file "monomorphizer-tests")
+               (:file "inliner-tests")
                (:file "file-tests")))

--- a/library/system.lisp
+++ b/library/system.lisp
@@ -88,7 +88,7 @@ While the result will always contain microseconds, some implementations may retu
       (cl:let ((env (uiop:getenvp var)))
         (cl:if env
                (Some env)
-               (None)))))
+               None))))
 
   
   (declare setenv! (String -> String -> Unit))
@@ -164,7 +164,7 @@ While the result will always contain microseconds, some implementations may retu
       (cl:let ((arg (uiop:argv0)))
         (cl:if arg
                (Some (uiop:argv0))
-               (None))))))
+               None)))))
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/SYSTEM")

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -15,88 +15,93 @@
    #:binding-list                       ; TYPE
    #:node-literal                       ; STRUCT
    #:make-node-literal                  ; CONSTRUCTOR
-   #:node-literal-value                 ; ACCESSOR
+   #:node-literal-value                 ; READER
    #:node-variable                      ; STRUCT
    #:make-node-variable                 ; CONSTRUCTOR
    #:node-variable-p                    ; FUNCTION
-   #:node-variable-value                ; ACCESSOR
+   #:node-variable-value                ; READER
    #:node-application                   ; STRUCT
    #:make-node-application              ; CONSTRUCTOR
    #:node-application-p                 ; FUNCTION
-   #:node-application-rator             ; ACCESSOR
-   #:node-application-rands             ; ACCESSOR
+   #:node-application-rator             ; READER
+   #:node-application-rands             ; READER
    #:node-direct-application            ; STRUCT
    #:make-node-direct-application       ; CONSTRUCTOR
-   #:node-direct-application-rator-type ; ACCESSOR
-   #:node-direct-application-rator      ; ACCESSOR
-   #:node-direct-application-rands      ; ACCESSOR
+   #:node-direct-application-rator-type ; READER
+   #:node-direct-application-rator      ; READER
+   #:node-direct-application-rands      ; READER
    #:node-direct-application-p          ; FUNCTION
    #:node-abstraction                   ; STRUCT
    #:make-node-abstraction              ; CONSTRUCTOR
-   #:node-abstraction-vars              ; ACCESSOR
-   #:node-abstraction-subexpr           ; ACCESSOR
+   #:node-abstraction-vars              ; READER
+   #:node-abstraction-subexpr           ; READER
    #:node-abstraction-p                 ; FUNCTION
    #:node-let                           ; STRUCT
    #:make-node-let                      ; CONSTRUCTOR
    #:node-let-p                         ; FUNCTION
-   #:node-let-bindings                  ; ACCESSOR
-   #:node-let-subexpr                   ; ACCESSOR
+   #:node-let-bindings                  ; READER
+   #:node-let-subexpr                   ; READER
    #:node-lisp                          ; STRUCT
    #:make-node-lisp                     ; CONSTRUCTOR
-   #:node-lisp-vars                     ; ACCESSOR
-   #:node-lisp-form                     ; ACCESSOR
+   #:node-lisp-vars                     ; READER
+   #:node-lisp-form                     ; READER
    #:match-branch                       ; STRUCT
    #:make-match-branch                  ; CONSTRUCTOR
-   #:match-branch-pattern               ; ACCESSOR
-   #:match-branch-bindings              ; ACCESSOR
-   #:match-branch-body                  ; ACCESSOR
+   #:match-branch-pattern               ; READER
+   #:match-branch-bindings              ; READER
+   #:match-branch-body                  ; READER
    #:branch-list                        ; TYPE
    #:node-match                         ; STRUCT
    #:make-node-match                    ; CONSTRUCTOR
-   #:node-match-expr                    ; ACCESSOR
-   #:node-match-branches                ; ACCESSOR
+   #:node-match-expr                    ; READER
+   #:node-match-branches                ; READER
    #:node-while                         ; STRUCT
    #:make-node-while                    ; CONSTRUCTOR
-   #:node-while-label                   ; ACCESSOR
-   #:node-while-expr                    ; ACCESSOR
+   #:node-while-label                   ; READER
+   #:node-while-expr                    ; READER
    #:node-while-body                    ; ACESSOR
    #:node-while-let                     ; STRUCT
    #:make-node-while-let                ; CONSTRUCTOR
    #:node-while-let-label               ; ACESSOR
-   #:node-while-let-pattern             ; ACCESSOR
-   #:node-while-let-expr                ; ACCESSOR
+   #:node-while-let-pattern             ; READER
+   #:node-while-let-expr                ; READER
    #:node-while-let-body                ; ACESSOR
    #:node-loop                          ; STRUCT
    #:make-node-loop                     ; CONSTRUCTOR
-   #:node-loop-body                     ; ACCESSOR
-   #:node-loop-label                    ; ACCESSOR
+   #:node-loop-body                     ; READER
+   #:node-loop-label                    ; READER
    #:node-break                         ; STRUCT
    #:make-node-break                    ; CONSTRUCTOR
-   #:node-break-label                   ; ACCESSOR
+   #:node-break-label                   ; READER
    #:node-continue                      ; STRUCT
    #:make-node-continue                 ; CONSTRUCTOR
-   #:node-continue-label                ; ACCESSOR
+   #:node-continue-label                ; READER
    #:node-seq                           ; STRUCT
    #:make-node-seq                      ; CONSTRUCTOR
-   #:node-seq-nodes                     ; ACCESSOR
-   #:node-return                        ; STRUCT
-   #:make-node-return                   ; CONSTRUCTOR
-   #:node-return-expr                   ; ACCESSOR
+   #:node-seq-nodes                     ; READER
+   #:node-return-from                   ; STRUCT
+   #:make-node-return-from              ; CONSTRUCTOR
+   #:node-return-from-name              ; READER
+   #:node-return-from-expr              ; READER
+   #:node-block                         ; STRUCT
+   #:make-node-block                    ; CONSTRUCTOR
+   #:node-block-name                    ; READER
+   #:node-block-body                    ; READER
    #:node-field                         ; STRUCT
    #:make-node-field                    ; CONSTRUCTOR
-   #:node-field-name                    ; ACCESSOR
-   #:node-field-dict                    ; ACCESSOR
+   #:node-field-name                    ; READER
+   #:node-field-dict                    ; READER
    #:node-field-p                       ; FUNCTION
    #:node-dynamic-extent                ; STRUCT
    #:make-node-dynamic-extent           ; CONSTRUCTOR
-   #:node-dynamic-extent-name           ; ACCESSOR
-   #:node-dynamic-extent-node           ; ACCESSOR
-   #:node-dynamic-extent-body           ; ACCESSOR
+   #:node-dynamic-extent-name           ; READER
+   #:node-dynamic-extent-node           ; READER
+   #:node-dynamic-extent-body           ; READER
    #:node-bind                          ; STRUCT
    #:make-node-bind                     ; CONSTRUCTOR
-   #:node-bind-name                     ; ACCESSOR
-   #:node-bind-expr                     ; ACCESSOR
-   #:node-bind-body                     ; ACCESSOR
+   #:node-bind-name                     ; READER
+   #:node-bind-expr                     ; READER
+   #:node-bind-body                     ; READER
    #:node-variables                     ; FUNCTION
    #:node-binding-sccs                  ; FUNCTION
    #:node-free-p                        ; FUNCTION
@@ -247,9 +252,15 @@ call to (break)."
   "A series of statements to be executed sequentially"
   (nodes (util:required 'nodes) :type node-list :read-only t))
 
-(defstruct (node-return (:include node))
-  "A return statement, used for early returns in functions"
-  (expr (util:required 'expr) :type node :read-only t))
+(defstruct (node-return-from (:include node))
+  "A return statement, used for explicit returns in functions"
+  (name (util:required 'name) :type symbol :read-only t)
+  (expr (util:required 'expr) :type node   :read-only t))
+
+(defstruct (node-block (:include node))
+  "A return target, used for explicit returns in functions"
+  (name (util:required 'node) :type symbol :read-only t)
+  (body (util:required 'body) :type node   :read-only t))
 
 (defstruct (node-field (:include node))
   "Accessing a superclass on a typeclass dictionary"

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -37,7 +37,8 @@
   (:import-from
    #:coalton-impl/codegen/transformations
    #:node-free-p
-   #:rename-type-variables)
+   #:rename-type-variables
+   #:localize-returns)
   (:import-from
    #:coalton-impl/codegen/ast-substitutions
    #:apply-ast-substitution

--- a/src/codegen/transformations.lisp
+++ b/src/codegen/transformations.lisp
@@ -10,7 +10,8 @@
   (:export
    #:rename-type-variables
    #:node-variables
-   #:node-free-p))
+   #:node-free-p
+   #:localize-returns))
 
 (in-package #:coalton-impl/codegen/transformations)
 

--- a/src/codegen/translate-instance.lisp
+++ b/src/codegen/translate-instance.lisp
@@ -52,7 +52,7 @@
                  :for binding := (gethash method-name (tc:toplevel-define-instance-methods instance))
                  :for codegen-sym := (tc:get-value method-codegen-syms method-name)
 
-                 :collect (cons codegen-sym (translate-toplevel binding env))))
+                 :collect (cons codegen-sym (translate-toplevel binding env method-name))))
 
          (unqualified-method-definitions
            (loop :for method :in (tc:ty-class-unqualified-methods class)
@@ -61,6 +61,7 @@
                  :for binding := (gethash method-name (tc:toplevel-define-instance-methods instance))
                  :collect (translate-toplevel (tc:attach-explicit-binding-type binding (tc:fresh-inst method-type))
                                               env
+                                              method-name
                                               :extra-context ctx)))
 
          (method-ty (mapcar #'node-type unqualified-method-definitions))

--- a/src/codegen/traverse.lisp
+++ b/src/codegen/traverse.lisp
@@ -157,10 +157,16 @@ nodes."
                (lambda (node)
                  (apply *traverse* node args))
                (node-seq-nodes node))))
-    (action (:traverse node-return node &rest args)
-      (make-node-return
+    (action (:traverse node-return-from node &rest args)
+      (make-node-return-from
        :type (node-type node)
-       :expr (apply *traverse* (node-return-expr node) args)))
+       :name (node-return-from-name node)
+       :expr (apply *traverse* (node-return-from-expr node) args)))
+    (action (:traverse node-block node &rest args)
+      (make-node-block
+       :type (node-type node)
+       :name (node-block-name node)
+       :body (apply *traverse* (node-block-body node) args)))
     (action (:traverse node-field node &rest args)
       (make-node-field
        :type (node-type node)

--- a/src/codegen/typecheck-node.lisp
+++ b/src/codegen/typecheck-node.lisp
@@ -157,10 +157,19 @@
       (setf subs (tc:unify subs (node-type last-node) (node-type expr)))
       (node-type last-node)))
 
-  (:method ((expr node-return) env)
+  (:method ((expr node-return-from) env)
     (declare (type tc:environment env)
              (values tc:ty))
-    (typecheck-node (node-return-expr expr) env)
+    (typecheck-node (node-return-from-expr expr) env)
+    (node-type expr))
+
+  (:method ((expr node-block) env)
+    (declare (type tc:environment env)
+             (values tc:ty))
+    (tc:unify
+     nil
+     (node-type expr)
+     (typecheck-node (node-block-body expr) env))
     (node-type expr))
 
   (:method ((expr node-field) env)

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -143,7 +143,6 @@
                    (codegen:direct-application
                     node
                     (codegen:make-function-table env))
-                   nil
                    env))))
 
             (let* ((tvars

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -305,7 +305,7 @@
   (declare (type ty ty)
            (type fixnum num))
 
-  (assert (>= num (length (function-type-arguments ty))))
+  (assert (<= num (length (function-type-arguments ty))))
 
   (make-function-type*
    (subseq (function-type-arguments ty) num)

--- a/tests/inliner-tests.lisp
+++ b/tests/inliner-tests.lisp
@@ -1,0 +1,8 @@
+(in-package #:coalton-native-tests)
+
+(named-readtables:in-readtable coalton:coalton)
+
+(define-test test-inline-return ()
+  ;; See gh #1202
+  (is (== 1 (1+
+             ((fn (x) (return x)) 0)))))

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -453,3 +453,11 @@
    "(define x (even? 2))"
 
    '("x" . "Boolean")))
+
+
+(deftest test-nameless-overapplication ()
+  ;; See gh #1208
+  (check-coalton-types
+   "(define f (fn (x) (fn (y) (+ x y))))"
+
+   '("f" . "(Num :a => :a -> :a -> :a)")))


### PR DESCRIPTION
Inlining bodies of functions with return nodes would make it so they returned to the most recent non-inlined function, which is wrong. This PR creates `node-block` and `node-return-from` and implements a traversal to fix this.