### PR TITLE
Use a package local nickname for coalton-impl/source

### DIFF
--- a/src/parser/binding.lisp
+++ b/src/parser/binding.lisp
@@ -6,7 +6,6 @@
 (defpackage #:coalton-impl/parser/binding
   (:use
    #:cl
-   #:coalton-impl/source
    #:coalton-impl/parser/base
    #:coalton-impl/parser/pattern
    #:coalton-impl/parser/expression

--- a/src/parser/pattern.lisp
+++ b/src/parser/pattern.lisp
@@ -1,7 +1,6 @@
 (defpackage #:coalton-impl/parser/pattern
   (:use
    #:cl
-   #:coalton-impl/source
    #:coalton-impl/parser/base)
   (:shadowing-import-from
    #:coalton-impl/parser/base
@@ -9,6 +8,7 @@
   (:local-nicknames
    (#:cst #:concrete-syntax-tree)
    (#:se #:source-error)
+   (#:source #:coalton-impl/source)
    (#:util #:coalton-impl/util))
   (:export
    #:pattern                            ; STRUCT
@@ -47,12 +47,12 @@
 (defstruct (pattern
             (:constructor nil)
             (:copier nil))
-  (location (util:required 'location) :type location :read-only t))
+  (location (util:required 'location) :type source:location :read-only t))
 
 (defmethod make-load-form ((self pattern) &optional env)
   (make-load-form-saving-slots self :environment env))
 
-(defmethod location ((self pattern))
+(defmethod source:location ((self pattern))
   (pattern-location self))
 
 (defun pattern-list-p (x)
@@ -98,12 +98,12 @@
           (typep (cst:raw form) 'util:literal-value))
      (make-pattern-literal
       :value (cst:raw form)
-      :location (make-location source form)))
+      :location (source:make-location source form)))
 
     ((and (cst:atom form)
           (eq (cst:raw form) 'coalton:_))
      (make-pattern-wildcard
-      :location (make-location source form)))
+      :location (source:make-location source form)))
 
     ((and (cst:atom form)
           (identifierp (cst:raw form)))
@@ -117,7 +117,7 @@
      (make-pattern-var
       :name (cst:raw form)
       :orig-name (cst:raw form)
-      :location (make-location source form)))
+      :location (source:make-location source form)))
 
     ((cst:atom form)
      (error 'parse-error
@@ -150,7 +150,7 @@
       :patterns (loop :for patterns := (cst:rest form) :then (cst:rest patterns)
                       :while (cst:consp patterns)
                       :collect (parse-pattern (cst:first patterns) source))
-      :location (make-location source form)))))
+      :location (source:make-location source form)))))
 
 (defun pattern-variables (pattern)
   (declare (type t pattern)

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -1,7 +1,6 @@
 (defpackage #:coalton-impl/parser/renamer
   (:use
    #:cl
-   #:coalton-impl/source
    #:coalton-impl/parser/base
    #:coalton-impl/parser/types
    #:coalton-impl/parser/pattern
@@ -15,6 +14,7 @@
    #:collect-type-variables)
   (:local-nicknames
    (#:util #:coalton-impl/util)
+   (#:source #:coalton-impl/source)
    (#:algo #:coalton-impl/algorithm))
   (:export
    #:rename-variables                   ; FUNCTION
@@ -42,7 +42,7 @@
        (if new-name
            (make-node-variable
             :name new-name
-            :location (location node))
+            :location (source:location node))
            node)
        ctx)))
 
@@ -80,7 +80,7 @@
 
         ;; ctx is used instead of new-ctx because bind creates non-recursive bindings
         :expr (rename-variables-generic% (node-bind-expr node) ctx)
-        :location (location node))
+        :location (source:location node))
        new-ctx)))
 
   (:method ((node node-body) ctx)
@@ -110,7 +110,7 @@
        (make-node-abstraction
         :params (rename-variables-generic% (node-abstraction-params node) new-ctx)
         :body (rename-variables-generic% (node-abstraction-body node) new-ctx)
-        :location (location node))
+        :location (source:location node))
        ctx)))
 
   (:method ((node node-let-binding) ctx)
@@ -121,7 +121,7 @@
      (make-node-let-binding
       :name (rename-variables-generic% (node-let-binding-name node) ctx)
       :value (rename-variables-generic% (node-let-binding-value node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-let-declare) ctx)
@@ -132,7 +132,7 @@
      (make-node-let-declare
       :name (rename-variables-generic% (node-let-declare-name node) ctx)
       :type (node-let-declare-type node)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-let) ctx)
@@ -151,7 +151,7 @@
         :bindings (rename-variables-generic% (node-let-bindings node) new-ctx)
         :declares (rename-variables-generic% (node-let-declares node) new-ctx)
         :body (rename-variables-generic% (node-let-body node) new-ctx)
-        :location (location node))
+        :location (source:location node))
        ctx)))
 
   (:method ((node node-lisp) ctx)
@@ -160,7 +160,7 @@
 
     (values
      (make-node-lisp
-      :location (location node)
+      :location (source:location node)
       :type (node-lisp-type node)
       :vars (rename-variables-generic% (node-lisp-vars node) ctx)
       :var-names (node-lisp-var-names node)
@@ -179,7 +179,7 @@
        (make-node-match-branch
         :pattern (rename-variables-generic% (node-match-branch-pattern node) new-ctx)
         :body (rename-variables-generic% (node-match-branch-body node) new-ctx)
-        :location (location node))
+        :location (source:location node))
        ctx)))
 
   (:method ((node node-match) ctx)
@@ -190,7 +190,7 @@
      (make-node-match
       :expr (rename-variables-generic% (node-match-expr node) ctx)
       :branches (rename-variables-generic% (node-match-branches node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-progn) ctx)
@@ -200,7 +200,7 @@
     (values
      (make-node-progn
       :body (rename-variables-generic% (node-progn-body node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-the) ctx)
@@ -211,7 +211,7 @@
      (make-node-the
       :type (node-the-type node)
       :expr (rename-variables-generic% (node-the-expr node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-return) ctx)
@@ -223,7 +223,7 @@
       :expr (if (node-return-expr node)
                 (rename-variables-generic% (node-return-expr node) ctx)
                 nil)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-application) ctx)
@@ -234,7 +234,7 @@
      (make-node-application
       :rator (rename-variables-generic% (node-application-rator node) ctx)
       :rands (rename-variables-generic% (node-application-rands node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-or) ctx)
@@ -244,7 +244,7 @@
     (values
      (make-node-or
       :nodes (rename-variables-generic% (node-or-nodes node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-and) ctx)
@@ -254,7 +254,7 @@
     (values
      (make-node-and
       :nodes (rename-variables-generic% (node-and-nodes node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-if) ctx)
@@ -266,7 +266,7 @@
       :expr (rename-variables-generic% (node-if-expr node) ctx)
       :then (rename-variables-generic% (node-if-then node) ctx)
       :else (rename-variables-generic% (node-if-else node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-when) ctx)
@@ -277,7 +277,7 @@
      (make-node-when
       :expr (rename-variables-generic% (node-when-expr node) ctx)
       :body (rename-variables-generic% (node-when-body node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-while) ctx)
@@ -288,7 +288,7 @@
       :expr (rename-variables-generic% (node-while-expr node) ctx)
       :label (node-while-label node)
       :body (rename-variables-generic% (node-while-body node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-while-let) ctx)
@@ -310,7 +310,7 @@
         :pattern (rename-variables-generic% (node-while-let-pattern node) new-ctx)
         :expr (rename-variables-generic% (node-while-let-expr node) ctx)
         :body (rename-variables-generic% (node-while-let-body node) new-ctx)
-        :location (location node))
+        :location (source:location node))
        new-ctx)))
 
   (:method ((node node-for) ctx)
@@ -331,7 +331,7 @@
         :pattern (rename-variables-generic% (node-for-pattern node) new-ctx)
         :expr (rename-variables-generic% (node-for-expr node) ctx)
         :body (rename-variables-generic% (node-for-body node) new-ctx)
-        :location (location node))
+        :location (source:location node))
        new-ctx)))
 
   (:method ((node node-loop) ctx)
@@ -339,7 +339,7 @@
              (values node algo:immutable-map))
     (values
      (make-node-loop
-      :location (location node)
+      :location (source:location node)
       :label (node-loop-label node)
       :body (rename-variables-generic% (node-loop-body node) ctx))
      ctx))
