### PR TITLE
Remove location parameter from check-duplicates

### DIFF
--- a/src/typechecker/base.lisp
+++ b/src/typechecker/base.lisp
@@ -99,13 +99,11 @@ This requires a valid PPRINT-VARIABLE-CONTEXT")
 ;;; Assertions
 ;;;
 
-(defun check-duplicates (elems f g callback)
-  "Check for duplicate elements in ELEMS. F maps items in ELEMS to
-symbols which are compared for equality. G maps items in ELEMS to
-source locations whose spans are compared for ordering."
+(defun check-duplicates (elems f callback)
+  "Check for duplicate elements in ELEMS.  F maps items in ELEMS to symbols which are compared for equality.
+As soon as two duplicate elements are detected, CALLBACK is invoked with those two elements, ordered by source location."
   (declare (type list elems)
            (type function f)
-           (type function g)
            (type function callback))
 
   (loop :with table := (make-hash-table :test #'eq)
@@ -119,8 +117,8 @@ source locations whose spans are compared for ordering."
           :do (let ((first (gethash id table))
                     (second elem))
 
-                (when (> (car (source:location-span (funcall g first)))
-                         (car (source:location-span (funcall g second))))
+                (unless (source:location< (source:location first)
+                                          (source:location second))
                   (psetf first second second first))
 
                 (funcall callback first second))

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -62,7 +62,6 @@
   (check-duplicates
    classes
    (alexandria:compose #'parser:identifier-src-name #'parser:toplevel-define-class-name)
-   #'source:location
    (lambda (first second)
      (tc:tc-error "Duplicate class definition"
                   (tc:tc-location (parser:toplevel-define-class-head-location first)
@@ -74,7 +73,6 @@
   (check-duplicates
    (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-class-methods) classes)
    (alexandria:compose #'parser:identifier-src-name #'parser:method-definition-name)
-   #'source:location
    (lambda (first second)
      (tc:tc-error "Duplicate method definition"
                   (tc:tc-note first "first definition here")
@@ -85,7 +83,6 @@
     (check-duplicates
      (parser:toplevel-define-class-vars class)
      #'parser:keyword-src-name
-     #'source:location
      (lambda (first second)
        (tc:tc-error "Duplicate class variable"
                     (tc:tc-note first "first usage here")
@@ -350,7 +347,6 @@
                (check-duplicates
                 vars
                 #'parser:keyword-src-name
-                #'source:location
                 (lambda (first second)
                   (tc:tc-error "Duplicate variable in function dependency"
                                (tc:tc-note first "first usage here")

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -210,7 +210,6 @@
     (check-duplicates
      (parser:toplevel-define-instance-methods unparsed-instance)
      (alexandria:compose #'parser:node-variable-name #'parser:instance-method-definition-name)
-     #'source:location
      (lambda (first second)
        (tc-error "Duplicate method definition"
                  (tc-note first "first definition here")

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -101,7 +101,6 @@
   (check-duplicates
    (append types structs)
    (alexandria:compose #'parser:identifier-src-name #'parser:type-definition-name)
-   #'source:location
    (lambda (first second)
      (tc:tc-error "Duplicate type definitions"
                   (tc:tc-note first "first definition here")
@@ -113,7 +112,6 @@
    (mapcan (alexandria:compose #'copy-list #'parser:type-definition-ctors)
            (append types structs))
    (alexandria:compose #'parser:identifier-src-name #'parser:type-definition-ctor-name)
-   #'source:location
    (lambda (first second)
      (tc:tc-error "Duplicate constructor definitions"
                   (tc:tc-note first "first definition here")
@@ -124,7 +122,6 @@
         :do (check-duplicates
              (parser:type-definition-vars type)
              #'parser:keyword-src-name
-             #'source:location
              (lambda (first second)
                (tc:tc-error "Duplicate type variable definitions"
                             (tc:tc-note first "first definition here")

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -103,7 +103,6 @@
   (check-duplicates
    defines
    (alexandria:compose #'parser:node-variable-name #'parser:toplevel-define-name)
-   #'source:location
    (lambda (first second)
      (tc-error "Duplicate definition"
                (tc-note (parser:toplevel-define-name first)
@@ -115,7 +114,6 @@
   (check-duplicates
    declares
    (alexandria:compose #'parser:identifier-src-name #'parser:toplevel-declare-name)
-   #'source:location
    (lambda (first second)
      (tc-error "Duplicate declaration"
                (tc-note (parser:toplevel-declare-name first)
@@ -480,7 +478,6 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
     (check-duplicates
      (parser:pattern-variables (parser:node-abstraction-params node))
      #'parser:pattern-var-name
-     #'source:location
      (lambda (first second)
        (tc-error "Duplicate parameters name"
                  (tc-note first "first parameter here")
@@ -571,7 +568,6 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
     (check-duplicates
      (parser:node-let-bindings node)
      (alexandria:compose #'parser:node-variable-name #'parser:node-let-binding-name)
-     #'source:location
      (lambda (first second)
        (tc-error "Duplicate definition in let"
                  (tc-note first "first definition here")
@@ -1497,7 +1493,6 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
       (check-duplicates (parser:pattern-variables pat)
                         #'parser:pattern-var-name
-                        #'source:location
                         (lambda (first second)
                           (tc-error "Duplicate pattern variable"
                                     (tc-note first "first definition here")
@@ -2125,7 +2120,6 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
   (check-duplicates
    (parser:pattern-variables (parser:binding-parameters binding))
    #'parser:pattern-var-name
-   #'source:location
    (lambda (first second)
      (tc-error "Duplicate parameters name"
                (tc-note first "first parameter here")


### PR DESCRIPTION
source:location is used to report duplicate locations, and doesn't need to be provided as a parameter.