### PR TITLE
Error message for toplevel-only faux macros

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -38,7 +38,9 @@
   :depends-on (#:coalton-compiler
                #:coalton/hashtable-shim
                #:trivial-garbage
-               #:alexandria)
+               #:alexandria
+               #+(or sb-thread threads openmcl-native-threads)
+               #:bordeaux-threads)
   :pathname "library/"
   :serial t
   :components ((:file "set-float-traps")
@@ -86,6 +88,8 @@
                (:file "seq")
                (:file "system")
                (:file "file")
+               #+(or sb-thread threads openmcl-native-threads)
+               (:file "threads")
                (:file "prelude")))
 
 (cl:when (cl:member (uiop:getenv "COALTON_PORTABLE_BIGFLOAT") '("1" "true" "t") :test #'cl:equalp)
@@ -265,4 +269,6 @@
                (:file "looping-native-tests")
                (:file "monomorphizer-tests")
                (:file "inliner-tests")
-               (:file "file-tests")))
+               (:file "file-tests")
+               #+(or sb-thread threads openmcl-native-threads)
+               (:file "thread-tests")))

--- a/library/threads.lisp
+++ b/library/threads.lisp
@@ -1,0 +1,257 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/threads
+  (:use
+   #:coalton
+   #:coalton-library/system
+   #:coalton-library/classes)
+  (:export
+   ;; Threads
+   #:Thread
+   #:spawn
+   #:make-thread
+   #:current-thread
+   #:all-threads
+   #:join
+   #:interrupt
+   #:destroy
+   #:alive?
+   ;; Locks
+   #:Lock
+   #:RecursiveLock
+   #:with-lock-held
+   #:with-recursive-lock-held
+   #:make-lock
+   #:make-recursive-lock
+   #:acquire-lock
+   #:acquire-recursive-lock
+   #:release-lock
+   #:release-recursive-lock
+   ;; Condition Variables
+   #:ConditionVariable
+   #:make-cv
+   #:wait-cv
+   #:notify-cv
+   #:broadcast-cv
+   ;; Semaphores
+   #:Semaphore
+   #:make-semaphore
+   #:signal-semaphore
+   #:await-semaphore
+   ;; Atomics
+   #:AtomicInteger
+   #:make-atomic
+   #:atomic-cmp-and-swap
+   #:decf-atomic
+   #:incf-atomic
+   #:atomic-value))
+
+(in-package #:coalton-library/threads)
+
+(named-readtables:in-readtable coalton:coalton)
+
+#+coalton-release
+(cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
+
+;;;
+;;; This module implements bindings to bordeaux-threads.
+;;; It will only be loaded if thread capabilities are 
+;;; detected in `cl:*features*'.
+;;;
+
+;;---------;;
+;; Threads ;;
+;;---------;;
+
+(cl:defmacro spawn (cl:&body body)
+  `(make-thread (fn () ,@body Unit)))
+
+(coalton-toplevel
+  (repr :native bt2:thread)
+  (define-type Thread)
+
+  (define-instance (Eq Thread)
+    (define (== a b)
+      (lisp Boolean (a b) (to-boolean (cl:equal a b)))))
+
+  (declare make-thread ((Unit -> Unit) -> Thread))
+  (define (make-thread f)
+    (lisp Thread (f)
+      (bt2:make-thread
+       (cl:lambda () (call-coalton-function f Unit)))))
+
+  (declare current-thread (Unit -> Thread))
+  (define (current-thread)
+    (lisp Thread ()
+      (bt2:current-thread)))
+
+  (declare all-threads (Unit -> (List Thread)))
+  (define (all-threads)
+    (lisp (List Thread) ()
+      (bt2:all-threads)))
+
+  (declare join (Thread -> Unit))
+  (define (join thread)
+    (lisp Unit (thread)
+      (bt2:join-thread thread)
+      Unit))
+
+  (declare interrupt (Thread -> (Unit -> Unit) -> Unit))
+  (define (interrupt thread f)
+    (lisp Unit (thread f)
+      (bt2:interrupt-thread
+       thread
+       (cl:lambda () (call-coalton-function f Unit)))))
+
+  (declare destroy (Thread -> (Result LispCondition Thread)))
+  (define (destroy thread)
+    (lisp (Result LispCondition Thread) (thread)
+      (cl:handler-case (Ok (bt2:join-thread thread))
+        (cl:error (c) (Err c)))))
+
+  (declare alive? (Thread -> Boolean))
+  (define (alive? thread)
+    (lisp Boolean (thread)
+      (bt2:thread-alive-p thread))))
+
+;;-------;;
+;; Locks ;;
+;;-------;;
+
+(cl:defmacro with-lock-held ((lock) cl:&body body)
+  `(progn
+     (acquire-lock ,lock)
+     (cl:unwind-protect (coalton ,@body)
+       (coalton (release-lock)))))
+
+(cl:defmacro with-recursive-lock-held ((lock) cl:&body body)
+  `(progn
+     (acquire-recursive-lock ,lock)
+     (cl:unwind-protect (coalton ,@body)
+       (coalton (release-recursive-lock)))))
+
+(coalton-toplevel
+  (repr :native bt2:lock)
+  (define-type Lock)
+
+  (repr :native bt2:recursive-lock)
+  (define-type RecursiveLock)
+
+  (declare make-lock (Unit -> Lock))
+  (define (make-lock)
+    (lisp Lock ()
+      (bt2:make-lock)))
+
+  (declare acquire-lock (Lock -> Boolean))
+  (define (acquire-lock lock)
+    (lisp Boolean (lock)
+      (bt2:acquire-lock lock)))
+
+  (declare release-lock (Lock -> Lock))
+  (define (release-lock lock)
+    (lisp Lock (lock)
+      (bt2:release-lock lock)))
+
+  (declare make-recursive-lock (Unit -> RecursiveLock))
+  (define (make-recursive-lock)
+    (lisp RecursiveLock ()
+      (bt2:make-recursive-lock)))
+
+  (declare acquire-recursive-lock (RecursiveLock -> Boolean))
+  (define (acquire-recursive-lock lock)
+    (lisp Boolean (lock)
+      (bt2:acquire-lock lock)))
+
+  (declare release-recursive-lock (RecursiveLock -> RecursiveLock))
+  (define (release-recursive-lock lock)
+    (lisp RecursiveLock (lock)
+      (bt2:release-recursive-lock lock))))
+
+;;---------------------;;
+;; Condition Variables ;;
+;;---------------------;;
+
+(coalton-toplevel
+  (repr :native bt2:condition-variable)
+  (define-type ConditionVariable)
+
+  (declare make-cv (Unit -> ConditionVariable))
+  (define (make-cv)
+    (lisp ConditionVariable ()
+      (bt2:make-condition-variable)))
+
+  (declare wait-cv (ConditionVariable -> Lock -> Unit))
+  (define (wait-cv cv lock)
+    (lisp Unit (cv lock)
+      (bt2:condition-wait cv lock)
+      Unit))
+
+  (declare notify-cv (ConditionVariable -> Unit))
+  (define (notify-cv cv)
+    (lisp Unit (cv)
+      (bt2:condition-notify cv)
+      Unit))
+
+  (declare broadcast-cv (ConditionVariable -> Unit))
+  (define (broadcast-cv cv)
+    (lisp Unit (cv)
+      (bt2:condition-broadcast cv)
+      Unit)))
+
+;;------------;;
+;; Semaphores ;;
+;;------------;;
+
+(coalton-toplevel
+  (repr :native bt2:semaphore)
+  (define-type Semaphore)
+
+  (declare make-semaphore (Unit -> Semaphore))
+  (define (make-semaphore)
+    (lisp Semaphore ()
+      (bt2:make-semaphore)))
+
+  (declare signal-semaphore (Semaphore -> UFix -> Unit))
+  (define (signal-semaphore sem count)
+    (lisp Unit (sem count)
+      (bt2:signal-semaphore sem :count count)
+      Unit))
+
+  (declare await-semaphore (Semaphore -> Unit))
+  (define (await-semaphore sem)
+    (lisp Unit (sem)
+      (bt2:wait-on-semaphore sem)
+      Unit)))
+
+;;---------;;
+;; Atomics ;;
+;;---------;;
+
+(coalton-toplevel
+  (repr :native bt2:atomic-integer)
+  (define-type AtomicInteger)
+
+  (declare make-atomic (#+32-bit U32 #+64-bit U64 -> AtomicInteger))
+  (define (make-atomic value)
+    (lisp AtomicInteger (value)
+      (bt2:make-atomic-integer :value value)))
+
+  (declare atomic-cmp-and-swap (AtomicInteger -> #+32-bit U32 #+64-bit U64 -> #+32-bit U32 #+64-bit U64 -> Boolean))
+  (define (atomic-cmp-and-swap atomic old new)
+    (lisp Boolean (atomic old new)
+      (bt2:atomic-integer-compare-and-swap atomic old new)))
+
+  (declare decf-atomic (AtomicInteger -> Unit))
+  (define (decf-atomic atomic)
+    (lisp Unit (atomic)
+      (bt2:atomic-integer-decf atomic)
+      Unit))
+
+  (declare incf-atomic (AtomicInteger -> Unit))
+  (define (incf-atomic atomic)
+    (lisp Unit (atomic)
+      (bt2:atomic-integer-incf atomic)
+      Unit))
+
+  (declare atomic-value (AtomicInteger -> #+32-bit U32 #+64-bit U64))
+  (define (atomic-value atomic)
+    (lisp #+32-bit U32 #+64-bit U64 (atomic)
+      (bt2:atomic-integer-value atomic))))

--- a/library/threads.lisp
+++ b/library/threads.lisp
@@ -30,7 +30,7 @@
    ;; Condition Variables
    #:ConditionVariable
    #:make-cv
-   #:wait-cv
+   #:await-cv
    #:notify-cv
    #:broadcast-cv
    ;; Semaphores
@@ -75,42 +75,51 @@
       (lisp Boolean (a b) (to-boolean (cl:equal a b)))))
 
   (declare make-thread ((Unit -> Unit) -> Thread))
-  (define (make-thread f)
-    (lisp Thread (f)
+  (define (make-thread thunk)
+    "Creates and returns a thread, which will call the function
+`thunk' with no arguments: when `thunk' returns, the thread terminates."
+    (lisp Thread (thunk)
       (bt2:make-thread
-       (cl:lambda () (call-coalton-function f Unit)))))
+       (cl:lambda () (call-coalton-function thunk Unit)))))
 
   (declare current-thread (Unit -> Thread))
   (define (current-thread)
+    "Returns the thread object representing the calling thread."
     (lisp Thread ()
       (bt2:current-thread)))
 
   (declare all-threads (Unit -> (List Thread)))
   (define (all-threads)
+    "Returns a fresh list of all running threads."
     (lisp (List Thread) ()
       (bt2:all-threads)))
 
   (declare join (Thread -> Unit))
   (define (join thread)
+    "Wait until `thread' terminates, or if it has already terminated, return immediately."
     (lisp Unit (thread)
       (bt2:join-thread thread)
       Unit))
 
-  (declare interrupt (Thread -> (Unit -> Unit) -> Unit))
-  (define (interrupt thread f)
-    (lisp Unit (thread f)
+  (declare interrupt (Thread -> (Unit -> Unit) -> Thread))
+  (define (interrupt thread thunk)
+    "Interrupt thread and call `thunk' within its dynamic context,
+then continue with the interrupted path of execution."
+    (lisp Thread (thread thunk)
       (bt2:interrupt-thread
        thread
-       (cl:lambda () (call-coalton-function f Unit)))))
+       (cl:lambda () (call-coalton-function thunk Unit)))))
 
   (declare destroy (Thread -> (Result LispCondition Thread)))
   (define (destroy thread)
+    "Terminates the thread `thread'."
     (lisp (Result LispCondition Thread) (thread)
-      (cl:handler-case (Ok (bt2:join-thread thread))
+      (cl:handler-case (Ok (bt2:destroy-thread thread))
         (cl:error (c) (Err c)))))
 
   (declare alive? (Thread -> Boolean))
   (define (alive? thread)
+    "Returns True if `thread' has not finished or `destroy' has not been called on it."
     (lisp Boolean (thread)
       (bt2:thread-alive-p thread))))
 
@@ -141,43 +150,65 @@
 
   (declare make-lock (Unit -> Lock))
   (define (make-lock)
+    "Creates a non-recursive lock."
     (lisp Lock ()
       (bt2:make-lock)))
 
   (declare acquire-lock (Lock -> Boolean))
   (define (acquire-lock lock)
+    "Acquire `lock' for the calling thread."
     (lisp Boolean (lock)
       (bt2:acquire-lock lock)))
 
   (declare acquire-lock-no-wait (Lock -> Boolean))
   (define (acquire-lock-no-wait lock)
+    "Acquire `lock' for the calling thread.
+Returns Boolean immediately, True if `lock' was acquired, False otherwise."
     (lisp Boolean (lock)
       (bt2:acquire-lock lock :wait nil)))
 
-  (declare release-lock (Lock -> Lock))
+  (declare release-lock (Lock -> (Result LispCondition Lock)))
   (define (release-lock lock)
-    (lisp Lock (lock)
-      (bt2:release-lock lock)))
+    "Release `lock'. It is an error to call this unless
+the lock has previously been acquired (and not released) by the same
+thread. If other threads are waiting for the lock, the
+`acquire-lock' call in one of them will now be able to continue.
+
+Returns the lock."
+    (lisp (Result LispCondition Lock) (lock)
+      (cl:handler-case (Ok (bt2:release-lock lock))
+        (cl:error (c) (Err c)))))
 
   (declare make-recursive-lock (Unit -> RecursiveLock))
   (define (make-recursive-lock)
+    "Creates a recursive lock."
     (lisp RecursiveLock ()
       (bt2:make-recursive-lock)))
 
   (declare acquire-recursive-lock (RecursiveLock -> Boolean))
   (define (acquire-recursive-lock lock)
+    "Acquire `lock' for the calling thread."
     (lisp Boolean (lock)
       (bt2:acquire-recursive-lock lock)))
 
   (declare acquire-recursive-lock-no-wait (Lock -> Boolean))
   (define (acquire-recursive-lock-no-wait lock)
+    "Acquire `lock' for the calling thread.
+Returns Boolean immediately, True if `lock' was acquired, False otherwise."
     (lisp Boolean (lock)
       (bt2:acquire-recursive-lock lock :wait nil)))
 
-  (declare release-recursive-lock (RecursiveLock -> RecursiveLock))
+  (declare release-recursive-lock (RecursiveLock -> (Result LispCondition RecursiveLock)))
   (define (release-recursive-lock lock)
-    (lisp RecursiveLock (lock)
-      (bt2:release-recursive-lock lock))))
+    "Release `lock'. It is an error to call this unless
+the lock has previously been acquired (and not released) by the same
+thread. If other threads are waiting for the lock, the
+`acquire-lock' call in one of them will now be able to continue.
+
+Returns the lock."
+    (lisp (Result LispCondition RecursiveLock) (lock)
+      (cl:handler-case (Ok (bt2:release-recursive-lock lock))
+        (cl:error (c) (Err c))))))
 
 ;;---------------------;;
 ;; Condition Variables ;;
@@ -189,23 +220,31 @@
 
   (declare make-cv (Unit -> ConditionVariable))
   (define (make-cv)
+    "Creates a condition variable."
     (lisp ConditionVariable ()
       (bt2:make-condition-variable)))
 
-  (declare wait-cv (ConditionVariable -> Lock -> Unit))
-  (define (wait-cv cv lock)
+  (declare await-cv (ConditionVariable -> Lock -> Unit))
+  (define (await-cv cv lock)
+    "Atomically release `lock' and enqueue the calling thread waiting for `cv'.
+The thread will resume when another thread has notified it using `notify-cv';
+it may also resume if interrupted by some external event or in other
+implementation-dependent circumstances: the caller must always test on waking
+that there is threading to be done, instead of assuming that it can go ahead."
     (lisp Unit (cv lock)
       (bt2:condition-wait cv lock)
       Unit))
 
   (declare notify-cv (ConditionVariable -> Unit))
   (define (notify-cv cv)
+    "Notify one of the threads waiting for `cv'."
     (lisp Unit (cv)
       (bt2:condition-notify cv)
       Unit))
 
   (declare broadcast-cv (ConditionVariable -> Unit))
   (define (broadcast-cv cv)
+    "Notify all of the threads waiting for `cv'."
     (lisp Unit (cv)
       (bt2:condition-broadcast cv)
       Unit)))
@@ -220,17 +259,22 @@
 
   (declare make-semaphore (Unit -> Semaphore))
   (define (make-semaphore)
+    "Creates a semaphore with initial count 0."
     (lisp Semaphore ()
       (bt2:make-semaphore)))
 
   (declare signal-semaphore (Semaphore -> UFix -> Unit))
   (define (signal-semaphore sem count)
+    "Increment `sem' by `count'.
+If there are threads awaiting this semaphore, then `count' of them are woken up."
     (lisp Unit (sem count)
       (bt2:signal-semaphore sem :count count)
       Unit))
 
   (declare await-semaphore (Semaphore -> Unit))
   (define (await-semaphore sem)
+    "Decrement the count of `sem' by 1 if the count is larger than zero.
+If the count is zero, blocks until `sem' can be decremented."
     (lisp Unit (sem)
       (bt2:wait-on-semaphore sem)
       Unit)))
@@ -245,27 +289,31 @@
 
   (declare make-atomic (#+32-bit U32 #+64-bit U64 -> AtomicInteger))
   (define (make-atomic value)
+    "Creates an `AtomicInteger' with initial value `value'."
     (lisp AtomicInteger (value)
       (bt2:make-atomic-integer :value value)))
 
   (declare atomic-cmp-and-swap (AtomicInteger -> #+32-bit U32 #+64-bit U64 -> #+32-bit U32 #+64-bit U64 -> Boolean))
   (define (atomic-cmp-and-swap atomic old new)
+    "If the current value of `atomic' is equal to `old', replace it with `new'.
+Returns True if the replacement was successful, otherwise False."
     (lisp Boolean (atomic old new)
       (bt2:atomic-integer-compare-and-swap atomic old new)))
 
-  (declare decf-atomic (AtomicInteger -> Unit))
-  (define (decf-atomic atomic)
-    (lisp Unit (atomic)
-      (bt2:atomic-integer-decf atomic)
-      Unit))
+  (declare decf-atomic (AtomicInteger -> #+32-bit U32 #+64-bit U64 -> #+32-bit U32 #+64-bit U64))
+  (define (decf-atomic atomic delta)
+    "Decrements the value of `atomic' by `delta'."
+    (lisp #+32-bit U32 #+64-bit U64 (atomic delta)
+      (bt2:atomic-integer-decf atomic delta)))
 
-  (declare incf-atomic (AtomicInteger -> Unit))
-  (define (incf-atomic atomic)
-    (lisp Unit (atomic)
-      (bt2:atomic-integer-incf atomic)
-      Unit))
+  (declare incf-atomic (AtomicInteger -> #+32-bit U32 #+64-bit U64 -> #+32-bit U32 #+64-bit U64))
+  (define (incf-atomic atomic delta)
+    "Increments the value of `atomic' by `delta'."
+    (lisp #+32-bit U32 #+64-bit U64 (atomic delta)
+      (bt2:atomic-integer-incf atomic delta)))
 
   (declare atomic-value (AtomicInteger -> #+32-bit U32 #+64-bit U64))
   (define (atomic-value atomic)
+    "Returns the current value of `atomic'."
     (lisp #+32-bit U32 #+64-bit U64 (atomic)
       (bt2:atomic-integer-value atomic))))

--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -12,8 +12,20 @@
 
 (in-package #:coalton-impl/faux-macros)
 
+(defun error-coalton-toplevel-only (name)
+  (error "The operator ~S is only valid in a Coalton toplevel expression." name))
+
 (defun error-coalton-only (name)
   (error "The operator ~S is only valid in a Coalton expression." name))
+
+(defmacro define-coalton-toplevel-editor-macro (name lambda-list &optional (docstring ""))
+  "Define a macro so that Emacs and SLIME see it nicely, and so the forms indent properly. Not intended for actual use in Lisp code."
+  (check-type docstring string)
+  `(defmacro ,name ,lambda-list
+     ,docstring
+     (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
+                                   lambda-list)))
+     (error-coalton-toplevel-only ',name)))
 
 (defmacro define-coalton-editor-macro (name lambda-list &optional (docstring ""))
   "Define a macro so that Emacs and SLIME see it nicely, and so the forms indent properly. Not intended for actual use in Lisp code."
@@ -27,28 +39,28 @@
 
 ;;; Top-Level Forms
 
-(define-coalton-editor-macro coalton:define (var-or-fun &body body)
+(define-coalton-toplevel-editor-macro coalton:define (var-or-fun &body body)
   "Define a variable or function. (Coalton top-level operator.)")
 
-(define-coalton-editor-macro coalton:define-type (name &body definition)
+(define-coalton-toplevel-editor-macro coalton:define-type (name &body definition)
   "Create a new algebraic data type named NAME. (Coalton top-level operator.)")
 
-(define-coalton-editor-macro coalton:define-struct (name &body definition)
+(define-coalton-toplevel-editor-macro coalton:define-struct (name &body definition)
   "Create a new sruct named NAME. (Coalton top-level operator.)")
 
-(define-coalton-editor-macro coalton:declare (var type)
+(define-coalton-toplevel-editor-macro coalton:declare (var type)
   "Declare the type of a variable. (Coalton top-level operator.)")
 
-(define-coalton-editor-macro coalton:define-class (class &body method-signatures)
+(define-coalton-toplevel-editor-macro coalton:define-class (class &body method-signatures)
   "Define a new type class. (Coalton top-level operator.")
 
-(define-coalton-editor-macro coalton:define-instance (instance &body method-definitions)
+(define-coalton-toplevel-editor-macro coalton:define-instance (instance &body method-definitions)
   "Define an instance of a type class. (Coalton top-level operator.)")
 
-(define-coalton-editor-macro coalton:lisp-toplevel (options &body lisp-toplevel-forms)
+(define-coalton-toplevel-editor-macro coalton:lisp-toplevel (options &body lisp-toplevel-forms)
   "Include lisp forms. (Coalton top-level operator.)")
 
-(define-coalton-editor-macro coalton:specialize (name from-ty to-ty)
+(define-coalton-toplevel-editor-macro coalton:specialize (name from-ty to-ty)
   "Declare a specialization for a function. (Coalton top-level operator.)")
 
 ;;; Attributes

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -36,7 +36,8 @@
    (#:red-black/map #:coalton-library/ord-map)
    (#:result #:coalton-library/result)
    (#:seq #:coalton-library/seq)
-   (#:file #:coalton-library/file)))
+   (#:file #:coalton-library/file)
+   (#:threads #:coalton-library/threads)))
 
 (in-package #:coalton-native-tests)
 

--- a/tests/thread-tests.lisp
+++ b/tests/thread-tests.lisp
@@ -16,15 +16,15 @@
 
 (define-test thread-all-threads ()
   (is (some?
-       (find (fn (thread) (== thread (threads:current-thread)))
+       (find (== (threads:current-thread))
              (threads:all-threads)))))
 
-(define-test thread-all-threads-count ()
-  (let ((count (length (threads:all-threads)))
-        (thread (threads:spawn (sleep 1))))
-    (is (== (length (threads:all-threads)) (1+ count)))
-    (threads:join thread)
-    (is (== (length (threads:all-threads)) count))))
+(define-test thread-all-threads-contains-new ()
+  (let ((old-threads (threads:all-threads))
+        (thread (threads:spawn (sleep 10))))
+    (is (none? (find (== thread) old-threads)))
+    (is (some? (find (== thread) (threads:all-threads))))
+    (threads:destroy thread)))
 
 ;;-------;;
 ;; Locks ;;
@@ -96,7 +96,6 @@
           (worker (- target x)))) 
       (threads:with-lock-held (lock) 
         (while (not (== target (threads:atomic-value atomic)))
-          (print (threads:atomic-value atomic))
           (threads:await-cv cv lock)))
       (is (== target (threads:atomic-value atomic))))))
 

--- a/tests/thread-tests.lisp
+++ b/tests/thread-tests.lisp
@@ -1,0 +1,23 @@
+(in-package #:coalton-native-tests)
+
+(define-test thread-spawn-and-join ()
+  (let ((thread (threads:spawn)))
+    (is (threads:alive? thread))
+    (threads:join thread)
+    (is (not (threads:alive? thread)))))
+
+(define-test thread-current-thread ()
+  (is (== (threads:current-thread)
+          (lisp threads:Thread () bt2::*current-thread*))))
+
+(define-test thread-all-threads ()
+  (is (some?
+       (find (fn (thread) (== thread (threads:current-thread)))
+             (threads:all-threads)))))
+
+(define-test thread-all-threads-count ()
+  (let ((count (length (threads:all-threads)))
+        (thread (threads:spawn (lisp Unit () (cl:sleep 60) Unit))))
+    (is (== (length (threads:all-threads)) (1+ count)))
+    (threads:destroy thread)
+    (is (== (length (threads:all-threads)) count))))

--- a/tests/thread-tests.lisp
+++ b/tests/thread-tests.lisp
@@ -23,7 +23,7 @@
   (let ((count (length (threads:all-threads)))
         (thread (threads:spawn (sleep 1))))
     (is (== (length (threads:all-threads)) (1+ count)))
-    (threads:destroy thread)
+    (threads:join thread)
     (is (== (length (threads:all-threads)) count))))
 
 ;;-------;;

--- a/tests/thread-tests.lisp
+++ b/tests/thread-tests.lisp
@@ -1,14 +1,16 @@
 (in-package #:coalton-native-tests)
 
+(coalton-toplevel 
+  (define (sleep n)
+    (lisp Unit (n) (cl:sleep n) Unit)))
+
+;; Threads
+
 (define-test thread-spawn-and-join ()
-  (let ((thread (threads:spawn)))
+  (let ((thread (threads:spawn (sleep 1))))
     (is (threads:alive? thread))
     (threads:join thread)
     (is (not (threads:alive? thread)))))
-
-(define-test thread-current-thread ()
-  (is (== (threads:current-thread)
-          (lisp threads:Thread () bt2::*current-thread*))))
 
 (define-test thread-all-threads ()
   (is (some?
@@ -17,7 +19,60 @@
 
 (define-test thread-all-threads-count ()
   (let ((count (length (threads:all-threads)))
-        (thread (threads:spawn (lisp Unit () (cl:sleep 60) Unit))))
+        (thread (threads:spawn (sleep 60))))
     (is (== (length (threads:all-threads)) (1+ count)))
     (threads:destroy thread)
     (is (== (length (threads:all-threads)) count))))
+
+;; Locks
+
+(define-test lock-acquire-release ()
+  (let ((lock (threads:make-lock)))
+    (is (threads:acquire-lock lock))
+    (threads:release-lock lock)
+    (is (threads:acquire-lock-no-wait lock))
+    (threads:release-lock lock)))
+
+(define-test lock-fail-acquire ()
+  (let ((lock (threads:make-lock)))
+    (threads:spawn
+      (threads:with-lock-held (lock)
+        (sleep 60)))
+    (sleep 1)
+    (is (not (threads:acquire-lock-no-wait lock)))))
+
+;; TODO Recursive Locks
+
+;; TODO Semaphores
+
+(define-test semaphore-signal-await ()
+  (let ((sem (threads:make-semaphore)))
+    (threads:spawn
+      (sleep 0.5)
+      (threads:signal-semaphore sem 2))
+    (threads:await-semaphore sem)
+    (threads:await-semaphore sem)
+    (is True)))
+
+(define-test semaphore-n-of-m ()
+  (let ((sem (threads:make-semaphore))
+        (count (threads:make-atomic 0)))
+    (threads:spawn
+      (sleep 1)
+      (threads:signal-semaphore sem 4))
+    ;; idk dotimes
+    (for x in (make-list 1 2 3 4 5)
+      (threads:spawn 
+        (threads:await-semaphore sem)
+        (threads:incf-atomic count)))
+    (sleep 1)
+    (is (== 4 (threads:atomic-value count)))
+    (threads:signal-semaphore sem 1)
+    (sleep 1)
+    (is (== 5 (threads:atomic-value count)))))
+
+;; TODO Condition Variables
+
+;; TODO Atomics
+
+

--- a/tests/thread-tests.lisp
+++ b/tests/thread-tests.lisp
@@ -92,10 +92,10 @@
      (iter:repeat-for 0 100))
     (sleep 1)
     (iter:for-each! threads:notify-cv (iter:repeat-for cv 25))
-    (sleep 1)
+    (sleep 2)
     (is (== 25 (threads:atomic-value atomic)))
     (threads:broadcast-cv cv)
-    (sleep 1)
+    (sleep 2)
     (is (== 100 (threads:atomic-value atomic)))))
 
 ;;---------;;

--- a/tests/thread-tests.lisp
+++ b/tests/thread-tests.lisp
@@ -4,7 +4,9 @@
   (define (sleep n)
     (lisp Unit (n) (cl:sleep n) Unit)))
 
-;; Threads
+;;---------;;
+;; Threads ;;
+;;---------;;
 
 (define-test thread-spawn-and-join ()
   (let ((thread (threads:spawn (sleep 1))))
@@ -19,12 +21,14 @@
 
 (define-test thread-all-threads-count ()
   (let ((count (length (threads:all-threads)))
-        (thread (threads:spawn (sleep 60))))
+        (thread (threads:spawn (sleep 1))))
     (is (== (length (threads:all-threads)) (1+ count)))
     (threads:destroy thread)
     (is (== (length (threads:all-threads)) count))))
 
-;; Locks
+;;-------;;
+;; Locks ;;
+;;-------;;
 
 (define-test lock-acquire-release ()
   (let ((lock (threads:make-lock)))
@@ -41,9 +45,9 @@
     (sleep 1)
     (is (not (threads:acquire-lock-no-wait lock)))))
 
-;; TODO Recursive Locks
-
-;; Semaphores
+;;------------;;
+;; Semaphores ;;
+;;------------;;
 
 (define-test semaphore-signal-await ()
   (let ((sem (threads:make-semaphore)))
@@ -60,26 +64,48 @@
     (threads:spawn
       (sleep 1)
       (threads:signal-semaphore sem 4))
-    ;; idk dotimes
     (for x in (range 1 5)
       (threads:spawn 
         (threads:await-semaphore sem)
-        (threads:incf-atomic count)))
+        (threads:incf-atomic count 1)))
     (sleep 1)
     (is (== 4 (threads:atomic-value count)))
     (threads:signal-semaphore sem 1)
     (sleep 1)
     (is (== 5 (threads:atomic-value count)))))
 
-;; TODO Condition Variables
+;;---------------------;;
+;; Condition Variables ;;
+;;---------------------;;
 
-;; Atomics
+(define-test condition-variable-concurrency ()
+  (let ((atomic (threads:make-atomic 0))
+        (cv (threads:make-cv))
+        (lock (threads:make-lock)))
+    (iter:for-each! 
+     (fn (_)
+       (threads:spawn
+         (threads:with-lock-held (lock)
+           (threads:await-cv cv lock))
+         (threads:incf-atomic atomic 1))
+       Unit)
+     (iter:repeat-for 0 100))
+    (sleep 1)
+    (iter:for-each! threads:notify-cv (iter:repeat-for cv 25))
+    (sleep 1)
+    (is (== 25 (threads:atomic-value atomic)))
+    (threads:broadcast-cv cv)
+    (sleep 1)
+    (is (== 100 (threads:atomic-value atomic)))))
+
+;;---------;;
+;; Atomics ;;
+;;---------;;
 
 (define-test atomic-incf-decf ()
   (let ((atomic (threads:make-atomic 3)))
-    (threads:incf-atomic 10)
-    (threads:decf-atomic 4)
-    (is (== 9 (threads:atomic-value atomic)))))
+    (is (== 13 (threads:incf-atomic atomic 10)))
+    (is (== 9 (threads:decf-atomic atomic 4)))))
 
 (define-test atomic-cmp-and-swap ()
   (let ((atomic (threads:make-atomic 4)))
@@ -91,10 +117,10 @@
   (let ((atomic (threads:make-atomic 4000))
         (incer (threads:spawn
                  (for x in (range 1 1000)
-                   (threads:incf-atomic atomic))))
+                   (threads:incf-atomic atomic 1))))
         (decer (threads:spawn
                  (for x in (range 1 1000)
-                   (threads:decf-atomic atomic)))))
+                   (threads:decf-atomic atomic 1)))))
     (threads:join incer)
     (threads:join decer)
     (is (== 4000 (threads:atomic-value atomic)))))


### PR DESCRIPTION
Improved error messages as requested here: https://github.com/coalton-lang/coalton/issues/1227

```lisp
error: Error during macro expansion
  --> <macroexpansion>:1:9
   |
 1 |  (COALTON (DEFINE-TYPE COW))
   |           ^^^^^^^^^^^^^^^^^ The operator DEFINE-TYPE is only valid in a Coalton toplevel expression.
note: Error occurs within macro context. Source locations may be imprecise
   [Condition of type COALTON-IMPL/PARSER/BASE:PARSE-ERROR]
```