### PR TITLE
Include variable name in error message if missing in environment

### DIFF
--- a/src/typechecker/tc-env.lisp
+++ b/src/typechecker/tc-env.lisp
@@ -74,8 +74,8 @@
       (error 'tc:tc-error
              :err (source:source-error
                    :location (source:location var)
-                   :message "Unknown variable"
-                   :primary-note "unknown variable"
+                   :message (format nil "Unknown variable ~a" var-name)
+                   :primary-note (format nil "unknown variable ~a" var-name)
                    :help-notes (loop :for suggestion :in (tc-env-suggest-value env var-name)
                                      :collect (se:make-source-error-help
                                                :span (source:location-span (source:location var))


### PR DESCRIPTION
I've encountered inaccurate source locations in errors. It can be difficult to tell which symbol I need to import a package or add a package prefix for. So this adds the variable name to the error.