### PR TITLE
Support 'shadow' clause in package.

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -224,6 +224,9 @@
                (:file "tarjan-scc-tests")
                (:file "reader-tests")
                (:file "error-tests")
+               (:module "parser"
+                :serial t
+                :components ((:file "cursor-tests")))
                (:file "parser-tests")
                (:file "entry-tests")
                (:file "toplevel-tests")

--- a/tests/parser-test-files/bad-files/package.1.coal
+++ b/tests/parser-test-files/bad-files/package.1.coal
@@ -1,2 +1,0 @@
-;; BAD: missing package name
-(package)

--- a/tests/parser-test-files/bad-files/package.1.error
+++ b/tests/parser-test-files/bad-files/package.1.error
@@ -1,5 +1,0 @@
-error: Malformed package declaration
-  --> test:2:8
-   |
- 2 |  (package)
-   |          ^ missing package name

--- a/tests/parser-test-files/bad-files/package.2.coal
+++ b/tests/parser-test-files/bad-files/package.2.coal
@@ -1,2 +1,0 @@
-;; BAD: invalid package name
-(package 5)

--- a/tests/parser-test-files/bad-files/package.2.error
+++ b/tests/parser-test-files/bad-files/package.2.error
@@ -1,5 +1,0 @@
-error: Malformed package declaration
-  --> test:2:9
-   |
- 2 |  (package 5)
-   |           ^ package name must be a symbol

--- a/tests/parser-test-files/bad-files/package.3.coal
+++ b/tests/parser-test-files/bad-files/package.3.coal
@@ -1,2 +1,0 @@
-;; BAD: invalid package declaration
-(pancake test)

--- a/tests/parser-test-files/bad-files/package.3.error
+++ b/tests/parser-test-files/bad-files/package.3.error
@@ -1,5 +1,0 @@
-error: Malformed package declaration
-  --> test:2:1
-   |
- 2 |  (pancake test)
-   |   ^^^^^^^ package declarations must start with `package`

--- a/tests/parser-test-files/bad-files/package.4.coal
+++ b/tests/parser-test-files/bad-files/package.4.coal
@@ -1,2 +1,0 @@
-;; BAD: Package
-(package test-package 1)

--- a/tests/parser-test-files/bad-files/package.4.error
+++ b/tests/parser-test-files/bad-files/package.4.error
@@ -1,5 +1,0 @@
-error: Malformed package declaration
-  --> test:2:22
-   |
- 2 |  (package test-package 1)
-   |                        ^ malformed package clause

--- a/tests/parser-test-files/package.txt
+++ b/tests/parser-test-files/package.txt
@@ -1,4 +1,44 @@
 ================================================================================
+Minimal package
+================================================================================
+
+(package coalton-unit-test/lib-example-simple)
+
+--------------------------------------------------------------------------------
+
+================================================================================
+Package with imports and exports
+================================================================================
+
+(package coalton-unit-test/lib-example-complex
+  (import
+    coalton-library/classes
+    (coalton-library/hash as hash))
+  (import-from
+    coalton-library/list
+    filter)
+  (export
+    first
+    second
+    third))
+
+--------------------------------------------------------------------------------
+
+================================================================================
+Missing package name
+================================================================================
+
+(package)
+
+--------------------------------------------------------------------------------
+
+error: Malformed package declaration
+  --> test:1:8
+   |
+ 1 |  (package)
+   |          ^ missing package name
+
+================================================================================
 Unknown package clause
 ================================================================================
 
@@ -12,7 +52,7 @@ error: Malformed package declaration
    |
  2 |    (xxx yyy zzz))
    |    ^^^^^^^^^^^^^ Unknown package clause
-help: Must be one of IMPORT, IMPORT-FROM, EXPORT
+help: Must be one of IMPORT, IMPORT-FROM, EXPORT, SHADOW
  2 |   (xxx yyy zzz))
    |    ---
 
@@ -75,3 +115,87 @@ error: Malformed package declaration
    |
  2 |    (import (something as)))
    |                         ^ missing package nickname
