### PR TITLE
Trivial fixes

### DIFF
--- a/benchmarks/gabriel-benchmarks/stak.lisp
+++ b/benchmarks/gabriel-benchmarks/stak.lisp
@@ -44,7 +44,7 @@
                  (stak-aux))))
         (stak-aux))))
 
-(declaim (ftype (function (fixnum) fixnum) lisp-stak))
+(declaim (ftype (function (fixnum fixnum fixnum) fixnum) lisp-stak))
 (defun lisp-stak (x y z)
   (stak-aux))
 

--- a/benchmarks/gabriel-benchmarks/tak.lisp
+++ b/benchmarks/gabriel-benchmarks/tak.lisp
@@ -1,6 +1,6 @@
 ;;;; gabriel-benchmarks/tak.lisp
 ;;;;
-;;;; 
+;;;;
 
 (cl:in-package #:coalton-benchmarks)
 
@@ -8,7 +8,7 @@
   (declare (optimize speed))
   (loop :repeat 1000
         :do (with-benchmark-sampling
-              (coalton:coalton (coalton-benchmarks/native:tak 18 12 6))))
+              (coalton-benchmarks/native:tak 18 12 6)))
   (report trivial-benchmark::*current-timer*))
 
 (define-benchmark tak-lisp ()

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -171,7 +171,7 @@
 ;;;; toplevel-define-type := "(" "define-type" identifier docstring? constructor* ")"
 ;;;;                       | "(" "define-type" "(" identifier keyword+ ")" docstring? constructor* ")"
 ;;;;
-;;;; struct-field := "(" identifier docstring? type)"
+;;;; struct-field := "(" identifier docstring? type ")"
 ;;;;
 ;;;; toplevel-define-struct := "(" "define-struct" identifier docstring? struct-field* ")"
 ;;;;                         | "(" "define-struct" "(" identifier keyword+ ")" docstring? struct-field* ")"


### PR DESCRIPTION
Hi, this is a collection of very minor fixes.  The first two commits fixes annoying warning / transient error when you load benchmarks.  The third commit fixes the formal syntax description in a comment.
