### PR TITLE
Refer to correct source during macroexpansion

### DIFF
--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -163,9 +163,8 @@ It ensures the presence of source metadata for STREAM and then calls MAYBE-READ-
   "Compile FORMS as Coalton using the indicated MODE."
   (let* ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
          (string (print-form (cons mode forms)))
-         (*source* (unless (source-filename)
-                     (coalton-impl/source:make-source-string string
-                                                             :name (buffer-name)))))
+         (*source* (coalton-impl/source:make-source-string string
+                                                           :name "<macroexpansion>")))
     (with-input-from-string (stream string)
       (cl:read stream))))
 


### PR DESCRIPTION
Bind *source* during expansion of coalton macros so that offsets refer to correct source location.

This restores the previous behavior of macroexpansion:

```
  error: 
    during macroexpansion of (COALTON HELLO). Use COMMON-LISP:*BREAK-ON-SIGNALS* to
    intercept.
    
     error: Unknown variable HELLO
      --> <macroexpansion>:1:9
       |
     1 |  (COALTON HELLO)
       |           ^^^^^ unknown variable HELLO
```

Closes #1263