### PR TITLE
source:location generic function

### DIFF
--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -68,7 +68,7 @@
 
   (declare with-capacity (Hash :key => Integer -> Hashtable :key :value))
   (define (with-capacity capacity)
-    "Crate a new empty hashtable with a given capacity"
+    "Create a new empty hashtable with a given capacity"
     (match (%get-hash-test-funcs)
       ((Tuple test hash)
        (%make-hashtable test hash capacity))))

--- a/src/analysis/analysis.lisp
+++ b/src/analysis/analysis.lisp
@@ -34,7 +34,7 @@
 
   (let ((missing (find-non-matching-value (list (list pattern)) 1 env)))
     (unless (eq t missing)
-      (tc-error (tc:pattern-location pattern)
+      (tc-error pattern
                 "Non-exhaustive match"
                 (format nil "Missing case ~W"
                         (print-pattern (first missing)))))))
@@ -57,14 +57,14 @@
                           (warn 'non-exhaustive-match-warning
                                 :err (source:source-error
                                       :type :warn
-                                      :location (tc:node-location node)
+                                      :location (source:location node)
                                       :message "Non-exhaustive match"
                                       :primary-note "non-exhaustive match"
                                       :notes (when (first exhaustive-or-missing)
                                                (list
                                                 (se:make-source-error-note
                                                  :type :secondary
-                                                 :span (source:location-span (tc:node-location node))
+                                                 :span (source:location-span (source:location node))
                                                  :message (format nil "Missing case ~W"
                                                                   (print-pattern (first exhaustive-or-missing)))))))))
                         (loop :for pattern :in patterns
@@ -72,14 +72,14 @@
                                 (warn 'useless-pattern-warning
                                       :err (source:source-error
                                             :type :warn
-                                            :location (tc:pattern-location pattern)
+                                            :location (source:location pattern)
                                             :message "Useless match case"
                                             :primary-note "useless match case"
                                             :notes
                                             (list
                                              (se:make-source-error-note
                                               :type :secondary
-                                              :span (source:location-span (tc:node-location node))
+                                              :span (source:location-span (source:location node))
                                               :message "in this match")))))))
                     node)
            :abstraction (lambda (node)
@@ -125,7 +125,7 @@
         (warn 'pattern-var-matches-constructor
               :err (source:source-error
                     :type :warn
-                    :location (tc:pattern-location pat)
+                    :location (source:location pat)
                     :message "Pattern warning"
                     :primary-note "pattern variable matches constructor name")))))
 

--- a/src/analysis/underapplied-values.lisp
+++ b/src/analysis/underapplied-values.lisp
@@ -27,7 +27,7 @@
                     :do (warn 'underapplied-value-warning
                               :err (source:source-error
                                     :type :warn
-                                    :location (tc:node-location elem)
+                                    :location (source:location elem)
                                     :message "Value may be underapplied"
                                     :primary-note "discard explicitly with (let _ = ...) to ignore this warning")))
             node))))

