### PR TITLE
Change `Quantization` from type to struct; doc upgrade

### DIFF
--- a/library/math/real.lisp
+++ b/library/math/real.lisp
@@ -198,18 +198,18 @@ Furthermore, `best-approx` returns the simplest fraction, and both functions may
 (%define-native-rationals Double-Float)
 
 (coalton-toplevel
-  (define-type (Quantization :a)
-    "Represents an integer quantization of `:a`.
-
-The fields are defined as follows:
-
-1. A value of type `:a`.
-2. The greatest integer less than or equal to a particular value.
-3. The remainder of this as a value of type `:a`.
-4. The least integer greater than or equal to a particular value.
-5. The remainder of this as a value of type `:a`.
-"
-    (Quantization :a Integer :a Integer :a))
+  (define-struct (Quantization :a)
+    "Represents an integer quantization of `:a`."
+    (value       "A value of type `:a`."
+                 :a)
+    (floor       "The greatest integer less than or equal to a particular value."
+                 Integer)
+    (floor-rem   "The remainder of the floor operation as type `:a`."
+                 :a)
+    (ceiling     "The least integer greater than or equal to a particular value."
+                 Integer)
+    (ceiling-rem "The remainder of the ceiling operation as type `:a`."
+                 :a))
 
   (declare quantize (Real :a => (:a -> (Quantization :a))))
   (define (quantize x)


### PR DESCRIPTION
Currently Quantization is a type with a single constructor, all the documentation is stuffed in the initial docstring. This moves documentation onto individual, named fields in a coalton struct