### PR TITLE
Define a docstring generic function

### DIFF
--- a/src/codegen/codegen-type-definition.lisp
+++ b/src/codegen/codegen-type-definition.lisp
@@ -8,6 +8,7 @@
    #:struct-or-class-field-name)
   (:local-nicknames
    (#:settings #:coalton-impl/settings)
+   (#:source #:coalton-impl/source)
    (#:global-lexical #:coalton-impl/global-lexical)
    (#:tc #:coalton-impl/typechecker)
    (#:rt #:coalton-impl/runtime))
@@ -46,13 +47,13 @@
              `(defstruct (,(tc:type-definition-name def)
                           (:constructor nil)
                           (:predicate nil))
-                ,@(when (tc:type-definition-docstring def)
-                    (list (tc:type-definition-docstring def))))
+                ,@(when (source:docstring def)
+                    (list (source:docstring def))))
 
              `(defclass ,(tc:type-definition-name def) ()
                 ()
-                ,@(when (tc:type-definition-docstring def)
-                    `((:documentation ,(tc:type-definition-docstring def))))))
+                ,@(when (source:docstring def)
+                    `((:documentation ,(source:docstring def))))))
 
         (defmethod make-load-form ((,(intern "OBJ") ,(tc:type-definition-name def)) &optional ,(intern "ENV"))
           (make-load-form-saving-slots ,(intern "OBJ") :environment ,(intern "ENV")))

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -241,11 +241,11 @@ Example:
         :for type := (tc:lookup-value-type env name :no-error t)
         :for docstring
           := (cond
-               ((and entry (tc:name-entry-docstring entry) type)
-                (format nil "~A :: ~A~%~A" name type (tc:name-entry-docstring entry)))
+               ((and entry (source:docstring entry) type)
+                (format nil "~A :: ~A~%~A" name type (source:docstring entry)))
 
-               ((and entry (tc:name-entry-docstring entry))
-                (tc:name-entry-docstring entry))
+               ((and entry (source:docstring entry))
+                (source:docstring entry))
 
                 (type
                  (format nil "~A :: ~A" name type)))

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -49,6 +49,7 @@
    #:coalton/doc/base
    #:coalton/doc/model)
   (:local-nicknames
+   (#:source #:coalton-impl/source)
    (#:tc #:coalton-impl/typechecker)))
 
 (in-package #:coalton/doc/markdown)
@@ -133,7 +134,7 @@
               :do (format stream "- <code>")
                   (write-string (to-markdown instance) stream)
                   (format stream "</code>~:[~;  ~%~:*~A~]~%"
-                          (tc:ty-class-instance-docstring instance)))
+                          (source:docstring instance)))
         (format stream "~%</details>~%~%")))))
 
 (defun source-location-link (backend object)

--- a/src/doc/model.lisp
+++ b/src/doc/model.lisp
@@ -152,7 +152,7 @@
                                          (tc:ty-scheme-type ctor-type)))))
 
 (defmethod object-doc ((self coalton-type))
-  (tc:type-entry-docstring (type-entry self)))
+  (source:docstring (type-entry self)))
 
 (defmethod source-location ((self coalton-type))
   (tc:type-entry-location (type-entry self)))
@@ -191,7 +191,7 @@
     (mapcar (lambda (field)
               (list (tc:struct-field-name field)
                     (tc:struct-field-type field)
-                    (tc:struct-field-docstring field)))
+                    (source:docstring field)))
             (tc:struct-entry-fields struct-entry))))
 
 (defmethod object-name ((self coalton-struct))
@@ -205,7 +205,7 @@
   (tc:type-entry-location (type-entry self)))
 
 (defmethod object-doc ((self coalton-struct))
-  (tc:type-entry-docstring (type-entry self)))
+  (source:docstring (type-entry self)))
 
 (defmethod object-type ((self coalton-struct))
   "STRUCT")
@@ -221,7 +221,7 @@
             :reader class-package)))
 
 (defmethod object-doc ((self coalton-class))
-  (tc:ty-class-docstring (ty-class self)))
+  (source:docstring (ty-class self)))
 
 (defmethod source-location ((self coalton-class))
   (tc:ty-class-location (ty-class self)))
