### PR TITLE
Include variable name in unknown variable errors

### DIFF
--- a/src/typechecker/tc-env.lisp
+++ b/src/typechecker/tc-env.lisp
@@ -74,8 +74,8 @@
       (error 'tc:tc-error
              :err (source:source-error
                    :location (source:location var)
-                   :message "Unknown variable"
-                   :primary-note "unknown variable"
+                   :message (format nil "Unknown variable ~a" var-name)
+                   :primary-note (format nil "unknown variable ~a" var-name)
                    :help-notes (loop :for suggestion :in (tc-env-suggest-value env var-name)
                                      :collect (se:make-source-error-help
                                                :span (source:location-span (source:location var))

--- a/tests/parser-test-files/fundeps.txt
+++ b/tests/parser-test-files/fundeps.txt
@@ -92,11 +92,11 @@ Fundeps improve type checking
 
 --------------------------------------------------------------------------------
 
-error: Unknown variable
+error: Unknown variable "HELLO"
   --> test:11:20
     |
  11 |  (define x (ambig (m \"hello\")))
-    |                      ^^^^^^^^^ unknown variable
+    |                      ^^^^^^^^^ unknown variable "HELLO"
 
 ================================================================================
 Ambiguous despite fundep

--- a/tests/parser-test-files/type-inference.txt
+++ b/tests/parser-test-files/type-inference.txt
@@ -236,11 +236,11 @@ Check that polymorphic recursion is not possible without an explicit binding
 
 --------------------------------------------------------------------------------
 
-error: Unknown variable
+error: Unknown variable SINGLETON
   --> test:13:9
     |
  13 |       (f (singleton a)
-    |           ^^^^^^^^^ unknown variable
+    |           ^^^^^^^^^ unknown variable SINGLETON
 
 ================================================================================
 Check that typeclasses cannot have additional constraints defined in a method


### PR DESCRIPTION
- Add variable name to unknown variable errors (courtesy @Mira-public)
- 2x corresponding test text updates