@@ -366,7 +366,7 @@
      (make-node-unless
       :expr (rename-variables-generic% (node-unless-expr node) ctx)
       :body (rename-variables-generic% (node-unless-body node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-cond-clause) ctx)
@@ -377,7 +377,7 @@
      (make-node-cond-clause
       :expr (rename-variables-generic% (node-cond-clause-expr node) ctx)
       :body (rename-variables-generic% (node-cond-clause-body node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-cond) ctx)
@@ -387,7 +387,7 @@
     (values
      (make-node-cond
       :clauses (rename-variables-generic% (node-cond-clauses node) ctx)
-      :location (location node))
+      :location (source:location node))
      ctx))
 
   (:method ((node node-do-bind) ctx)
@@ -402,7 +402,7 @@
        (make-node-do-bind
         :pattern (rename-variables-generic% (node-do-bind-pattern node) new-ctx)
         :expr (rename-variables-generic% (node-do-bind-expr node) ctx)
-        :location (location node))
+        :location (source:location node))
        new-ctx)))
 
   (:method ((node node-do) ctx)
@@ -418,7 +418,7 @@
                                 (setf new-ctx new-ctx_)
                                 elem))
         :last-node (rename-variables-generic% (node-do-last-node node) new-ctx)
-        :location (location node))
+        :location (source:location node))
        ctx)))
 
   (:method ((pattern pattern-var) ctx)
@@ -431,7 +431,7 @@
            (make-pattern-var
             :name new-name
             :orig-name (pattern-var-orig-name pattern)
-            :location (location pattern))
+            :location (source:location pattern))
            pattern)
        ctx)))
 
@@ -455,7 +455,7 @@
      (make-pattern-constructor
       :name (pattern-constructor-name pattern)
       :patterns (rename-variables-generic% (pattern-constructor-patterns pattern) ctx)
-      :location (location pattern))
+      :location (source:location pattern))
      ctx))
 
   (:method ((toplevel toplevel-define) ctx)
@@ -471,9 +471,9 @@
         :name (toplevel-define-name toplevel)
         :params (rename-variables-generic% (toplevel-define-params toplevel) new-ctx)
         :orig-params (toplevel-define-orig-params toplevel)
-        :docstring (docstring toplevel)
+        :docstring (source:docstring toplevel)
         :body (rename-variables-generic% (toplevel-define-body toplevel) new-ctx)
-        :location (location toplevel)
+        :location (source:location toplevel)
         :monomorphize (toplevel-define-monomorphize toplevel))
        ctx)))
 
@@ -490,7 +490,7 @@
         :name (instance-method-definition-name method)
         :params (rename-variables-generic% (instance-method-definition-params method) new-ctx)
         :body (rename-variables-generic% (instance-method-definition-body method) new-ctx)
-        :location (location method))
+        :location (source:location method))
        ctx)))
 
   (:method ((toplevel toplevel-define-instance) ctx)
@@ -502,9 +502,9 @@
       :context (toplevel-define-instance-context toplevel)
       :pred (toplevel-define-instance-pred toplevel)
       :methods (rename-variables-generic% (toplevel-define-instance-methods toplevel) ctx)
-      :location (location toplevel)
+      :location (source:location toplevel)
       :head-location (toplevel-define-instance-head-location toplevel)
-      :docstring (docstring toplevel)
+      :docstring (source:docstring toplevel)
       :compiler-generated (toplevel-define-instance-compiler-generated toplevel))
      ctx))
 