@@ -244,7 +244,7 @@
     (mapcar (lambda (method)
               (list (symbol-name (tc:ty-class-method-name method))
                     (tc:ty-class-method-type method)
-                    (tc:ty-class-method-docstring method)))
+                    (source:docstring method)))
             (remove-if (lambda (method)
                          (and package (exported-symbol-p (tc:ty-class-method-name method) package t)))
                        (tc:ty-class-unqualified-methods class)))))
@@ -277,7 +277,7 @@
   (tc:function-type-p (value-type coalton-value)))
 
 (defmethod object-doc ((self coalton-value))
-  (tc:name-entry-docstring (name-entry self)))
+  (source:docstring (name-entry self)))
 
 (defmethod source-location ((self coalton-value))
   (tc:name-entry-location (name-entry self)))

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/parser/renamer
   (:use
    #:cl
+   #:coalton-impl/source
    #:coalton-impl/parser/base
    #:coalton-impl/parser/types
    #:coalton-impl/parser/pattern
@@ -470,7 +471,7 @@
         :name (toplevel-define-name toplevel)
         :params (rename-variables-generic% (toplevel-define-params toplevel) new-ctx)
         :orig-params (toplevel-define-orig-params toplevel)
-        :docstring (toplevel-define-docstring toplevel)
+        :docstring (docstring toplevel)
         :body (rename-variables-generic% (toplevel-define-body toplevel) new-ctx)
         :location (toplevel-define-location toplevel)
         :monomorphize (toplevel-define-monomorphize toplevel))
@@ -503,7 +504,7 @@
       :methods (rename-variables-generic% (toplevel-define-instance-methods toplevel) ctx)
       :location (toplevel-define-instance-location toplevel)
       :head-location (toplevel-define-instance-head-location toplevel)
-      :docstring (toplevel-define-instance-docstring toplevel)
+      :docstring (docstring toplevel)
       :compiler-generated (toplevel-define-instance-compiler-generated toplevel))
      ctx))
 
@@ -619,7 +620,7 @@
       (make-toplevel-define-type
        :name (toplevel-define-type-name toplevel)
        :vars (rename-type-variables-generic% (toplevel-define-type-vars toplevel) new-ctx)
-       :docstring (toplevel-define-type-docstring toplevel)
+       :docstring (docstring toplevel)
        :ctors (rename-type-variables-generic% (toplevel-define-type-ctors toplevel) new-ctx)
        :location (toplevel-define-type-location toplevel)
        :repr (toplevel-define-type-repr toplevel)
@@ -632,7 +633,7 @@
     (make-struct-field
      :name (struct-field-name field)
      :type (rename-type-variables-generic% (struct-field-type field) ctx)
-     :docstring (struct-field-docstring field)
+     :docstring (docstring field)
      :location (struct-field-location field)))
 
   (:method ((toplevel toplevel-define-struct) ctx)
@@ -648,7 +649,7 @@
       (make-toplevel-define-struct
        :name (toplevel-define-struct-name toplevel)
        :vars (rename-type-variables-generic% (toplevel-define-struct-vars toplevel) new-ctx)
-       :docstring (toplevel-define-struct-docstring toplevel)
+       :docstring (docstring toplevel)
        :fields (rename-type-variables-generic% (toplevel-define-struct-fields toplevel) new-ctx)
        :location (toplevel-define-struct-location toplevel)
        :repr (toplevel-define-struct-repr toplevel)
@@ -680,7 +681,7 @@
       (make-method-definition
        :name (method-definition-name method)
        :type (rename-type-variables-generic% (method-definition-type method) new-ctx)
-       :docstring (method-definition-docstring method)
+       :docstring (docstring method)
        :location (method-definition-location method))))
 
   (:method ((toplevel toplevel-define-class) ctx)
@@ -698,7 +699,7 @@
        :vars (rename-type-variables-generic% (toplevel-define-class-vars toplevel) new-ctx)
        :preds (rename-type-variables-generic% (toplevel-define-class-preds toplevel) new-ctx)
        :fundeps (rename-type-variables-generic% (toplevel-define-class-fundeps toplevel) new-ctx)
-       :docstring (toplevel-define-class-docstring toplevel)
+       :docstring (docstring toplevel)
        :methods (rename-type-variables-generic% (toplevel-define-class-methods toplevel) new-ctx)
        :location (toplevel-define-class-location toplevel)
        :head-location (toplevel-define-class-head-location toplevel))))

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -35,7 +35,6 @@
    #:make-toplevel-define-type                   ; CONSTRUCTOR
    #:toplevel-define-type-name                   ; ACCESSOR
    #:toplevel-define-type-vars                   ; ACCESSOR
