### PR TITLE
 Allow additional constraints in typeclass methods 

### DIFF
--- a/src/codegen/translate-instance.lisp
+++ b/src/codegen/translate-instance.lisp
@@ -46,6 +46,10 @@
            (loop :for pred :in (tc:toplevel-define-instance-context instance)
                  :collect (pred-type pred env)))
 
+         (subs (tc:predicate-match (tc:ty-class-predicate class) pred))
+
+         (superclass-preds (tc:apply-substitution subs (mapcar #'car (tc:ty-class-superclass-dict class))))
+
          (method-definitions
            (loop :for method :in (tc:ty-class-unqualified-methods class)
                  :for method-name := (tc:ty-class-method-name method)
@@ -57,7 +61,7 @@
          (unqualified-method-definitions
            (loop :for method :in (tc:ty-class-unqualified-methods class)
                  :for method-name := (tc:ty-class-method-name method)
-                 :for method-type := (tc:ty-class-method-type method)
+                 :for method-type := (tc:apply-substitution subs (tc:ty-class-method-type method))
                  :for binding := (gethash method-name (tc:toplevel-define-instance-methods instance))
                  :collect (translate-toplevel (tc:attach-explicit-binding-type binding (tc:fresh-inst method-type))
                                               env
@@ -65,10 +69,6 @@
                                               :extra-context ctx)))
 
          (method-ty (mapcar #'node-type unqualified-method-definitions))
-
-         (subs (tc:predicate-match (tc:ty-class-predicate class) pred))
-
-         (superclass-preds (tc:apply-substitution subs (mapcar #'car (tc:ty-class-superclass-dict class))))
 
          (superclass-ty
            (loop :for pred :in superclass-preds

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -391,19 +391,6 @@
                                    (tc-note method
                                             "the method is ambiguous"))
 
-                         ;; Ensure that the type variables in each
-                         ;; pred are not a subset of the class
-                         ;; variables.
-                   :do (loop :for pred :in (parser:qualified-ty-predicates ty)
-                             :for tyvars := (remove-duplicates
-                                             (mapcar #'parser:tyvar-name (parser:collect-type-variables pred))
-                                             :test #'eq)
-
-                             :when (subsetp tyvars var-names)
-                               :do (tc-error "Invalid method predicate"
-                                             (tc-note pred
-                                                      "method predicate contains only class variables")))
-
                    :do (loop :for tyvar :in new-tyvars
                              :do (partial-type-env-add-var env tyvar))
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -287,7 +287,7 @@
                                                           (node-type
                                                            (instance-method-definition-name method)))
                                       :do (setf subs (tc:compose-substitution-lists
-                                                      (tc:predicate-match node-pred context-pred)
+                                                      (tc:predicate-match node-pred context-pred instance-subs)
                                                       subs)))
 
                                 (setf (gethash name table) (tc:apply-substitution subs method)))

--- a/tests/test-files/type-inference.txt
+++ b/tests/test-files/type-inference.txt
@@ -242,23 +242,61 @@ error: Unknown variable SINGLETON
     |           ^^^^^^^^^ unknown variable SINGLETON
 
 ================================================================================
-Check that typeclasses cannot have additional constraints defined in a method
-
-this is a stylistic decision and not a technical limitation
+Typeclasses methods with additional constraints cannot be called without them
 ================================================================================
 
-(package coalton-unit-tests/inference)
+(package coalton-unit-tests/additional-constraints
+  (import coalton-prelude))
 
 (define-class (Test :a)
-  (test (Eq :a => :a -> :a)))
+  (f (Eq :a => :a -> :a)))
+
+(define-type TestType A B C)
+
+(define-instance (Test TestType)
+  (define f id))
+
+(declare test-f (Test :a => :a -> :a))
+
+(define (test-f a)
+  (f a))
 
 --------------------------------------------------------------------------------
 
-error: Invalid method predicate
-  --> test:4:9
-   |
- 4 |    (test (Eq :a => :a -> :a)))
-   |           ^^^^^ method predicate contains only class variables
+error: Explicit type is missing inferred predicate
+  --> test:14:9
+    |
+ 14 |  (define (test-f a)
+    |           ^^^^^^ Declared type TEST :A => (:A -> :A) is missing inferred predicate EQ :A
+
+================================================================================
+Typeclasses methods with additional constraints cannot be called without them,
+even through a generic interface
+================================================================================
+
+(package coalton-unit-tests/additional-constraints
+  (import coalton-prelude))
+
+(define-class (Test :a)
+  (f (Eq :a => :a -> :a)))
+
+(define-type TestType A B C)
+
+(define-instance (Test TestType)
+  (define f id))
+
+(declare test-generic (Test :a => :a -> :a))
+
+(define (test-generic a)
+  (f a))
+
+--------------------------------------------------------------------------------
+
+error: Explicit type is missing inferred predicate
+  --> test:14:9
+    |
+ 14 |  (define (test-generic a)
+    |           ^^^^^^^^^^^^ Declared type TEST :A => (:A -> :A) is missing inferred predicate EQ :A
 
 ================================================================================
 Check than non overlapping instances can be defined

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -236,7 +236,25 @@
       (define test-addl id))
 
     (declare test-bare-testtype (TestType -> TestType))
-    (define test-bare-testtype test-bare)"))
+    (define test-bare-testtype test-bare)")
+
+  ;; Check that it works with functional dependencies
+  (check-coalton-types
+   "(define-type (Box :a)
+      (Box :a))
+
+    (define-class (ClassA :m :a (:m -> :a))
+      (get-a (:m -> :a)))
+
+    (define-class (ClassB :m :a (:m -> :a))
+      (convert (ClassA :n :a => :n -> :m)))
+
+    (define-instance (ClassA (Box :a) :a)
+      (define (get-a (Box a)) a))
+
+    (define-instance (ClassB (Box :a) :a)
+      (define (convert bx)
+        (Box (get-a bx))))"))
 
 (deftest test-typeclass-flexible-instances ()
   (check-coalton-types

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -192,6 +192,51 @@
    "(define-class (Test :a)
       (test (Eq :b => :a -> :b)))"))
 
+(deftest test-typeclass-additional-constraints ()
+
+  ;; Check that typeclass methods can provide additional constraints
+  (check-coalton-types
+   "(define-class (Test :a)
+      (test-bare (:a -> :a))
+      (test-addl (Eq :a => :a -> :a)))
+
+    ;; Can define on types without Eq
+    (define-type TestType A B)
+
+    (define-instance (Test TestType)
+      (define test-bare id)
+      (define test-addl id))
+
+    ;; Can define generic function that uses Eq if constrained
+    (declare test-generic ((Eq :a) (Test :a) => :a -> :a))
+    (define test-generic test-addl)
+
+    ;; Can use test-addl on TestType if Eq defined
+    (define-instance (Eq TestType)
+      (define (== x y)
+        (match (Tuple x y)
+          ((Tuple (A) (A)) True)
+          ((Tuple (B) (B)) True)
+          (_ False))))
+
+    (declare test-addl-testtype (TestType -> TestType))
+    (define test-addl-testtype test-addl)")
+
+  ;; Check that methods not requiring additional constraints can be used
+  (check-coalton-types
+   "(define-class (Test :a)
+      (test-bare (:a -> :a))
+      (test-addl (Eq :a => :a -> :a)))
+
+    ;; Can define on types without Eq
+    (define-type TestType A B)
+
+    (define-instance (Test TestType)
+      (define test-bare id)
+      (define test-addl id))
+
+    (declare test-bare-testtype (TestType -> TestType))
+    (define test-bare-testtype test-bare)"))
 
 (deftest test-typeclass-flexible-instances ()
   (check-coalton-types


### PR DESCRIPTION
This pull request allows typeclass methods to provide additional constraints on the typeclass variables within individual method definitions.

The motivating use case is developing the collections library, to allow for a hierarchy of collection types so that Dictionary/Map like types are collections of tuples and so that linear collections like Vectors/Lists have the same interface as maps of UFix's.

The following is currently compiling ([on this branch that fixes a bug](https://github.com/coalton-lang/coalton/pull/1342)):
```lisp
  (define-class (Collection :m :a (:m -> :a)))

  (define-class (Collection :m (Tuple :k :v) => KeyedCollection :m :k :v (:m -> :k :v)))

  (define-class (KeyedCollection :m UFix :a => LinearCollection_ :m :a (:m -> :a))))
```
However, some collection functions rely on an `Eq` instance for the contained type. Under Coalton's current limitations on method constraints, supporting these functions requires creating an additional typeclass:
```lisp
  (define-class ((Eq :a) (Collection :m :a) => EqCollection :m :a (:m -> :a)))
```

This PR follows a discussion on the best way to approach this problem in the Discord.

---

The actual change is small. This was essentially already supported, most of what needed to be done was removing checks against this use case.

See the tests in the commit for examples of what will/won't compile.