### PR TITLE
Add a constant-propagation pass

### DIFF
--- a/coalton-compiler.asd
+++ b/coalton-compiler.asd
@@ -109,6 +109,7 @@
                              (:file "codegen-expression")
                              (:file "codegen-class")
                              (:file "monomorphize")
+                             (:file "constant-propagation")
                              (:file "optimizer")
                              (:file "program")
                              (:file "package")))

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -15,6 +15,7 @@
    #:binding-list                       ; TYPE
    #:node-literal                       ; STRUCT
    #:make-node-literal                  ; CONSTRUCTOR
+   #:node-literal-p                     ; FUNCTION
    #:node-literal-value                 ; READER
    #:node-variable                      ; STRUCT
    #:make-node-variable                 ; CONSTRUCTOR

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -44,6 +44,7 @@
    #:node-let-subexpr                   ; READER
    #:node-lisp                          ; STRUCT
    #:make-node-lisp                     ; CONSTRUCTOR
+   #:node-lisp-p                        ; FUNCTION
    #:node-lisp-vars                     ; READER
    #:node-lisp-form                     ; READER
    #:match-branch                       ; STRUCT

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -24,7 +24,7 @@
           (no-error
            nil)
           (t
-           (error "Expected VAR ~S to be a constant but is not" var)))))
+           (error "Expected VAR ~S to be a constant but it is not" var)))))
 
 (defun constant-node-p (env node constant-bindings)
   "If NODE is a constant, returns the constant value corresponding to it.

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -40,17 +40,11 @@
                  (and (node-variable-p node)
                       (constant-var-value (node-variable-value node) constant-bindings :no-error t))))
            (propagate-constants-node-variable (node constant-bindings)
-             (declare (type node-variable node))
              ;; FIXME: Do we need more nodes classified as constants?
-             (cond ((node-literal-p node)
-                    node)
-                   ((and (node-variable-p node)
-                         (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t))
-                    node)
-                   ((node-variable-p node)
-                    (constant-var-value (node-variable-value node) constant-bindings :no-error t))
-                   (t
-                    nil)))
+             (declare (type node-variable node))
+             (if (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t)
+                 node
+                 (constant-var-value (node-variable-value node) constant-bindings :no-error t)))
 
            (propagate-constants-node-let (node constant-bindings)
              (declare (type node-let node))

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -7,12 +7,8 @@
   (:import-from
    #:coalton-impl/codegen/traverse
    #:action
-   #:count-applications
-   #:count-nodes
-   #:make-traverse-let-action-skipping-cons-bindings
    #:*traverse*
-   #:traverse
-   #:traverse-with-binding-list)
+   #:traverse)
   (:export
    #:propagate-constants))
 

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -23,10 +23,16 @@
       "Bound inside CONSTANT-PROPAGATION.")
 
 (defun constant-var-value (var &key no-error)
-  (the (or node null)
-       (or (cdr (assoc var *constant-bindings*))
-           (unless no-error
-             (error "Expected VAR ~S to be a constant but is not" var)))))
+  (declare (type symbol var)
+           (values (or node null) &optional))
+  (let ((may-be-value (cdr (assoc var *constant-bindings*))))
+    (cond (may-be-value
+           ;; Whenever it exists, it is always a NODE (thus, non-NIL)
+           may-be-value)
+          (no-error
+           nil)
+          (t
+           (error "Expected VAR ~S to be a constant but is not" var)))))
 
 (defun propagate-constants (node env)
   (declare (optimize debug))

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -39,7 +39,8 @@
                       (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t))
                  (and (node-variable-p node)
                       (constant-var-value (node-variable-value node) constant-bindings :no-error t))))