-   #:toplevel-define-type-docstring              ; ACCESSOR
    #:toplevel-define-type-ctors                  ; ACCESSOR
    #:toplevel-define-type-location               ; ACCESSOR
    #:toplevel-define-type-repr                   ; ACCESSOR
@@ -45,14 +44,12 @@
    #:make-struct-field                           ; CONSTRUCTOR
    #:struct-field-name                           ; ACCESSOR
    #:struct-field-type                           ; ACCESSOR
-   #:struct-field-docstring                      ; ACCESSOR
    #:struct-field-location                       ; ACCESSOR
    #:struct-field-list                           ; TYPE
    #:toplevel-define-struct                      ; STRUCT
    #:make-toplevel-define-struct                 ; CONSTRUCTOR
    #:toplevel-define-struct-name                 ; ACCESSOR
    #:toplevel-define-struct-vars                 ; ACCESSOR
-   #:toplevel-define-struct-docstring            ; ACCESSOR
    #:toplevel-define-struct-fields               ; ACCESSOR
    #:toplevel-define-struct-location             ; ACCESSOR
    #:toplevel-define-struct-repr                 ; ACCESSOR
@@ -70,7 +67,6 @@
    #:toplevel-define-name                        ; ACCESSOR
    #:toplevel-define-params                      ; ACCESSOR
    #:toplevel-define-orig-params                 ; ACCESSOR
-   #:toplevel-define-docstring                   ; ACCESSOR
    #:toplevel-define-body                        ; ACCESSOR
    #:toplevel-define-location                    ; ACCESSOR
    #:toplevel-define-monomorphize                ; ACCESSOR
@@ -85,7 +81,6 @@
    #:make-method-definition                      ; STRUCT
    #:method-definition-name                      ; ACCESSOR
    #:method-definition-type                      ; ACCESSOR
-   #:method-definition-docstring                 ; ACCESSOR
    #:method-definition-location                  ; ACCESSOR
    #:method-definition-list                      ; TYPE
    #:toplevel-define-class                       ; STRUCT
@@ -94,9 +89,7 @@
    #:toplevel-define-class-vars                  ; ACCESSOR
    #:toplevel-define-class-preds                 ; ACCESSOR
    #:toplevel-define-class-fundeps               ; ACCESSOR
-   #:toplevel-define-class-docstring             ; ACCESSOR
    #:toplevel-define-class-methods               ; ACCESSOR
-   #:toplevel-define-class-method-docstrings     ; ACCESSOR
    #:toplevel-define-class-location              ; ACCESSOR
    #:toplevel-define-class-head-location         ; ACCESSOR
    #:toplevel-define-class-list                  ; TYPE
@@ -114,7 +107,6 @@
    #:toplevel-define-instance-methods            ; ACCESSOR
    #:toplevel-define-instance-location           ; ACCESSOR
    #:toplevel-define-instance-head-location      ; ACCESSOR
-   #:toplevel-define-instance-docstring          ; ACCESSOR
    #:toplevel-define-instance-compiler-generated ; ACCESSOR
    #:toplevel-define-instance-list               ; TYPE
    #:toplevel-package-name                       ; ACCESSOR
