### PR TITLE
Change print to cr-print, change package-check behavior

### DIFF
--- a/library/computable-reals/computable-reals.lisp
+++ b/library/computable-reals/computable-reals.lisp
@@ -17,7 +17,7 @@
    #:approx
    #:rational-approx
    #:rationalize
-   #:print))
+   #:cr-print))
 
 (in-package #:coalton-library/computable-reals)
 
@@ -317,8 +317,8 @@ See `rational` or `rationalize` to produce a rational approximation of `Creal`."
     (lisp Integer (x)
       (cr:raw-approx-r x)))
 
-  (declare print (CReal -> UFix -> Boolean))
-  (define (print x k)
+  (declare cr-print (CReal -> UFix -> Boolean))
+  (define (cr-print x k)
     "Prints a real `R` up to `K` bits of precision."
     (lisp Boolean (x k)
       (cr:print-r x k))))

--- a/src/typechecker/base.lisp
+++ b/src/typechecker/base.lisp
@@ -133,9 +133,10 @@ source locations whose spans are compared for ordering."
         :do (check-type id symbol)
 
         :unless (equalp (symbol-package id) *package*)
-          :do (tc-error (funcall source elem)
-                        "Invalid identifier name"
-                        (format nil "The symbol ~S is defined in the package ~A and not the current package ~A"
-                                id
-                                (symbol-package id)
-                                *package*))))
+          :do (tc-located-error
+               (funcall source elem)
+               "Invalid identifier name"
+               (format nil "The symbol ~S is defined in the package ~A and not the current package ~A"
+                       id
+                       (symbol-package id)
+                       *package*))))


### PR DESCRIPTION
This avoids a package conflict with `coalton:print`, while also fixing the error message generated when running into a package conflict.

This should fix the CI error for #1253