@@ -551,7 +551,7 @@
       (if new-name
           (make-tyvar
            :name new-name
-           :location (location ty))
+           :location (source:location ty))
           ty)))
 
   (:method ((ty tycon) ctx)
@@ -567,7 +567,7 @@
     (make-tapp
      :from (rename-type-variables-generic% (tapp-from ty) ctx)
      :to (rename-type-variables-generic% (tapp-to ty) ctx)
-     :location (location ty)))
+     :location (source:location ty)))
 
   (:method ((pred ty-predicate) ctx)
     (declare (type algo:immutable-map ctx)
@@ -576,7 +576,7 @@
     (make-ty-predicate
      :class (ty-predicate-class pred)
      :types (rename-type-variables-generic% (ty-predicate-types pred) ctx)
-     :location (location pred)))
+     :location (source:location pred)))
 
   (:method ((qual-ty qualified-ty) ctx)
     (declare (type algo:immutable-map ctx)
@@ -585,7 +585,7 @@
     (make-qualified-ty
      :predicates (rename-type-variables-generic% (qualified-ty-predicates qual-ty) ctx)
      :type (rename-type-variables-generic% (qualified-ty-type qual-ty) ctx)
-     :location (location qual-ty)))
+     :location (source:location qual-ty)))
 
   (:method ((ctor constructor) ctx)
     (declare (type algo:immutable-map ctx)
@@ -593,7 +593,7 @@
     (make-constructor
      :name (constructor-name ctor)
      :fields (rename-type-variables-generic% (constructor-fields ctor) ctx)
-     :location (location ctor)))
+     :location (source:location ctor)))
 
   (:method ((keyword keyword-src) ctx)
     (declare (type algo:immutable-map ctx)
@@ -604,7 +604,7 @@
       (if new-name
           (make-keyword-src
            :name new-name
-           :location (location keyword))
+           :location (source:location keyword))
           keyword)))
 
   (:method ((toplevel toplevel-define-type) ctx)
@@ -620,9 +620,9 @@
       (make-toplevel-define-type
        :name (toplevel-define-type-name toplevel)
        :vars (rename-type-variables-generic% (toplevel-define-type-vars toplevel) new-ctx)
-       :docstring (docstring toplevel)
+       :docstring (source:docstring toplevel)
        :ctors (rename-type-variables-generic% (toplevel-define-type-ctors toplevel) new-ctx)
-       :location (location toplevel)
+       :location (source:location toplevel)
        :repr (toplevel-define-type-repr toplevel)
        :head-location (toplevel-define-type-head-location toplevel))))
 
@@ -633,8 +633,8 @@
     (make-struct-field
      :name (struct-field-name field)
      :type (rename-type-variables-generic% (struct-field-type field) ctx)
-     :docstring (docstring field)
-     :location (location field)))
+     :docstring (source:docstring field)
+     :location (source:location field)))
 
   (:method ((toplevel toplevel-define-struct) ctx)
     (declare (type algo:immutable-map ctx)
@@ -649,9 +649,9 @@
       (make-toplevel-define-struct
        :name (toplevel-define-struct-name toplevel)
        :vars (rename-type-variables-generic% (toplevel-define-struct-vars toplevel) new-ctx)
-       :docstring (docstring toplevel)
+       :docstring (source:docstring toplevel)
        :fields (rename-type-variables-generic% (toplevel-define-struct-fields toplevel) new-ctx)
-       :location (location toplevel)
+       :location (source:location toplevel)
        :repr (toplevel-define-struct-repr toplevel)
        :head-location (toplevel-define-struct-head-location toplevel))))
 
