### PR TITLE
Add class method docstrings to lisp symbol documentation

### DIFF
--- a/src/codegen/codegen-class.lisp
+++ b/src/codegen/codegen-class.lisp
@@ -6,6 +6,7 @@
    #:struct-or-class
    #:make-struct-or-class-field)
   (:local-nicknames
+   (#:source #:coalton-impl/source)
    (#:settings #:coalton-impl/settings)
    (#:global-lexical #:coalton-impl/global-lexical)
    (#:rt #:coalton-impl/runtime)
@@ -65,6 +66,8 @@
            (tc:ty-class-codegen-sym class))
          (method-name
            (tc:ty-class-method-name method))
+         (method-docstring
+           (source:docstring method))
          (method-accessor
            (alexandria:format-symbol (symbol-package class-codegen-sym)
                                      "~A-~A" class-codegen-sym method-name)))
@@ -80,6 +83,12 @@
             ;; We need a function of arity + 1 to account for DICT
             ,(rt:construct-function-entry `#',method-name (+ arity 1))
             (documentation ',method-name 'variable)
-            ,(format nil "~A :: ~A" method-name (tc:lookup-value-type env method-name))
+            ,(format nil "~A :: ~A~@[~%~A~]~%"
+                     method-name
+                     (tc:lookup-value-type env method-name)
+                     method-docstring)
             (documentation ',method-name 'function)
-            ,(format nil "~A :: ~A" method-name (tc:lookup-value-type env method-name))))))
+            ,(format nil "~A :: ~A~@[~%~A~]~%"
+                     method-name
+                     (tc:lookup-value-type env method-name)
+                     method-docstring)))))


### PR DESCRIPTION
This adds method docstrings to lisp symbol documentation:
```
COALTON-LIBRARY/CLASSES> (cl:describe 'foldr)
COALTON-LIBRARY/CLASSES:FOLDR
  [symbol]

FOLDR names a symbol macro:
  Expansion: (COMMON-LISP:THE
              COALTON-IMPL/RUNTIME/FUNCTION-ENTRY:FUNCTION-ENTRY
              (COALTON-IMPL/GLOBAL-LEXICAL::TOP-LEVEL-BINDING-VALUE
               (COMMON-LISP:LOAD-TIME-VALUE
                (COALTON-IMPL/GLOBAL-LEXICAL:GET-TOP-LEVEL-BINDING
                 'FOLDR
                 COALTON-IMPL/GLOBAL-LEXICAL::*TOP-LEVEL-ENVIRONMENT*))))
  Documentation:
    FOLDR :: ∀ A B C. FOLDABLE C ⇒ ((A → B → B) → B → (C A) → B)
    A right non-tail-recursive fold.
    

FOLDR names a compiled function:
  Lambda-list: (DICT _0 _1 _2)
  Derived type: (FUNCTION (T T T T) *)
  Documentation:
    FOLDR :: ∀ A B C. FOLDABLE C ⇒ ((A → B → B) → B → (C A) → B)
    A right non-tail-recursive fold.

  Inline proclamation: INLINE (inline expansion available)
```