+
+================================================================================
+Shadow clause is accepted
+================================================================================
+
+(package test
+  (shadow and xor))
+
+--------------------------------------------------------------------------------
+
+================================================================================
+Missing dependencies
+================================================================================
+
+(package coalton-unit-test/package-c
+  (import coalton-unit-test/package-d))
+
+--------------------------------------------------------------------------------
+
+error: Malformed package declaration
+  --> test:1:0
+   |
+ 1 |   (package coalton-unit-test/package-c
+   |  _^
+ 2 | |   (import coalton-unit-test/package-d))
+   | |_______________________________________^ unable to evaluate package definition
+
+
+================================================================================
+Invalid package name
+================================================================================
+
+(package 5)
+
+--------------------------------------------------------------------------------
+
+error: Malformed package declaration
+  --> test:1:9
+   |
+ 1 |  (package 5)
+   |           ^ package name must be a symbol
+
+================================================================================
+Malformed clause
+================================================================================
+
+(package test-package 1)
+
+--------------------------------------------------------------------------------
+
+error: Malformed package declaration
+  --> test:1:22
+   |
+ 1 |  (package test-package 1)
+   |                        ^ malformed package clause
+
+================================================================================
+Invalid package declaration
+================================================================================
+
+(pancake test)
+
+--------------------------------------------------------------------------------
+
+error: Malformed package declaration
+  --> test:1:1
+   |
+ 1 |  (pancake test)
+   |   ^^^^^^^ package declarations must start with `package`
+
+================================================================================
+Invalid shadow clause
+================================================================================
+
+(package test
+  (shadow ()))
+
+--------------------------------------------------------------------------------
+
+error: Malformed package declaration
+  --> test:2:10
+   |
+ 2 |    (shadow ()))
+   |            ^^ value must be a symbol

