### PR TITLE
coalton:coalton implicit progn

### DIFF
--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -162,7 +162,7 @@ It ensures the presence of source metadata for STREAM and then calls MAYBE-READ-
 (defun compile-forms (mode forms)
   "Compile FORMS as Coalton using the indicated MODE."
   (let* ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-         (string (print-form (cons mode forms)))
+         (string (print-form (list mode (cons 'coalton:progn forms))))
          (*source* (coalton-impl/source:make-source-string string
                                                            :name "<macroexpansion>")))
     (with-input-from-string (stream string)


### PR DESCRIPTION
Implicit progn in `coalton:coalton` seems like a good thing to have, we added it to `coalton:lisp` and it will make REPL usage nicer.

Before:
```lisp
COALTON-USER> (coalton 1 2 3)
;;=>
error: Malformed coalton expression
  --> <macroexpansion>:1:11
   |
 1 |  (COALTON 1 2 3)
   |             ^ unexpected form
   [Condition of type COALTON-IMPL/PARSER/BASE:PARSE-ERROR]
```

After:

```lisp
COALTON-USER> (coalton 1 2 3)
3 (2 bits, #x3, #o3, #b11)
```