@@ -259,6 +251,9 @@
   (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
   (head-location  (util:required 'head-location)  :type location                     :read-only t))
 
+(defmethod docstring ((self toplevel-define-type))
+  (toplevel-define-type-docstring self))
+
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-type-list-p (x)
     (and (alexandria:proper-list-p x)
@@ -273,6 +268,9 @@
   (type      (util:required 'type)      :type ty               :read-only t)
   (docstring (util:required 'docstring) :type (or null string) :read-only t)
   (location    (util:required 'location)    :type location             :read-only t))
+
+(defmethod docstring ((self struct-field))
+  (struct-field-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun struct-field-list-p (x)
@@ -291,6 +289,9 @@
   (location    (util:required 'location)    :type location          :read-only t)
   (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
   (head-location  (util:required 'head-location)  :type location          :read-only t))
+
+(defmethod docstring ((self toplevel-define-struct))
+  (toplevel-define-struct-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-struct-list-p (x)
@@ -325,6 +326,9 @@
   (location       (util:required 'location)       :type location                  :read-only t)
   (monomorphize (util:required 'monomorphize) :type (or null attribute-monomorphize) :read-only nil))
 
+(defmethod docstring ((self toplevel-define))
+  (toplevel-define-docstring self))
+
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-list-p (x)
     (and (alexandria:proper-list-p x)
@@ -353,6 +357,9 @@
   (docstring (util:required 'docstring) :type (or string null) :read-only t)
   (location    (util:required 'location)    :type location  :read-only t))
 
+(defmethod docstring ((self method-definition))
+  (method-definition-docstring self))
+
 (defmethod make-load-form ((self method-definition) &optional env)
   (make-load-form-saving-slots self :environment env))
 
@@ -374,6 +381,9 @@
   (location    (util:required 'location)    :type location        :read-only t)
   ;; Source information for context, name, and vars
   (head-location  (util:required 'head-location) :type location         :read-only t))
+
+(defmethod docstring ((self toplevel-define-class))
+  (toplevel-define-class-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-class-list-p (x)
@@ -408,6 +418,9 @@
   ;; Source information for the context and the pred
   (head-location           (util:required 'head-location)           :type location                 :read-only t)
   (compiler-generated (util:required 'compiler-generated) :type boolean                         :read-only t))
+
+(defmethod docstring ((self toplevel-define-instance))
+  (toplevel-define-instance-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-instance-list-p (x)

--- a/src/parser/type-definition.lisp
+++ b/src/parser/type-definition.lisp
@@ -21,7 +21,6 @@
    #:type-definition-location             ; FUNCTION
    #:type-definition-vars               ; FUNCTION
    #:type-definition-repr               ; FUNCTION
-   #:type-definition-docstring          ; FUNCTION
    #:type-definition-ctors              ; FUNCTION
    #:type-definition-ctor-name          ; FUNCTION
    #:type-definition-ctor-location        ; FUNCTION
@@ -78,15 +77,6 @@
   (:method ((def toplevel-define-struct))
     (declare (values (or null attribute-repr)))
     (toplevel-define-struct-repr def)))
-
-(defgeneric type-definition-docstring (def)
-  (:method ((def toplevel-define-type))
-    (declare (values (or null string)))
-    (toplevel-define-type-docstring def))
-
-  (:method ((def toplevel-define-struct))
-    (declare (values (or null string)))
-    (toplevel-define-struct-docstring def)))
 
 (defgeneric type-definition-ctors (def)
   (:method ((def toplevel-define-type))

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -11,6 +11,7 @@
    #:make-location
    #:location-source
    #:location-span
+   #:docstring
    #:source-error))
 
 (in-package #:coalton-impl/source)
@@ -126,6 +127,9 @@ OFFSET indicates starting character offset within the file."
 
 (defmethod source-error:source-name ((self source-string))
   (or (original-name self) "<string input>"))
+
+(defgeneric docstring (object)
+  (:documentation "The docstring accompanying a Coalton object's definition."))
 
 (defstruct (location
             (:constructor %make-location))

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -294,11 +294,11 @@
 
                                              :collect (tc:make-ty-class-method :name method-name
                                                                                :type (tc:quantify nil method-ty)
-                                                                               :docstring (parser:method-definition-docstring method)))
+                                                                               :docstring (source:docstring method)))
                   :codegen-sym codegen-sym
                   :superclass-dict superclass-dict
                   :superclass-map superclass-map
-                  :docstring (parser:toplevel-define-class-docstring class)
+                  :docstring (source:docstring class)
                   :location (parser:toplevel-define-class-location class))
 
            :for method-tys := (loop :for (name . qual-ty) :in unqualifed-methods

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -115,15 +115,13 @@
                                                          method-name))
                      :finally (return table)))
 
-             (docstring (parser:toplevel-define-instance-docstring instance))
-
              (instance-entry
                (tc:make-ty-class-instance
                 :constraints context
                 :predicate pred
                 :codegen-sym instance-codegen-sym
                 :method-codegen-syms method-codegen-syms
-                :docstring docstring)))
+                :docstring (source:docstring instance))))
 
         (cond (context
                (setf env (tc:set-function env instance-codegen-sym (tc:make-function-env-entry

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -52,9 +52,11 @@
   (constructors      (util:required 'constructors)      :type tc:constructor-entry-list :read-only t)
   (constructor-types (util:required 'constructor-types) :type tc:scheme-list            :read-only t)
   (constructor-args  (util:required 'constructor-args)  :type list                      :read-only t)
-
   (docstring         (util:required 'docstring)         :type (or null string)          :read-only t)
-  (location            (util:required 'location)            :type location                      :read-only t))
+  (location          (util:required 'location)          :type location                  :read-only t))
+
+(defmethod docstring ((self type-definition))
+  (type-definition-docstring self))
 
 (defstruct field-definition
   (name   (util:required 'name)   :type symbol :read-only t)
@@ -237,7 +239,7 @@
                              :collect (tc:make-struct-field :name (parser:struct-field-name field)
                                                             :type ty
                                                             :index index
-                                                            :docstring (parser:struct-field-docstring field)))))
+                                                            :docstring (docstring field)))))
            (setf env (tc:set-struct
                       env
                       (type-definition-name type)
@@ -262,7 +264,7 @@
           :explicit-repr (type-definition-explicit-repr type)
           :enum-repr (type-definition-enum-repr type)
           :newtype (type-definition-newtype type)
-          :docstring (type-definition-docstring type)
+          :docstring (docstring type)
           :location (parser:type-definition-location parsed-type))))
 
   ;; Define the type's constructors in the environment
@@ -441,7 +443,7 @@
 
                                 :constructor-types constructor-types
                                 :constructor-args constructor-args
-                                :docstring (parser:type-definition-docstring type)
+                                :docstring (docstring type)
                                 :location (parser:type-definition-location type)))
 
                              (runtime-repr-instance (maybe-runtime-repr-instance type-definition)))

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -191,7 +191,7 @@
               :do (setf env (tc:set-name env name (tc:make-name-entry
                                                    :name name
                                                    :type :value
-                                                   :docstring (parser:toplevel-define-docstring define)
+                                                   :docstring (docstring define)
                                                    :location (parser:binding-location define))))
 
               :if (parser:toplevel-define-orig-params define)

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -39,7 +39,6 @@
    #:type-entry-explicit-repr               ; ACCESSOR
    #:type-entry-enum-repr                   ; ACCESSOR
    #:type-entry-newtype                     ; ACCESSOR
-   #:type-entry-docstring                   ; ACCESSOR
    #:type-entry-location                    ; ACCESSOR
    #:type-environment                       ; STRUCT
    #:constructor-entry                      ; STRUCT
@@ -56,7 +55,6 @@
    #:struct-field-name                      ; ACCESSOR
    #:struct-field-type                      ; ACCESSOR
    #:struct-field-index                     ; ACCESSOR
-   #:struct-field-docstring                 ; ACCESSOR
    #:struct-field-list                      ; TYPE
    #:struct-entry                           ; STRUCT
    #:make-struct-entry                      ; CONSTRUCTOR
@@ -69,7 +67,6 @@
    #:make-ty-class-method                   ; CONSTRUCTOR
    #:ty-class-method-name                   ; ACCESSOR
    #:ty-class-method-type                   ; ACCESSOR
-   #:ty-class-method-docstring              ; ACCESSOR
    #:ty-class                               ; STRUCT
    #:make-ty-class                          ; CONSTRUCTOR
    #:ty-class-name                          ; ACCESSOR
@@ -82,7 +79,6 @@
    #:ty-class-codegen-sym                   ; ACCESSOR
    #:ty-class-superclass-dict               ; ACCESSOR
    #:ty-class-superclass-map                ; ACCESSOR
-   #:ty-class-docstring                     ; ACCESSOR
    #:ty-class-location                      ; ACCESSOR
    #:ty-class-list                          ; TYPE
    #:class-environment                      ; STRUCT
@@ -92,7 +88,6 @@
    #:ty-class-instance-predicate            ; ACCESSOR
    #:ty-class-instance-codegen-sym          ; ACCESSOR
    #:ty-class-instance-method-codegen-syms  ; ACCESSOR
-   #:ty-class-instance-docstring            ; ACCESSOR
    #:ty-class-instance-list                 ; TYPE
    #:instance-environment                   ; STRUCT
    #:instance-environment-instances         ; ACCESSOR
@@ -105,7 +100,6 @@
    #:make-name-entry                        ; CONSTRUCTOR
    #:name-entry-name                        ; ACCESSOR
    #:name-entry-type                        ; ACCESSOR
-   #:name-entry-docstring                   ; ACCESSOR
    #:name-entry-location                      ; ACCESSOR
    #:name-environment                       ; STRUCT
    #:method-inline-environment              ; STRUCT
@@ -275,6 +269,9 @@
 
   (docstring (util:required 'docstring) :type (or null string)   :read-only t)
   (location  nil                        :type (or null location) :read-only t))
+
+(defmethod docstring ((self type-entry))
+  (type-entry-docstring self))
 
 (defmethod make-load-form ((self type-entry) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -502,6 +499,9 @@
   (index     (util:required 'index)     :type fixnum            :read-only t)
   (docstring (util:required 'docstring) :type (or null string)  :read-only t))
 
+(defmethod docstring ((self struct-field))
+  (struct-field-docstring self))
+
 (defmethod make-load-form ((self struct-field) &optional env)
   (make-load-form-saving-slots self :environment env))
 
@@ -516,6 +516,9 @@
   (name             (util:required 'name)      :type symbol            :read-only t)
   (fields           (util:required 'fields)    :type struct-field-list :read-only t)
   (docstring        (util:required 'docstring) :type (or null string)  :read-only t))
+
+(defmethod docstring ((self struct-entry))
+  (struct-entry-docstring self))
 
 (defmethod make-load-form ((self struct-entry) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -546,6 +549,9 @@
   (type      (util:required 'type)      :type ty-scheme        :read-only t)
   (docstring (util:required 'docstring) :type (or null string) :read-only t))
 
+(defmethod docstring ((self ty-class-method))
+  (ty-class-method-docstring self))
+
 (defmethod make-load-form ((self ty-class-method) &optional env)
   (make-load-form-saving-slots self :environment env))
 
@@ -574,6 +580,9 @@
   (superclass-map      (util:required 'superclass-map)      :type environment-map     :read-only t)
   (docstring           (util:required 'docstring)           :type (or null string)    :read-only t)
   (location              (util:required 'location)              :type location :read-only t))
+
+(defmethod docstring ((self ty-class))
+  (ty-class-docstring self))
 
 (defmethod make-load-form ((self ty-class) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -636,6 +645,9 @@
   (codegen-sym         (util:required 'codegen-sym)         :type symbol            :read-only t)
   (method-codegen-syms (util:required 'method-codegen-syms) :type environment-map   :read-only t)
   (docstring           (util:required 'docstring)           :type (or null string)  :read-only t))
+
+(defmethod docstring ((self ty-class-instance))
+  (ty-class-instance-docstring self))
 
 (defmethod make-load-form ((self ty-class-instance) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -705,6 +717,9 @@
   (type      (util:required 'type)      :type (member :value :method :constructor) :read-only t)
   (docstring (util:required 'docstring) :type (or null string)                     :read-only t)
   (location    (util:required 'location)    :type location                      :read-only t))
+
+(defmethod docstring ((self name-entry))
+  (name-entry-docstring self))
 
 (defmethod make-load-form ((self name-entry) &optional env)
   (make-load-form-saving-slots self :environment env))


### PR DESCRIPTION
Generalize coalton-impl/parser:type-definition-docstring so that it works for all toplevel definitions.

Part of support for generic source information protocols in doc generation and IDE: documentation lookup, definition location.