### PR TITLE
Documentation source links point to main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ web-docs:
 	sbcl --noinform \
 		 --non-interactive \
 		 --eval "(ql:quickload :coalton/doc :silent t)" \
-		 --eval "(coalton/doc:write-stdlib-documentation-to-file \"../coalton-website/content/reference.md\" :backend :hugo)"
+		 --eval "(coalton/doc:write-stdlib-documentation-to-file \"../coalton-website/content/reference.md\" :backend :hugo :revision \"main\")"
 
 
 .PHONY: bench


### PR DESCRIPTION
Source links point to main branch rather than source revision hash, preventing repetitive content-free modifications to markdown text.