### PR TITLE
Remove check of class constraints for specialization

### DIFF
--- a/src/typechecker/specialize.lisp
+++ b/src/typechecker/specialize.lisp
@@ -62,10 +62,8 @@
     (let ((from-qual-ty (tc:fresh-inst from-ty))
           (to-qual-ty (tc:fresh-inst to-ty)))
 
-      (when (null (tc:qualified-ty-predicates from-qual-ty))
-        (tc-error "Invalid specialization"
-                  (tc-note (parser:toplevel-specialize-from specialize)
-                           "must be a function or variable with class constraints")))
+      ;; NB: There used to be a check if from-ty contains predicates, and raises an
+      ;; error if not.  It doesn't seem necessary.
 
       (unless (equalp to-ty scheme)
         (tc-error "Invalid specialization"


### PR DESCRIPTION
The original code rejects specializing a function/variable of type without class constraints.  That restriction seems unecessary.  I had talked with @stylewarning about removing this restriciton.

This is necessary to introduce specialization for LispArrays ( https://github.com/shirok/coalton/commit/33ccdd9a7cb50b7f0427f1d9d0744b2631e67d82 ), which allows LispArray accessors/mutators to be inlined and omit runtime dispatch.
