### PR TITLE
Allow Coalton config before Coalton is loaded

### DIFF
--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -167,7 +167,7 @@ A function bound here will be called with a keyword category, and one or more ad
                       ,(codegen-expression node nil env)))
 
   ;; Print types of definitions
-  (when (or *compile-print* settings:*compile-print-types*) 
+  (when settings:*compile-print-types*
     (dolist (binding bindings)
       (let* ((name (car binding))
              (type (tc:lookup-value-type env name :no-error t)))


### PR DESCRIPTION
This PR allows configuration to reside in one's lisp config directory without relying on environment variables

my sbclrc has:

```
;;; Coalton configuration

(let ((config '((:compiler-mode          "development")
                (:print-unicode          t)
                (:perform-specialization t)
                (:perform-inlining       nil)
                (:emit-type-annotations  t)
                (:print-types            t))))
  (setf (symbol-plist ':coalton-config) nil)
  (loop :for (key value) :in config
        :do (setf (get ':coalton-config key) value)))
```

as my preferred default