### PR TITLE
Use source:location references when constructing conditions

### DIFF
--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -246,7 +246,7 @@ Examples:
   (cl:let* ((keys (cl:mapcar #'cl:first pairs))
             (values (cl:mapcar #'cl:second pairs))
             (ht (cl:gensym "HASH-TABLE-")))
-    (cl:multiple-value-bind (duplicatep dup-a dup-b)
+    (cl:multiple-value-bind (duplicatep dup-a)
         (find-duplicate-entry pairs)
       (cl:if duplicatep
              (cl:error 'static-duplicate-key

--- a/src/parser/base.lisp
+++ b/src/parser/base.lisp
@@ -21,6 +21,7 @@
    #:identifier-src-name                ; ACCESSOR
    #:identifier-src-list                ; TYPE
    #:parse-error                        ; CONDITION
+   #:source-note                        ; FUNCTION
    #:parse-list                         ; FUNCTION
    ))
 
@@ -73,9 +74,6 @@
 (deftype identifier-src-list ()
   '(satisfies identifier-src-list-p))
 
-(define-condition parse-error (se:source-base-error)
-  ())
-
 (defun parse-list (f list_ file)
   (declare (type function f)
            (type cst:cst list_)
@@ -84,3 +82,29 @@
   (loop :for list := list_ :then (cst:rest list)
         :while (cst:consp list)
         :collect (funcall f (cst:first list) file)))
+
+;;; Condition types and helper functions specific to errors
+;;; encountered during parsing.
+;;;
+;;; A complex parse error may be signaled with:
+;;;
+;;;   (parse-error "Overall description of condition"
+;;;                (source-note SOURCE CST1 "Primary ~A: ~A" ARG1 ARG2)
+;;;                (source-note SOURCE CST2 "Related ~A: ~A" ARG3 ARG4)
+;;;                ... )
+
+(define-condition parse-error (se:source-base-error)
+  ()
+  (:documentation "A condition indicating a syntax error in Coalton source code."))
+
+(defun parse-error (message &rest notes)
+  "Signal a PARSE-ERROR with provided MESSAGE and source NOTES."
+  (error 'parse-error :err (source:make-source-error ':error message notes)))
+
+(defun source-note (source cst format-string &rest format-args)
+  "Helper function to make a source note using SOURCE and CST:SOURCE as location."
+  (declare (type cst:cst cst)
+           (type string format-string))
+  (apply #'source:note
+         (source:make-location source (cst:source cst))
+         format-string format-args))

--- a/src/parser/cursor.lisp
+++ b/src/parser/cursor.lisp
@@ -1,29 +1,26 @@
 ;;; This package provides utilities for incremental consumption of
-;;; concrete syntax tree values.
-;;;
-;;; The package has two main points. The first is the definition of a
-;;; cursor struct that maintains a reference to the current value and a
-;;; pointer within it, if it is cons-valued. The functions 'next' and
-;;; 'empty-p' are sufficient to build more specialized parsing
-;;; functions that don't need knowledge of the cst package.
-;;;
-;;; The second is the definition of a syntax-error condition that
-;;; wraps a list of labeled spans. Many errors reflect to the current
-;;; state of the cursor (empty, not cons-valued, pointing at wron
-;;; type, etc.). A function is provided to convert syntax-error
-;;; conditions to base/parse-error conditions.
+;;; concrete syntax tree values.  A cursor struct maintains a
+;;; reference to the current value and a pointer within it, if it is
+;;; cons-valued. The functions 'next' and 'empty-p' are sufficient to
+;;; build more specialized parsing functions that don't need knowledge
+;;; of the cst package.
 
 (defpackage #:coalton-impl/parser/cursor
   (:use
    #:cl)
   (:local-nicknames
    (#:cst #:concrete-syntax-tree)
-   (#:se #:source-error))
+   (#:se #:source-error)
+   (#:source #:coalton-impl/source)
+   (#:util #:coalton-impl/util))
   (:shadowing-import-from
    #:coalton-impl/parser/base
    #:parse-error)
   (:export
    #:collect-symbols
+   #:cursor-location
+   #:cursor-message
+   #:cursor-source
    #:cursor-value
    #:do-every
    #:empty-p
@@ -33,7 +30,6 @@
    #:next-symbol
    #:parse-error
    #:peek
-   #:span-error
    #:syntax-error))
 
 (in-package #:coalton-impl/parser/cursor)
@@ -44,12 +40,24 @@
 
 (defstruct (cursor (:constructor %make-cursor))
   "A CST node-valued cursor."
-  value                                  ; current value
-  pointer)                               ; pointer into current value
+  (value   (util:required 'value)   :type cst:cst) ; current value
+  (pointer (util:required 'value)   :type cst:cst) ; pointer into current value
+  (source  (util:required 'source)               ) ; the source:location of cursor
+  (message (util:required 'message) :type string)) ; a message providing context for errors
 
-(defun make-cursor (value)
+;;; The implementation of source:location for a cursor returns the
+;;; entire span of the cursor.
+
+(defmethod source:location ((self cursor))
+  (source:make-location (cursor-source self)
+                        (cst:source (cursor-value self))))
+
+(defun make-cursor (value source message)
   "Make a cursor that points at VALUE."
-  (%make-cursor :value value :pointer value))
+  (%make-cursor :value value
+                :pointer value
+                :source source
+                :message message))
 
 (defun peek (cursor)
   "Peek at the Lisp value of CURSOR without changing cursor state."
@@ -68,28 +76,7 @@
     (or (not (cst:consp pointer))
         (null (cst:first pointer)))))
 
-(defstruct note
-  "A source text annotation. The TYPE field is compatible with base/parse-error."
-  (span nil :type (cons integer integer) :read-only t) ; offsets into source
-  (text nil :type string                 :read-only t) ; error message or label
-  (type ':primary))                                    ; primary, secondary or help
-
-(defmethod print-object ((self note) stream)
-  (if *print-readably*
-      (call-next-method)
-      (format stream "~(~a~): for input range ~a: ~a"
-              (note-type self)
-              (note-span self)
-              (note-text self))))
-
-(define-condition syntax-error (error)
-  ((notes :initarg :notes
-          :reader error-notes))
-  (:report (lambda (condition stream)
-             (format stream "cursor syntax-error~%~{~a~%~}"
-                     (error-notes condition)))))
-
-(defun pointer-span (cursor)
+(defun cursor-span (cursor)
   "Return the span that CURSOR is pointing at.
 
 If the wrapped node pointed to a non-empty cons, the span is the first value.
@@ -108,18 +95,19 @@ Otherwise, the span is the cst:source of the wrapped node."
           (t
            (cst:source pointer)))))
 
-(declaim (inline span-error))
-(defun span-error (span note)
-  "Signal an error with message NOTE that points at SPAN."
-  (error 'syntax-error
-         :notes (list (make-note :span span
-                                 :text note))))
+(defun cursor-location (cursor)
+  "Return the location of the value that CURSOR is pointing at."
+  (source:make-location (cursor-source cursor)
+                        (cursor-span cursor)))
 
-(declaim (inline syntax-error))
-(defun syntax-error (cursor note)
-  "Signal an error with message NOTE that points at the current span indicated by CURSOR."
-  (declare (type cursor cursor))
-  (span-error (pointer-span cursor) note))
+(defun syntax-error (cursor note &key (end nil))
+  "Signal a PARSE-ERROR related to the current value of a cursor.
+If END is T, indicate the location directly following the current value."
+  (let ((location (if end
+                      (source:end-location (cursor-location cursor))
+                      (cursor-location cursor))))
+    (parse-error (cursor-message cursor)
+                 (source:note location note))))
 
 (defun next (cursor &key (pred nil) (unwrap t))
   "Return the next value from a nonempty cursor.
@@ -144,14 +132,20 @@ If UNWRAP is NIL, return the CST node, otherwise, return the raw value."
 (defun do-every (cursor fn)
   "Wrap each value in CURSOR in a subcursor, and call FN with it."
   (loop :until (empty-p cursor)
-        :do (funcall fn (make-cursor (next cursor :unwrap nil)))))
-
-;; type-specific helpers
+        :do (funcall fn (make-cursor (next cursor :unwrap nil)
+                                     (cursor-source cursor)
+                                     (cursor-message cursor)))))
 
 (defun next-symbol (cursor &key message missing require)
   "Return the next value in CURSOR as a symbol. The cursor must be nonempty, and the next value must be a symbol."
   (when (empty-p cursor)
-    (syntax-error cursor (or missing "symbol is missing")))
+    ;; When empty, indicate the character immediately preceding the
+    ;; end of the cursor's outside span.
+    (let ((end (1- (source:span-end (source:location-span (source:location cursor))))))
+      (parse-error (cursor-message cursor)
+                   (source:note (source:make-location (cursor-source cursor)
+                                                      (cons end end))
+                                (or missing "symbol is missing")))))
   (next cursor
         :pred (lambda (value)
                 (when (or (null value)
@@ -168,36 +162,3 @@ If UNWRAP is NIL, return the CST node, otherwise, return the raw value."
   "Return all remaining values in CURSOR as a list of symbols."
   (loop :until (empty-p cursor)
         :collect (next-symbol cursor)))
-
-;; conversion to parse-error conditions
-
-(defun help-note-p (note)
-  "T if NOTE is a help note."
-  (eq ':help (note-type note)))
-
-(defun note->source-note (note)
-  "Convert NOTE to a source error help note."
-  (se:make-source-error-note :span (note-span note)
-                             :type (note-type note)
-                             :message (note-text note)))
-
-(defun note->help-note (note)
-  "Convert NOTE to a source error help note."
-  (se:make-source-error-help :span (note-span note)
-                             :replacement #'identity
-                             :message (note-text note)))
-
-(defun parse-error (source message syntax-error &optional notes)
-  "Rethrow SYNTAX-ERROR as a PARSE-ERROR."
-  (destructuring-bind (primary-note &rest secondary-notes)
-      (append (error-notes syntax-error) notes)
-    (error
-     'parse-error
-     :err (se:source-error :span (note-span primary-note)
-                           :source source
-                           :message message
-                           :primary-note (note-text primary-note)
-                           :notes (mapcar #'note->source-note
-                                          (remove-if #'help-note-p secondary-notes))
-                           :help-notes (mapcar #'note->help-note
-                                               (remove-if-not #'help-note-p secondary-notes))))))

--- a/tests/parser-test-files/package.txt
+++ b/tests/parser-test-files/package.txt
@@ -36,7 +36,7 @@ error: Malformed package declaration
   --> test:1:8
    |
  1 |  (package)
-   |          ^ missing package name
+   |         ^ missing package name
 
 ================================================================================
 4 Unknown package clause
@@ -66,7 +66,7 @@ help: Must be one of IMPORT, IMPORT-FROM, EXPORT, SHADOW
 --------------------------------------------------------------------------------
 
 error: Malformed package declaration
-  --> test:2:9
+  --> test:2:10
    |
  2 |    (import))
    |           ^ empty IMPORT form
@@ -114,7 +114,7 @@ error: Malformed package declaration
   --> test:2:23
    |
  2 |    (import (something as)))
-   |                         ^ missing package nickname
+   |                        ^ missing package nickname
 
 ================================================================================
 9 Shadow clause is accepted

--- a/tests/parser/cursor-tests.lisp
+++ b/tests/parser/cursor-tests.lisp
@@ -3,15 +3,20 @@
    #:cl)
   (:local-nicknames
    (#:parser #:coalton-impl/parser)
+   (#:source #:coalton-impl/source)
+   (#:se #:source-error)
    (#:cursor #:coalton-impl/parser/cursor)
    (#:cst #:concrete-syntax-tree)))
 
 (in-package #:coalton-impl/parser/cursor-tests)
 
 (defun make-cursor (string)
-  (with-input-from-string (stream string)
-    (parser:with-reader-context stream
-      (cursor:make-cursor (parser:maybe-read-form stream parser::*coalton-eclector-client*)))))
+  (let ((source (source:make-source-string string)))
+    (with-open-stream (stream (se:source-stream source))
+      (parser:with-reader-context stream
+        (cursor:make-cursor (parser:maybe-read-form stream parser::*coalton-eclector-client*)
+                            source
+                            "Unit Test")))))
 
 (deftest read-forward ()
   (let ((c (make-cursor "(1 2 3)")))
@@ -20,7 +25,7 @@
     (is (eql 2 (cursor:next c)))
     (is (eql 3 (cursor:next c)))
     (is (cursor:empty-p c))
-    (signals cursor:syntax-error
+    (signals parser:parse-error
       (cursor:next c))))
 
 (deftest collect-symbols ()
@@ -28,5 +33,5 @@
     (is (equal '(a b c)
                (cursor:collect-symbols c))))
 
-  (signals cursor:syntax-error
+  (signals parser:parse-error
     (cursor:collect-symbols (make-cursor "(a () c)"))))

--- a/tests/toplevel-tests.lisp
+++ b/tests/toplevel-tests.lisp
@@ -7,8 +7,7 @@
       (parser:with-reader-context stream
         (let* ((form (parser:maybe-read-form stream parser::*coalton-eclector-client*))
                (package (coalton-impl/parser/toplevel::parse-package
-                         (coalton-impl/parser/cursor:make-cursor form)
-                         source)))
+                         (coalton-impl/parser/cursor:make-cursor form source "Unit Test"))))
           (funcall fn package))))))
 
 (deftest test-lisp-package ()


### PR DESCRIPTION
- make cursor 'note' generic by relocating it to src/source
- parse-error constructor with `message` `note*` arguments