### PR TITLE
Bind *print-circle* t when dumping Lisp code

### DIFF
--- a/src/codegen/ast-substitutions.lisp
+++ b/src/codegen/ast-substitutions.lisp
@@ -48,7 +48,7 @@ a subtree of `node`."
     (action (:after node-lisp node)
       (multiple-value-bind (let-bindings lisp-var-bindings)
           (loop :for (lisp-var . coalton-var) :in (node-lisp-vars node)
-                :for new-var := (gentemp (symbol-name coalton-var))
+                :for new-var := (gensym (symbol-name coalton-var))
                 :for res := (find coalton-var subs :key #'ast-substitution-from)
                 :if (and res (node-variable-p (ast-substitution-to res)))
                   :collect (cons lisp-var (node-variable-value (ast-substitution-to res)))

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -123,7 +123,7 @@
     (let ((match-expr (codegen-expression (node-while-let-expr expr) env))
           (body-expr (codegen-expression (node-while-let-body expr) env))
           (label (node-while-let-label expr))
-          (match-var (gentemp "MATCH")))
+          (match-var (gensym "MATCH")))
 
       (multiple-value-bind (pred bindings)
           (codegen-pattern (node-while-let-pattern expr) match-var env)
@@ -174,7 +174,7 @@
 
     ;; Otherwise do the thing
     (let ((subexpr (codegen-expression (node-match-expr expr) env))
-          (match-var (gentemp "MATCH")))
+          (match-var (gensym "MATCH")))
       `(let ((,match-var
                ,(if settings:*emit-type-annotations*
                     `(the ,(tc:lisp-type (node-type (node-match-expr expr)) env) ,subexpr)

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -277,12 +277,12 @@
                               :if orig-param-names
                                 :collect (let ((param (nth (+ i (length args)) orig-param-names)))
                                            (if (parser:pattern-var-p param)
-                                               (gentemp (concatenate 'string
+                                               (gensym (concatenate 'string
                                                                      (symbol-name (parser:pattern-var-name param))
                                                                      "-"))
-                                               (gentemp)))
+                                               (gensym)))
                               :else
-                                :collect (gentemp)))
+                                :collect (gensym)))
 
            (param-types (subseq (tc:function-type-arguments (node-type function)) (length args)))
 
@@ -379,7 +379,7 @@ requires direct constructor calls."
                ;; a unique xi').
                :for var :in vars
                :for val :in vals
-               :for new-var := (gentemp (symbol-name var))
+               :for new-var := (gensym (symbol-name var))
                :collect (cons new-var val)
                  :into bindings
                :collect (make-ast-substitution

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -76,9 +76,9 @@ TRANSLATE-EXPRESSION when an abstraction is being translated.")
                      :if (tc:pattern-var-p param)
                        :collect (tc:pattern-var-name param)
                      :else :if (tc:pattern-wildcard-p param)
-                             :collect (gentemp "_")
+                             :collect (gensym "_")
                      :else
-                       :collect (let ((name (gentemp)))
+                       :collect (let ((name (gensym)))
                                   (push (cons name param) pattern-params)
                                   name)))
 
@@ -109,7 +109,7 @@ TRANSLATE-EXPRESSION when an abstraction is being translated.")
                      :if (tc:pattern-var-p param)
                        :collect (tc:pattern-var-name param)
                      :else :if (tc:pattern-wildcard-p param)
-                             :collect (gentemp "_")
+                             :collect (gensym "_")
                      :else
                        :collect (let ((name (gensym)))
                                   (push (cons name param) pattern-params)
@@ -337,7 +337,7 @@ Returns a `node'.")
                         :if (tc:pattern-var-p param)
                           :collect (tc:pattern-var-name param)
                         :else
-                          :collect (let ((name (gentemp)))
+                          :collect (let ((name (gensym)))
                                      (push (cons name param) pattern-params)
                                      name)))))
 
@@ -838,7 +838,7 @@ Returns a `node'.")
 
                                 (callback-ty (tc:make-function-type var-type (node-type out-node)))
 
-                                (var-name (gentemp)))
+                                (var-name (gensym)))
 
                            (make-node-application
                             :type (node-type out-node)
@@ -874,7 +874,7 @@ Returns a `node'.")
 
                                 (callback-ty (tc:make-function-type var-type (node-type out-node)))
 
-                                (var-name (gentemp)))
+                                (var-name (gensym)))
 
                            (make-node-application
                             :type (node-type out-node)

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -228,6 +228,9 @@
   (with-standard-io-syntax
     (let ((*package* (find-package package))
           (*print-case* ':downcase)
+          ;; *print-circle* t allows gensym-generated, uninterned
+          ;; *symbols to serve as variables in readable source.
+          (*print-circle* t)
           (*print-pretty* t)
           (*print-right-margin* 80))
       (prin1 form stream)


### PR DESCRIPTION
Variable names must be interned symbols when written as lisp code.

These cases came up during benchmarking and library conversion.

# Note

Binding `*print-circle* t` produces working code, so this MR was changed to replace most cases of `gentemp` in codegen with `gensym`.