--- a/tests/parser/cursor-tests.lisp
+++ b/tests/parser/cursor-tests.lisp
@@ -1,0 +1,32 @@
+(fiasco:define-test-package #:coalton-impl/parser/cursor-tests
+  (:use
+   #:cl)
+  (:local-nicknames
+   (#:parser #:coalton-impl/parser)
+   (#:cursor #:coalton-impl/parser/cursor)
+   (#:cst #:concrete-syntax-tree)))
+
+(in-package #:coalton-impl/parser/cursor-tests)
+
+(defun make-cursor (string)
+  (with-input-from-string (stream string)
+    (parser:with-reader-context stream
+      (cursor:make-cursor (parser:maybe-read-form stream parser::*coalton-eclector-client*)))))
+
+(deftest read-forward ()
+  (let ((c (make-cursor "(1 2 3)")))
+    (is (cst:consp (cursor:cursor-value c)))
+    (is (eql 1 (cursor:next c)))
+    (is (eql 2 (cursor:next c)))
+    (is (eql 3 (cursor:next c)))
+    (is (cursor:empty-p c))
+    (signals cursor:syntax-error
+      (cursor:next c))))
+
+(deftest collect-symbols ()
+  (let ((c (make-cursor "(a b c)")))
+    (is (equal '(a b c)
+               (cursor:collect-symbols c))))
+
+  (signals cursor:syntax-error
+    (cursor:collect-symbols (make-cursor "(a () c)"))))

--- a/tests/toplevel-tests.lisp
+++ b/tests/toplevel-tests.lisp
@@ -1,34 +1,14 @@
 (in-package #:coalton-tests)
 
-(defun parse-package (string)
+(defun check-package (string fn)
   "Parse the package form present in STRING."
   (with-input-from-string (stream string)
     (parser:with-reader-context stream
-      (let ((form (parser:maybe-read-form stream parser::*coalton-eclector-client*)))
-        (coalton-impl/parser/toplevel::parse-package
-         (coalton-impl/parser/cursor:make-cursor form))))))
-       
-
-(deftest test-parse-package ()
-  "Coalton toplevel package forms are successfully parsed."
-  (not-signals
-   parser:parse-error
-   (parse-package
-    "(package coalton-unit-test/lib-example-simple)"))
-  (not-signals
-   parser:parse-error
-   (parse-package
-    "(package coalton-unit-test/lib-example-complex
-          (import
-            coalton-library/classes
-            (coalton-library/hash as hash))
-          (import-from
-            coalton-library/list
-            filter)
-          (export
-            first
-            second
-            third))")))
+      (let* ((form (parser:maybe-read-form stream parser::*coalton-eclector-client*))
+             (file (se:make-file :stream stream :name "test"))
+             (package (coalton-impl/parser/toplevel::parse-package
+                       (coalton-impl/parser/cursor:make-cursor form))))
+        (funcall fn package file)))))
 
 (deftest test-lisp-package ()
   "Lisp packages can be constructed from parsed Coalton package forms."
@@ -45,28 +25,34 @@
 
     (del-pkg 'coalton-unit-test/package-b)
     (del-pkg 'coalton-unit-test/package-a)
+    (del-pkg 'coalton-unit-test/package-c)
 
-    (let* ((pkg-a (parse-package
-                   "(package coalton-unit-test/package-a
-                      (export a b c))"))
-           (lisp-pkg-a (coalton-impl/parser/toplevel::lisp-package pkg-a)))
-      (is (= 3 (length (ext-syms lisp-pkg-a))))
-      (is (equal '("COALTON")
-                 (use-pkgs lisp-pkg-a)))
-      (let* ((pkg-b (parse-package
-                     "(package coalton-unit-test/package-b
-                        (import coalton-unit-test/package-a
-                          (coalton-library/list as list))
-                        (export d e f))"))
-             (lisp-pkg-b (coalton-impl/parser/toplevel::lisp-package pkg-b)))
-        (is (= 3 (length (ext-syms lisp-pkg-b))))
-        (is (equal '("COALTON" "COALTON-UNIT-TEST/PACKAGE-A")
-                   (use-pkgs lisp-pkg-b)))))))
+    (check-package
+     "(package coalton-unit-test/package-a
+        (export a b c))"
+     (lambda (pkg-a file)
+       (let ((lisp-pkg-a (coalton-impl/parser/toplevel::lisp-package pkg-a file)))
+         (is (= 3 (length (ext-syms lisp-pkg-a))))
+         (is (equal '("COALTON")
+                    (use-pkgs lisp-pkg-a))))))
 
-(deftest test-lisp-package-error ()
-  "An error is signaled when attempting to construct packages with missing dependencies."
-  (signals error
-    (let ((package (parse-package
-                    "(package coalton-unit-test/package-c
-                       (import coalton-unit-test/package-d))")))
-      (coalton-impl/parser/toplevel::lisp-package package))))
+    (check-package
+     "(package coalton-unit-test/package-b
+        (import coalton-unit-test/package-a
+          (coalton-library/list as list))
+        (export d e f))"
+     (lambda (pkg-b file)
+       (let ((lisp-pkg-b (coalton-impl/parser/toplevel::lisp-package pkg-b file)))
+         (is (= 3 (length (ext-syms lisp-pkg-b))))
+         (is (equal '("COALTON" "COALTON-UNIT-TEST/PACKAGE-A")
+                    (use-pkgs lisp-pkg-b))))))
+
+    (check-package
+     "(package coalton-unit-test/package-c
+        (shadow not))"
+     (lambda (pkg-c file)
+       (let ((lisp-pkg-c (coalton-impl/parser/toplevel::lisp-package pkg-c file)))
+         (is (= 1 (length (package-shadowing-symbols lisp-pkg-c))))
+         (is (equal "NOT"
+                    (symbol-name (first
+                                  (package-shadowing-symbols lisp-pkg-c))))))))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -112,7 +112,8 @@ Returns (values SOURCE-PATHNAME COMPILED-PATHNAME)."
             :in (coalton-tests/loader:load-suite file)
           :for generated-error := (collect-compiler-error program)
           :do (cond ((null generated-error)
-                     (is nil "program should have failed to compile: ~A" description))
+                     (is (zerop (length expected-error))
+                         "program should have failed to compile: ~A" description))
                     (t
                      (check-string= (format nil "program text.~%~
 input file: ~A~%~


### PR DESCRIPTION
Extend the syntax of `package` to support shadowing of symbols:

```
(package
  ...
  (shadow a b c ...))
```

This has the same effect as a Lisp defpackage :shadow clause. 


- unify package tests
  - where possible, move tests to single-file test suite in parser-test-files/package.txt
- add cursor tests
- add condition printer for cursor errors
- add source span to package AST node
- support 'good' assertions in parser test suite input files
  - if error block is blank, parser input should be accepted

Closes #1210