@@ -662,7 +662,7 @@
     (make-fundep
      :left (rename-type-variables-generic% (fundep-left fundep) ctx)
      :right (rename-type-variables-generic% (fundep-right fundep) ctx)
-     :location (location fundep)))
+     :location (source:location fundep)))
 
   (:method ((method method-definition) ctx)
     (declare (type algo:immutable-map ctx)
@@ -681,8 +681,8 @@
       (make-method-definition
        :name (method-definition-name method)
        :type (rename-type-variables-generic% (method-definition-type method) new-ctx)
-       :docstring (docstring method)
-       :location (location method))))
+       :docstring (source:docstring method)
+       :location (source:location method))))
 
   (:method ((toplevel toplevel-define-class) ctx)
     (declare (type algo:immutable-map ctx)
@@ -699,9 +699,9 @@
        :vars (rename-type-variables-generic% (toplevel-define-class-vars toplevel) new-ctx)
        :preds (rename-type-variables-generic% (toplevel-define-class-preds toplevel) new-ctx)
        :fundeps (rename-type-variables-generic% (toplevel-define-class-fundeps toplevel) new-ctx)
-       :docstring (docstring toplevel)
+       :docstring (source:docstring toplevel)
        :methods (rename-type-variables-generic% (toplevel-define-class-methods toplevel) new-ctx)
-       :location (location toplevel)
+       :location (source:location toplevel)
        :head-location (toplevel-define-class-head-location toplevel))))
 
   (:method ((list list) ctx)

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -1,7 +1,6 @@
 (defpackage #:coalton-impl/parser/toplevel
   (:use
    #:cl
-   #:coalton-impl/source
    #:coalton-impl/parser/base
    #:coalton-impl/parser/reader
    #:coalton-impl/parser/types
@@ -15,6 +14,7 @@
    (#:cst #:concrete-syntax-tree)
    (#:cursor #:coalton-impl/parser/cursor)
    (#:se #:source-error)
+   (#:source #:coalton-impl/source)
    (#:util #:coalton-impl/util))
   (:export
    #:attribute                                   ; TYPE
@@ -200,9 +200,9 @@
 (defstruct (attribute
             (:constructor nil)
             (:copier nil))
-  (location (util:required 'location) :type location :read-only t))
+  (location (util:required 'location) :type source:location :read-only t))
 
-(defmethod location ((self attribute))
+(defmethod source:location ((self attribute))
   (attribute-location self))
 
 (defstruct (attribute-monomorphize
@@ -219,11 +219,11 @@
 
 (defstruct (constructor
             (:copier nil))
-  (name   (util:required 'name)   :type identifier-src  :read-only t)
-  (fields (util:required 'fields) :type ty-list         :read-only t)
-  (location (util:required 'location) :type location :read-only t))
+  (name     (util:required 'name)     :type identifier-src  :read-only t)
+  (fields   (util:required 'fields)   :type ty-list         :read-only t)
+  (location (util:required 'location) :type source:location :read-only t))
 
-(defmethod location ((self constructor))
+(defmethod source:location ((self constructor))
   (constructor-location self))
 
 (defun constructor-list-p (x)
@@ -235,23 +235,23 @@
 
 (defstruct (toplevel-definition
             (:constructor nil))
-  (location  (util:required 'location)  :type location         :read-only t)
+  (location  (util:required 'location)  :type source:location  :read-only t)
   (docstring (util:required 'docstring) :type (or null string) :read-only t))
 
-(defmethod location ((self toplevel-definition))
+(defmethod source:location ((self toplevel-definition))
   (toplevel-definition-location self))
 
-(defmethod docstring ((self toplevel-definition))
+(defmethod source:docstring ((self toplevel-definition))
   (toplevel-definition-docstring self))
 
 (defstruct (toplevel-define-type
             (:include toplevel-definition)
             (:copier nil))
-  (name      (util:required 'name)      :type identifier-src           :read-only t)
-  (vars      (util:required 'vars)      :type keyword-src-list         :read-only t)
-  (ctors     (util:required 'ctors)     :type constructor-list         :read-only t)
-  (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
-  (head-location  (util:required 'head-location)  :type location                     :read-only t))
+  (name          (util:required 'name)          :type identifier-src           :read-only t)
+  (vars          (util:required 'vars)          :type keyword-src-list         :read-only t)
+  (ctors         (util:required 'ctors)         :type constructor-list         :read-only t)
+  (repr          (util:required 'repr)          :type (or null attribute-repr) :read-only nil)
+  (head-location (util:required 'head-location) :type source:location          :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-type-list-p (x)
@@ -264,8 +264,8 @@
 (defstruct (struct-field
             (:include toplevel-definition)
             (:copier nil))
-  (name      (util:required 'name)      :type string           :read-only t)
-  (type      (util:required 'type)      :type ty               :read-only t))
+  (name (util:required 'name) :type string :read-only t)
+  (type (util:required 'type) :type ty     :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun struct-field-list-p (x)
@@ -278,11 +278,11 @@
 (defstruct (toplevel-define-struct
             (:include toplevel-definition)
             (:copier nil))
-  (name      (util:required 'name)      :type identifier-src           :read-only t)
-  (vars      (util:required 'vars)      :type keyword-src-list         :read-only t)
-  (fields    (util:required 'fields)    :type struct-field-list        :read-only t)
-  (repr      (util:required 'repr)      :type (or null attribute-repr) :read-only nil)
-  (head-location  (util:required 'head-location)  :type location          :read-only t))
+  (name          (util:required 'name)          :type identifier-src           :read-only t)
+  (vars          (util:required 'vars)          :type keyword-src-list         :read-only t)
+  (fields        (util:required 'fields)        :type struct-field-list        :read-only t)
+  (repr          (util:required 'repr)          :type (or null attribute-repr) :read-only nil)
+  (head-location (util:required 'head-location) :type source:location          :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-struct-list-p (x)
@@ -296,10 +296,10 @@
             (:copier nil))
   (name         (util:required 'name)         :type identifier-src                   :read-only t)
   (type         (util:required 'type)         :type qualified-ty                     :read-only t)
-  (location     (util:required 'location)     :type location                         :read-only t)
+  (location     (util:required 'location)     :type source:location                  :read-only t)
   (monomorphize (util:required 'monomorphize) :type (or null attribute-monomorphize) :read-only nil))
 
-(defmethod location ((self toplevel-declare))
+(defmethod source:location ((self toplevel-declare))
   (toplevel-declare-location self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -331,9 +331,9 @@
             (:copier nil))
   (left     (util:required 'left)     :type keyword-src-list :read-only t)
   (right    (util:required 'right)    :type keyword-src-list :read-only t)
-  (location (util:required 'location) :type location         :read-only t))
+  (location (util:required 'location) :type source:location  :read-only t))
 
-(defmethod location ((self fundep))
+(defmethod source:location ((self fundep))
   (fundep-location self))
 
 (defun fundep-list-p (x)
@@ -368,7 +368,7 @@
   (fundeps   (util:required 'fundeps)   :type fundep-list            :read-only t)
   (methods   (util:required 'methods)   :type method-definition-list :read-only t)
   ;; Source information for context, name, and vars
-  (head-location  (util:required 'head-location) :type location         :read-only t))
+  (head-location (util:required 'head-location) :type source:location :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-class-list-p (x)
@@ -383,9 +383,9 @@
   (name     (util:required 'name)     :type node-variable   :read-only t)
   (params   (util:required 'params)   :type pattern-list    :read-only t)
   (body     (util:required 'body)     :type node-body       :read-only t)
-  (location (util:required 'location) :type location :read-only t))
+  (location (util:required 'location) :type source:location :read-only t))
 
-(defmethod location ((self instance-method-definition))
+(defmethod source:location ((self instance-method-definition))
   (instance-method-definition-location self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -403,7 +403,7 @@
   (pred               (util:required 'pred)               :type ty-predicate                    :read-only t)
   (methods            (util:required 'methods)            :type instance-method-definition-list :read-only t)
   ;; Source information for the context and the pred
-  (head-location           (util:required 'head-location)           :type location                 :read-only t)
+  (head-location      (util:required 'head-location)      :type source:location                 :read-only t)
   (compiler-generated (util:required 'compiler-generated) :type boolean                         :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -416,10 +416,10 @@
 
 (defstruct (toplevel-lisp-form
             (:copier nil))
-  (body   (util:required 'body)   :type cons  :read-only t)
-  (location (util:required 'location) :type location :read-only t))
+  (body   (util:required 'body)       :type cons            :read-only t)
+  (location (util:required 'location) :type source:location :read-only t))
 
-(defmethod location ((self toplevel-lisp-form))
+(defmethod source:location ((self toplevel-lisp-form))
   (toplevel-lisp-form-location self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -435,9 +435,9 @@
   (from   (util:required 'from)       :type node-variable   :read-only t)
   (to     (util:required 'to)         :type node-variable   :read-only t)
   (type   (util:required 'type)       :type ty              :read-only t)
-  (location (util:required 'location) :type location        :read-only t))
+  (location (util:required 'location) :type source:location :read-only t))
 
-(defmethod location ((self toplevel-specialize))
+(defmethod source:location ((self toplevel-specialize))
   (toplevel-specialize-location self))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
@@ -646,7 +646,7 @@ If MODE is :macro, a package form is forbidden, and an explicit check is made fo
          (package
            (make-toplevel-package :name (symbol-name package-name)
                                   :docstring package-doc
-                                  :location (make-location source
+                                  :location (source:make-location source
                                                            (cursor:cursor-value cursor)))))
     (cursor:do-every cursor (alexandria:curry 'parse-package-clause package))
     package))
@@ -705,8 +705,8 @@ If MODE is :macro, a package form is forbidden, and an explicit check is made fo
       (eval (make-defpackage package))
     (package-error ()
       (error 'parse-error
-             :err (se:source-error :span (location-span (toplevel-package-location package))
-                                   :source (location-source (toplevel-package-location package))
+             :err (se:source-error :span (source:location-span (toplevel-package-location package))
+                                   :source (source:location-source (toplevel-package-location package))
                                    :message "Malformed package declaration"
                                    :primary-note "unable to evaluate package definition")))))
 
@@ -754,7 +754,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
           :do (dolist (form (cddr form))
                 (eval form)))
   (push (make-toplevel-lisp-form :body (cddr (cst:raw form))
-                                 :location (make-location source form))
+                                 :location (source:make-location source form))
         (program-lisp-forms program)))
 
 (defun parse-toplevel-form (form program attributes source)
@@ -814,7 +814,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                  (list
                                   (se:make-source-error-note
                                    :type ':secondary
-                                   :span (location-span (location (toplevel-define-name define)))
+                                   :span (source:location-span (source:location (toplevel-define-name define)))
                                    :message "when parsing define")))))
 
                    (attribute-monomorphize
@@ -833,7 +833,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                      :message "previous attribute here")
                                     (se:make-source-error-note
                                      :type ':secondary
-                                     :span (location-span (location (toplevel-define-name define)))
+                                     :span (source:location-span (source:location (toplevel-define-name define)))
                                      :message "when parsing define")))))
 
                     (setf monomorphize attribute)
@@ -917,7 +917,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                      :message "previous attribute here")
                                     (se:make-source-error-note
                                      :type ':secondary
-                                     :span (location-span (toplevel-define-type-head-location type))
+                                     :span (source:location-span (toplevel-define-type-head-location type))
                                      :message "when parsing define-type")))))
 
                     (setf repr attribute)
@@ -934,7 +934,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                  (list
                                   (se:make-source-error-note
                                    :type ':secondary
-                                   :span (location-span (toplevel-define-type-head-location type))
+                                   :span (source:location-span (toplevel-define-type-head-location type))
                                    :message "when parsing define-type")))))))
 
        (setf (fill-pointer attributes) 0)
@@ -966,7 +966,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                      :message "previous attribute here")
                                     (se:make-source-error-note
                                      :type ':secondary
-                                     :span (location-span (toplevel-define-struct-head-location struct) )
+                                     :span (source:location-span (toplevel-define-struct-head-location struct) )
                                      :message "when parsing define-struct")))))
 
                     (unless (eq :transparent (keyword-src-name (attribute-repr-type attribute)))
@@ -980,7 +980,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                    (list
                                     (se:make-source-error-note
                                      :type ':secondary
-                                     :span (location-span (toplevel-define-struct-head-location struct))
+                                     :span (source:location-span (toplevel-define-struct-head-location struct))
                                      :message "when parsing define-struct")))))
 
                     (setf repr attribute)
@@ -997,7 +997,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                                  (list
                                   (se:make-source-error-note
                                    :type ':secondary
-                                   :span (location-span (location (toplevel-define-struct-name struct)))
+                                   :span (source:location-span (source:location (toplevel-define-struct-name struct)))
                                    :message "when parsing define-type")))))))
 
        (setf (fill-pointer attributes) 0)
@@ -1019,7 +1019,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                       (list
                        (se:make-source-error-note
                         :type ':secondary
-                        :span (location-span (toplevel-define-class-head-location class))
+                        :span (source:location-span (toplevel-define-class-head-location class))
                         :message "while parsing define-class")))))
 
        (push class (program-classes program))
@@ -1039,7 +1039,7 @@ If the outermost form matches (eval-when (compile-toplevel) ..), evaluate the en
                       (list
                        (se:make-source-error-note
                         :type ':secondary
-                        :span (location-span (toplevel-define-instance-head-location instance))
+                        :span (source:location-span (toplevel-define-instance-head-location instance))
                         :message "while parsing define-instance")))))
 
 
@@ -1179,7 +1179,7 @@ consume all attributes")))
        :docstring docstring
        :body body
        :monomorphize nil
-       :location (make-location source form)))))
+       :location (source:make-location source form)))))
 
 (defun parse-declare (form source)
   (declare (type cst:cst form)
@@ -1226,10 +1226,10 @@ consume all attributes")))
   (make-toplevel-declare
    :name (make-identifier-src
           :name (cst:raw (cst:second form))
-          :location (make-location source (cst:second form)))
+          :location (source:make-location source (cst:second form)))
    :type (parse-qualified-type (cst:third form) source)
    :monomorphize nil
-   :location (make-location source form)))
+   :location (source:make-location source form)))
 
 (defun parse-define-type (form source)
   (declare (type cst:cst form)
@@ -1263,7 +1263,7 @@ consume all attributes")))
                       :primary-note "expected symbol")))
 
        (setf name (make-identifier-src :name (cst:raw (cst:second form))
-                                       :location (make-location source form))))
+                                       :location (source:make-location source form))))
 
       (t                                ; (define-type (T ...) ...)
        ;; (define-type ((T) ...) ...)
@@ -1293,7 +1293,7 @@ consume all attributes")))
                       :primary-note "expected symbol")))
 
        (setf name (make-identifier-src :name (cst:raw (cst:first (cst:second form)))
-                                       :location (make-location source (cst:first (cst:second form)))))
+                                       :location (source:make-location source (cst:first (cst:second form)))))
 
        ;; (define-type (T) ...)
        (when (cst:atom (cst:rest (cst:second form)))
@@ -1329,8 +1329,8 @@ consume all attributes")))
                   :while (cst:consp constructors_)
                   :collect (parse-constructor (cst:first constructors_) form source))
      :repr nil
-     :location (make-location source form)
-     :head-location (make-location source (cst:second form)))))
+     :location (source:make-location source form)
+     :head-location (source:make-location source (cst:second form)))))
 
 (defun parse-define-struct (form source)
   (declare (type cst:cst form))
@@ -1375,9 +1375,9 @@ consume all attributes")))
               #'parse-struct-field
               (cst:nthrest (if docstring 3 2) form)
               source)
-     :location (make-location source form)
+     :location (source:make-location source form)
      :repr nil
-     :head-location (make-location source (cst:second form)))))
+     :head-location (source:make-location source (cst:second form)))))
 
 (defun parse-define-class (form source)
   (declare (type cst:cst form)
@@ -1565,13 +1565,13 @@ consume all attributes")))
         (if (cst:atom (first left))
             ;; (C1 ... => C2 ...)
             (setf predicates (list (parse-predicate left
-                                                    (make-location source
+                                                    (source:make-location source
                                                                    (util:cst-source-range left)))))
 
             ;; ((C1 ...) (C2 ...) ... => C3 ...)
             (setf predicates
                   (loop :for pred :in left
-                        :collect (parse-predicate (cst:listify pred) (make-location source pred))))))
+                        :collect (parse-predicate (cst:listify pred) (source:make-location source pred))))))
 
       (when (and (cst:consp (cst:rest (cst:rest form)))
                  (cst:atom (cst:third form))
@@ -1586,14 +1586,14 @@ consume all attributes")))
       (make-toplevel-define-class
        :name (make-identifier-src
               :name name
-              :location (make-location source unparsed-name))
+              :location (source:make-location source unparsed-name))
        :vars variables
        :preds predicates
        :fundeps fundeps
        :docstring docstring
        :methods methods
-       :location (make-location source form)
-       :head-location (make-location source (cst:second form))))))
+       :location (source:make-location source form)
+       :head-location (source:make-location source (cst:second form))))))
 
 (defun parse-define-instance (form source)
   (declare (type cst:cst form)
@@ -1707,12 +1707,12 @@ consume all attributes")))
         (if (cst:atom (first unparsed-context))
             (setf context
                   (list (parse-predicate unparsed-context
-                                         (make-location source
+                                         (source:make-location source
                                                         (util:cst-source-range unparsed-context)))))
 
             (setf context
                   (loop :for unparsed :in unparsed-context
-                        :collect (parse-predicate (cst:listify unparsed) (make-location source unparsed))))))
+                        :collect (parse-predicate (cst:listify unparsed) (source:make-location source unparsed))))))
 
       (when (and (cst:consp (cst:rest (cst:rest form)))
                  (cst:atom (cst:third form))
@@ -1722,15 +1722,15 @@ consume all attributes")))
       (make-toplevel-define-instance
        :context context
        :pred (parse-predicate unparsed-predicate
-                              (make-location source
+                              (source:make-location source
                                              (util:cst-source-range unparsed-predicate)))
        :docstring docstring
        :methods (loop :for methods := (cst:nthrest (if docstring 3 2) form) :then (cst:rest methods)
                       :while (cst:consp methods)
                       :for method := (cst:first methods)
                       :collect (parse-instance-method-definition method (cst:second form) source))
-       :location (make-location source form)
-       :head-location (make-location source (cst:second form))
+       :location (source:make-location source form)
+       :head-location (source:make-location source (cst:second form))
        :compiler-generated nil))))
 
 (defun parse-specialize (form source)
@@ -1782,7 +1782,7 @@ consume all attributes")))
    :from (parse-variable (cst:second form) source)
    :to (parse-variable (cst:third form) source)
    :type (parse-type (cst:fourth form) source)
-   :location (make-location source form)))
+   :location (source:make-location source form)))
 
 (defun parse-method (method-form form source)
   (declare (type cst:cst method-form)
@@ -1880,13 +1880,13 @@ consume all attributes")))
     (make-method-definition
      :name (make-identifier-src
             :name (node-variable-name (parse-variable (cst:first method-form) source))
-            :location (make-location source (cst:first method-form)))
+            :location (source:make-location source (cst:first method-form)))
      :docstring docstring
      :type (parse-qualified-type (if docstring
                                      (cst:third method-form)
                                      (cst:second method-form))
                                  source)
-     :location (make-location source method-form))))
+     :location (source:make-location source method-form))))
 
 (defun parse-type-variable (form source)
   (declare (type cst:cst form)
@@ -1918,7 +1918,7 @@ consume all attributes")))
 
   (make-keyword-src
    :name (cst:raw form)
-   :location (make-location source form)))
+   :location (source:make-location source form)))
 
 (defun parse-constructor (form enclosing-form source)
   (declare (type cst:cst form enclosing-form)
@@ -1964,10 +1964,10 @@ consume all attributes")))
     (make-constructor
      :name (make-identifier-src
             :name (cst:raw unparsed-name)
-            :location (make-location source unparsed-name))
+            :location (source:make-location source unparsed-name))
      :fields (loop :for field :in unparsed-fields
                    :collect (parse-type field source))
-     :location (make-location source form))))
+     :location (source:make-location source form))))
 
 (defun parse-argument-list (form source)
   (declare (type cst:cst form)
@@ -1991,7 +1991,7 @@ consume all attributes")))
    (if (cst:null (cst:rest form))
        (list
         (make-pattern-wildcard
-         :location (make-location source form)))
+         :location (source:make-location source form)))
        (loop :for vars := (cst:rest form) :then (cst:rest vars)
              :while (cst:consp vars)
              :collect (parse-pattern (cst:first vars) source)))))
@@ -2034,7 +2034,7 @@ consume all attributes")))
 
   (make-identifier-src
    :name (cst:raw form)
-   :location (make-location source form)))
+   :location (source:make-location source form)))
 
 (defun parse-definition-body (form enclosing-form source)
   (declare (type cst:cst form)
@@ -2113,7 +2113,7 @@ consume all attributes")))
        :name name
        :params params
        :body (parse-body (cst:rest (cst:rest form)) form source)
-       :location (make-location source form)))))
+       :location (source:make-location source form)))))
 
 (defun parse-fundep (form source)
   (declare (type cst:cst form)
@@ -2164,7 +2164,7 @@ consume all attributes")))
                  :collect (parse-type-variable var source))
      :right (loop :for var :in (cdr right)
                   :collect (parse-type-variable var source))
-     :location (make-location source form))))
+     :location (source:make-location source form))))
 
 
 (defun parse-monomorphize (form source)
@@ -2182,7 +2182,7 @@ consume all attributes")))
                  :primary-note "unexpected form")))
 
   (make-attribute-monomorphize
-   :location (make-location source form)))
+   :location (source:make-location source form)))
 
 (defun parse-repr (form source)
   (declare (type cst:cst form)
@@ -2223,7 +2223,7 @@ consume all attributes")))
           (make-attribute-repr
            :type type
            :arg (cst:third form)
-           :location (make-location source form)))
+           :location (source:make-location source form)))
 
         (progn ;; other reprs do not have an argument
           (when (cst:consp (cst:rest (cst:rest form)))
@@ -2249,7 +2249,7 @@ consume all attributes")))
           (make-attribute-repr
            :type type
            :arg nil
-           :location (make-location source form))))))
+           :location (source:make-location source form))))))
 
 (defun parse-struct-field (form source)
   (declare (type cst:cst form)
@@ -2314,4 +2314,4 @@ consume all attributes")))
      :type (parse-type (cst:first rest-field)
                        source)
      :docstring docstring
-     :location (make-location source form))))
+     :location (source:make-location source form))))

--- a/src/parser/type-definition.lisp
+++ b/src/parser/type-definition.lisp
@@ -7,7 +7,6 @@
 (defpackage #:coalton-impl/parser/type-definition
   (:use
    #:cl
-   #:coalton-impl/source
    #:coalton-impl/parser/base
    #:coalton-impl/parser/types
    #:coalton-impl/parser/toplevel)

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -2,7 +2,6 @@
   (:use
    #:cl
    #:coalton-impl/algorithm
-   #:coalton-impl/source
    #:coalton-impl/typechecker/base
    #:coalton-impl/typechecker/map
    #:coalton-impl/typechecker/type-errors
@@ -24,6 +23,7 @@
    #:+fundep-max-depth+)
   (:local-nicknames
    (#:util #:coalton-impl/util)
+   (#:source #:coalton-impl/source)
    (#:parser #:coalton-impl/parser))
   (:export
    #:*update-hook*                          ; VARIABLE
@@ -265,12 +265,12 @@
   (newtype (util:required 'newtype)     :type boolean :read-only t)
 
   (docstring (util:required 'docstring) :type (or null string)   :read-only t)
-  (location  nil                        :type (or null location) :read-only t))
+  (location  nil                        :type (or null source:location) :read-only t))
 
-(defmethod location ((self type-entry))
+(defmethod source:location ((self type-entry))
   (type-entry-location self))
 
-(defmethod docstring ((self type-entry))
+(defmethod source:docstring ((self type-entry))
   (type-entry-docstring self))
 
 (defmethod make-load-form ((self type-entry) &optional env)
@@ -499,7 +499,7 @@
   (index     (util:required 'index)     :type fixnum            :read-only t)
   (docstring (util:required 'docstring) :type (or null string)  :read-only t))
 
-(defmethod docstring ((self struct-field))
+(defmethod source:docstring ((self struct-field))
   (struct-field-docstring self))
 
 (defmethod make-load-form ((self struct-field) &optional env)
@@ -517,7 +517,7 @@
   (fields           (util:required 'fields)    :type struct-field-list :read-only t)
   (docstring        (util:required 'docstring) :type (or null string)  :read-only t))
 
-(defmethod docstring ((self struct-entry))
+(defmethod source:docstring ((self struct-entry))
   (struct-entry-docstring self))
 
 (defmethod make-load-form ((self struct-entry) &optional env)
@@ -549,7 +549,7 @@
   (type      (util:required 'type)      :type ty-scheme        :read-only t)
   (docstring (util:required 'docstring) :type (or null string) :read-only t))
 
-(defmethod docstring ((self ty-class-method))
+(defmethod source:docstring ((self ty-class-method))
   (ty-class-method-docstring self))
 
 (defmethod make-load-form ((self ty-class-method) &optional env)
@@ -579,12 +579,12 @@
   (superclass-dict     (util:required 'superclass-dict)     :type list                 :read-only t)
   (superclass-map      (util:required 'superclass-map)      :type environment-map      :read-only t)
   (docstring           (util:required 'docstring)           :type (or null string)     :read-only t)
-  (location            (util:required 'location)            :type location             :read-only t))
+  (location            (util:required 'location)            :type source:location             :read-only t))
 
-(defmethod location ((self ty-class))
+(defmethod source:location ((self ty-class))
   (ty-class-location self))
 
-(defmethod docstring ((self ty-class))
+(defmethod source:docstring ((self ty-class))
   (ty-class-docstring self))
 
 (defmethod make-load-form ((self ty-class) &optional env)
@@ -621,8 +621,8 @@
                                     (cdr entry)))
                             (ty-class-superclass-dict class))
    :superclass-map (ty-class-superclass-map class)
-   :docstring (docstring class)
-   :location (location class)))
+   :docstring (source:docstring class)
+   :location (source:location class)))
 
 (defstruct (class-environment (:include immutable-map)))
 
@@ -649,7 +649,7 @@
   (method-codegen-syms (util:required 'method-codegen-syms) :type environment-map   :read-only t)
   (docstring           (util:required 'docstring)           :type (or null string)  :read-only t))
 
-(defmethod docstring ((self ty-class-instance))
+(defmethod source:docstring ((self ty-class-instance))
   (ty-class-instance-docstring self))
 
 (defmethod make-load-form ((self ty-class-instance) &optional env)
@@ -719,12 +719,12 @@
   (name      (util:required 'name)      :type symbol                               :read-only t)
   (type      (util:required 'type)      :type (member :value :method :constructor) :read-only t)
   (docstring (util:required 'docstring) :type (or null string)                     :read-only t)
-  (location  (util:required 'location)  :type location                             :read-only t))
+  (location  (util:required 'location)  :type source:location                      :read-only t))
 
-(defmethod location ((self name-entry))
+(defmethod source:location ((self name-entry))
   (name-entry-location self))
 
-(defmethod docstring ((self name-entry))
+(defmethod source:docstring ((self name-entry))
   (name-entry-docstring self))
 
 (defmethod make-load-form ((self name-entry) &optional env)
@@ -1465,7 +1465,7 @@
                  :else
                    :collect (make-variable)))
 
-         (new-pred (make-ty-predicate :class class-name :types vars :location (location pred))))
+         (new-pred (make-ty-predicate :class class-name :types vars :location (source:location pred))))
 
     (fset:do-seq (inst (lookup-class-instances env class-name))
       (handler-case

--- a/src/typechecker/toplevel.lisp
+++ b/src/typechecker/toplevel.lisp
@@ -8,12 +8,12 @@
 (defpackage #:coalton-impl/typechecker/toplevel
   (:use
    #:cl
-   #:coalton-impl/source
    #:coalton-impl/typechecker/pattern
    #:coalton-impl/typechecker/expression)
   (:local-nicknames
    (#:util #:coalton-impl/util)
    (#:parser #:coalton-impl/parser)
+   (#:source #:coalton-impl/source)
    (#:tc #:coalton-impl/typechecker/stage-1))
   (:export
    #:toplevel-define                    ; STRUCT
@@ -33,7 +33,7 @@
    #:toplevel-define-instance-context   ; ACCESSOR
    #:toplevel-define-instance-pred      ; ACCESSOR
    #:toplevel-define-instance-methods   ; ACCESSOR
-   #:toplevel-define-instance-head-location  ; ACCESSOR
+   #:toplevel-define-instance-head-location ; ACCESSOR
    #:toplevel-define-instance-list      ; TYPE
    ))
 
@@ -42,9 +42,9 @@
 (defstruct (toplevel-definition
             (:constructor nil)
             (:copier nil))
-  (location (util:required 'location) :type location :read-only t))
+  (location (util:required 'location) :type source:location :read-only t))
 
-(defmethod location ((self toplevel-definition))
+(defmethod source:location ((self toplevel-definition))
   (toplevel-definition-location self))
 
 (defstruct (toplevel-define
@@ -70,7 +70,7 @@
    :name (tc:apply-substitution subs (toplevel-define-name node))
    :params (tc:apply-substitution subs (toplevel-define-params node))
    :body (tc:apply-substitution subs (toplevel-define-body node))
-   :location (location node)))
+   :location (source:location node)))
 
 (defstruct (instance-method-definition
             (:include toplevel-definition)
@@ -95,7 +95,7 @@
    :name (tc:apply-substitution subs (instance-method-definition-name method))
    :params (tc:apply-substitution subs (instance-method-definition-params method))
    :body (tc:apply-substitution subs (instance-method-definition-body method))
-   :location (location method)))
+   :location (source:location method)))
 
 (defstruct (toplevel-define-instance
             (:include toplevel-definition)
@@ -103,7 +103,7 @@
   (context       (util:required 'context)       :type tc:ty-predicate-list :read-only t)
   (pred          (util:required 'pred)          :type tc:ty-predicate      :read-only t)
   (methods       (util:required 'methods)       :type hash-table           :read-only t)
-  (head-location (util:required 'head-location) :type location             :read-only t))
+  (head-location (util:required 'head-location) :type source:location      :read-only t))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-instance-list-p (x)

--- a/src/typechecker/traverse.lisp
+++ b/src/typechecker/traverse.lisp
@@ -1,8 +1,9 @@
 (defpackage #:coalton-impl/typechecker/traverse
   (:use
    #:cl
-   #:coalton-impl/source
    #:coalton-impl/typechecker/expression)
+  (:local-nicknames
+   (#:source #:coalton-impl/source))
   (:export
    #:traverse-block                     ; STRUCT
    #:make-traverse-block                ; CONSTRUCTOR
@@ -78,7 +79,7 @@
      (make-node-bind
       :pattern (node-bind-pattern node)
       :expr (traverse (node-bind-expr node) block)
-      :location (location node))))
+      :location (source:location node))))
 
   (:method ((node node-body) block)
     (declare (type traverse-block block)
@@ -98,7 +99,7 @@
      (traverse-abstraction block)
      (make-node-abstraction
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :params (node-abstraction-params node)
       :body (traverse (node-abstraction-body node) block))))
 
@@ -111,7 +112,7 @@
      (make-node-let-binding
       :name (node-let-binding-name node)
       :value (traverse (node-let-binding-value node) block)
-      :location (location node))))
+      :location (source:location node))))
 
   (:method ((node node-let) block)
     (declare (type traverse-block block)
@@ -121,7 +122,7 @@
      (traverse-let block)
      (make-node-let
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :bindings (traverse (node-let-bindings node) block)
       :body (traverse (node-let-body node) block))))
 
@@ -133,7 +134,7 @@
      (traverse-lisp block)
      (make-node-lisp
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :vars (traverse (node-lisp-vars node) block)
       :var-names (node-lisp-var-names node)
       :body (node-lisp-body node))))
@@ -147,7 +148,7 @@
      (make-node-match-branch
       :pattern (node-match-branch-pattern node)
       :body (traverse (node-match-branch-body node) block)
-      :location (location node))))
+      :location (source:location node))))
 
   (:method ((node node-match) block)
     (declare (type traverse-block block)
@@ -157,7 +158,7 @@
      (traverse-match block)
      (make-node-match
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :expr (traverse (node-match-expr node) block)
       :branches (traverse (node-match-branches node) block))))
 
@@ -169,7 +170,7 @@
      (traverse-progn block)
      (make-node-progn
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :body (traverse (node-progn-body node) block))))
 
   (:method ((node node-return) block)
@@ -180,7 +181,7 @@
      (traverse-return block)
      (make-node-return
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :expr (traverse (node-return-expr node) block) ; the nil case is handled by the list instance
       )))
 
@@ -192,7 +193,7 @@
      (traverse-application block)
      (make-node-application
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :rator (traverse (node-application-rator node) block)
       :rands (traverse (node-application-rands node) block))))
 
@@ -204,7 +205,7 @@
      (traverse-or block)
      (make-node-or
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :nodes (traverse (node-or-nodes node) block))))
 
   (:method ((node node-and) block)
@@ -215,7 +216,7 @@
      (traverse-and block)
      (make-node-and
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :nodes (traverse (node-and-nodes node) block))))
 
   (:method ((node node-if) block)
@@ -226,7 +227,7 @@
      (traverse-if block)
      (make-node-if
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :expr (traverse (node-if-expr node) block)
       :then (traverse (node-if-then node) block)
       :else (traverse (node-if-else node) block))))
@@ -239,7 +240,7 @@
      (traverse-when block)
      (make-node-when
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :expr (traverse (node-when-expr node) block)
       :body (traverse (node-when-body node) block))))
 
@@ -251,7 +252,7 @@
      (traverse-unless block)
      (make-node-unless
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :expr (traverse (node-unless-expr node) block)
       :body (traverse (node-unless-body node) block))))
 
@@ -264,7 +265,7 @@
      (make-node-cond-clause
       :expr (traverse (node-cond-clause-expr node) block)
       :body (traverse (node-cond-clause-body node) block)
-      :location (location node))))
+      :location (source:location node))))
 
   (:method ((node node-cond) block)
     (declare (type traverse-block block)
@@ -274,7 +275,7 @@
      (traverse-cond block)
      (make-node-cond
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :clauses (traverse (node-cond-clauses node) block))))
 
   (:method ((node node-while) block)
@@ -284,7 +285,7 @@
      (traverse-while block)
      (make-node-while
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :label (node-while-label node)
       :expr (traverse (node-while-expr node) block)
       :body (traverse (node-while-body node) block))))
@@ -296,7 +297,7 @@
      (traverse-while-let block)
      (make-node-while-let
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :label (node-while-let-label node)
       :pattern (node-while-let-pattern node)
       :expr (traverse (node-while-let-expr node) block)
@@ -309,7 +310,7 @@
      (traverse-for block)
      (make-node-for
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :label (node-for-label node)
       :pattern (node-for-pattern node)
       :expr (traverse (node-for-expr node) block)
@@ -322,7 +323,7 @@
      (traverse-loop block)
      (make-node-loop
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :label (node-loop-label node)
       :body (traverse (node-loop-body node) block))))
 
@@ -349,7 +350,7 @@
      (make-node-do-bind
       :pattern (node-do-bind-pattern node)
       :expr (traverse (node-do-bind-expr node) block)
-      :location (location node))))
+      :location (source:location node))))
 
   (:method ((node node-do) block)
     (declare (type traverse-block block)
@@ -359,7 +360,7 @@
      (traverse-do block)
      (make-node-do
       :type (node-type node)
-      :location (location node)
+      :location (source:location node)
       :nodes (traverse (node-do-nodes node) block)
       :last-node (traverse (node-do-last-node node) block))))
 


### PR DESCRIPTION
Be more consistent with use of this package by always importing it using a nickname, rather than in the package :use clause.

Aside from changes to defpackage, this is a purely mechanical change.