-           (constant-node-value (node constant-bindings &key no-error)
+           (propagate-constants-node-variable (node constant-bindings)
+             (declare (type node-variable node))
              ;; FIXME: Do we need more nodes classified as constants?
              (cond ((node-literal-p node)
                     node)
@@ -47,16 +48,9 @@
                          (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t))
                     node)
                    ((node-variable-p node)
-                    (constant-var-value (node-variable-value node) constant-bindings :no-error no-error))
-                   (no-error
-                    nil)
+                    (constant-var-value (node-variable-value node) constant-bindings :no-error t))
                    (t
-                    (error "Expected the node to be a constant but is not ~%~S" node))))
-
-           (propagate-constants-node-variable (node constant-bindings)
-             (declare (type node-variable node))
-             (or (constant-node-value node constant-bindings :no-error t)
-                 node))
+                    nil)))
 
            (propagate-constants-node-let (node constant-bindings)
              (declare (type node-let node))

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -103,12 +103,11 @@
               :rator (node-direct-application-rator node)
               :rands (node-direct-application-rands node))))
 
-    (let ((*constant-bindings* nil))
-      (traverse
-       node
-       (list
-        (action (:after node-variable) #'propagate-constants-node-variable)
-        (action (:traverse node-let) #'propagate-constants-node-let)
-        (action (:after node-lisp) #'propagate-constants-node-lisp)
-        (action (:after node-direct-application) #'direct-application-better-infer-types))
-       nil))))
+    (traverse
+     node
+     (list
+      (action (:after node-variable) #'propagate-constants-node-variable)
+      (action (:traverse node-let) #'propagate-constants-node-let)
+      (action (:after node-lisp) #'propagate-constants-node-lisp)
+      (action (:after node-direct-application) #'direct-application-better-infer-types))
+     nil)))

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -33,7 +33,7 @@ If not, returns NIL"
            (type node node)
            (type list constant-bindings))
   (cond ((node-literal-p node)
-         (if (numberp (node-literal-value node))
+         (if (or (numberp (node-literal-value node)) (characterp (node-literal-value node)))
              node
              nil))
         ((node-variable-p node)

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -37,8 +37,8 @@ If not, returns NIL"
              node
              nil))
         ((node-variable-p node)
-         (cond ((and (eq 'coalton:boolean (node-type node))
-                     (member (node-variable-value node) '(coalton:true coalton:false)))
+         (cond ((and (eq 'coalton:Boolean (node-type node))
+                     (member (node-variable-value node) '(coalton:True coalton:False)))
                 node)
                ((tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t)
                 node)

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -124,6 +124,5 @@
         (action (:after node-variable) #'propagate-constants-node-variable)
         (action (:traverse node-let) #'propagate-constants-node-let)
         (action (:after node-lisp) #'propagate-constants-node-lisp)
-        (action (:after node-direct-application) #'direct-application-better-infer-types)
-        (make-traverse-let-action-skipping-cons-bindings))
+        (action (:after node-direct-application) #'direct-application-better-infer-types))
        nil))))

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -98,18 +98,16 @@
                     :form (node-lisp-form node)))))
 
            (direct-application-better-infer-types (node constant-bindings)
+             (declare (type node-direct-application node)
+                      (ignore constant-bindings))
              ;; FIXME: Can we do something similar for non-direct APPLICATION?
-             (let ((constant-propagated-rands
-                     (mapcar (lambda (rand)
-                               (funcall *traverse* rand constant-bindings))
-                             (node-direct-application-rands node))))
-               (make-node-direct-application
-                :type (node-type node)
-                :rator-type (tc:make-function-type*
-                             (mapcar #'node-type constant-propagated-rands)
-                             (tc:function-return-type (node-type node)))
-                :rator (node-direct-application-rator node)
-                :rands constant-propagated-rands))))
+             (make-node-direct-application
+              :type (node-type node)
+              :rator-type (tc:make-function-type*
+                           (mapcar #'node-type (node-direct-application-rands node))
+                           (tc:function-return-type (node-type node)))
+              :rator (node-direct-application-rator node)
+              :rands (node-direct-application-rands node))))
 
     (let ((*constant-bindings* nil))
       (traverse

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -1,0 +1,129 @@
+(defpackage #:coalton-impl/codegen/constant-propagation
+  (:use
+   #:cl
+   #:coalton-impl/codegen/ast)
+  (:local-nicknames
+   (#:tc #:coalton-impl/typechecker))
+  (:import-from
+   #:coalton-impl/codegen/traverse
+   #:action
+   #:count-applications
+   #:count-nodes
+   #:make-traverse-let-action-skipping-cons-bindings
+   #:*traverse*
+   #:traverse
+   #:traverse-with-binding-list)
+  (:export
+   #:propagate-constants))
+
+(in-package #:coalton-impl/codegen/constant-propagation)
+
+(defvar *constant-bindings*)
+(setf (documentation '*constant-bindings* 'variable)
+      "Bound inside CONSTANT-PROPAGATION.")
+
+(defun constant-var-value (var &key no-error)
+  (the (or node null)
+       (or (cdr (assoc var *constant-bindings*))
+           (unless no-error
+             (error "Expected VAR ~S to be a constant but is not" var)))))
+
+(defun propagate-constants (node env)
+  (declare (optimize debug))
+  (labels ((constant-node-p (node)
+             ;; FIXME: Do we need more nodes classified as constants?
+             (or (node-literal-p node)
+                 (and (node-variable-p node)
+                      (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t))
+                 (and (node-variable-p node)
+                      (constant-var-value (node-variable-value node) :no-error t))))
+           (constant-node-value (node &key no-error)
+             ;; FIXME: Do we need more nodes classified as constants?
+             (cond ((node-literal-p node)
+                    node)
+                   ((and (node-variable-p node)
+                         (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t))
+                    node)
+                   ((node-variable-p node)
+                    (constant-var-value (node-variable-value node) :no-error no-error))
+                   (no-error
+                    nil)
+                   (t
+                    (error "Expected the node to be a constant but is not ~%~S" node))))
+
+           (propagate-constants-node-variable (node call-stack)
+             (declare (ignore call-stack)
+                      (type node-variable node))
+             (or (constant-node-value node :no-error t)
+                 node))
+
+           (propagate-constants-node-let (node call-stack)
+             (declare (type node-let node))
+             (let ((node-bindings (node-let-bindings node))
+                   (new-constant-bindings nil)
+                   (nonconstant-bindings nil))
+               (loop :for (var . value) :in node-bindings
+                     :for propagated-value-node := (funcall *traverse* value call-stack)
+                     :do (if (constant-node-p propagated-value-node)
+                             (push (cons var propagated-value-node)
+                                   new-constant-bindings)
+                             (push (cons var propagated-value-node)
+                                   nonconstant-bindings)))
+               (let ((*constant-bindings* (append new-constant-bindings *constant-bindings*)))
+                 (if nonconstant-bindings
+                     (make-node-let
+                      :type (node-type node)
+                      :bindings nonconstant-bindings
+                      :subexpr (funcall *traverse* (node-let-subexpr node) call-stack))
+                     (funcall *traverse* (node-let-subexpr node) call-stack)))))
+
+           (propagate-constants-node-lisp (node call-stack)
+             (declare (type node-lisp node)
+                      (ignore call-stack))
+             (let* ((new-lisp-vars nil)
+                    (let-bindings
+                      (loop :for (lisp-var . coalton-var) :in (node-lisp-vars node)
+                            :for constant-value := (constant-var-value coalton-var :no-error t)
+                            :if constant-value
+                              :collect (let ((new-coalton-var (gentemp (symbol-name coalton-var))))
+                                         (push (cons lisp-var new-coalton-var) new-lisp-vars)
+                                         (cons new-coalton-var constant-value))
+                            :else
+                              :do (push (cons lisp-var coalton-var) new-lisp-vars))))
+               (if let-bindings
+                   (make-node-let
+                    :type (node-type node)
+                    :bindings let-bindings
+                    :subexpr (make-node-lisp
+                              :type (node-type node)
+                              :vars new-lisp-vars
+                              :form (node-lisp-form node)))
+                   (make-node-lisp
+                    :type (node-type node)
+                    :vars new-lisp-vars
+                    :form (node-lisp-form node)))))
+
+           (direct-application-better-infer-types (node call-stack)
+             ;; FIXME: Can we do something similar for non-direct APPLICATION?
+             (let ((constant-propagated-rands
+                     (mapcar (lambda (rand)
+                               (funcall *traverse* rand call-stack))
+                             (node-direct-application-rands node))))
+               (make-node-direct-application
+                :type (node-type node)
+                :rator-type (tc:make-function-type*
+                             (mapcar #'node-type constant-propagated-rands)
+                             (tc:function-return-type (node-type node)))
+                :rator (node-direct-application-rator node)
+                :rands constant-propagated-rands))))
+
+    (let ((*constant-bindings* nil))
+      (traverse
+       node
+       (list
+        (action (:after node-variable) #'propagate-constants-node-variable)
+        (action (:after node-let) #'propagate-constants-node-let)
+        (action (:after node-lisp) #'propagate-constants-node-lisp)
+        (action (:after node-direct-application) #'direct-application-better-infer-types)
+        (make-traverse-let-action-skipping-cons-bindings))
+       nil))))

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -122,7 +122,7 @@
        node
        (list
         (action (:after node-variable) #'propagate-constants-node-variable)
-        (action (:after node-let) #'propagate-constants-node-let)
+        (action (:traverse node-let) #'propagate-constants-node-let)
         (action (:after node-lisp) #'propagate-constants-node-lisp)
         (action (:after node-direct-application) #'direct-application-better-infer-types)
         (make-traverse-let-action-skipping-cons-bindings))

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -43,6 +43,9 @@
    #:coalton-impl/codegen/ast-substitutions
    #:apply-ast-substitution
    #:make-ast-substitution)
+  (:import-from
+   #:coalton-impl/codegen/constant-propagation
+   #:propagate-constants)
   (:local-nicknames
    (#:settings #:coalton-impl/settings)
    (#:util #:coalton-impl/util)
@@ -206,6 +209,8 @@
    node
    canonicalize
    (match-dynamic-extent-lift env)
+   ;; FIXME: Is this the right place to propagate-constants?
+   (propagate-constants env)
    (apply-specializations env)
    (resolve-static-superclass env)
    (inline-methods env)


### PR DESCRIPTION
EDIT: This PR aims to propagate constant literals or other constant objects such as obtained from node-lisp or dict-variables/codegen-syms required to resolve method instances. 

Two issues remain for future work:

1. Determining the set of constant objects might require a list of predicates which may be domain-specific. Let's leave that for future work. Implementing it is trivial, but brainstorming what the right way to do it might take some time. (See [this thread](https://github.com/coalton-lang/coalton/pull/1212#discussion_r1717913405).)
2. It turns out that while propagating constants, it also becomes possible to update the types of certain nodes. (See [this thread](https://github.com/coalton-lang/coalton/pull/1212#discussion_r1720887020).) It's also possible that there are other passes which may make it advantageous to update the node types. In that case, it seems more appropriate to implement node type updation in the traverse pass itself, rather than specifically as part of constant propagation. Thus, updating the traverse functions to update the node types is another branch of future work.

---

Consider the following example:

```lisp
(in-package :coalton-user)

(coalton-toplevel
  (declare add-df (double-float -> double-float -> double-float))
  (define (add-df x y)
    (lisp double-float (x y) (cl:+ x y)))

  (define (add-df-caller)
    (let ((x 5.0d0))
      (add-df x x))))
```

Without the constant-propagation pass, `(lookup-code 'add-df-caller)` returns a node containing a let with a variable binding followed by direct-application:

```lisp
#s(coalton-impl/codegen/ast:node-let
   :type double-float
   :bindings ((x-4321
               . #s(coalton-impl/codegen/ast:node-literal
                    :type double-float
                    :value 5.0d0)))
   :subexpr #s(coalton-impl/codegen/ast:node-direct-application
               :type double-float
               :rator-type (double-float → double-float → double-float)
               :rator add-df
               :rands (#s(coalton-impl/codegen/ast:node-variable
                          :type double-float
                          :value x-4321)
                         #s(coalton-impl/codegen/ast:node-variable
                            :type double-float
                            :value x-4321))))
```

With constant-propagation in place, the constant let bindings are substituted with the literals instead:

```lisp
#s(coalton-impl/codegen/ast:node-direct-application
   :type double-float
   :rator-type (double-float → double-float → double-float)
   :rator add-df
   :rands (#s(coalton-impl/codegen/ast:node-literal
              :type double-float
              :value 5.0d0)
             #s(coalton-impl/codegen/ast:node-literal
                :type double-float
                :value 5.0d0)))
```