### PR TITLE
Supply source-error:file to maybe-read-form

### DIFF
--- a/coalton-asdf.lisp
+++ b/coalton-asdf.lisp
@@ -15,11 +15,6 @@
     (call-with-around-compile-hook
      c (lambda (&rest flags)
          (declare (ignore flags))
-         (with-open-file (stream coal-file
-                                 :direction ':INPUT
-                                 :element-type 'character
-                                 :external-format ':UTF8)
-           (let ((char-stream (coalton-impl/stream:make-char-position-stream stream)))
-             (coalton-impl/entry:compile char-stream (pathname-name coal-file)
-                                         :load nil
-                                         :output-file fasl-file)))))))
+         (coalton-impl/entry:compile (source-error:make-source-file coal-file)
+                                     :load nil
+                                     :output-file fasl-file)))))

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -237,40 +237,39 @@
       (terpri stream)
       (terpri stream))))
 
-(defun compile-to-lisp (stream name output)
-  "Read Coalton source from STREAM and write Lisp source to OUTPUT. NAME may be the filename related to the input stream."
+(defun compile-to-lisp (file output)
+  "Read Coalton source from FILE and write Lisp source to OUTPUT. NAME may be the filename related to the input stream."
   (declare (optimize (debug 3)))
-  (parser:with-reader-context stream
-    (with-environment-updates updates
-      (let* ((file (se:make-file :stream stream
-                                 :name name))
-             (program (parser:read-program stream file ':file))
-             (program-text (entry-point program))
-             (program-package (parser:program-package program))
-             (package-name (parser:toplevel-package-name program-package)))
-        (print-form output (make-prologue))
-        (print-form output (make-environment-updater updates))
-        (print-form output (parser:make-defpackage program-package))
-        (print-form output `(in-package ,package-name))
-        ;; coalton-impl/codegen/program:compile-translation-unit wraps
-        ;; definitions in progn to provide a single expression as the
-        ;; macroexpansion of coalton-toplevel: unwrap for better
-        ;; readability
-        (dolist (form (cdr program-text))
-          (print-form output form package-name))))))
+  (with-open-stream (stream (se:file-stream file))
+    (parser:with-reader-context stream
+      (with-environment-updates updates
+        (let* ((program (parser:read-program stream file ':file))
+               (program-text (entry-point program))
+               (program-package (parser:program-package program))
+               (package-name (parser:toplevel-package-name program-package)))
+          (print-form output (make-prologue))
+          (print-form output (make-environment-updater updates))
+          (print-form output (parser:make-defpackage program-package))
+          (print-form output `(in-package ,package-name))
+          ;; coalton-impl/codegen/program:compile-translation-unit wraps
+          ;; definitions in progn to provide a single expression as the
+          ;; macroexpansion of coalton-toplevel: unwrap for better
+          ;; readability
+          (dolist (form (cdr program-text))
+            (print-form output form package-name)))))))
 
-(defun codegen (stream name)
-  "Compile Coalton source from STREAM and return Lisp program text. NAME may be the filename related to the input stream."
+(defun codegen (file)
+  "Compile Coalton source from FILE and return Lisp program text. NAME may be the filename related to the input stream."
   (with-output-to-string (output)
-    (compile-to-lisp stream name output)))
+    (compile-to-lisp file output)))
 
-(defun compile (stream name &key (load t) (output-file nil))
-   "Compile Coalton code in STREAM, returning the pathname of the generated .fasl file. If OUTPUT-FILE is nil, the built-in compiler default output location will be used."
+(defun compile (file &key (load t) (output-file nil))
+   "Compile Coalton code in FILE, returning the pathname of the generated .fasl file. If OUTPUT-FILE is nil, the built-in compiler default output location will be used."
    (uiop:with-temporary-file (:stream lisp-stream
                               :pathname lisp-file
                               :type "lisp"
                               :direction ':output)
-     (compile-to-lisp stream name lisp-stream)
+     (compile-to-lisp file lisp-stream)
      :close-stream
      (cond ((null output-file)
             (setf output-file (compile-file lisp-file)))

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -505,7 +505,7 @@ If MODE is :macro, a package form is forbidden, and an explicit check is made fo
 
       (loop :do
         (multiple-value-bind (form presentp eofp)
-            (maybe-read-form stream *coalton-eclector-client*)
+            (maybe-read-form stream file *coalton-eclector-client*)
 
           (when (and eofp (eq mode ':macro))
             (error 'parse-error
@@ -550,7 +550,7 @@ consume all attributes"))))
 
     ;; Read the coalton form
     (multiple-value-bind (form presentp)
-        (maybe-read-form stream *coalton-eclector-client*)
+        (maybe-read-form stream file *coalton-eclector-client*)
 
       (unless presentp
         (error 'parse-error
@@ -563,7 +563,7 @@ consume all attributes"))))
 
       ;; Ensure there is only one form
       (multiple-value-bind (form presentp)
-          (maybe-read-form stream *coalton-eclector-client*)
+          (maybe-read-form stream file *coalton-eclector-client*)
 
         (when presentp
           (error 'parse-error
@@ -676,7 +676,7 @@ consume all attributes"))))
                                            "Malformed package declaration"
                                            syntax-error))))
       (multiple-value-bind (form presentp)
-          (maybe-read-form stream *coalton-eclector-client*)
+          (maybe-read-form stream file *coalton-eclector-client*)
         (unless presentp
           (cursor:span-error (cons (- (file-position stream) 2)
                                    (- (file-position stream) 1))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -17,43 +17,6 @@
   "Is the Coalton reader allowed to parse the current input?
 Used to forbid reading while inside quasiquoted forms.")
 
-
-
-(defmacro with-coalton-file ((file stream) &body body)
-  "Given a stream STREAM, bind a COALTON-IMPL/ERROR:COALTON-FILE instance to the symbol FILE and execute BODY. In the event of a Coalton compiler error or warning, render the error message (which may rely on operations on STREAM)."
-  (let ((opened-streams (gensym))
-        (pathname (gensym))
-        (filename (gensym))
-        (file-input-stream (gensym)))
-    `(let ((,opened-streams nil))
-       (unwind-protect
-            (let* ((,pathname (or *compile-file-truename* *load-truename*))
-                   (,filename (if ,pathname (namestring ,pathname) "<unknown>"))
-                   ;; Ensure that coalton-file has a reference to an
-                   ;; FD-STREAM, so that stream positioning works.
-                   (,file-input-stream
-                     (cond
-                       ((or #+sbcl (sb-int:form-tracking-stream-p ,stream)
-                            nil)
-                        (let ((s (open (pathname ,stream))))
-                          (push s ,opened-streams)
-                          s))
-                       (t
-                        ,stream)))
-                   (,file (se:make-file :stream ,file-input-stream :name ,filename)))
-              (handler-bind
-                  ;; Render errors and set highlights
-                  ((se:source-base-error
-                     (lambda (c)
-                       (set-highlight-position-for-error stream (funcall (se:source-base-error-err c)))
-                       (se:render-source-error c)))
-                   (se:source-base-warning
-                     #'se:render-source-warning))
-                ,@body))
-         ;; Clean up any opened file streams
-         (dolist (s ,opened-streams)
-           (close s))))))
-
 (defun read-coalton-toplevel-open-paren (stream char)
   (declare (optimize (debug 2)))
 
@@ -62,43 +25,41 @@ Used to forbid reading while inside quasiquoted forms.")
       (funcall (get-macro-character #\( (named-readtables:ensure-readtable :standard)) stream char)))
 
   (parser:with-reader-context stream
-    (let ((first-form
-            (multiple-value-bind (form presentp)
-                (parser:maybe-read-form stream)
-              (unless presentp
-                (return-from read-coalton-toplevel-open-paren
-                  nil))
-              form)))
+    (let* ((file
+             (se:make-source-file *compile-file-truename*
+                                  :offset (file-position stream)))
+           (first-form
+             (multiple-value-bind (form presentp)
+                 (parser:maybe-read-form stream file)
+               (unless presentp
+                 (return-from read-coalton-toplevel-open-paren
+                   nil))
+               form)))
       (case (cst:raw first-form)
         (coalton:coalton-toplevel
-          (with-coalton-file (file stream)
-            (entry:compile-coalton-toplevel (parser:read-program stream file ':macro))))
+          (entry:compile-coalton-toplevel (parser:read-program stream file ':macro)))
 
         (coalton:coalton-codegen
-          (with-coalton-file (file stream)
-            (let ((settings:*emit-type-annotations* nil))
-              `',(entry:entry-point (parser:read-program stream file ':macro)))))
+          (let ((settings:*emit-type-annotations* nil))
+            `',(entry:entry-point (parser:read-program stream file ':macro))))
 
         (coalton:coalton-codegen-types
-          (with-coalton-file (file stream)
-            (let ((settings:*emit-type-annotations* t))
-              `',(entry:entry-point (parser:read-program stream file ':macro)))))
+          (let ((settings:*emit-type-annotations* t))
+            `',(entry:entry-point (parser:read-program stream file ':macro))))
 
         (coalton:coalton-codegen-ast
-          (with-coalton-file (file stream)
-            (let* ((settings:*emit-type-annotations* nil)
-                   (ast nil)
-                   (codegen:*codegen-hook* (lambda (op &rest args)
-                                             (when (eql op ':AST)
-                                               (push args ast)))))
-              (entry:entry-point (parser:read-program stream file ':macro))
-              (loop :for (name type value) :in (nreverse ast)
-                    :do (format t "~A :: ~A~%~A~%~%~%" name type value))))
+          (let* ((settings:*emit-type-annotations* nil)
+                 (ast nil)
+                 (codegen:*codegen-hook* (lambda (op &rest args)
+                                           (when (eql op ':AST)
+                                             (push args ast)))))
+            (entry:entry-point (parser:read-program stream file ':macro))
+            (loop :for (name type value) :in (nreverse ast)
+                  :do (format t "~A :: ~A~%~A~%~%~%" name type value)))
           nil)
 
         (coalton:coalton
-          (with-coalton-file (file stream)
-            (entry:expression-entry-point (parser:read-expression stream file) file)))
+         (entry:expression-entry-point (parser:read-expression stream file) file))
 
         ;; Fall back to reading the list manually
         (t
@@ -107,7 +68,7 @@ Used to forbid reading while inside quasiquoted forms.")
            (loop :do
              (handler-case
                  (multiple-value-bind (form presentp)
-                     (parser:maybe-read-form stream)
+                     (parser:maybe-read-form stream file)
 
                    (cond
                      ((and (not presentp)
@@ -119,7 +80,7 @@ Used to forbid reading while inside quasiquoted forms.")
                         (nreverse collected-forms)))
 
                      (dotted-context
-                      (when (nth-value 1 (parser:maybe-read-form stream))
+                      (when (nth-value 1 (parser:maybe-read-form stream file))
                         (error "Invalid dotted list"))
 
                       (return-from read-coalton-toplevel-open-paren
@@ -132,33 +93,6 @@ Used to forbid reading while inside quasiquoted forms.")
                    (error "Invalid dotted list"))
                  (setf dotted-context t)
                  (eclector.reader:recover c))))))))))
-
-(defun set-highlight-position-for-error (stream error)
-  "Set the highlight position within the editor using implementation specific magic."
-  #+sbcl
-  ;; We need some way of setting FILE-POSITION so that
-  ;; when Slime grabs the location of the error it
-  ;; highlights the correct form.
-  ;;
-  ;; In SBCL, we can't unread more than ~512
-  ;; characters due to limitations with ANSI streams,
-  ;; which breaks our old method of unreading
-  ;; characters until the file position is
-  ;; correct. Instead, we now patch in our own
-  ;; version of FILE-POSITION.
-  ;;
-  ;; This is a massive hack and might start breaking
-  ;; with future changes in SBCL.
-  (when (typep stream 'sb-impl::form-tracking-stream)
-    (let* ((file-offset
-             (- (sb-impl::fd-stream-get-file-position stream)
-                (file-position stream)))
-           (loc (se:source-error-location error)))
-      (setf (sb-impl::fd-stream-misc stream)
-            (lambda (stream operation arg1)
-              (if (= (sb-impl::%stream-opcode :get-file-position) operation)
-                  (+ file-offset loc 1)
-                  (sb-impl::tracking-stream-misc stream operation arg1)))))))
 
 (named-readtables:defreadtable coalton:coalton
   (:merge :standard)

--- a/tests/entry-tests.lisp
+++ b/tests/entry-tests.lisp
@@ -11,12 +11,12 @@
 
 (deftest test-compile-to-lisp ()
   "Test that the Coalton compiler compiles a test file into something that looks like Lisp source."
-  (with-open-file (input (compile-test-file) :direction ':input)
-    (let ((source-form-types (mapcar #'first
-                                     (source-forms (entry:codegen input "test")))))
-      (dolist (expect-type '(defpackage in-package defun eval-when let setf))
-        (is (position expect-type source-form-types)
-            "Missing expected ~A form in generated code" expect-type)))))
+  (let* ((file (source-error:make-source-file (compile-test-file)))
+         (source-form-types (mapcar #'first
+                                    (source-forms (entry:codegen file)))))
+    (dolist (expect-type '(defpackage in-package defun eval-when let setf))
+      (is (position expect-type source-form-types)
+          "Missing expected ~A form in generated code" expect-type))))
 
 (deftest test-compile-to-fasl ()
   "Test that the Coalton compiler compiles a test file into a working .fasl that persists environment updates."
@@ -27,8 +27,8 @@
     (let ((fact (test-sym)))
       (fmakunbound fact)
       (setf entry:*global-environment* (tc:unset-function entry:*global-environment* fact)))
-    (with-open-file (stream (compile-test-file))
-      (entry:compile stream "test" :load t)
+    (let ((file (se:make-source-file (compile-test-file) :name "test")))
+      (entry:compile file :load t)
       (let ((fact (test-sym)))
         (is (fboundp fact)
             "Test function was bound as side effect of loading fasl")

--- a/tests/error-tests.lisp
+++ b/tests/error-tests.lisp
@@ -29,39 +29,38 @@
 "
                   output-stream)
     :close-stream
-    (with-open-file (stream program-file)
-      (let* ((f (se:make-file :stream stream :name "file"))
-             (msg (with-output-to-string (output)
-                    ;; an annotating error
-                    (se:display-source-error
-                     output
-                     (se:source-error
-                      :span '(76 . 321)
-                      :file f
-                      :message "message"
-                      :primary-note "define instance form"
-                      :notes (list
-                              (se:make-source-error-note
-                               :type :secondary
-                               :span  '(132 . 319)
-                               :message "message 2")
-                              (se:make-source-error-note
-                               :type :secondary
-                               :span  '(140 . 145)
-                               :message "message 3")
-                              (se:make-source-error-note
-                               :type :secondary
-                               :span  '(170 . 174)
-                               :message "message 4"))
-                      :help-notes
-                      (list
-                       (se:make-source-error-help
-                        :span  '(289 . 291)
-                        :replacement (lambda (existing)
-                                       (concatenate 'string "*" existing "*"))
-                        :message "message 5")))))))
-        ;; output text
-        (is (string= msg "error: message
+    (let* ((f (se:make-source-file program-file :name "file"))
+           (msg (with-output-to-string (output)
+                  ;; an annotating error
+                  (se:display-source-error
+                   output
+                   (se:source-error
+                    :span '(76 . 321)
+                    :file f
+                    :message "message"
+                    :primary-note "define instance form"
+                    :notes (list
+                            (se:make-source-error-note
+                             :type :secondary
+                             :span  '(132 . 319)
+                             :message "message 2")
+                            (se:make-source-error-note
+                             :type :secondary
+                             :span  '(140 . 145)
+                             :message "message 3")
+                            (se:make-source-error-note
+                             :type :secondary
+                             :span  '(170 . 174)
+                             :message "message 4"))
+                    :help-notes
+                    (list
+                     (se:make-source-error-help
+                      :span  '(289 . 291)
+                      :replacement (lambda (existing)
+                                     (concatenate 'string "*" existing "*"))
+                      :message "message 5")))))))
+      ;; output text
+      (is (string= msg "error: message
   --> file:9:2
     |
  9  |      (define-instance (Eq Kind)
@@ -81,4 +80,4 @@
 help: message 5
  16 |               (*==* a2 b2)))
     |                ----
-"))))))
+")))))

--- a/tests/parser-test-files/package.txt
+++ b/tests/parser-test-files/package.txt
@@ -75,3 +75,20 @@ error: Malformed package declaration
    |
  2 |    (import (something as)))
    |                         ^ missing package nickname
+
+================================================================================
+Unterminated package form
+================================================================================
+
+(package test
+  (import (something as s))
+
+--------------------------------------------------------------------------------
+
+error: Unterminated form
+  --> test:1:0
+   |
+ 1 |   (package test
+   |  _^
+ 2 | |   (import (something as s))
+   | |___________________________^ Missing close parenthesis for form starting at offset 0

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -8,24 +8,19 @@
                files))
 
            (parse-file (file)
-             (with-open-file (stream file
-                                     :direction :input
-                                     :element-type 'character
-                                     :external-format :utf-8)
-               (let ((stream (stream:make-char-position-stream stream)))
-                 (parser:with-reader-context stream
-                   (parser:read-program stream (se:make-file :stream stream :name (namestring file)) ':file)))))
+             (let ((source (source-error:make-source-file file :name "test")))
+               (with-open-stream (stream (source-error:file-stream source))
+                 (let ((stream (stream:make-char-position-stream stream)))
+                   (parser:with-reader-context stream
+                     (parser:read-program stream source ':file))))))
 
            (parse-error-text (file)
-             (with-open-file (stream file
-                                     :direction :input
-                                     :element-type 'character
-                                     :external-format :utf-8)
-               (let ((stream (stream:make-char-position-stream stream)))
+             (let ((source (source-error:make-source-file file :name "test")))
+               (with-open-stream (stream (source-error:file-stream source))
                  (handler-case
                      (parser:with-reader-context stream
                        (entry:entry-point
-                        (parser:read-program stream (se:make-file :stream stream :name "test") ':file))
+                        (parser:read-program stream source ':file))
                        "no errors")
                    (se:source-base-error (c)
                      (princ-to-string c)))))))


### PR DESCRIPTION
This change builds a source-error:file object immediately when Coalton is passed control of an input stream, so that any activity against that stream can be wrapped in a handler that rethrows lower-level reader errors as parser-errors.

source-error:file is made abstract, and the error printer reads source text from a newly opened stream when printing. This allows `file` objects to be attached directly to and dumped along with coalton objects to support runtime navigation to symbols, as #1194

Closes #1206 