### PR TITLE
Record source location; check text of hashtable errors

### DIFF
--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -204,18 +204,12 @@
        (default)
        (map hash (entries table))))))
 
-(cl:define-condition make-hash-table-static-duplicate-keys (cl:error)
-  ((offending-key :initarg :offending-key
-                  :reader duplicate-offending-key)
-   (entry-a :initarg :entry-a
-            :reader duplicate-entry-a)
-   (entry-b :initarg :entry-b
-            :reader duplicate-entry-b))
+(cl:define-condition static-duplicate-key (cl:error)
+  ((duplicate-key :initarg :duplicate-key
+                  :reader duplicate-key))
   (:report (cl:lambda (c s)
-             (cl:format s "Statically-detected duplicate keys in `make-hash-table': key ~S applies to both ~S and ~S"
-                        (duplicate-offending-key c)
-                        (duplicate-entry-a c)
-                        (duplicate-entry-b c)))))
+             (cl:format s "Duplicate hashtable key: ~S"
+                        (duplicate-key c)))))
 
 (cl:defun find-duplicate-entry (elements cl:&key (test #'cl:equal) (key #'cl:first))
   (cl:declare (cl:type cl:function test key))
@@ -255,10 +249,8 @@ Examples:
     (cl:multiple-value-bind (duplicatep dup-a dup-b)
         (find-duplicate-entry pairs)
       (cl:if duplicatep
-             (cl:error 'make-hash-table-static-duplicate-keys
-                       :offending-key (cl:first dup-a)
-                       :entry-a dup-a
-                       :entry-b dup-b)
+             (cl:error 'static-duplicate-key
+                       :duplicate-key (cl:first dup-a))
              `(progn
                 (let ,ht = (with-capacity ,(cl:length keys)))
                 ,@(cl:mapcar (cl:lambda (key val)

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -1208,15 +1208,7 @@ Rebound to NIL parsing an anonymous FN.")
                         :message "Error occurs within macro context. Source locations may be imprecise")
                        se:*source-error-context*
                        :test #'equalp)))
-         (handler-case
-             (parse-expression (expand-macro form) source)
-           (error (c)
-             (error 'parse-error
-                    :err (se:source-error
-                          :span (cst:source form)
-                          :source source
-                          :message "Error during macro expansion"
-                          :primary-note (princ-to-string c))))))))
+         (parse-expression (expand-macro form source) source))))
 
     ;;
     ;; Function Application

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -1208,7 +1208,15 @@ Rebound to NIL parsing an anonymous FN.")
                         :message "Error occurs within macro context. Source locations may be imprecise")
                        se:*source-error-context*
                        :test #'equalp)))
-         (parse-expression (expand-macro form) source))))
+         (handler-case
+             (parse-expression (expand-macro form) source)
+           (error (c)
+             (error 'parse-error
+                    :err (se:source-error
+                          :span (cst:source form)
+                          :source source
+                          :message "Error during macro expansion"
+                          :primary-note (princ-to-string c))))))))
 
     ;;
     ;; Function Application

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -1143,7 +1143,7 @@ consume all attributes")))
                          :message "Error occurs within macro context. Source locations may be imprecise")
                         se:*source-error-context*
                         :test #'equalp)))
-          (parse-toplevel-form (expand-macro form) program attributes source)))
+          (parse-toplevel-form (expand-macro form source) program attributes source)))
 
        ((error 'parse-error
                :err (se:source-error

--- a/tests/hashtable-tests.lisp
+++ b/tests/hashtable-tests.lisp
@@ -68,25 +68,3 @@
 
   (is (/= (hash (the (Hashtable String String) (hashtable:make)))
           (hash (hashtable:make ("a" "b"))))))
-
-(in-package #:coalton-tests)
-
-(deftest hashtable-static-duplicate-keys ()
-  (signals coalton-library/hashtable::make-hash-table-static-duplicate-keys
-    (check-coalton-types
-     "(define my-ht
-        (coalton-library/hashtable:make (\"zero\" 0)
-                                         (\"one\" 1)
-                                         (\"two\" 2)
-                                         (\"zero\" 3)))"))
-
-  (signals coalton-library/hashtable::make-hash-table-static-duplicate-keys
-    (check-coalton-types
-     "(define my-ht
-        (let ((zero \"zero\")
-                       (one \"one\")
-                       (two \"two\"))
-           (coalton-library/hashtable:make (zero 0)
-                                           (one 1)
-                                           (two 2)
-                                           (zero 3))))")))

--- a/tests/parser-test-files/hashtable.txt
+++ b/tests/parser-test-files/hashtable.txt
@@ -20,9 +20,7 @@ error: Error during macro expansion
  5 | |                                   ("one" 1)
  6 | |                                   ("two" 2)
  7 | |                                   ("zero" 3)))
-   | |_____________________________________________^ Statically-detected duplicate keys in `make-hash-table': key "zero" applies to both ("zero"
-                                                                                     0) and ("zero"
-                                                                                             3)
+   | |_____________________________________________^ Duplicate hashtable key: "zero"
 note: Error occurs within macro context. Source locations may be imprecise
 
 ================================================================================
@@ -50,7 +48,5 @@ error: Error during macro expansion
  8  | |                                     (one 1)
  9  | |                                     (two 2)
  10 | |                                     (zero 3))))
-    | |_____________________________________________^ Statically-detected duplicate keys in `make-hash-table': key ZERO applies to both (ZERO
-                                                                                   0) and (ZERO
-                                                                                           3)
+    | |_____________________________________________^ Duplicate hashtable key: ZERO
 note: Error occurs within macro context. Source locations may be imprecise

--- a/tests/parser-test-files/hashtable.txt
+++ b/tests/parser-test-files/hashtable.txt
@@ -1,0 +1,56 @@
+================================================================================
+1 duplicate keys
+================================================================================
+
+(package coalton-unit-tests/hashtable)
+
+(define my-ht
+  (coalton-library/hashtable:make ("zero" 0)
+                                  ("one" 1)
+                                  ("two" 2)
+                                  ("zero" 3)))
+
+--------------------------------------------------------------------------------
+
+error: Error during macro expansion
+  --> test:4:2
+   |
+ 4 |     (coalton-library/hashtable:make ("zero" 0)
+   |  ___^
+ 5 | |                                   ("one" 1)
+ 6 | |                                   ("two" 2)
+ 7 | |                                   ("zero" 3)))
+   | |_____________________________________________^ Statically-detected duplicate keys in `make-hash-table': key "zero" applies to both ("zero"
+                                                                                     0) and ("zero"
+                                                                                             3)
+note: Error occurs within macro context. Source locations may be imprecise
+
+================================================================================
+1 duplicate keys
+================================================================================
+
+(package coalton-unit-tests/hashtable)
+
+(define my-ht
+  (let ((zero "zero")
+        (one "one")
+        (two "two"))
+    (coalton-library/hashtable:make (zero 0)
+                                    (one 1)
+                                    (two 2)
+                                    (zero 3))))
+
+--------------------------------------------------------------------------------
+
+error: Error during macro expansion
+  --> test:7:4
+    |
+ 7  |       (coalton-library/hashtable:make (zero 0)
+    |  _____^
+ 8  | |                                     (one 1)
+ 9  | |                                     (two 2)
+ 10 | |                                     (zero 3))))
+    | |_____________________________________________^ Statically-detected duplicate keys in `make-hash-table': key ZERO applies to both (ZERO
+                                                                                   0) and (ZERO
+                                                                                           3)
+note: Error occurs within macro context. Source locations may be imprecise

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -42,4 +42,5 @@
     (run-test-file "tests/parser-test-files/lisp-toplevel.txt"))
   (run-test-file "tests/parser-test-files/lisp-toplevel-forbid.txt")
   (run-test-file "tests/parser-test-files/package.txt")
+  (run-test-file "tests/parser-test-files/hashtable.txt")
   (run-test-file "tests/parser-test-files/define.txt"))


### PR DESCRIPTION
Catch and resignal conditions signalled during macroexpansion.

Improves UX of hashtable key errors, and potentially others.

Closes #1231