--- a/src/analysis/unused-variables.lisp
+++ b/src/analysis/unused-variables.lisp
@@ -73,11 +73,11 @@
         (tc:node-variable
          (cons
           (tc:node-variable-name var)
-          (tc:node-location var)))
+          (source:location var)))
         (tc:pattern-var
          (cons
           (tc:pattern-var-name var)
-          (tc:pattern-location var))))
+          (source:location var))))
 
     (unless (char= (aref (symbol-name name) 0) #\_)
         (unless (gethash name used-variables)

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -106,7 +106,7 @@ Example:
                         :collect (cons (bindings-offset bindings offsets)
                                        (compile-scc bindings env))))
         (lisp-forms (mapcar (lambda (lisp-form)
-                              (cons (car (source:location-span (parser:toplevel-lisp-form-location lisp-form)))
+                              (cons (car (source:location-span (source:location lisp-form)))
                                     (parser:toplevel-lisp-form-body lisp-form)))
                             lisp-forms)))
     (mapcan #'cdr (merge-forms bindings lisp-forms))))
@@ -114,7 +114,7 @@ Example:
 (defun definition-bindings (definitions env offsets)
   "Translate the DEFINITIONS in this TU into bindings, updating an OFFSETS hashtable to record the source offset of each binding's source definition."
   (loop :for define :in definitions
-        :for offset := (car (source:location-span (tc:toplevel-define-location define)))
+        :for offset := (car (source:location-span (source:location define)))
         :for name := (tc:node-variable-name (tc:toplevel-define-name define))
         :for compiled-node := (translate-toplevel define env name)
 
@@ -130,7 +130,7 @@ Example:
 (defun instance-bindings (instances env offsets)
   "Translate the INSTANCES defined by this TU into bindings, updating an OFFSETS hashtable to record the source offset of each binding's source instance."
   (loop :for instance :in instances
-        :for offset := (car (source:location-span (tc:toplevel-define-instance-location instance)))
+        :for offset := (car (source:location-span (source:location instance)))
         :for instance-bindings := (translate-instance instance env)
 
         :do (dolist (binding instance-bindings)

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -18,6 +18,7 @@
    #:*traverse*
    #:traverse)
   (:local-nicknames
+   (#:source #:coalton-impl/source)
    (#:util #:coalton-impl/util)
    (#:tc #:coalton-impl/typechecker))
   (:export
@@ -681,7 +682,7 @@ Returns a `node'.")
              (tc:make-ty-predicate
               :class intoiter-class
               :types (list into-iter-arg-ty pat-arg-ty)
-              :location (tc:node-location expr)))
+              :location (source:location expr)))
 
            (into-iter-node
              (make-node-application
@@ -806,7 +807,7 @@ Returns a `node'.")
            (pred (tc:make-ty-predicate
                   :class monad-symbol
                   :types (list m-type)
-                  :location (tc:node-location node))))
+                  :location (source:location node))))
 
       (loop :with out-node := (translate-expression (tc:node-do-last-node node) ctx env)
 

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -159,7 +159,7 @@
 
 (defun write-doc (backend object)
   "When OBJECT has a nonempty docstring, write it using BACKEND's stream."
-  (let ((string (source:docstring (coalton-object object)))
+  (let ((string (object-docstring object))
         (stream (output-stream backend)))
     (when (and string (not (zerop (length string))))
       (terpri stream)

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -159,7 +159,7 @@
 
 (defun write-doc (backend object)
   "When OBJECT has a nonempty docstring, write it using BACKEND's stream."
-  (let ((string (object-doc object))
+  (let ((string (source:docstring (coalton-object object)))
         (stream (output-stream backend)))
     (when (and string (not (zerop (length string))))
       (terpri stream)

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -110,7 +110,7 @@
           (setf subs (tc:compose-substitution-lists subs subs_))
 
           (when accessors
-            (tc:tc-error (tc:accessor-location (first accessors))
+            (tc:tc-error (first accessors)
                          "Amqbiguous accessor"
                          "accessor is ambiguous"))
 
@@ -145,7 +145,7 @@
                                tvars
                                (tc:ty-scheme-type scheme))))
 
-              (tc:tc-error (tc:node-location node)
+              (tc:tc-error node
                            "Unable to codegen"
                            (format nil
                                    "expression has type ~A~{ ~S~}.~{ (~S)~} => ~S with unresolved constraint~A ~S"
@@ -162,7 +162,7 @@
                            (list
                             (se:make-source-error-note
                              :type :secondary
-                             :span (source:location-span (tc:node-location node))
+                             :span (source:location-span (source:location node))
                              :message "Add a type assertion with THE to resolve ambiguity"))))))))))
 
 (defmacro with-environment-updates (updates &body body)

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -111,7 +111,7 @@
 
           (when accessors
             (tc:tc-error (first accessors)
-                         "Amqbiguous accessor"
+                         "Ambiguous accessor"
                          "accessor is ambiguous"))
 
           (let* ((preds (tc:reduce-context env preds subs))

--- a/src/parser/base.lisp
+++ b/src/parser/base.lisp
@@ -15,12 +15,10 @@
    #:keyword-src                        ; STRUCT
    #:make-keyword-src                   ; CONSTRUCTOR
    #:keyword-src-name                   ; ACCESSOR
-   #:keyword-src-location                 ; ACCESSOR
    #:keyword-src-list                   ; TYPE
    #:identifier-src                     ; STRUCT
    #:make-identifier-src                ; CONSTRUCTOR
    #:identifier-src-name                ; ACCESSOR
-   #:identifier-src-location              ; ACCESSOR
    #:identifier-src-list                ; TYPE
    #:parse-error                        ; CONDITION
    #:parse-list                         ; FUNCTION
@@ -50,6 +48,9 @@
   (name     (util:required 'name)     :type keyword :read-only t)
   (location (util:required 'location) :type source:location :read-only t))
 
+(defmethod source:location ((self keyword-src))
+  (keyword-src-location self))
+
 (defun keyword-src-list-p (x)
   (and (alexandria:proper-list-p x)
        (every #'keyword-src-p x)))
@@ -61,6 +62,9 @@
             (:copier nil))
   (name     (util:required 'name)     :type identifier :read-only t)
   (location (util:required 'location) :type source:location :read-only t))
+
+(defmethod source:location ((self identifier-src))
+  (identifier-src-location self))
 
 (defun identifier-src-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/parser/binding.lisp
+++ b/src/parser/binding.lisp
@@ -17,7 +17,6 @@
   (:export
    #:binding-name                       ; FUNCTION
    #:binding-value                      ; FUNCTION
-   #:binding-location                     ; FUNCTION
    #:binding-parameters                 ; FUNCTION
    #:binding-toplevel-p                 ; FUNCTION
    #:binding-function-p                 ; FUNCTION
@@ -55,21 +54,6 @@
   (:method ((binding instance-method-definition))
     (declare (values node-body))
     (instance-method-definition-body binding)))
-
-(defgeneric binding-location (binding)    ; location
-  (:documentation "Returns the source location of BINDING")
-
-  (:method ((binding node-let-binding))
-    (declare (values location))
-    (node-let-binding-location binding))
-
-  (:method ((binding toplevel-define))
-    (declare (values location))
-    (toplevel-define-location binding))
-
-  (:method ((binding instance-method-definition))
-    (declare (values location))
-    (instance-method-definition-location binding)))
 
 (defgeneric binding-parameters (binding)
   (:documentation "Returns the parameters bound in BINDING")

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -16,7 +16,6 @@
    (#:const #:coalton-impl/constants))
   (:export
    #:node                               ; STRUCT
-   #:node-location                        ; ACCESSOR
    #:node-list                          ; TYPE
    #:node-variable                      ; STRUCT
    #:make-node-variable                 ; CONSTRUCTOR
@@ -35,7 +34,6 @@
    #:make-node-bind                     ; CONSTRUCTOR
    #:node-bind-pattern                  ; ACCESSOR
    #:node-bind-expr                     ; ACCESSOR
-   #:node-bind-location                   ; ACCESSOR
    #:node-body-element                  ; TYPE
    #:node-body-element-list             ; TYPE
    #:node-body                          ; STRUCT
@@ -51,13 +49,11 @@
    #:make-node-let-binding              ; CONSTRUCTOR
    #:node-let-binding-name              ; ACCESSOR
    #:node-let-binding-value             ; ACCESSOR
-   #:node-let-binding-location            ; ACCESSOR
    #:node-let-binding-list              ; TYPE
    #:node-let-declare                   ; STRUCT
    #:make-node-let-declare              ; CONSTRUCTOR
    #:node-let-declare-name              ; ACCESSOR
    #:node-let-declare-type              ; ACCESSOR
-   #:node-let-declare-location            ; ACCESSOR
    #:node-let-declare-list              ; TYPE
    #:node-let                           ; STRUCT
    #:make-node-let                      ; CONSTRUCTOR
@@ -74,7 +70,6 @@
    #:make-node-match-branch             ; CONSTRUCTOR
    #:node-match-branch-pattern          ; ACCESSOR
    #:node-match-branch-body             ; ACCESSOR
-   #:node-match-branch-location           ; ACCESSOR
    #:node-match-branch-list             ; TYPE
    #:node-match                         ; STRUCT
    #:make-node-match                    ; CONSTRUCTOR
@@ -117,7 +112,6 @@
    #:make-node-cond-clause              ; CONSTRUCTOR
    #:node-cond-clause-expr              ; ACCESSOR
    #:node-cond-clause-body              ; ACCESSOR
-   #:node-cond-clause-location            ; ACCESSOR
    #:node-cond-clause-list              ; TYPE
    #:node-cond                          ; STRUCT
    #:make-node-cond                     ; CONSTRUCTOR
@@ -126,7 +120,6 @@
    #:make-node-do-bind                  ; CONSTRUCTOR
    #:node-do-bind-pattern               ; ACCESSOR
    #:node-do-bind-expr                  ; ACCESSOR
-   #:node-do-bind-location                ; ACCESSOR
    #:node-do-body-element               ; TYPE
    #:node-body-element-list             ; TYPE
    #:node-do                            ; STRUCT
@@ -272,6 +265,9 @@ Rebound to NIL parsing an anonymous FN.")
             (:copier nil))
   (location (util:required 'location) :type location :read-only t))
 
+(defmethod location ((self node))
+  (node-location self))
+
 (defun node-list-p (x)
   (and (alexandria:proper-list-p x)
        (every #'node-p x)))
@@ -311,9 +307,12 @@ Rebound to NIL parsing an anonymous FN.")
 ;;
 (defstruct (node-bind
             (:copier nil))
-  (pattern (util:required 'pattern) :type pattern :read-only t)
-  (expr    (util:required 'expr)    :type node    :read-only t)
-  (location  (util:required 'location)  :type location    :read-only t))
+  (pattern  (util:required 'pattern)   :type pattern  :read-only t)
+  (expr     (util:required 'expr)      :type node     :read-only t)
+  (location (util:required 'location)  :type location :read-only t))
+
+(defmethod location ((self node-bind))
+  (node-bind-location self))
 
 (deftype node-body-element ()
   '(or node node-bind))
@@ -352,6 +351,9 @@ Rebound to NIL parsing an anonymous FN.")
   (value  (util:required 'value)  :type node            :read-only t)
   (location (util:required 'location) :type location :read-only t))
 
+(defmethod location ((self node-let-binding))
+  (node-let-binding-location self))
+
 (defun node-let-binding-list-p (x)
   (and (alexandria:proper-list-p x)
        (every #'node-let-binding-p x)))
@@ -364,6 +366,9 @@ Rebound to NIL parsing an anonymous FN.")
   (name   (util:required 'name)   :type node-variable   :read-only t)
   (type   (util:required 'type)   :type qualified-ty    :read-only t)
   (location (util:required 'location) :type location :read-only t))
+
+(defmethod location ((self node-let-declare))
+  (node-let-declare-location self))
 
 (defun node-let-declare-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -392,6 +397,9 @@ Rebound to NIL parsing an anonymous FN.")
   (pattern (util:required 'pattern) :type pattern         :read-only t)
   (body    (util:required 'body)    :type node-body       :read-only t)
   (location  (util:required 'location)  :type location :read-only t))
+
+(defmethod location ((self node-match-branch))
+  (node-match-branch-location self))
 
 (defun node-match-branch-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -463,6 +471,9 @@ Rebound to NIL parsing an anonymous FN.")
   (body   (util:required 'body)   :type node-body       :read-only t)
   (location (util:required 'location) :type location :read-only t))
 
+(defmethod location ((self node-cond-clause))
+  (node-cond-clause-location self))
+
 (defun node-cond-clause-list-p (x)
   (and (alexandria:proper-list-p x)
        (every #'node-cond-clause-p x)))
@@ -480,6 +491,9 @@ Rebound to NIL parsing an anonymous FN.")
   (pattern (util:required 'name)   :type pattern         :read-only t)
   (expr    (util:required 'expr)   :type node            :read-only t)
   (location  (util:required 'location) :type location :read-only t))
+
+(defmethod location ((self node-do-bind))
+  (node-do-bind-location self))
 
 (deftype node-do-body-element ()
   '(or node node-bind node-do-bind))

--- a/src/parser/pattern.lisp
+++ b/src/parser/pattern.lisp
@@ -12,7 +12,6 @@
    (#:util #:coalton-impl/util))
   (:export
    #:pattern                            ; STRUCT
-   #:pattern-location                     ; ACCESSOR
    #:pattern-list                       ; TYPE
    #:pattern-var                        ; STRUCT
    #:make-pattern-var                   ; ACCESSOR
@@ -52,6 +51,9 @@
 
 (defmethod make-load-form ((self pattern) &optional env)
   (make-load-form-saving-slots self :environment env))
+
+(defmethod location ((self pattern))
+  (pattern-location self))
 
 (defun pattern-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -42,7 +42,7 @@
        (if new-name
            (make-node-variable
             :name new-name
-            :location (node-location node))
+            :location (location node))
            node)
        ctx)))
 
@@ -80,7 +80,7 @@
 
         ;; ctx is used instead of new-ctx because bind creates non-recursive bindings
         :expr (rename-variables-generic% (node-bind-expr node) ctx)
-        :location (node-bind-location node))
+        :location (location node))
        new-ctx)))
 
   (:method ((node node-body) ctx)
@@ -110,7 +110,7 @@
        (make-node-abstraction
         :params (rename-variables-generic% (node-abstraction-params node) new-ctx)
         :body (rename-variables-generic% (node-abstraction-body node) new-ctx)
-        :location (node-location node))
+        :location (location node))
        ctx)))
 
   (:method ((node node-let-binding) ctx)
@@ -121,7 +121,7 @@
      (make-node-let-binding
       :name (rename-variables-generic% (node-let-binding-name node) ctx)
       :value (rename-variables-generic% (node-let-binding-value node) ctx)
-      :location (node-let-binding-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-let-declare) ctx)
@@ -132,7 +132,7 @@
      (make-node-let-declare
       :name (rename-variables-generic% (node-let-declare-name node) ctx)
       :type (node-let-declare-type node)
-      :location (node-let-declare-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-let) ctx)
@@ -151,7 +151,7 @@
         :bindings (rename-variables-generic% (node-let-bindings node) new-ctx)
         :declares (rename-variables-generic% (node-let-declares node) new-ctx)
         :body (rename-variables-generic% (node-let-body node) new-ctx)
-        :location (node-location node))
+        :location (location node))
        ctx)))
 
   (:method ((node node-lisp) ctx)
@@ -160,7 +160,7 @@
 
     (values
      (make-node-lisp
-      :location (node-location node)
+      :location (location node)
       :type (node-lisp-type node)
       :vars (rename-variables-generic% (node-lisp-vars node) ctx)
       :var-names (node-lisp-var-names node)
@@ -179,7 +179,7 @@
        (make-node-match-branch
         :pattern (rename-variables-generic% (node-match-branch-pattern node) new-ctx)
         :body (rename-variables-generic% (node-match-branch-body node) new-ctx)
-        :location (node-match-branch-location node))
+        :location (location node))
        ctx)))
 
   (:method ((node node-match) ctx)
@@ -190,7 +190,7 @@
      (make-node-match
       :expr (rename-variables-generic% (node-match-expr node) ctx)
       :branches (rename-variables-generic% (node-match-branches node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-progn) ctx)
@@ -200,7 +200,7 @@
     (values
      (make-node-progn
       :body (rename-variables-generic% (node-progn-body node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-the) ctx)
@@ -211,7 +211,7 @@
      (make-node-the
       :type (node-the-type node)
       :expr (rename-variables-generic% (node-the-expr node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-return) ctx)
@@ -223,7 +223,7 @@
       :expr (if (node-return-expr node)
                 (rename-variables-generic% (node-return-expr node) ctx)
                 nil)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-application) ctx)
@@ -234,7 +234,7 @@
      (make-node-application
       :rator (rename-variables-generic% (node-application-rator node) ctx)
       :rands (rename-variables-generic% (node-application-rands node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-or) ctx)
@@ -244,7 +244,7 @@
     (values
      (make-node-or
       :nodes (rename-variables-generic% (node-or-nodes node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-and) ctx)
@@ -254,7 +254,7 @@
     (values
      (make-node-and
       :nodes (rename-variables-generic% (node-and-nodes node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-if) ctx)
@@ -266,7 +266,7 @@
       :expr (rename-variables-generic% (node-if-expr node) ctx)
       :then (rename-variables-generic% (node-if-then node) ctx)
       :else (rename-variables-generic% (node-if-else node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-when) ctx)
@@ -277,7 +277,7 @@
      (make-node-when
       :expr (rename-variables-generic% (node-when-expr node) ctx)
       :body (rename-variables-generic% (node-when-body node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-while) ctx)
@@ -288,7 +288,7 @@
       :expr (rename-variables-generic% (node-while-expr node) ctx)
       :label (node-while-label node)
       :body (rename-variables-generic% (node-while-body node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-while-let) ctx)
@@ -310,7 +310,7 @@
         :pattern (rename-variables-generic% (node-while-let-pattern node) new-ctx)
         :expr (rename-variables-generic% (node-while-let-expr node) ctx)
         :body (rename-variables-generic% (node-while-let-body node) new-ctx)
-        :location (node-location node))
+        :location (location node))
        new-ctx)))
 
   (:method ((node node-for) ctx)
@@ -331,7 +331,7 @@
         :pattern (rename-variables-generic% (node-for-pattern node) new-ctx)
         :expr (rename-variables-generic% (node-for-expr node) ctx)
         :body (rename-variables-generic% (node-for-body node) new-ctx)
-        :location (node-location node))
+        :location (location node))
        new-ctx)))
 
   (:method ((node node-loop) ctx)
@@ -339,7 +339,7 @@
              (values node algo:immutable-map))
     (values
      (make-node-loop
-      :location (node-location node)
+      :location (location node)
       :label (node-loop-label node)
       :body (rename-variables-generic% (node-loop-body node) ctx))
      ctx))
@@ -366,7 +366,7 @@
      (make-node-unless
       :expr (rename-variables-generic% (node-unless-expr node) ctx)
       :body (rename-variables-generic% (node-unless-body node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-cond-clause) ctx)
@@ -377,7 +377,7 @@
      (make-node-cond-clause
       :expr (rename-variables-generic% (node-cond-clause-expr node) ctx)
       :body (rename-variables-generic% (node-cond-clause-body node) ctx)
-      :location (node-cond-clause-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-cond) ctx)
@@ -387,7 +387,7 @@
     (values
      (make-node-cond
       :clauses (rename-variables-generic% (node-cond-clauses node) ctx)
-      :location (node-location node))
+      :location (location node))
      ctx))
 
   (:method ((node node-do-bind) ctx)
@@ -402,7 +402,7 @@
        (make-node-do-bind
         :pattern (rename-variables-generic% (node-do-bind-pattern node) new-ctx)
         :expr (rename-variables-generic% (node-do-bind-expr node) ctx)
-        :location (node-do-bind-location node))
+        :location (location node))
        new-ctx)))
 
   (:method ((node node-do) ctx)
@@ -418,7 +418,7 @@
                                 (setf new-ctx new-ctx_)
                                 elem))
         :last-node (rename-variables-generic% (node-do-last-node node) new-ctx)
-        :location (node-location node))
+        :location (location node))
        ctx)))
 
   (:method ((pattern pattern-var) ctx)
@@ -431,7 +431,7 @@
            (make-pattern-var
             :name new-name
             :orig-name (pattern-var-orig-name pattern)
-            :location (pattern-location pattern))
+            :location (location pattern))
            pattern)
        ctx)))
 
@@ -455,7 +455,7 @@
      (make-pattern-constructor
       :name (pattern-constructor-name pattern)
       :patterns (rename-variables-generic% (pattern-constructor-patterns pattern) ctx)
-      :location (pattern-location pattern))
+      :location (location pattern))
      ctx))
 
   (:method ((toplevel toplevel-define) ctx)
@@ -473,7 +473,7 @@
         :orig-params (toplevel-define-orig-params toplevel)
         :docstring (docstring toplevel)
         :body (rename-variables-generic% (toplevel-define-body toplevel) new-ctx)
-        :location (toplevel-define-location toplevel)
+        :location (location toplevel)
         :monomorphize (toplevel-define-monomorphize toplevel))
        ctx)))
 
@@ -490,7 +490,7 @@
         :name (instance-method-definition-name method)
         :params (rename-variables-generic% (instance-method-definition-params method) new-ctx)
         :body (rename-variables-generic% (instance-method-definition-body method) new-ctx)
-        :location (instance-method-definition-location method))
+        :location (location method))
        ctx)))
 
   (:method ((toplevel toplevel-define-instance) ctx)
@@ -502,7 +502,7 @@
       :context (toplevel-define-instance-context toplevel)
       :pred (toplevel-define-instance-pred toplevel)
       :methods (rename-variables-generic% (toplevel-define-instance-methods toplevel) ctx)
-      :location (toplevel-define-instance-location toplevel)
+      :location (location toplevel)
       :head-location (toplevel-define-instance-head-location toplevel)
       :docstring (docstring toplevel)
       :compiler-generated (toplevel-define-instance-compiler-generated toplevel))
@@ -551,7 +551,7 @@
       (if new-name
           (make-tyvar
            :name new-name
-           :location (ty-location ty))
+           :location (location ty))
           ty)))
 
   (:method ((ty tycon) ctx)
@@ -567,7 +567,7 @@
     (make-tapp
      :from (rename-type-variables-generic% (tapp-from ty) ctx)
      :to (rename-type-variables-generic% (tapp-to ty) ctx)
-     :location (ty-location ty)))
+     :location (location ty)))
 
   (:method ((pred ty-predicate) ctx)
     (declare (type algo:immutable-map ctx)
@@ -576,7 +576,7 @@
     (make-ty-predicate
      :class (ty-predicate-class pred)
      :types (rename-type-variables-generic% (ty-predicate-types pred) ctx)
-     :location (ty-predicate-location pred)))
+     :location (location pred)))
 
   (:method ((qual-ty qualified-ty) ctx)
     (declare (type algo:immutable-map ctx)
@@ -585,7 +585,7 @@
     (make-qualified-ty
      :predicates (rename-type-variables-generic% (qualified-ty-predicates qual-ty) ctx)
      :type (rename-type-variables-generic% (qualified-ty-type qual-ty) ctx)
-     :location (qualified-ty-location qual-ty)))
+     :location (location qual-ty)))
 
   (:method ((ctor constructor) ctx)
     (declare (type algo:immutable-map ctx)
@@ -593,7 +593,7 @@
     (make-constructor
      :name (constructor-name ctor)
      :fields (rename-type-variables-generic% (constructor-fields ctor) ctx)
-     :location (constructor-location ctor)))
+     :location (location ctor)))
 
   (:method ((keyword keyword-src) ctx)
     (declare (type algo:immutable-map ctx)
@@ -604,7 +604,7 @@
       (if new-name
           (make-keyword-src
            :name new-name
-           :location (keyword-src-location keyword))
+           :location (location keyword))
           keyword)))
 
   (:method ((toplevel toplevel-define-type) ctx)
@@ -622,7 +622,7 @@
        :vars (rename-type-variables-generic% (toplevel-define-type-vars toplevel) new-ctx)
        :docstring (docstring toplevel)
        :ctors (rename-type-variables-generic% (toplevel-define-type-ctors toplevel) new-ctx)
-       :location (toplevel-define-type-location toplevel)
+       :location (location toplevel)
        :repr (toplevel-define-type-repr toplevel)
        :head-location (toplevel-define-type-head-location toplevel))))
 
@@ -634,7 +634,7 @@
      :name (struct-field-name field)
      :type (rename-type-variables-generic% (struct-field-type field) ctx)
      :docstring (docstring field)
-     :location (struct-field-location field)))
+     :location (location field)))
 
   (:method ((toplevel toplevel-define-struct) ctx)
     (declare (type algo:immutable-map ctx)
@@ -651,7 +651,7 @@
        :vars (rename-type-variables-generic% (toplevel-define-struct-vars toplevel) new-ctx)
        :docstring (docstring toplevel)
        :fields (rename-type-variables-generic% (toplevel-define-struct-fields toplevel) new-ctx)
-       :location (toplevel-define-struct-location toplevel)
+       :location (location toplevel)
        :repr (toplevel-define-struct-repr toplevel)
        :head-location (toplevel-define-struct-head-location toplevel))))
 
@@ -662,7 +662,7 @@
     (make-fundep
      :left (rename-type-variables-generic% (fundep-left fundep) ctx)
      :right (rename-type-variables-generic% (fundep-right fundep) ctx)
-     :location (fundep-location fundep)))
+     :location (location fundep)))
 
   (:method ((method method-definition) ctx)
     (declare (type algo:immutable-map ctx)
@@ -682,7 +682,7 @@
        :name (method-definition-name method)
        :type (rename-type-variables-generic% (method-definition-type method) new-ctx)
        :docstring (docstring method)
-       :location (method-definition-location method))))
+       :location (location method))))
 
   (:method ((toplevel toplevel-define-class) ctx)
     (declare (type algo:immutable-map ctx)

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -18,7 +18,6 @@
    (#:util #:coalton-impl/util))
   (:export
    #:attribute                                   ; TYPE
-   #:attribute-location                          ; ACCESSOR
    #:attribute-monomorphize                      ; STRUCT
    #:make-attribute-monomorphize                 ; CONSTRUCTOR
    #:attribute-repr                              ; STRUCT
@@ -29,14 +28,12 @@
    #:make-constructor                            ; CONSTRUCTOR
    #:constructor-name                            ; ACCESSOR
    #:constructor-fields                          ; ACCESSOR
-   #:constructor-location                        ; ACCESSOR
    #:constructor-list                            ; TYPE
    #:toplevel-define-type                        ; STRUCT
    #:make-toplevel-define-type                   ; CONSTRUCTOR
    #:toplevel-define-type-name                   ; ACCESSOR
    #:toplevel-define-type-vars                   ; ACCESSOR
    #:toplevel-define-type-ctors                  ; ACCESSOR
-   #:toplevel-define-type-location               ; ACCESSOR
    #:toplevel-define-type-repr                   ; ACCESSOR
    #:toplevel-define-type-head-location          ; ACCESSOR
    #:toplevel-define-type-list                   ; TYPE
@@ -44,14 +41,12 @@
    #:make-struct-field                           ; CONSTRUCTOR
    #:struct-field-name                           ; ACCESSOR
    #:struct-field-type                           ; ACCESSOR
-   #:struct-field-location                       ; ACCESSOR
    #:struct-field-list                           ; TYPE
    #:toplevel-define-struct                      ; STRUCT
    #:make-toplevel-define-struct                 ; CONSTRUCTOR
    #:toplevel-define-struct-name                 ; ACCESSOR
    #:toplevel-define-struct-vars                 ; ACCESSOR
    #:toplevel-define-struct-fields               ; ACCESSOR
-   #:toplevel-define-struct-location             ; ACCESSOR
    #:toplevel-define-struct-repr                 ; ACCESSOR
    #:toplevel-define-struct-head-location        ; ACCESSOR
    #:toplevel-define-struct-list                 ; TYPE
@@ -59,7 +54,6 @@
    #:make-toplevel-declare                       ; CONSTRUCTOR
    #:toplevel-declare-name                       ; ACCESSOR
    #:toplevel-declare-type                       ; ACCESSOR
-   #:toplevel-declare-location                   ; ACCESSOR
    #:toplevel-declare-list                       ; TYPE
    #:toplevel-declare-monomorphize               ; ACCESSOR
    #:toplevel-define                             ; STRUCT
@@ -68,20 +62,17 @@
    #:toplevel-define-params                      ; ACCESSOR
    #:toplevel-define-orig-params                 ; ACCESSOR
    #:toplevel-define-body                        ; ACCESSOR
-   #:toplevel-define-location                    ; ACCESSOR
    #:toplevel-define-monomorphize                ; ACCESSOR
    #:toplevel-define-list                        ; TYPE
    #:fundep                                      ; STRUCT
    #:make-fundep                                 ; CONSTRUCTOR
    #:fundep-left                                 ; ACCESSOR
    #:fundep-right                                ; ACCESSOR
-   #:fundep-location                             ; ACCESSOR
    #:fundep-list                                 ; TYPE
    #:method-definition                           ; STRUCT
    #:make-method-definition                      ; STRUCT
    #:method-definition-name                      ; ACCESSOR
    #:method-definition-type                      ; ACCESSOR
-   #:method-definition-location                  ; ACCESSOR
    #:method-definition-list                      ; TYPE
    #:toplevel-define-class                       ; STRUCT
    #:make-toplevel-define-class                  ; CONSTRUCTOR
@@ -97,14 +88,12 @@
    #:instance-method-definition-name             ; ACCESSOR
    #:instance-method-definition-params           ; ACCESSOR
    #:instance-method-definition-body             ; ACCESSOR
-   #:instance-method-definition-location         ; ACCESSOR
    #:instance-method-definition-list             ; TYPE
    #:toplevel-define-instance                    ; STRUCT
    #:make-toplevel-define-instance               ; CONSTRUCTOR
    #:toplevel-define-instance-context            ; ACCESSOR
    #:toplevel-define-instance-pred               ; ACCESSOR
    #:toplevel-define-instance-methods            ; ACCESSOR
-   #:toplevel-define-instance-location           ; ACCESSOR
    #:toplevel-define-instance-head-location      ; ACCESSOR
    #:toplevel-define-instance-compiler-generated ; ACCESSOR
    #:toplevel-define-instance-list               ; TYPE
@@ -112,14 +101,12 @@
    #:toplevel-lisp-form                          ; STRUCT
    #:make-toplevel-lisp-form                     ; CONSTRUCTOR
    #:toplevel-lisp-form-body                     ; ACCESSOR
-   #:toplevel-lisp-form-location                 ; ACCESSOR
    #:toplevel-lisp-form-list                     ; TYPE
    #:toplevel-specialize                         ; STRUCT
    #:make-toplevel-specialize                    ; CONSTRUCTOR
    #:toplevel-specialize-from                    ; ACCESSOR
    #:toplevel-specialize-to                      ; ACCESSOR
    #:toplevel-specialize-type                    ; ACCESSOR
-   #:toplevel-specialize-location                ; ACCESSOR
    #:toplevel-specialize-list                    ; TYPE
    #:program                                     ; STRUCT
    #:make-program                                ; CONSTRUCTOR
@@ -215,6 +202,9 @@
             (:copier nil))
   (location (util:required 'location) :type location :read-only t))
 
+(defmethod location ((self attribute))
+  (attribute-location self))
+
 (defstruct (attribute-monomorphize
             (:include attribute)))
 
@@ -233,6 +223,9 @@
   (fields (util:required 'fields) :type ty-list         :read-only t)
   (location (util:required 'location) :type location :read-only t))
 
+(defmethod location ((self constructor))
+  (constructor-location self))
+
 (defun constructor-list-p (x)
   (and (alexandria:proper-list-p x)
        (every #'constructor-p x)))
@@ -240,18 +233,25 @@
 (deftype constructor-list ()
   '(satisfies constructor-list-p))
 
+(defstruct (toplevel-definition
+            (:constructor nil))
+  (location  (util:required 'location)  :type location         :read-only t)
+  (docstring (util:required 'docstring) :type (or null string) :read-only t))
+
+(defmethod location ((self toplevel-definition))
+  (toplevel-definition-location self))
+
+(defmethod docstring ((self toplevel-definition))
+  (toplevel-definition-docstring self))
+
 (defstruct (toplevel-define-type
+            (:include toplevel-definition)
             (:copier nil))
   (name      (util:required 'name)      :type identifier-src           :read-only t)
   (vars      (util:required 'vars)      :type keyword-src-list         :read-only t)
-  (docstring (util:required 'docstring) :type (or null string)         :read-only t)
   (ctors     (util:required 'ctors)     :type constructor-list         :read-only t)
-  (location    (util:required 'location)    :type location          :read-only t)
   (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
   (head-location  (util:required 'head-location)  :type location                     :read-only t))
-
-(defmethod docstring ((self toplevel-define-type))
-  (toplevel-define-type-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-type-list-p (x)
@@ -262,14 +262,10 @@
   '(satisfies toplevel-define-type-list-p))
 
 (defstruct (struct-field
+            (:include toplevel-definition)
             (:copier nil))
   (name      (util:required 'name)      :type string           :read-only t)
-  (type      (util:required 'type)      :type ty               :read-only t)
-  (docstring (util:required 'docstring) :type (or null string) :read-only t)
-  (location    (util:required 'location)    :type location             :read-only t))
-
-(defmethod docstring ((self struct-field))
-  (struct-field-docstring self))
+  (type      (util:required 'type)      :type ty               :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun struct-field-list-p (x)
@@ -280,17 +276,13 @@
   '(satisfies struct-field-list-p))
 
 (defstruct (toplevel-define-struct
+            (:include toplevel-definition)
             (:copier nil))
   (name      (util:required 'name)      :type identifier-src           :read-only t)
   (vars      (util:required 'vars)      :type keyword-src-list         :read-only t)
-  (docstring (util:required 'docstring) :type (or null string)         :read-only t)
   (fields    (util:required 'fields)    :type struct-field-list        :read-only t)
-  (location    (util:required 'location)    :type location          :read-only t)
   (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
   (head-location  (util:required 'head-location)  :type location          :read-only t))
-
-(defmethod docstring ((self toplevel-define-struct))
-  (toplevel-define-struct-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-struct-list-p (x)
@@ -304,8 +296,11 @@
             (:copier nil))
   (name         (util:required 'name)         :type identifier-src                   :read-only t)
   (type         (util:required 'type)         :type qualified-ty                     :read-only t)
-  (location       (util:required 'location)       :type location                  :read-only t)
+  (location     (util:required 'location)     :type location                         :read-only t)
   (monomorphize (util:required 'monomorphize) :type (or null attribute-monomorphize) :read-only nil))
+
+(defmethod location ((self toplevel-declare))
+  (toplevel-declare-location self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-declare-list-p (x)
@@ -316,17 +311,13 @@
   '(satisfies toplevel-declare-list-p))
 
 (defstruct (toplevel-define
+            (:include toplevel-definition)
             (:copier nil))
   (name         (util:required 'name)         :type node-variable                    :read-only t)
   (params       (util:required 'params)       :type pattern-list                     :read-only t)
   (orig-params  (util:required 'orig-params)  :type pattern-list                     :read-only t)
-  (docstring    (util:required 'docstring)    :type (or null string)                 :read-only t)
   (body         (util:required 'body)         :type node-body                        :read-only t)
-  (location       (util:required 'location)       :type location                  :read-only t)
   (monomorphize (util:required 'monomorphize) :type (or null attribute-monomorphize) :read-only nil))
-
-(defmethod docstring ((self toplevel-define))
-  (toplevel-define-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-list-p (x)
@@ -338,9 +329,12 @@
 
 (defstruct (fundep
             (:copier nil))
-  (left   (util:required 'left)   :type keyword-src-list :read-only t)
-  (right  (util:required 'right)  :type keyword-src-list :read-only t)
-  (location (util:required 'location) :type location  :read-only t))
+  (left     (util:required 'left)     :type keyword-src-list :read-only t)
+  (right    (util:required 'right)    :type keyword-src-list :read-only t)
+  (location (util:required 'location) :type location         :read-only t))
+
+(defmethod location ((self fundep))
+  (fundep-location self))
 
 (defun fundep-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -350,14 +344,10 @@
   '(satisfies fundep-list-p))
 
 (defstruct (method-definition
+            (:include toplevel-definition)
             (:copier nil))
-  (name      (util:required 'name)      :type identifier-src   :read-only t)
-  (type      (util:required 'type)      :type qualified-ty     :read-only t)
-  (docstring (util:required 'docstring) :type (or string null) :read-only t)
-  (location    (util:required 'location)    :type location  :read-only t))
-
-(defmethod docstring ((self method-definition))
-  (method-definition-docstring self))
+  (name (util:required 'name) :type identifier-src :read-only t)
+  (type (util:required 'type) :type qualified-ty   :read-only t))
 
 (defmethod make-load-form ((self method-definition) &optional env)
   (make-load-form-saving-slots self :environment env))
@@ -401,10 +391,13 @@
 
 (defstruct (instance-method-definition
             (:copier nil))
-  (name      (util:required 'name)      :type node-variable   :read-only t)
-  (params    (util:required 'params)    :type pattern-list    :read-only t)
-  (body      (util:required 'body)      :type node-body       :read-only t)
-  (location    (util:required 'location)    :type location :read-only t))
+  (name     (util:required 'name)     :type node-variable   :read-only t)
+  (params   (util:required 'params)   :type pattern-list    :read-only t)
+  (body     (util:required 'body)     :type node-body       :read-only t)
+  (location (util:required 'location) :type location :read-only t))
+
+(defmethod location ((self instance-method-definition))
+  (instance-method-definition-location self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun instance-method-definition-list-p (x)
@@ -415,18 +408,14 @@
   '(satisfies instance-method-definition-list-p))
 
 (defstruct (toplevel-define-instance
+            (:include toplevel-definition)
             (:copier nil))
   (context            (util:required 'context)            :type ty-predicate-list               :read-only t)
   (pred               (util:required 'pred)               :type ty-predicate                    :read-only t)
-  (docstring          (util:required 'docstring)          :type (or null string)                :read-only t)
   (methods            (util:required 'methods)            :type instance-method-definition-list :read-only t)
-  (location             (util:required 'location)             :type location                 :read-only t)
   ;; Source information for the context and the pred
   (head-location           (util:required 'head-location)           :type location                 :read-only t)
   (compiler-generated (util:required 'compiler-generated) :type boolean                         :read-only t))
-
-(defmethod docstring ((self toplevel-define-instance))
-  (toplevel-define-instance-docstring self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-instance-list-p (x)
@@ -441,6 +430,9 @@
   (body   (util:required 'body)   :type cons  :read-only t)
   (location (util:required 'location) :type location :read-only t))
 
+(defmethod location ((self toplevel-lisp-form))
+  (toplevel-lisp-form-location self))
+
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-lisp-form-list-p (x)
     (and (alexandria:proper-list-p x)
@@ -451,10 +443,13 @@
 
 (defstruct (toplevel-specialize
             (:copier nil))
-  (from   (util:required 'from)   :type node-variable   :read-only t)
-  (to     (util:required 'to)     :type node-variable   :read-only t)
-  (type   (util:required 'type)   :type ty              :read-only t)
-  (location (util:required 'location) :type location :read-only t))
+  (from   (util:required 'from)       :type node-variable   :read-only t)
+  (to     (util:required 'to)         :type node-variable   :read-only t)
+  (type   (util:required 'type)       :type ty              :read-only t)
+  (location (util:required 'location) :type location        :read-only t))
+
+(defmethod location ((self toplevel-specialize))
+  (toplevel-specialize-location self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-specialize-list-p (x)
@@ -465,16 +460,15 @@
   '(satisfies toplevel-specialize-list-p))
 
 (defstruct (toplevel-package
+            (:include toplevel-definition)
             (:copier nil))
   "A Coalton package definition, which can be used to generate either a DEFPACKAGE form or a package instance directly."
   (name        (util:required 'name)     :type string           :read-only t)
-  (docstring   nil                       :type (or null string) :read-only t)
   (import      nil                       :type list)
   (import-as   nil                       :type list)
   (import-from nil                       :type list)
   (shadow      nil                       :type list)
-  (export      nil                       :type list)
-  (location    (util:required 'location) :type location         :read-only t))
+  (export      nil                       :type list))
 
 (defstruct program
   (package         nil :type (or null toplevel-package)    :read-only t)
@@ -831,7 +825,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                  (list
                                   (se:make-source-error-note
                                    :type ':secondary
-                                   :span (location-span (node-location (toplevel-define-name define)))
+                                   :span (location-span (location (toplevel-define-name define)))
                                    :message "when parsing define")))))
 
                    (attribute-monomorphize
@@ -850,7 +844,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                      :message "previous attribute here")
                                     (se:make-source-error-note
                                      :type ':secondary
-                                     :span (location-span (node-location (toplevel-define-name define)))
+                                     :span (location-span (location (toplevel-define-name define)))
                                      :message "when parsing define")))))
 
                     (setf monomorphize attribute)
@@ -1014,7 +1008,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                  (list
                                   (se:make-source-error-note
                                    :type ':secondary
-                                   :span (location-span (identifier-src-location (toplevel-define-struct-name struct)))
+                                   :span (location-span (location (toplevel-define-struct-name struct)))
                                    :message "when parsing define-type")))))))
 
        (setf (fill-pointer attributes) 0)

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -359,17 +359,6 @@
 (deftype method-definition-list ()
   '(satisfies method-definition-list-p))
 
-(defstruct (toplevel-definition
-            (:constructor nil))
-  (location  (util:required 'location)  :type location         :read-only t)
-  (docstring (util:required 'docstring) :type (or null string) :read-only t))
-
-(defmethod location ((self toplevel-definition))
-  (toplevel-definition-location self))
-
-(defmethod docstring ((self toplevel-definition))
-  (toplevel-definition-docstring self))
-
 (defstruct (toplevel-define-class
             (:include toplevel-definition)
             (:copier nil))

--- a/src/parser/type-definition.lisp
+++ b/src/parser/type-definition.lisp
@@ -18,12 +18,10 @@
    #:type-definition                    ; TYPE
    #:type-definition-list               ; TYPE
    #:type-definition-name               ; FUNCTION
-   #:type-definition-location             ; FUNCTION
    #:type-definition-vars               ; FUNCTION
    #:type-definition-repr               ; FUNCTION
    #:type-definition-ctors              ; FUNCTION
    #:type-definition-ctor-name          ; FUNCTION
-   #:type-definition-ctor-location        ; FUNCTION
    #:type-definition-ctor-field-types   ; FUNCTION
    ))
 
@@ -50,15 +48,6 @@
   (:method ((def toplevel-define-struct))
     (declare (values identifier-src))
     (toplevel-define-struct-name def)))
-
-(defgeneric type-definition-location (def)
-  (:method ((def toplevel-define-type))
-    (declare (values location))
-    (toplevel-define-type-location def))
-
-  (:method ((def toplevel-define-struct))
-    (declare (values location))
-    (toplevel-define-struct-location def)))
 
 (defgeneric type-definition-vars (def)
   (:method ((def toplevel-define-type))
@@ -95,15 +84,6 @@
   (:method ((ctor toplevel-define-struct))
     (declare (values identifier-src))
     (toplevel-define-struct-name ctor)))
-
-(defgeneric type-definition-ctor-location (ctor)
-  (:method ((ctor constructor))
-    (declare (values location))
-    (constructor-location ctor))
-
-  (:method ((ctor toplevel-define-struct))
-    (declare (values location))
-    (toplevel-define-struct-location ctor)))
 
 (defgeneric type-definition-ctor-field-types (ctor)
   (:method ((ctor constructor))

--- a/src/parser/types.lisp
+++ b/src/parser/types.lisp
@@ -73,6 +73,9 @@
                (:copier nil))
   (location (util:required 'location) :type location :read-only t))
 
+(defmethod location ((self ty))
+  (ty-location self))
+
 (defun ty-list-p (x)
   (and (alexandria:proper-list-p x)
        (every #'ty-p x)))
@@ -115,6 +118,9 @@
   (types    (util:required 'types)    :type ty-list         :read-only t)
   (location (util:required 'location) :type location        :read-only t))
 
+(defmethod location ((self ty-predicate))
+  (ty-predicate-location self))
+
 (defun ty-predicate-list-p (x)
   (and (alexandria:proper-list-p x)
        (every #'ty-predicate-p x)))
@@ -128,6 +134,9 @@
   (predicates (util:required 'predicates) :type ty-predicate-list :read-only t)
   (type       (util:required 'type)       :type ty                :read-only t)
   (location   (util:required 'location)   :type location          :read-only t))
+
+(defmethod location ((self qualified-ty))
+  (qualified-ty-location self))
 
 (defun parse-qualified-type (form source)
   (declare (type cst:cst form))

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -155,6 +155,9 @@ OFFSET indicates starting character offset within the file."
 (defmethod source-error:source-name ((self source-string))
   (or (original-name self) "<string input>"))
 
+(defgeneric location (object)
+  (:documentation "The source location of a Coalton object's definition."))
+
 (defgeneric docstring (object)
   (:documentation "The docstring accompanying a Coalton object's definition."))
 

--- a/src/typechecker/accessor.lisp
+++ b/src/typechecker/accessor.lisp
@@ -13,7 +13,6 @@
    #:accessor-from                      ; ACCESSOR
    #:accessor-to                        ; ACCESSOR
    #:accessor-field                     ; ACCESSOR
-   #:accessor-location                    ; ACCESSOR
    #:accessor-list                      ; TYPE
    #:base-type                          ; FUNCTION
    #:solve-accessors                    ; FUNCTION
@@ -27,6 +26,9 @@
   (to     (util:required 'to)     :type tc:ty           :read-only t)
   (field  (util:required 'field)  :type string          :read-only t)
   (location (util:required 'location) :type source:location :read-only t))
+
+(defmethod source:location ((self accessor))
+  (accessor-location self))
 
 (defun accessor-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/typechecker/accessor.lisp
+++ b/src/typechecker/accessor.lisp
@@ -105,7 +105,7 @@
            (struct-entry (tc:lookup-struct env ty-name :no-error t)))
 
       (unless struct-entry
-        (tc-error (accessor-location accessor)
+        (tc-error accessor
                   "Invalid accessor"
                   (format nil "type '~S' is not a struct" ty-name)))
 
@@ -113,7 +113,7 @@
             (field (tc:get-field struct-entry (accessor-field accessor) :no-error t)))
 
         (unless field
-          (tc-error (accessor-location accessor)
+          (tc-error accessor
                     "Invalid accessor"
                     (format nil "struct '~S' does not have the field '~A'"
                             ty-name

--- a/src/typechecker/base.lisp
+++ b/src/typechecker/base.lisp
@@ -69,11 +69,14 @@ This requires a valid PPRINT-VARIABLE-CONTEXT")
        (se:display-source-error s (se:source-condition-err c))))))
 
 (defun tc-error (location message note &optional notes)
-  (error 'tc-error
-         :err (source:source-error :location location
-                                   :message message
-                                   :primary-note note
-                                   :notes notes)))
+  (let ((location (if (typep location 'source:location)
+                      location
+                      (source:location location))))
+    (error 'tc-error
+           :err (source:source-error :location location
+                                     :message message
+                                     :primary-note note
+                                     :notes notes))))
 
 (define-condition coalton-internal-type-error (error)
   ()

--- a/src/typechecker/base.lisp
+++ b/src/typechecker/base.lisp
@@ -11,6 +11,7 @@
    #:*pprint-variable-symbol-code*
    #:*pprint-variable-symbol-suffix*
    #:tc-error                           ; CONDITION, FUNCTION
+   #:tc-located-error                   ; CONDITION, FUNCTION
    #:coalton-internal-type-error        ; CONDITION
    #:check-duplicates                   ; FUNCTION
    #:check-package                      ; FUNCTION
@@ -68,15 +69,19 @@ This requires a valid PPRINT-VARIABLE-CONTEXT")
      (with-pprint-variable-context ()
        (se:display-source-error s (se:source-condition-err c))))))
 
-(defun tc-error (location message note &optional notes)
-  (let ((location (if (typep location 'source:location)
-                      location
-                      (source:location location))))
-    (error 'tc-error
-           :err (source:source-error :location location
-                                     :message message
-                                     :primary-note note
-                                     :notes notes))))
+(defun tc-located-error (location message note &optional notes)
+  "Signal a typechecker error with a NOTE about a LOCATION."
+  (declare (type source:location location)
+           (type string message note))
+  (error 'tc-error
+         :err (source:source-error :location location
+                                   :message message
+                                   :primary-note note
+                                   :notes notes)))
+
+(defun tc-error (object message note &optional notes)
+  "Signal a typechecker error with a NOTE about an OBJECT that implements SOURCE:LOCATION."
+  (tc-located-error (source:location object) message note notes))
 
 (define-condition coalton-internal-type-error (error)
   ()

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -316,9 +316,9 @@
            ;; Fundeps cannot be redefined
            :when (and prev-class (not (equalp (tc:ty-class-fundeps prev-class)
                                               fundeps))) 
-             :do (tc-error (parser:toplevel-define-class-head-location class)
-                           "Invalid fundep redefinition"
-                           (format nil "unable to redefine the fudndeps of class ~S." class-name))
+             :do (tc-located-error (parser:toplevel-define-class-head-location class)
+                                   "Invalid fundep redefinition"
+                                   (format nil "unable to redefine the fudndeps of class ~S." class-name))
 
            :when fundeps
              :do (setf env (tc:initialize-fundep-environment env class-name))

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -372,7 +372,7 @@
 
   (let ((var-names (mapcar #'parser:keyword-src-name (parser:toplevel-define-class-vars class))))
 
-    ;; Ensure fudneps don't have duplicate variables
+    ;; Ensure fundeps don't have duplicate variables
     (labels ((check-duplicate-fundep-variables (vars)
                (check-duplicates
                 vars

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -57,7 +57,7 @@
                          classes)
                  (alexandria:compose #'parser:identifier-src-name
                                      #'parser:method-definition-name)
-                 #'parser:method-definition-location)
+                 #'source:location)
 
   ;; Check for duplicate class definitions
   (check-duplicates
@@ -81,18 +81,18 @@
   (check-duplicates
    (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-class-methods) classes)
    (alexandria:compose #'parser:identifier-src-name #'parser:method-definition-name)
-   #'parser:method-definition-location
+   #'source:location
    (lambda (first second)
      (error 'tc:tc-error
             :err (source:source-error
-                  :location (parser:method-definition-location first)
+                  :location (source:location first)
                   :message "Duplicate method definition"
                   :primary-note "first definition here"
                   :notes
                   (list
                    (se:make-source-error-note
                     :type :primary
-                    :span (source:location-span (parser:method-definition-location second))
+                    :span (source:location-span (source:location second))
                     :message "second definition here"))))))
 
   (loop :for class :in classes :do
@@ -100,18 +100,18 @@
     (check-duplicates
      (parser:toplevel-define-class-vars class)
      #'parser:keyword-src-name
-     #'parser:keyword-src-location
+     #'source:location
      (lambda (first second)
        (error 'tc:tc-error
               :err (source:source-error
-                    :location (parser:keyword-src-location first)
+                    :location (source:location first)
                     :message "Duplicate class variable"
                     :primary-note "first usage here"
                     :notes
                     (list
                      (se:make-source-error-note
                       :type :primary
-                      :span (source:location-span (parser:keyword-src-location second))
+                      :span (source:location-span (source:location second))
                       :message "second usage here")))))))
 
   (let* ((class-table
@@ -377,18 +377,18 @@
                (check-duplicates
                 vars
                 #'parser:keyword-src-name
-                #'parser:keyword-src-location
+                #'source:location
                 (lambda (first second)
                   (error 'tc:tc-error
                          :err (source:source-error
-                               :location (parser:keyword-src-location first)
+                               :location (source:location first)
                                :message "Duplicate variable in function dependency"
                                :primary-note "first usage here"
                                :notes
                                (list
                                 (se:make-source-error-note
                                  :type :primary
-                                 :span (source:location-span (parser:keyword-src-location second))
+                                 :span (source:location-span (source:location second))
                                  :message "second usage here"))))))))
       (loop :for fundep :in (parser:toplevel-define-class-fundeps class)
             :do (check-duplicate-fundep-variables (parser:fundep-left fundep))
@@ -398,7 +398,7 @@
     (labels ((check-fundep-variables (vars)
                (loop :for var :in vars
                      :unless (find (parser:keyword-src-name var) var-names :test #'eq)
-                       :do (tc-error (parser:keyword-src-location var)
+                       :do (tc-error var
                                      "Unkown type variable"
                                      (format nil "unknown type variable ~S"
                                              (parser:keyword-src-name var))))))
@@ -438,7 +438,7 @@
 
                    ;; Ensure that methods are not ambiguous
                    :unless (subsetp var-names (tc:closure tyvars fundeps) :test #'eq)
-                     :do (tc-error (parser:method-definition-location method)
+                     :do (tc-error method
                                    "Ambiguous method"
                                    "the method is ambiguous")
 
@@ -451,7 +451,7 @@
                                              :test #'eq)
 
                              :when (subsetp tyvars var-names)
-                               :do (tc-error (parser:ty-predicate-location pred)
+                               :do (tc-error pred
                                              "Invalid method predicate"
                                              "method predicate contains only class variables"))
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -212,15 +212,15 @@
     (check-duplicates
      (parser:toplevel-define-instance-methods unparsed-instance)
      (alexandria:compose #'parser:node-variable-name #'parser:instance-method-definition-name)
-     #'parser:instance-method-definition-location
+     #'source:location
      (lambda (first second)
-       (tc-error (parser:instance-method-definition-location first)
+       (tc-error first
                  "Duplicate method definition"
                  "first definition here"
                  (list
                   (se:make-source-error-note
                    :type :primary
-                   :span (source:location-span (parser:instance-method-definition-location second))
+                   :span (source:location-span (source:location second))
                    :message "second definition here")))))
 
     ;; Ensure each method is part for the class
@@ -228,7 +228,7 @@
           :for name := (parser:node-variable-name (parser:instance-method-definition-name method))
 
           :unless (gethash name method-table)
-            :do (tc-error (parser:instance-method-definition-location method)
+            :do (tc-error method
                           "Unknown method"
                           (let ((*package* util:+keyword-package+))
                             (format nil "The method ~S is not part of class ~S"
@@ -241,7 +241,7 @@
                                :key (alexandria:compose #'parser:node-variable-name
                                                         #'parser:instance-method-definition-name))
           :unless method
-            :do (tc-error (parser:toplevel-define-instance-location unparsed-instance)
+            :do (tc-error unparsed-instance
                           "Missing method"
                           (format nil "The method ~S is not defined" name)))
 
@@ -266,7 +266,7 @@
                           :do (multiple-value-bind (preds method subs)
                                   (infer-expl-binding-type method
                                                            instance-method-scheme
-                                                           (parser:instance-method-definition-location method)
+                                                           (source:location method)
                                                            nil
                                                            (make-tc-env :env env))
 
@@ -293,7 +293,7 @@
        :context context
        :pred pred
        :methods methods
-       :location (parser:toplevel-define-instance-location unparsed-instance)
+       :location (source:location unparsed-instance)
        :head-location (parser:toplevel-define-instance-head-location unparsed-instance)))))
 
 (defun check-instance-valid (instance)

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -134,18 +134,18 @@
           (handler-case 
               (setf env (tc:update-instance-fundeps env pred))
             (tc:fundep-conflict (e)
-              (tc-error (parser:toplevel-define-instance-head-location instance)
-                        "Instance fundep conflict"
-                        (let ((*print-escape* nil))
-                          (with-output-to-string (s)
-                            (print-object e s)))))))
+              (tc-located-error (parser:toplevel-define-instance-head-location instance)
+                                "Instance fundep conflict"
+                                (let ((*print-escape* nil))
+                                  (with-output-to-string (s)
+                                    (print-object e s)))))))
 
         (handler-case
             (setf env (tc:add-instance env class-name instance-entry))
           (tc:overlapping-instance-error (e)
-            (tc-error (parser:toplevel-define-instance-head-location instance)
-                      "Overlapping instance"
-                      (format nil "instance overlaps with ~S" (tc:overlapping-instance-error-inst2 e)))))
+            (tc-located-error (parser:toplevel-define-instance-head-location instance)
+                              "Overlapping instance"
+                              (format nil "instance overlaps with ~S" (tc:overlapping-instance-error-inst2 e)))))
 
         (loop :for method-name :in method-names
               :for method-codegen-sym := (tc:get-value method-codegen-syms method-name) :do
@@ -189,9 +189,9 @@
                     env
                     superclass
                     :no-error t)
-                   (tc-error (parser:toplevel-define-instance-head-location unparsed-instance)
-                             "Instance missing context"
-                             (format nil "No instance for ~S" superclass)))
+                   (tc-located-error (parser:toplevel-define-instance-head-location unparsed-instance)
+                                     "Instance missing context"
+                                     (format nil "No instance for ~S" superclass)))
 
           :for additional-context
             := (tc:apply-substitution
@@ -202,12 +202,12 @@
 
           :do (loop :for pred :in additional-context
                     :do (unless (tc:entail env context pred)
-                          (tc-error (parser:toplevel-define-instance-head-location unparsed-instance)
-                                     "Instance missing context"
-                                     (format nil
-                                             "No instance for ~S arising from constraints of superclasses ~S"
-                                             pred
-                                             superclass)))))
+                          (tc-located-error (parser:toplevel-define-instance-head-location unparsed-instance)
+                                            "Instance missing context"
+                                            (format nil
+                                                    "No instance for ~S arising from constraints of superclasses ~S"
+                                                    pred
+                                                    superclass)))))
 
     (check-duplicates
      (parser:toplevel-define-instance-methods unparsed-instance)
@@ -313,9 +313,9 @@
 
 
     (when (eq (parser:identifier-src-name (parser:ty-predicate-class (parser:toplevel-define-instance-pred instance))) runtime-repr)
-      (tc-error (parser:toplevel-define-instance-head-location instance)
-                "Invalid instance"
-                "RuntimeRepr instances cannot be written manually"))))
+      (tc-located-error (parser:toplevel-define-instance-head-location instance)
+                        "Invalid instance"
+                        "RuntimeRepr instances cannot be written manually"))))
 
 (defun check-for-orphan-instance (instance)
   (declare (type parser:toplevel-define-instance instance)
@@ -355,6 +355,6 @@
                  :append (mapcar #'parser:tycon-name (parser:collect-referenced-types type))))))
 
     (unless (find *package* instance-syms :key #'symbol-package)
-      (tc-error (parser:toplevel-define-instance-head-location instance)
-                "Invalid orphan instance"
-                "instances must be defined in the same package as their class or reference one or more types in their defining package"))))
+      (tc-located-error (parser:toplevel-define-instance-head-location instance)
+                        "Invalid orphan instance"
+                        "instances must be defined in the same package as their class or reference one or more types in their defining package"))))

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -1878,20 +1878,20 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
                 ;; Check that the declared and inferred schemes match
                 (unless (equalp declared-ty output-scheme)
-                  (tc-error location
-                            "Declared type is too general"
-                            (format nil "Declared type ~S is more general than inferred type ~S."
-                                    declared-ty
-                                    output-scheme)))
+                  (tc-located-error location
+                                    "Declared type is too general"
+                                    (format nil "Declared type ~S is more general than inferred type ~S."
+                                            declared-ty
+                                            output-scheme)))
 
                 ;; Check for undeclared predicates
                 (when (not (null retained-preds))
-                  (tc-error location
-                            "Explicit type is missing inferred predicate"
-                            (with-pprint-variable-context ()
-                              (format nil "Declared type ~S is missing inferred predicate ~S"
-                                      output-qual-type
-                                      (first retained-preds)))))
+                  (tc-located-error location
+                                    "Explicit type is missing inferred predicate"
+                                    (with-pprint-variable-context ()
+                                      (format nil "Declared type ~S is missing inferred predicate ~S"
+                                              output-qual-type
+                                              (first retained-preds)))))
 
                 (values deferred-preds
                         (attach-explicit-binding-type (tc:apply-substitution subs binding-node)
@@ -2245,33 +2245,33 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                          :do (handler-case
                                  (setf subs (tc:unify subs ty1 ty2))
                                (tc:coalton-internal-type-error ()
-                                 (tc-error s1
-                                           "Return type mismatch"
-                                            (format nil "First return is of type '~S'"
-                                                    (tc:apply-substitution subs ty1))
-                                            (list
-                                             (se:make-source-error-note
-                                              :type :primary
-                                              :span (location-span s2)
-                                              :message (format nil "Second return is of type '~S'"
-                                                               (tc:apply-substitution subs ty2))))))))
+                                 (tc-located-error s1
+                                                   "Return type mismatch"
+                                                   (format nil "First return is of type '~S'"
+                                                           (tc:apply-substitution subs ty1))
+                                                   (list
+                                                    (se:make-source-error-note
+                                                     :type :primary
+                                                     :span (location-span s2)
+                                                     :message (format nil "Second return is of type '~S'"
+                                                                      (tc:apply-substitution subs ty2))))))))
 
                    ;; Unify the function's inferred type with one of the early returns.
                    (when *returns*
                      (handler-case
                          (setf subs (tc:unify subs (cdr (first *returns*)) ret-ty))
                        (tc:coalton-internal-type-error ()
-                         (tc-error (car (first *returns*))
-                                   "Return type mismatch"
-                                   (format nil "First return is of type '~S'"
-                                           (tc:apply-substitution subs (cdr (first *returns*))))
-                                   (list
-                                    (se:make-source-error-note
-                                     :type :primary
-                                     :span (location-span
-                                            (location (parser:binding-last-node binding)))
-                                     :message (format nil "Second return is of type '~S'"
-                                                      (tc:apply-substitution subs ret-ty))))))))
+                         (tc-located-error (car (first *returns*))
+                                           "Return type mismatch"
+                                           (format nil "First return is of type '~S'"
+                                                   (tc:apply-substitution subs (cdr (first *returns*))))
+                                           (list
+                                            (se:make-source-error-note
+                                             :type :primary
+                                             :span (location-span
+                                                    (location (parser:binding-last-node binding)))
+                                             :message (format nil "Second return is of type '~S'"
+                                                              (tc:apply-substitution subs ret-ty))))))))
 
                    value-node))
 

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -62,10 +62,10 @@
 (defun error-ambiguous-pred (pred)
   (declare (type tc:ty-predicate pred))
 
-  (unless (tc:ty-predicate-location pred)
+  (unless (location pred)
     (util:coalton-bug "Predicate ~S does not have source information" pred))
 
-  (tc-error (tc:ty-predicate-location pred)
+  (tc-error pred
             "Ambiguous predicate"
             (with-pprint-variable-context ()
               (format nil "Ambiguous predicate ~S" pred))))
@@ -73,16 +73,16 @@
 (defun error-unknown-pred (pred)
   (declare (type tc:ty-predicate pred))
 
-  (unless (tc:ty-predicate-location pred)
+  (unless (location pred)
     (util:coalton-bug "Predicate ~S does not have source information" pred))
 
-  (tc-error (tc:ty-predicate-location pred)
+  (tc-error pred
             "Unknown instance"
             (format nil "Unknown instance ~S" pred)))
 
 (defun standard-expression-type-mismatch-error (node subs expected-type ty)
   "Utility for signalling a type-mismatch error in INFER-EXPRESSION-TYPE"
-  (tc-error (parser:node-location node)
+  (tc-error node
             "Type mismatch"
             (format nil "Expected type '~S' but got '~S'"
                     (tc:apply-substitution subs expected-type)
@@ -102,37 +102,37 @@
   (check-package defines
                  (alexandria:compose #'parser:node-variable-name
                                      #'parser:toplevel-define-name)
-                 (alexandria:compose #'parser:node-location
+                 (alexandria:compose #'location
                                      #'parser:toplevel-define-name))
 
   ;; Ensure that there are no duplicate definitions
   (check-duplicates
    defines
    (alexandria:compose #'parser:node-variable-name #'parser:toplevel-define-name)
-   #'parser:toplevel-define-location
+   #'location
    (lambda (first second)
-     (tc-error (parser:node-location (parser:toplevel-define-name first))
+     (tc-error (parser:toplevel-define-name first)
                "Duplicate definition"
                "first definition here"
                (list
                 (se:make-source-error-note
                  :type :primary
-                 :span (location-span (parser:node-location (parser:toplevel-define-name second)))
+                 :span (location-span (location (parser:toplevel-define-name second)))
                  :message "second definition here")))))
 
   ;; Ensure that there are no duplicate declarations
   (check-duplicates
    declares
    (alexandria:compose #'parser:identifier-src-name #'parser:toplevel-declare-name)
-   #'parser:toplevel-define-location
+   #'location
    (lambda (first second)
-     (tc-error (parser:identifier-src-location (parser:toplevel-declare-name first))
+     (tc-error (parser:toplevel-declare-name first)
                "Duplicate declaration"
                "first declaration here"
                (list
                 (se:make-source-error-note
                  :type :primary
-                 :span (location-span (parser:identifier-src-location (parser:toplevel-declare-name second)))
+                 :span (location-span (location (parser:toplevel-declare-name second)))
                  :message "second declaration here")))))
 
   ;; Ensure that each declaration has an associated definition
@@ -151,7 +151,7 @@
         :for name := (parser:identifier-src-name (parser:toplevel-declare-name declare))
 
         :unless (gethash name def-table)
-          :do (tc-error (parser:identifier-src-location (parser:toplevel-declare-name declare))
+          :do (tc-error (parser:toplevel-declare-name declare)
                         "Orphan declaration"
                         "declaration does not have an associated definition"))
 
@@ -193,7 +193,7 @@
                                                    :name name
                                                    :type :value
                                                    :docstring (docstring define)
-                                                   :location (parser:binding-location define))))
+                                                   :location (location define))))
 
               :if (parser:toplevel-define-orig-params define)
                 :do (setf env (tc:set-function-source-parameter-names
@@ -240,7 +240,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                nil
                (make-node-literal
                 :type (tc:qualify nil type)
-                :location (parser:node-location node)
+                :location (location node)
                 :value (parser:node-literal-value node))
                subs)))
 
@@ -271,10 +271,10 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  :from from-ty
                  :to to-ty
                  :field (parser:node-accessor-name node)
-                 :location (parser:node-location node)))
+                 :location (location node)))
                (make-node-accessor
                 :type (tc:qualify nil type)
-                :location (parser:node-location node)
+                :location (location node)
                 :name (parser:node-accessor-name node))
                subs))))))
 
@@ -289,7 +289,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
            (tvar
              (tc:make-variable))
            (pred
-             (tc:make-ty-predicate :class num :types (list tvar) :location (parser:node-location node))))
+             (tc:make-ty-predicate :class num :types (list tvar) :location (location node))))
       (handler-case
           (progn
             (setf subs (tc:unify subs tvar expected-type))
@@ -300,7 +300,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                nil
                (make-node-integer-literal
                 :type (tc:qualify nil type)
-                :location (parser:node-location node)
+                :location (location node)
                 :value (parser:node-integer-literal-value node))
                subs)))
         (tc:coalton-internal-type-error ()
@@ -326,7 +326,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                nil
                (make-node-variable
                 :type (tc:qualify preds type)
-                :location (parser:node-location node)
+                :location (location node)
                 :name (parser:node-variable-name node))
                subs)))
         (tc:coalton-internal-type-error ()
@@ -347,7 +347,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
       (let* ((rands (or (parser:node-application-rands node)
                         (list
                          (parser:make-node-variable
-                          :location (parser:node-location node)
+                          :location (location node)
                           :name 'coalton:unit))))
 
              (fun-ty_ fun-ty)
@@ -395,8 +395,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                 ;; Otherwise signal an error
                                 (t
                                  (setf fun-ty (tc:apply-substitution subs fun-ty))
-
-                                 (tc-error (parser:node-location node)
+                                 (tc-error node
                                            "Argument error"
                                            (if (null (tc:function-type-arguments fun-ty))
                                                (format nil "Unable to call '~S': it is not a function"
@@ -414,7 +413,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                         preds
                         accessors
                         (make-node-application :type (tc:qualify nil type)
-                                               :location (parser:node-location node)
+                                               :location (location node)
                                                :rator rator-node
                                                :rands rand-nodes)
                         subs)))
@@ -446,7 +445,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 (make-node-bind
                  ;; NOTE: We don't attach type here because NODE-BIND has no
                  ;; meaningful type.
-                 :location (parser:node-bind-location node)
+                 :location (location node)
                  :pattern pat-node
                  :expr expr-node)
          subs))))
@@ -494,14 +493,14 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
     (check-duplicates
      (parser:pattern-variables (parser:node-abstraction-params node))
      #'parser:pattern-var-name
-     #'parser:pattern-location
+     #'location
      (lambda (first second)
-       (tc-error (parser:node-location first)
+       (tc-error first
                  "Duplicate parameters name"
                  "first parameter here"
                  (list (se:make-source-error-note
                         :type :primary
-                        :span (location-span (parser:node-location second))
+                        :span (location-span (location second))
                         :message "second parameter here")))))
 
     (let* (;; Setup return environment
@@ -518,7 +517,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  (list
                   (make-pattern-wildcard
                    :type (tc:qualify nil (first arg-tys))
-                   :location (parser:node-location node)))
+                   :location (location node)))
                  (loop :for pattern :in (parser:node-abstraction-params node)
                        :for ty :in arg-tys
                        :collect (multiple-value-bind (ty_ pattern subs_)
@@ -564,7 +563,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                          (se:make-source-error-note
                           :type :primary
                           :span (location-span
-                                 (parser:node-location
+                                 (location
                                   (parser:node-body-last-node (parser:node-abstraction-body node))))
                           :message (format nil "Second return is of type '~S'"
                                            (tc:apply-substitution subs body-ty))))))))
@@ -580,7 +579,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                    accessors
                    (make-node-abstraction
                     :type (tc:qualify nil type)
-                    :location (parser:node-location node)
+                    :location (location node)
                     :params params
                     :body body-node)
                    subs)))
@@ -597,14 +596,14 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
     (check-duplicates
      (parser:node-let-bindings node)
      (alexandria:compose #'parser:node-variable-name #'parser:node-let-binding-name)
-     #'parser:node-let-binding-location
+     #'location
      (lambda (first second)
-       (tc-error (parser:node-let-binding-location first)
+       (tc-error first
                  "Duplicate definition in let"
                  "first definition here"
                  (list (se:make-source-error-note
                         :type :primary
-                        :span (location-span (parser:node-let-binding-location second))
+                        :span (location-span (location second))
                         :message "second definition here")))))
 
     (multiple-value-bind (preds accessors binding-nodes subs)
@@ -624,7 +623,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
          accessors
          (make-node-let
           :type (tc:qualify nil ty)
-          :location (parser:node-location node)
+          :location (location node)
           :bindings binding-nodes
           :body body-node)
          subs))))
@@ -646,7 +645,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                     (mapcar (lambda (var)
                               (make-node-variable
                                :type (tc:qualify nil (tc-env-lookup-value env var))
-                               :location (parser:node-location var)
+                               :location (location var)
                                :name (parser:node-variable-name var)))
                             (parser:node-lisp-vars node))))
               (values
@@ -655,7 +654,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                nil
                (make-node-lisp
                 :type (tc:qualify nil type)
-                :location (parser:node-location node)
+                :location (location node)
                 :vars var-nodes
                 :var-names (parser:node-lisp-var-names node)
                 :body (parser:node-lisp-body node))
@@ -707,7 +706,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                      :collect (make-node-match-branch
                                :pattern pat-node
                                :body branch-body-node
-                               :location (parser:node-match-branch-location branch)))))
+                               :location (location branch)))))
 
         (handler-case
             (progn
@@ -719,7 +718,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  accessors
                  (make-node-match
                   :type (tc:qualify nil type)
-                  :location (parser:node-location node)
+                  :location (location node)
                   :expr expr-node
                   :branches branch-nodes)
                  subs)))
@@ -743,7 +742,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
        accessors
        (make-node-progn
         :type (tc:qualify nil body-ty)
-        :location (parser:node-location node)
+        :location (location node)
         :body body-node)
        subs)))
 
@@ -768,7 +767,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         (handler-case
             (setf subs (tc:unify subs declared-ty expr-ty))
           (tc:coalton-internal-type-error ()
-            (tc-error (parser:node-location node)
+            (tc-error node
                       "Type mismatch"
                       (format nil "Declared type '~S' does not match inferred type '~S'"
                               (tc:apply-substitution subs declared-ty)
@@ -778,7 +777,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         (handler-case
             (tc:match expr-ty declared-ty)
           (tc:coalton-internal-type-error ()
-            (tc-error (parser:node-location node)
+            (tc-error node
                       "Declared type too general"
                       (format nil "Declared type '~S' is more general than inferred type '~S'"
                               (tc:apply-substitution subs declared-ty)
@@ -809,13 +808,13 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
     ;; Returns must be inside a lambda
     (when (eq *return-status* :toplevel)
-      (tc-error (parser:node-location node)
+      (tc-error node
                 "Unexpected return"
                 "returns must be inside a lambda"))
 
     ;; Returns cannot be in a do expression
     (when (eq *return-status* :do)
-      (tc-error (parser:node-location node)
+      (tc-error node
                 "Invalid return"
                 "returns cannot be in a do expression"))
 
@@ -823,14 +822,14 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         (infer-expression-type (or (parser:node-return-expr node)
                                    ;; If the return looks like (return) then it returns unit
                                    (parser:make-node-variable
-                                    :location (parser:node-location node)
+                                    :location (location node)
                                     :name 'coalton:Unit))
                                (tc:make-variable)
                                subs
                                env)
 
       ;; Add node the the list of returns
-      (push (cons (parser:node-location node) ty) *returns*)
+      (push (cons (location node) ty) *returns*)
 
       (values
        expected-type
@@ -838,7 +837,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
        accessors
        (make-node-return
         :type (tc:qualify nil expected-type)
-        :location (parser:node-location node)
+        :location (location node)
         :expr expr-node)
        subs)))
 
@@ -873,11 +872,11 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              accessors
              (make-node-or
               :type (tc:qualify nil tc:*boolean-type*)
-              :location (parser:node-location node)
+              :location (location node)
               :nodes body-nodes)
              subs))
         (tc:coalton-internal-type-error ()
-          (tc-error (parser:node-location node)
+          (tc-error node
                     "Type mismatch"
                     (format nil "Expected type '~S' but 'or' evaluates to '~S'"
                             (tc:apply-substitution subs expected-type)
@@ -914,11 +913,11 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              accessors
              (make-node-and
               :type (tc:qualify nil tc:*boolean-type*)
-              :location (parser:node-location node)
+              :location (location node)
               :nodes body-nodes)
              subs))
         (tc:coalton-internal-type-error ()
-          (tc-error (parser:node-location node)
+          (tc-error node
                     "Type mismatch"
                     (format nil "Expected type '~S' but 'and' evaluates to '~S'"
                             (tc:apply-substitution subs expected-type)
@@ -962,7 +961,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  accessors
                  (make-node-if
                   :type (tc:qualify nil type)
-                  :location (parser:node-location node)
+                  :location (location node)
                   :expr expr-node
                   :then then-node
                   :else else-node)
@@ -1000,7 +999,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                accessors
                (make-node-when
                 :type (tc:qualify nil tc:*unit-type*)
-                :location (parser:node-location node)
+                :location (location node)
                 :expr expr-node
                 :body body-node)
                subs))
@@ -1037,7 +1036,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                accessors
                (make-node-unless
                 :type (tc:qualify nil tc:*unit-type*)
-                :location (parser:node-location node)
+                :location (location node)
                 :expr expr-node
                 :body body-node)
                subs))
@@ -1076,7 +1075,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                accessors
                (make-node-while
                 :type (tc:qualify nil tc:*unit-type*)
-                :location (parser:node-location node)
+                :location (location node)
                 :label (parser:node-while-label node)
                 :expr expr-node
                 :body body-node)
@@ -1118,7 +1117,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  accessors
                  (make-node-while-let
                   :type (tc:qualify nil tc:*unit-type*)
-                  :location (parser:node-location node)
+                  :location (location node)
                   :label (parser:node-while-let-label node)
                   :pattern pat-node
                   :expr expr-node
@@ -1160,12 +1159,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                     (tc:make-ty-predicate
                      :class intoiter-symbol
                      :types (list expr-ty pat-ty)
-                     :location (parser:node-location node))
+                     :location (location node))
                     preds)
                    accessors
                    (make-node-for
                     :type (tc:qualify nil tc:*unit-type*)
-                    :location (parser:node-location node)
+                    :location (location node)
                     :label (parser:node-for-label node)
                     :pattern pat-node
                     :expr expr-node
@@ -1195,7 +1194,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              accessors
              (make-node-loop
               :type (tc:qualify nil tc:*unit-type*)
-              :location (parser:node-location node)
+              :location (location node)
               :label (parser:node-loop-label node)
               :body body-node)
              subs))
@@ -1216,7 +1215,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
            nil
            (make-node-break
             :type (tc:qualify nil tc:*unit-type*)
-            :location (parser:node-location node)
+            :location (location node)
             :label (parser:node-break-label node))
            subs))
       (tc:coalton-internal-type-error ()
@@ -1236,7 +1235,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
            nil
            (make-node-continue
             :type (tc:qualify nil tc:*unit-type*)
-            :location (parser:node-location node)
+            :location (location node)
             :label (parser:node-continue-label node))
            subs))
       (tc:coalton-internal-type-error ()
@@ -1270,7 +1269,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
            preds
            accessors
            (make-node-cond-clause
-            :location (parser:node-cond-clause-location node)
+            :location (location node)
             :expr expr-node
             :body body-node)
            subs)))))
@@ -1309,7 +1308,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                accessors
                (make-node-cond
                 :type (tc:qualify nil type)
-                :location (parser:node-location node)
+                :location (location node)
                 :clauses clause-nodes)
                subs)))
         (tc:coalton-internal-type-error ()
@@ -1346,10 +1345,10 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  (make-node-do-bind
                   :pattern pattern
                   :expr expr-node
-                  :location (parser:node-do-bind-location node))
+                  :location (location node))
                  subs))
             (tc:coalton-internal-type-error ()
-              (tc-error (parser:node-do-bind-location node)
+              (tc-error node
                         "Type mismatch"
                         (format nil "Expected type '~S' but got '~S'"
                                 (tc:apply-substitution subs expected-type)
@@ -1436,17 +1435,17 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 (tc:make-ty-predicate
                  :class monad-symbol
                  :types (list m-type)
-                 :location (parser:node-location node))
+                 :location (location node))
                 preds)
                accessors
                (make-node-do
                 :type (tc:qualify nil ty)
-                :location (parser:node-location node)
+                :location (location node)
                 :nodes nodes
                 :last-node last-node) 
                subs))
           (tc:coalton-internal-type-error ()
-            (tc-error (parser:node-location node)
+            (tc-error node
                       "Type mismatch"
                       (format nil "Expected type '~S' but do expression has type '~S'"
                               (tc:apply-substitution subs expected-type)
@@ -1476,7 +1475,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
          type
          (make-pattern-var
           :type (tc:qualify nil type)
-          :location (parser:pattern-location pat)
+          :location (location pat)
           :name (parser:pattern-var-name pat)
           :orig-name (parser:pattern-var-orig-name pat))
          subs))))
@@ -1503,11 +1502,11 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                type
                (make-pattern-literal
                 :type (tc:qualify nil type)
-                :location (parser:pattern-location pat)
+                :location (location pat)
                 :value (parser:pattern-literal-value pat))
                subs)))
         (tc:coalton-internal-type-error ()
-          (tc-error (parser:pattern-location pat)
+          (tc-error pat
                     "Type mismatch"
                     (format nil "Expected type '~S' but pattern literal has type '~S'"
                             (tc:apply-substitution subs expected-type)
@@ -1523,7 +1522,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
      expected-type
      (make-pattern-wildcard
       :type (tc:qualify nil expected-type)
-      :location (parser:pattern-location pat))
+      :location (location pat))
      subs))
 
   (:method ((pat parser:pattern-constructor) expected-type subs env)
@@ -1536,19 +1535,19 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
       (check-duplicates (parser:pattern-variables pat)
                         #'parser:pattern-var-name
-                        #'parser:pattern-location
+                        #'location
                         (lambda (first second)
-                          (tc-error (parser:pattern-location first)
+                          (tc-error first
                                     "Duplicate pattern variable"
                                     "first definition here"
                                     (list
                                      (se:make-source-error-note
                                       :type :primary
-                                      :span (location-span (parser:pattern-location second))
+                                      :span (location-span (location second))
                                       :message "second definition here")))))
 
       (unless ctor
-        (tc-error (parser:pattern-location pat)
+        (tc-error pat
                   "Unknown constructor"
                   "constructor is not known"))
 
@@ -1557,7 +1556,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
             (num-args
               (length (parser:pattern-constructor-patterns pat))))
         (unless (= arity num-args)
-          (tc-error (parser:pattern-location pat)
+          (tc-error pat
                     "Argument mismatch"
                     (format nil "Constructor ~A takes ~D arguments but is given ~D"
                             (parser:pattern-constructor-name pat)
@@ -1587,12 +1586,12 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                    type
                    (make-pattern-constructor
                     :type (tc:qualify nil pat-ty)
-                    :location (parser:pattern-location pat)
+                    :location (location pat)
                     :name (parser:pattern-constructor-name pat)
                     :patterns pattern-nodes)
                    subs)))
             (tc:coalton-internal-type-error ()
-              (tc-error (parser:pattern-location pat)
+              (tc-error pat
                         "Type mismatch"
                         (format nil "Expected type '~S' but pattern has type '~S'"
                                 (tc:apply-substitution subs expected-type)
@@ -1618,14 +1617,14 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
           :for name := (parser:node-variable-name (parser:node-let-binding-name binding))
 
           :if (gethash name def-table)
-            :do (tc-error (parser:node-location (parser:node-let-binding-name binding))
+            :do (tc-error (parser:node-let-binding-name binding)
                           "Duplicate binding in let"
                           "second definition here"
                           (list
                            (se:make-source-error-note
                             :type :primary
                             :span (location-span
-                                   (parser:node-location
+                                   (location
                                     (parser:node-let-binding-name
                                      (gethash name def-table))))
                             :message "first definition here")))
@@ -1637,14 +1636,14 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
           :for name := (parser:node-variable-name (parser:node-let-declare-name declare))
 
           :if (gethash name dec-table)
-            :do (tc-error (parser:node-location (parser:node-let-declare-name declare))
+            :do (tc-error (parser:node-let-declare-name declare)
                           "Duplicate declaration in let"
                           "second declaration here"
                           (list
                            (se:make-source-error-note
                             :type :primary
                             :span (location-span
-                                   (parser:node-location
+                                   (location
                                     (parser:node-let-declare-name
                                      (gethash name dec-table))))
                             :message "first declaration here")))
@@ -1656,7 +1655,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
           :for name := (parser:node-variable-name (parser:node-let-declare-name declare))
 
           :unless (gethash name def-table)
-            :do (tc-error (parser:node-location (parser:node-let-declare-name declare))
+            :do (tc-error (parser:node-let-declare-name declare)
                           "Orphan declare in let"
                           "declaration does not have an associated definition"))
 
@@ -1748,7 +1747,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                  :collect (multiple-value-bind (preds_ node_ subs_)
                               (infer-expl-binding-type binding
                                                        scheme
-                                                       (parser:node-location
+                                                       (location
                                                         (parser:binding-name binding))
                                                        subs
                                                        env)
@@ -1797,7 +1796,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
         (setf subs (tc:compose-substitution-lists subs subs_))
 
         (when accessors
-          (tc-error (accessor-location (first accessors))
+          (tc-error (first accessors)
                     "Ambiguous accessor"
                     "accessor is ambiguous"))
 
@@ -1919,13 +1918,13 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     (let ((first-fn (find-if #'parser:binding-function-p bindings)))
       (assert first-fn)
 
-      (tc-error (parser:node-location (parser:binding-name first-fn))
+      (tc-error (parser:binding-name first-fn)
                 "Invalid recursive bindings"
                 "function can not be defined recursively with variables"
                 (loop :for binding :in (remove first-fn bindings :test #'eq)
                       :collect (se:make-source-error-note
                                 :type :secondary
-                                :span (location-span (parser:node-location (parser:binding-name binding)))
+                                :span (location-span (location (parser:binding-name binding)))
                                 :message "with definition")))))
 
   ;; If there is a single non-recursive binding then it is valid
@@ -1938,13 +1937,13 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
   ;; Toplevel bindings cannot be recursive values
   (when (parser:binding-toplevel-p (first bindings))
-    (tc-error (parser:node-location (parser:binding-name (first bindings)))
+    (tc-error (parser:binding-name (first bindings))
               "Invalid recursive bindings"
               "invalid recursive variable bindings"
               (loop :for binding :in (rest bindings)
                     :collect (se:make-source-error-note
                               :type :secondary
-                              :span (location-span (parser:node-location (parser:binding-name binding)))
+                              :span (location-span (location (parser:binding-name binding)))
                               :message "with definition"))))
 
   (let ((binding-names (mapcar (alexandria:compose #'parser:node-variable-name
@@ -2003,13 +2002,13 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
       (when (every (alexandria:compose #'valid-recursive-constructor-call-p #'parser:binding-value) bindings)
         (return-from check-for-invalid-recursive-scc))
 
-      (tc-error (parser:node-location (parser:binding-name (first bindings)))
+      (tc-error (parser:binding-name (first bindings))
                 "Invalid recursive bindings"
                 "invalid recursive variable bindings"
                 (loop :for binding :in (rest bindings)
                       :collect (se:make-source-error-note
                                 :type :secondary
-                                :span (location-span (parser:node-location (parser:binding-name binding)))
+                                :span (location-span (location (parser:binding-name binding)))
                                 :message "with definition"))))))
 
 (defun infer-impls-binding-type (bindings subs env)
@@ -2056,7 +2055,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
       (setf subs (tc:compose-substitution-lists subs subs_))
 
       (when accessors
-        (tc-error (accessor-location (first accessors))
+        (tc-error (first accessors)
                   "Ambiguous accessor"
                   "accessor is ambiguous"))
 
@@ -2189,15 +2188,15 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
   (check-duplicates
    (parser:pattern-variables (parser:binding-parameters binding))
    #'parser:pattern-var-name
-   #'parser:pattern-location
+   #'location
    (lambda (first second)
-     (tc-error (parser:node-location first)
+     (tc-error first
                "Duplicate parameters name"
                "first parameter here"
                (list (se:make-source-error-note
                       :type :primary
                       :span (location-span
-                             (parser:node-location second))
+                             (location second))
                       :message "second parameter here")))))
 
   (let* ((param-tys (loop :with args := (tc:function-type-arguments expected-type)
@@ -2270,7 +2269,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                                     (se:make-source-error-note
                                      :type :primary
                                      :span (location-span
-                                            (parser:node-location (parser:binding-last-node binding)))
+                                            (location (parser:binding-last-node binding)))
                                      :message (format nil "Second return is of type '~S'"
                                                       (tc:apply-substitution subs ret-ty))))))))
 
@@ -2298,7 +2297,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                    (name-node
                      (make-node-variable
                       :type (tc:qualify nil type)
-                      :location (parser:node-location (parser:binding-name binding))
+                      :location (location (parser:binding-name binding))
                       :name (parser:node-variable-name (parser:binding-name binding))))
 
                    (typed-binding (build-typed-binding binding name-node value-node params)))
@@ -2308,7 +2307,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                typed-binding
                subs)))
         (tc:coalton-internal-type-error ()
-          (tc-error (parser:binding-location binding)
+          (tc-error binding
                     "Type mismatch"
                     (format nil "Expected type '~S' but got type '~S'"
                             (tc:apply-substitution subs expected-type)
@@ -2329,7 +2328,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
      :name name
      :params params
      :body value
-     :location (parser:toplevel-define-location binding)))
+     :location (location binding)))
 
   (:method ((binding parser:node-let-binding) name value params)
     (declare (type node-variable name)
@@ -2342,7 +2341,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     (make-node-let-binding
      :name name
      :value value
-     :location (parser:node-let-binding-location binding)))
+     :location (location binding)))
 
   (:method ((binding parser:instance-method-definition) name value params)
     (declare (type node-variable name)
@@ -2354,7 +2353,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
      :name name
      :params params
      :body value
-     :location (parser:instance-method-definition-location binding))))
+     :location (location binding))))
 
 (defgeneric attach-explicit-binding-type (binding explicit-type)
   (:method ((binding toplevel-define) explicit-type)
@@ -2365,10 +2364,10 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     :name (make-node-variable
            :name (node-variable-name (toplevel-define-name binding))
            :type explicit-type
-           :location (node-location (toplevel-define-name binding)))
+           :location (location (toplevel-define-name binding)))
     :params (toplevel-define-params binding)
     :body (toplevel-define-body binding)
-    :location (toplevel-define-location binding)))
+    :location (location binding)))
 
   (:method ((binding node-let-binding) explicit-type)
     (declare (type tc:qualified-ty explicit-type)
@@ -2378,9 +2377,9 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     :name (make-node-variable
            :name (node-variable-name (node-let-binding-name binding))
            :type explicit-type
-           :location (node-location (node-let-binding-name binding)))
+           :location (location (node-let-binding-name binding)))
     :value (node-let-binding-value binding)
-    :location (node-let-binding-location binding)))
+    :location (location binding)))
 
   (:method ((binding instance-method-definition) explicit-type)
     (declare (type tc:qualified-ty explicit-type)
@@ -2390,10 +2389,10 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
      :name (make-node-variable
             :name (node-variable-name (instance-method-definition-name binding))
             :type explicit-type
-            :location (node-location (instance-method-definition-name binding)))
+            :location (location (instance-method-definition-name binding)))
      :params (instance-method-definition-params binding)
      :body (instance-method-definition-body binding)
-     :location (instance-method-definition-location binding))))
+     :location (location binding))))
 
 ;;; When inferring the types of bindings in a recursive binding group,
 ;;; references to those bindings will not yet have predicates. If
@@ -2413,7 +2412,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
                  (make-node-variable
                   :type (gethash (node-variable-name node) table)
-                  :location (node-location node)
+                  :location (location node)
                   :name (node-variable-name node))
 
                  node)))
@@ -2427,7 +2426,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                (toplevel-define-body binding)
                (make-traverse-block
                 :variable #'rewrite-variable-ref))
-        :location (toplevel-define-location binding)))
+        :location (location binding)))
 
       (node-let-binding
        (make-node-let-binding
@@ -2436,7 +2435,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                 (node-let-binding-value binding)
                 (make-traverse-block
                  :variable #'rewrite-variable-ref))
-        :location (node-let-binding-location binding))))))
+        :location (location binding))))))
 
 ;;; When type checking bindings, Coalton computes the set of type
 ;;; variables that can be qualified over. Predicates that contain type

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -39,7 +39,6 @@
    #:type-entry-explicit-repr               ; ACCESSOR
    #:type-entry-enum-repr                   ; ACCESSOR
    #:type-entry-newtype                     ; ACCESSOR
-   #:type-entry-location                    ; ACCESSOR
    #:type-environment                       ; STRUCT
    #:constructor-entry                      ; STRUCT
    #:make-constructor-entry                 ; ACCESSOR
@@ -79,7 +78,6 @@
    #:ty-class-codegen-sym                   ; ACCESSOR
    #:ty-class-superclass-dict               ; ACCESSOR
    #:ty-class-superclass-map                ; ACCESSOR
-   #:ty-class-location                      ; ACCESSOR
    #:ty-class-list                          ; TYPE
    #:class-environment                      ; STRUCT
    #:ty-class-instance                      ; STRUCT
@@ -100,7 +98,6 @@
    #:make-name-entry                        ; CONSTRUCTOR
    #:name-entry-name                        ; ACCESSOR
    #:name-entry-type                        ; ACCESSOR
-   #:name-entry-location                      ; ACCESSOR
    #:name-environment                       ; STRUCT
    #:method-inline-environment              ; STRUCT
    #:code-environment                       ; STRUCT
@@ -269,6 +266,9 @@
 
   (docstring (util:required 'docstring) :type (or null string)   :read-only t)
   (location  nil                        :type (or null location) :read-only t))
+
+(defmethod location ((self type-entry))
+  (type-entry-location self))
 
 (defmethod docstring ((self type-entry))
   (type-entry-docstring self))
@@ -575,11 +575,14 @@
   ;; Methods of the class containing the same tyvars in PREDICATE for
   ;; use in pretty printing
   (unqualified-methods (util:required 'unqualified-methods) :type ty-class-method-list :read-only t)
-  (codegen-sym         (util:required 'codegen-sym)         :type symbol              :read-only t)
-  (superclass-dict     (util:required 'superclass-dict)     :type list                :read-only t)
-  (superclass-map      (util:required 'superclass-map)      :type environment-map     :read-only t)
-  (docstring           (util:required 'docstring)           :type (or null string)    :read-only t)
-  (location              (util:required 'location)              :type location :read-only t))
+  (codegen-sym         (util:required 'codegen-sym)         :type symbol               :read-only t)
+  (superclass-dict     (util:required 'superclass-dict)     :type list                 :read-only t)
+  (superclass-map      (util:required 'superclass-map)      :type environment-map      :read-only t)
+  (docstring           (util:required 'docstring)           :type (or null string)     :read-only t)
+  (location            (util:required 'location)            :type location             :read-only t))
+
+(defmethod location ((self ty-class))
+  (ty-class-location self))
 
 (defmethod docstring ((self ty-class))
   (ty-class-docstring self))
@@ -618,8 +621,8 @@
                                     (cdr entry)))
                             (ty-class-superclass-dict class))
    :superclass-map (ty-class-superclass-map class)
-   :docstring (ty-class-docstring class)
-   :location (ty-class-location class)))
+   :docstring (docstring class)
+   :location (location class)))
 
 (defstruct (class-environment (:include immutable-map)))
 
@@ -716,7 +719,10 @@
   (name      (util:required 'name)      :type symbol                               :read-only t)
   (type      (util:required 'type)      :type (member :value :method :constructor) :read-only t)
   (docstring (util:required 'docstring) :type (or null string)                     :read-only t)
-  (location    (util:required 'location)    :type location                      :read-only t))
+  (location  (util:required 'location)  :type location                             :read-only t))
+
+(defmethod location ((self name-entry))
+  (name-entry-location self))
 
 (defmethod docstring ((self name-entry))
   (name-entry-docstring self))
@@ -1459,7 +1465,7 @@
                  :else
                    :collect (make-variable)))
 
-         (new-pred (make-ty-predicate :class class-name :types vars :location (ty-predicate-location pred))))
+         (new-pred (make-ty-predicate :class class-name :types vars :location (location pred))))
 
     (fset:do-seq (inst (lookup-class-instances env class-name))
       (handler-case

--- a/src/typechecker/expression.lisp
+++ b/src/typechecker/expression.lisp
@@ -15,7 +15,6 @@
   (:export
    #:node                               ; STRUCT
    #:node-type                          ; ACCESSOR
-   #:node-location                        ; ACCESSOR
    #:node-list                          ; TYPE
    #:node-variable                      ; STRUCT
    #:make-node-variable                 ; CONSTRUCTOR
@@ -34,7 +33,6 @@
    #:make-node-bind                     ; CONSTRUCTOR
    #:node-bind-pattern                  ; ACCESSOR
    #:node-bind-expr                     ; ACCESSOR
-   #:node-bind-location                   ; ACCESSOR
    #:node-body-element                  ; TYPE
    #:node-body-element-list             ; TYPE
    #:node-body                          ; STRUCT
@@ -50,13 +48,11 @@
    #:make-node-let-binding              ; CONSTRUCTOR
    #:node-let-binding-name              ; ACCESSOR
    #:node-let-binding-value             ; ACCESSOR
-   #:node-let-binding-location            ; ACCESSOR
    #:node-let-binding-list              ; TYPE
    #:node-let-declare                   ; STRUCT
    #:make-node-let-declare              ; CONSTRUCTOR
    #:node-let-declare-name              ; ACCESSOR
    #:node-let-declare-type              ; ACCESSOR
-   #:node-let-declare-location            ; ACCESSOR
    #:node-let-declare-list              ; TYPE
    #:node-let                           ; STRUCT
    #:make-node-let                      ; CONSTRUCTOR
@@ -73,7 +69,6 @@
    #:make-node-match-branch             ; CONSTRUCTOR
    #:node-match-branch-pattern          ; ACCESSOR
    #:node-match-branch-body             ; ACCESSOR
-   #:node-match-branch-location           ; ACCESSOR
    #:node-match-branch-list             ; TYPE
    #:node-match                         ; STRUCT
    #:make-node-match                    ; CONSTRUCTOR
@@ -143,7 +138,6 @@
    #:make-node-cond-clause              ; CONSTRUCTOR
    #:node-cond-clause-expr              ; ACCESSOR
    #:node-cond-clause-body              ; ACCESSOR
-   #:node-cond-clause-location            ; ACCESSOR
    #:node-cond-clause-list              ; TYPE
    #:node-cond                          ; STRUCT
    #:make-node-cond                     ; CONSTRUCTOR
@@ -152,7 +146,6 @@
    #:make-node-do-bind                  ; CONSTRUCTOR
    #:node-do-bind-pattern               ; ACCESSOR
    #:node-do-bind-expr                  ; ACCESSOR
-   #:node-do-bind-location                ; ACCESSOR
    #:node-do-body-element               ; TYPE
    #:node-body-element-list             ; TYPE
    #:node-do                            ; STRUCT
@@ -170,8 +163,11 @@
 (defstruct (node
             (:constructor nil)
             (:copier nil))
-  (type   (util:required 'type)   :type tc:qualified-ty :read-only t)
-  (location (util:required 'location) :type source:location            :read-only t))
+  (type     (util:required 'type)     :type tc:qualified-ty :read-only t)
+  (location (util:required 'location) :type source:location :read-only t))
+
+(defmethod source:location ((self node))
+  (node-location self))
 
 (defun node-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -209,9 +205,12 @@
 
 (defstruct (node-bind
             (:copier nil))
-  (pattern (util:required 'pattern) :type pattern :read-only t)
-  (expr    (util:required 'expr)    :type node    :read-only t)
-  (location  (util:required 'location)  :type source:location    :read-only t))
+  (pattern  (util:required 'pattern)   :type pattern         :read-only t)
+  (expr     (util:required 'expr)      :type node            :read-only t)
+  (location (util:required 'location)  :type source:location :read-only t))
+
+(defmethod source:location ((self node-bind))
+  (node-bind-location self))
 
 (deftype node-body-element ()
   '(or node node-bind))
@@ -239,9 +238,12 @@
 
 (defstruct (node-let-binding
             (:copier nil))
-  (name   (util:required 'name)   :type node-variable :read-only t)
-  (value  (util:required 'value)  :type node          :read-only t)
-  (location (util:required 'location) :type source:location          :read-only t))
+  (name     (util:required 'name)     :type node-variable   :read-only t)
+  (value    (util:required 'value)    :type node            :read-only t)
+  (location (util:required 'location) :type source:location :read-only t))
+
+(defmethod source:location ((self node-let-binding))
+  (node-let-binding-location self))
 
 (defun node-let-binding-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -265,9 +267,12 @@
 
 (defstruct (node-match-branch
             (:copier nil))
-  (pattern    (util:required 'pattern) :type pattern   :read-only t)
-  (body       (util:required 'body)    :type node-body :read-only t)
-  (location     (util:required 'location)  :type source:location      :read-only t))
+  (pattern  (util:required 'pattern)  :type pattern         :read-only t)
+  (body     (util:required 'body)     :type node-body       :read-only t)
+  (location (util:required 'location) :type source:location :read-only t))
+
+(defmethod source:location ((self node-match-branch))
+  (node-match-branch-location self))
 
 (defun node-match-branch-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -359,7 +364,7 @@
   (label (util:required 'label) :type keyword   :read-only t)
   (body  (util:required 'body)  :type node-body :read-only t))
 
-(defstruct (node-break 
+(defstruct (node-break
             (:include node)
             (:copier nil))
   (label (util:required 'label) :type keyword :read-only t))
@@ -371,9 +376,12 @@
 
 (defstruct (node-cond-clause
             (:copier nil))
-  (expr   (util:required 'expr)   :type node      :read-only t)
-  (body   (util:required 'body)   :type node-body :read-only t)
-  (location (util:required 'location) :type source:location      :read-only t))
+  (expr     (util:required 'expr)     :type node            :read-only t)
+  (body     (util:required 'body)     :type node-body       :read-only t)
+  (location (util:required 'location) :type source:location :read-only t))
+
+(defmethod source:location ((self node-cond-clause))
+  (node-cond-clause-location self))
 
 (defun node-cond-clause-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -389,9 +397,12 @@
 
 (defstruct (node-do-bind
             (:copier nil))
-  (pattern (util:required 'pattern) :type pattern :read-only t)
-  (expr    (util:required 'expr)    :type node    :read-only t)
-  (location  (util:required 'location)  :type source:location    :read-only t))
+  (pattern  (util:required 'pattern)  :type pattern         :read-only t)
+  (expr     (util:required 'expr)     :type node            :read-only t)
+  (location (util:required 'location) :type source:location :read-only t))
+
+(defmethod source:location ((self node-do-bind))
+  (node-do-bind-location self))
 
 (deftype node-do-body-element ()
   '(or node node-bind node-do-bind))
@@ -421,7 +432,7 @@
            (values node-variable))
   (make-node-variable
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :name (node-variable-name node)))
 
 (defmethod tc:apply-substitution (subs (node node-accessor))
@@ -429,7 +440,7 @@
            (values node-accessor))
   (make-node-accessor
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :name (node-accessor-name node)))
 
 (defmethod tc:apply-substitution (subs (node node-literal))
@@ -437,7 +448,7 @@
            (values node-literal))
   (make-node-literal
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :value (node-literal-value node)))
 
 (defmethod tc:apply-substitution (subs (node node-integer-literal))
@@ -445,7 +456,7 @@
            (values node-integer-literal))
   (make-node-integer-literal
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :value (node-integer-literal-value node)))
 
 (defmethod tc:apply-substitution (subs (node node-bind))
@@ -454,7 +465,7 @@
   (make-node-bind
    :pattern (tc:apply-substitution subs (node-bind-pattern node))
    :expr (tc:apply-substitution subs (node-bind-expr node))
-   :location (node-bind-location node)))
+   :location (source:location node)))
 
 (defmethod tc:apply-substitution (subs (node node-body))
   (declare (type tc:substitution-list subs)
@@ -468,7 +479,7 @@
            (values node-abstraction))
   (make-node-abstraction
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :params (tc:apply-substitution subs (node-abstraction-params node))
    :body (tc:apply-substitution subs (node-abstraction-body node))))
 
@@ -478,14 +489,14 @@
   (make-node-let-binding
    :name (tc:apply-substitution subs (node-let-binding-name node))
    :value (tc:apply-substitution subs (node-let-binding-value node))
-   :location (node-let-binding-location node)))
+   :location (source:location node)))
 
 (defmethod tc:apply-substitution (subs (node node-let))
   (declare (type tc:substitution-list subs)
            (values node-let))
   (make-node-let
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :bindings (tc:apply-substitution subs (node-let-bindings node))
    :body (tc:apply-substitution subs (node-let-body node))))
 
@@ -494,7 +505,7 @@
            (values node-lisp))
   (make-node-lisp
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :vars (tc:apply-substitution subs (node-lisp-vars node))
    :var-names (node-lisp-var-names node)
    :body (node-lisp-body node)))
@@ -505,14 +516,14 @@
   (make-node-match-branch
    :pattern (tc:apply-substitution subs (node-match-branch-pattern node))
    :body (tc:apply-substitution subs (node-match-branch-body node))
-   :location (node-match-branch-location node)))
+   :location (source:location node)))
 
 (defmethod tc:apply-substitution (subs (node node-match))
   (declare (type tc:substitution-list subs)
            (values node-match))
   (make-node-match
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :expr (tc:apply-substitution subs (node-match-expr node))
    :branches (tc:apply-substitution subs (node-match-branches node))))
 
@@ -521,7 +532,7 @@
            (values node-progn))
   (make-node-progn
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :body (tc:apply-substitution subs (node-progn-body node))))
 
 (defmethod tc:apply-substitution (subs (node node-return))
@@ -529,7 +540,7 @@
            (values node-return))
   (make-node-return
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :expr (tc:apply-substitution subs (node-return-expr node))))
 
 (defmethod tc:apply-substitution (subs (node node-application))
@@ -537,7 +548,7 @@
            (values node-application))
   (make-node-application
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :rator (tc:apply-substitution subs (node-application-rator node))
    :rands (tc:apply-substitution subs (node-application-rands node))))
 
@@ -546,7 +557,7 @@
            (values node-or))
   (make-node-or
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :nodes (tc:apply-substitution subs (node-or-nodes node))))
 
 (defmethod tc:apply-substitution (subs (node node-and))
@@ -554,7 +565,7 @@
            (values node-and))
   (make-node-and
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :nodes (tc:apply-substitution subs (node-and-nodes node))))
 
 (defmethod tc:apply-substitution (subs (node node-if))
@@ -562,7 +573,7 @@
            (values node-if))
   (make-node-if
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :expr (tc:apply-substitution subs (node-if-expr node))
    :then (tc:apply-substitution subs (node-if-then node))
    :else (tc:apply-substitution subs (node-if-else node))))
@@ -572,7 +583,7 @@
            (values node-when))
   (make-node-when
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :expr (tc:apply-substitution subs (node-when-expr node))
    :body (tc:apply-substitution subs (node-when-body node))))
 
@@ -581,7 +592,7 @@
            (values node-unless))
   (make-node-unless
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :expr (tc:apply-substitution subs (node-unless-expr node))
    :body (tc:apply-substitution subs (node-unless-body node))))
 
@@ -590,7 +601,7 @@
            (values node-while))
   (make-node-while
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :label (node-while-label node)
    :expr (tc:apply-substitution subs (node-while-expr node))
    :body (tc:apply-substitution subs (node-while-body node))))
@@ -600,7 +611,7 @@
            (values node-while-let))
   (make-node-while-let
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :label (node-while-let-label node)
    :pattern (tc:apply-substitution subs (node-while-let-pattern node))
    :expr (tc:apply-substitution subs (node-while-let-expr node))
@@ -611,7 +622,7 @@
            (values node-for))
   (make-node-for
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :label (node-for-label node)
    :pattern (tc:apply-substitution subs (node-for-pattern node))
    :expr (tc:apply-substitution subs (node-for-expr node))
@@ -622,7 +633,7 @@
            (values node-loop))
   (make-node-loop
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :label (node-loop-label node)
    :body (tc:apply-substitution subs (node-loop-body node))))
 
@@ -642,14 +653,14 @@
   (make-node-cond-clause
    :expr (tc:apply-substitution subs (node-cond-clause-expr node))
    :body (tc:apply-substitution subs (node-cond-clause-body node))
-   :location (node-cond-clause-location node)))
+   :location (source:location node)))
 
 (defmethod tc:apply-substitution (subs (node node-cond))
   (declare (type tc:substitution-list subs)
            (values node-cond))
   (make-node-cond
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :clauses (tc:apply-substitution subs (node-cond-clauses node))))
 
 (defmethod tc:apply-substitution (subs (node node-do-bind))
@@ -658,13 +669,13 @@
   (make-node-do-bind
    :pattern (tc:apply-substitution subs (node-do-bind-pattern node))
    :expr (tc:apply-substitution subs (node-do-bind-expr node))
-   :location (node-do-bind-location node)))
+   :location (source:location node)))
 
 (defmethod tc:apply-substitution (subs (node node-do))
   (declare (type tc:substitution-list subs)
            (values node-do))
   (make-node-do
    :type (tc:apply-substitution subs (node-type node))
-   :location (node-location node)
+   :location (source:location node)
    :nodes (tc:apply-substitution subs (node-do-nodes node))
    :last-node (tc:apply-substitution subs (node-do-last-node node))))

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -173,7 +173,7 @@
             (setf ksubs (tc:kunify kvar expected-kind ksubs))
             (values (tc:apply-ksubstitution ksubs tvar) ksubs))
         (tc:coalton-internal-type-error ()
-          (tc-error (parser:ty-location type)
+          (tc-error type
                     "Kind mismatch"
                     (format nil "Expected kind '~S' but variable is of kind '~S'"
                             expected-kind
@@ -191,7 +191,7 @@
             (setf ksubs (tc:kunify (tc:kind-of type_) expected-kind ksubs))
             (values (tc:apply-ksubstitution ksubs type_) ksubs))
         (tc:coalton-internal-type-error ()
-          (tc-error (parser:ty-location type)
+          (tc-error type
                     "Kind mismatch"
                     (format nil "Expected kind '~S' but got kind '~S'"
                             expected-kind
@@ -228,7 +228,7 @@
                  (tc:apply-type-argument fun-ty arg-ty :ksubs ksubs)
                  ksubs))
             (tc:coalton-internal-type-error ()
-              (tc-error (parser:ty-location (parser:tapp-from type))
+              (tc-error (parser:tapp-from type)
                         "Kind mismatch"
                         (format nil "Expected kind '~S' but got kind '~S'"
                                 (tc:make-kfun

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -126,7 +126,7 @@
     (unless (subsetp (tc:type-variables preds) unambiguous-vars :test #'equalp)
       (let* ((ambiguous-vars (set-difference (tc:type-variables preds) unambiguous-vars :test #'equalp))
              (single-variable (= 1 (length ambiguous-vars))))
-        (tc-error (parser:qualified-ty-location qual-ty)
+        (tc-error qual-ty
                   "Invalid qualified type"
                   (format nil "The type ~A ~{~S ~}ambiguous in the type ~S"
                           (if single-variable
@@ -273,7 +273,7 @@
 
     ;; Check that pred has the correct number of arguments
     (unless (= class-arity (length (parser:ty-predicate-types pred)))
-      (tc-error (parser:ty-predicate-location pred)
+      (tc-error pred
                 "Predicate arity mismatch"
                 (format nil "Expected ~D arguments but received ~D"
                         class-arity

--- a/src/typechecker/partial-type-env.lisp
+++ b/src/typechecker/partial-type-env.lisp
@@ -124,7 +124,7 @@
     (let ((class-entry (tc:lookup-class (partial-type-env-env env) name :no-error t)))
 
       (unless class-entry
-        (tc-error (parser:ty-predicate-location pred)
+        (tc-error pred
                   "Unknown class"
                   (format nil "unknown class ~S"
                           (parser:identifier-src-name

--- a/src/typechecker/partial-type-env.lisp
+++ b/src/typechecker/partial-type-env.lisp
@@ -92,7 +92,7 @@
     (let ((type-entry (tc:lookup-type (partial-type-env-env env) name :no-error t)))
 
       (unless type-entry
-        (tc-error (parser:ty-location tycon)
+        (tc-error tycon
                   "Unknown type"
                   (format nil "unknown type ~S" (parser:tycon-name tycon))))
 

--- a/src/typechecker/pattern.lisp
+++ b/src/typechecker/pattern.lisp
@@ -13,7 +13,6 @@
   (:export
    #:pattern                            ; STRUCT
    #:pattern-type                       ; ACCESSOR
-   #:pattern-location                     ; ACCESSOR
    #:pattern-list-p                     ; FUNCTION
    #:pattern-list                       ; TYPE
    #:pattern-var                        ; STRUCT
@@ -43,6 +42,9 @@
             (:copier nil))
   (type     (util:required 'type)   :type tc:qualified-ty           :read-only t)
   (location nil                     :type (or source:location null) :read-only t))
+
+(defmethod source:location ((self pattern))
+  (pattern-location self))
 
 (defun pattern-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -13,7 +13,6 @@
    #:make-ty-predicate                  ; CONSTRUCTOR
    #:ty-predicate-class                 ; ACCESSOR
    #:ty-predicate-types                 ; ACCESSOR
-   #:ty-predicate-location                ; ACCESSOR
    #:ty-predicate-p                     ; FUNCTION
    #:ty-predicate-list                  ; TYPE
    #:qualified-ty                       ; STRUCT
@@ -36,12 +35,15 @@
 
 (defstruct ty-predicate
   "A type predicate indicating that TYPE is of the CLASS"
-  (class (util:required 'class) :type symbol                    :read-only t)
-  (types (util:required 'types) :type ty-list                   :read-only t)
-  (location nil                   :type (or source:location null) :read-only t))
+  (class    (util:required 'class) :type symbol                    :read-only t)
+  (types    (util:required 'types) :type ty-list                   :read-only t)
+  (location nil                    :type (or source:location null) :read-only t))
 
 (defmethod make-load-form ((self ty-predicate) &optional env)
   (make-load-form-saving-slots self :environment env))
+
+(defmethod source:location ((self ty-predicate))
+  (ty-predicate-location self))
 
 (defun ty-predicate-list-p (x)
   (and (alexandria:proper-list-p x)

--- a/src/typechecker/specialize.lisp
+++ b/src/typechecker/specialize.lisp
@@ -43,20 +43,20 @@
                               (tc:qualify nil type))))
 
     (unless from-ty
-      (tc-error (parser:node-location (parser:toplevel-specialize-from specialize))
+      (tc-error (parser:toplevel-specialize-from specialize)
                 "Invalid specialization"
                 "unknown function or variable"))
     (unless to-ty
-      (tc-error (parser:node-location (parser:toplevel-specialize-to specialize))
+      (tc-error (parser:toplevel-specialize-to specialize)
                 "Invalid specialization"
                 "unknown function or variable"))
 
     (unless (eq :value (tc:name-entry-type from-name-entry))
-      (tc-error (parser:node-location (parser:toplevel-specialize-from specialize))
+      (tc-error (parser:toplevel-specialize-from specialize)
                 "Invalid specialization"
                 (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry))))
     (unless (eq :value (tc:name-entry-type to-name-entry))
-      (tc-error (parser:node-location (parser:toplevel-specialize-to specialize))
+      (tc-error (parser:toplevel-specialize-to specialize)
                 "Invalid specialization"
                 (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry))))
 
@@ -64,24 +64,24 @@
           (to-qual-ty (tc:fresh-inst to-ty)))
 
       (when (null (tc:qualified-ty-predicates from-qual-ty))
-        (tc-error (parser:node-location (parser:toplevel-specialize-from specialize))
+        (tc-error (parser:toplevel-specialize-from specialize)
                   "Invalid specialization"
                   "must be a function or variable with class constraints"))
 
       (unless (equalp to-ty scheme)
-        (tc-error (parser:toplevel-specialize-location specialize)
+        (tc-error specialize
                   "Invalid specialization"
                   (format nil "function ~S does not match declared type" to-name)))
 
       (when (equalp from-ty to-ty)
-        (tc-error (parser:toplevel-specialize-location specialize)
+        (tc-error specialize
                   "Invalid specialization"
                   "specialize must result in a more specific type"))
 
       (handler-case
           (tc:match (tc:qualified-ty-type from-qual-ty) (tc:qualified-ty-type to-qual-ty))
         (tc:coalton-internal-type-error ()
-          (tc-error (parser:toplevel-specialize-location specialize)
+          (tc-error specialize
                     "Invalid specialization"
                     "cannot specialize to declared type")))
 
@@ -91,7 +91,7 @@
         (handler-case
             (tc:add-specialization env entry)
           (tc:overlapping-specialization-error (c)
-            (tc-error (parser:toplevel-specialize-location specialize)
+            (tc-error specialize
                       "Overlapping specialization"
                        (format nil "overlaps with specialization ~S"
                                (tc:overlapping-specialization-error-existing c)))))))))

--- a/src/typechecker/tc-env.lisp
+++ b/src/typechecker/tc-env.lisp
@@ -73,12 +73,12 @@
       ;; Variable is unbound: create an error
       (error 'tc:tc-error
              :err (source:source-error
-                   :location (parser:node-location var)
+                   :location (source:location var)
                    :message "Unknown variable"
                    :primary-note "unknown variable"
                    :help-notes (loop :for suggestion :in (tc-env-suggest-value env var-name)
                                      :collect (se:make-source-error-help
-                                               :span (source:location-span (parser:node-location var))
+                                               :span (source:location-span (source:location var))
                                                :replacement #'identity
                                                :message suggestion)))))
     (let ((qualified-type (tc:fresh-inst scheme)))
@@ -86,7 +86,7 @@
               (loop :for pred :in (tc:qualified-ty-predicates qualified-type)
                     :collect (tc:make-ty-predicate :class (tc:ty-predicate-class pred)
                                                    :types (tc:ty-predicate-types pred)
-                                                   :location (parser:node-location var)))))))
+                                                   :location (source:location var)))))))
 
 (defun tc-env-add-definition (env name scheme)
   "Add a type named NAME to ENV."

--- a/src/typechecker/toplevel.lisp
+++ b/src/typechecker/toplevel.lisp
@@ -21,33 +21,38 @@
    #:toplevel-define-name               ; ACCESSOR
    #:toplevel-define-params             ; ACCESSOR
    #:toplevel-define-body               ; ACCESSOR
-   #:toplevel-define-location             ; ACCESSOR
    #:toplevel-define-list               ; TYPE
    #:instance-method-definition         ; STRUCT
    #:make-instance-method-definition    ; CONSTRUCTOR
    #:instance-method-definition-name    ; ACCESSOR
    #:instance-method-definition-params  ; ACCESSOR
    #:instance-method-definition-body    ; ACCESSOR
-   #:instance-method-definition-location  ; ACCESSOR
    #:instance-method-definition-list    ; TYPE
    #:toplevel-define-instance           ; STRUCT
    #:make-toplevel-define-instance      ; CONSTRUCTOR
    #:toplevel-define-instance-context   ; ACCESSOR
    #:toplevel-define-instance-pred      ; ACCESSOR
    #:toplevel-define-instance-methods   ; ACCESSOR
-   #:toplevel-define-instance-location    ; ACCESSOR
    #:toplevel-define-instance-head-location  ; ACCESSOR
    #:toplevel-define-instance-list      ; TYPE
    ))
 
 (in-package #:coalton-impl/typechecker/toplevel)
 
-(defstruct (toplevel-define
+(defstruct (toplevel-definition
+            (:constructor nil)
             (:copier nil))
-  (name    (util:required 'name)   :type node-variable   :read-only t)
-  (params  (util:required 'params) :type pattern-list    :read-only t)
-  (body    (util:required 'body)   :type node-body       :read-only t)
-  (location  (util:required 'location) :type location :read-only t))
+  (location (util:required 'location) :type location :read-only t))
+
+(defmethod location ((self toplevel-definition))
+  (toplevel-definition-location self))
+
+(defstruct (toplevel-define
+            (:include toplevel-definition)
+            (:copier nil))
+  (name   (util:required 'name)   :type node-variable :read-only t)
+  (params (util:required 'params) :type pattern-list  :read-only t)
+  (body   (util:required 'body)   :type node-body     :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-list-p (x)
@@ -65,14 +70,14 @@
    :name (tc:apply-substitution subs (toplevel-define-name node))
    :params (tc:apply-substitution subs (toplevel-define-params node))
    :body (tc:apply-substitution subs (toplevel-define-body node))
-   :location (toplevel-define-location node)))
+   :location (location node)))
 
 (defstruct (instance-method-definition
+            (:include toplevel-definition)
             (:copier nil))
-  (name    (util:required 'name)    :type node-variable   :read-only t)
-  (params  (util:required 'params)  :type pattern-list    :read-only t)
-  (body    (util:required 'body)    :type node-body       :read-only t)
-  (location  (util:required 'location)  :type location :read-only t))
+  (name   (util:required 'name)   :type node-variable :read-only t)
+  (params (util:required 'params) :type pattern-list  :read-only t)
+  (body   (util:required 'body)   :type node-body     :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun instance-method-definition-list-p (x)
@@ -90,20 +95,15 @@
    :name (tc:apply-substitution subs (instance-method-definition-name method))
    :params (tc:apply-substitution subs (instance-method-definition-params method))
    :body (tc:apply-substitution subs (instance-method-definition-body method))
-   :location (instance-method-definition-location method)))
+   :location (location method)))
 
 (defstruct (toplevel-define-instance
+            (:include toplevel-definition)
             (:copier nil))
-  (context
-   (util:required 'context)       :type tc:ty-predicate-list :read-only t)
-  (pred
-   (util:required 'pred)          :type tc:ty-predicate      :read-only t)
-  (methods
-   (util:required 'methods)       :type hash-table           :read-only t)
-  (location
-   (util:required 'location)      :type location             :read-only t)
-  (head-location
-   (util:required 'head-location) :type location             :read-only t))
+  (context       (util:required 'context)       :type tc:ty-predicate-list :read-only t)
+  (pred          (util:required 'pred)          :type tc:ty-predicate      :read-only t)
+  (methods       (util:required 'methods)       :type hash-table           :read-only t)
+  (head-location (util:required 'head-location) :type location             :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-instance-list-p (x)

--- a/src/typechecker/traverse.lisp
+++ b/src/typechecker/traverse.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-impl/typechecker/traverse
   (:use
    #:cl
+   #:coalton-impl/source
    #:coalton-impl/typechecker/expression)
   (:export
    #:traverse-block                     ; STRUCT
@@ -77,7 +78,7 @@
      (make-node-bind
       :pattern (node-bind-pattern node)
       :expr (traverse (node-bind-expr node) block)
-      :location (node-bind-location node))))
+      :location (location node))))
 
   (:method ((node node-body) block)
     (declare (type traverse-block block)
@@ -97,7 +98,7 @@
      (traverse-abstraction block)
      (make-node-abstraction
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :params (node-abstraction-params node)
       :body (traverse (node-abstraction-body node) block))))
 
@@ -110,7 +111,7 @@
      (make-node-let-binding
       :name (node-let-binding-name node)
       :value (traverse (node-let-binding-value node) block)
-      :location (node-let-binding-location node))))
+      :location (location node))))
 
   (:method ((node node-let) block)
     (declare (type traverse-block block)
@@ -120,7 +121,7 @@
      (traverse-let block)
      (make-node-let
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :bindings (traverse (node-let-bindings node) block)
       :body (traverse (node-let-body node) block))))
 
@@ -132,7 +133,7 @@
      (traverse-lisp block)
      (make-node-lisp
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :vars (traverse (node-lisp-vars node) block)
       :var-names (node-lisp-var-names node)
       :body (node-lisp-body node))))
@@ -146,7 +147,7 @@
      (make-node-match-branch
       :pattern (node-match-branch-pattern node)
       :body (traverse (node-match-branch-body node) block)
-      :location (node-match-branch-location node))))
+      :location (location node))))
 
   (:method ((node node-match) block)
     (declare (type traverse-block block)
@@ -156,7 +157,7 @@
      (traverse-match block)
      (make-node-match
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :expr (traverse (node-match-expr node) block)
       :branches (traverse (node-match-branches node) block))))
 
@@ -168,7 +169,7 @@
      (traverse-progn block)
      (make-node-progn
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :body (traverse (node-progn-body node) block))))
 
   (:method ((node node-return) block)
@@ -179,7 +180,7 @@
      (traverse-return block)
      (make-node-return
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :expr (traverse (node-return-expr node) block) ; the nil case is handled by the list instance
       )))
 
@@ -191,7 +192,7 @@
      (traverse-application block)
      (make-node-application
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :rator (traverse (node-application-rator node) block)
       :rands (traverse (node-application-rands node) block))))
 
@@ -203,7 +204,7 @@
      (traverse-or block)
      (make-node-or
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :nodes (traverse (node-or-nodes node) block))))
 
   (:method ((node node-and) block)
@@ -214,7 +215,7 @@
      (traverse-and block)
      (make-node-and
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :nodes (traverse (node-and-nodes node) block))))
 
   (:method ((node node-if) block)
@@ -225,7 +226,7 @@
      (traverse-if block)
      (make-node-if
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :expr (traverse (node-if-expr node) block)
       :then (traverse (node-if-then node) block)
       :else (traverse (node-if-else node) block))))
@@ -238,7 +239,7 @@
      (traverse-when block)
      (make-node-when
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :expr (traverse (node-when-expr node) block)
       :body (traverse (node-when-body node) block))))
 
@@ -250,7 +251,7 @@
      (traverse-unless block)
      (make-node-unless
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :expr (traverse (node-unless-expr node) block)
       :body (traverse (node-unless-body node) block))))
 
@@ -263,7 +264,7 @@
      (make-node-cond-clause
       :expr (traverse (node-cond-clause-expr node) block)
       :body (traverse (node-cond-clause-body node) block)
-      :location (node-cond-clause-location node))))
+      :location (location node))))
 
   (:method ((node node-cond) block)
     (declare (type traverse-block block)
@@ -273,7 +274,7 @@
      (traverse-cond block)
      (make-node-cond
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :clauses (traverse (node-cond-clauses node) block))))
 
   (:method ((node node-while) block)
@@ -283,7 +284,7 @@
      (traverse-while block)
      (make-node-while
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :label (node-while-label node)
       :expr (traverse (node-while-expr node) block)
       :body (traverse (node-while-body node) block))))
@@ -295,7 +296,7 @@
      (traverse-while-let block)
      (make-node-while-let
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :label (node-while-let-label node)
       :pattern (node-while-let-pattern node)
       :expr (traverse (node-while-let-expr node) block)
@@ -308,12 +309,12 @@
      (traverse-for block)
      (make-node-for
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :label (node-for-label node)
       :pattern (node-for-pattern node)
       :expr (traverse (node-for-expr node) block)
       :body (traverse (node-for-body node) block))))
-  
+
   (:method ((node node-loop) block)
     (declare (type traverse-block block)
              (values node &optional))
@@ -321,24 +322,24 @@
      (traverse-loop block)
      (make-node-loop
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :label (node-loop-label node)
       :body (traverse (node-loop-body node) block))))
-  
+
   (:method ((node node-break) block)
     (declare (type traverse-block block)
              (values node &optional))
     (funcall
      (traverse-break block)
      node))
-  
+
   (:method ((node node-continue) block)
     (declare (type traverse-block block)
              (values node &optional))
     (funcall
      (traverse-continue block)
      node))
-  
+
   (:method ((node node-do-bind) block)
     (declare (type traverse-block block)
              (values node-do-bind &optional))
@@ -348,7 +349,7 @@
      (make-node-do-bind
       :pattern (node-do-bind-pattern node)
       :expr (traverse (node-do-bind-expr node) block)
-      :location (node-do-bind-location node))))
+      :location (location node))))
 
   (:method ((node node-do) block)
     (declare (type traverse-block block)
@@ -358,7 +359,7 @@
      (traverse-do block)
      (make-node-do
       :type (node-type node)
-      :location (node-location node)
+      :location (location node)
       :nodes (traverse (node-do-nodes node) block)
       :last-node (traverse (node-do-last-node node) block))))
 


### PR DESCRIPTION
Make location generic across parser and typechecker nodes using :include to provide slot definitions.

This change is similar to the introduction of #'source:docstring in #1220 and has similar motivation.

- four existing generics are merged
- use of :include reduces the number of method definitions
- error constructors become more generic