### PR TITLE
Fixed seq:make for large number of elements.

### DIFF
--- a/library/seq.lisp
+++ b/library/seq.lisp
@@ -523,11 +523,11 @@ It attempts to rebalance with a minimum of array copying."
               (cl:length elems))
             (leaf-arrays
               (cl:loop :for i :from 0 :to l :by 32
-                 :for i+32 := (cl:+ i 32)
-                 :when (cl:< i+32 l)
-                   :collect (cl:subseq elems i i+32)
-                 :else
-                   :collect (cl:subseq elems i)))
+                       :for i+32 := (cl:+ i 32)
+                       :when (cl:< i+32 l)
+                         :collect (cl:subseq elems i i+32)
+                       :else
+                         :collect (cl:subseq elems i)))
             (la-count
               (cl:length leaf-arrays)))
     (cl:cond
@@ -538,11 +538,11 @@ It attempts to rebalance with a minimum of array copying."
       ((cl:<= la-count 32)
        `(rebuild-size-table
          (RelaxedNode 2 32 (vector:new) (vector:make ,@(cl:loop :for a :in leaf-arrays
-                                                          :collect `(LeafArray (vector:make ,@a)))))))
+                                                                :collect `(LeafArray (vector:make ,@a)))))))
       (cl:t
        (cl:reduce (cl:lambda (acc la) `(conc ,acc (LeafArray (vector:make ,@la))))
                   (cl:rest leaf-arrays)
-                  :initial-value `(LeafArray (vector:make ,@ (cl:first leaf-arrays))))))))
+                  :initial-value `(LeafArray (vector:make ,@(cl:first leaf-arrays))))))))
 
 ;; This method implementation uses :around because sum types implement
 ;; cl:print-object for each representation, to avoid a brittle design

--- a/tests/seq-tests.lisp
+++ b/tests/seq-tests.lisp
@@ -135,7 +135,7 @@ edge all have between MIN-BRANCHING and MAX-BRANCHING subnodes."
 
 (cl:eval-when (:compile-toplevel :load-toplevel :execute)
   (cl:defmacro make-large-seq (n)
-    `(seq:make ,@(cl:loop :for x :from 0 :to (cl:1- n) :collect x))))
+    `(seq:make ,@(cl:loop :for x :from 0 :below n :collect x))))
 
 (define-test seq-make ()
   (let short-seq = (the (seq:Seq Integer)

--- a/tests/seq-tests.lisp
+++ b/tests/seq-tests.lisp
@@ -133,6 +133,9 @@ edge all have between MIN-BRANCHING and MAX-BRANCHING subnodes."
     (is (== seq1 seq2))
     (is (not (== seq1 seq3)))))
 
+(cl:defmacro make-large-seq (n)
+  `(seq:make ,@(cl:loop :for x :from 0 :to (cl:1- n) :collect x)))
+
 (define-test seq-make ()
   (let short-seq = (the (seq:Seq Integer)
                         (seq:make 1 2 3)))
@@ -143,5 +146,15 @@ edge all have between MIN-BRANCHING and MAX-BRANCHING subnodes."
                                    38 39 40 41 42 43 44 45 46 47 48 49
                                    50 51 52 53 54 55 56 57 58 59 60 61
                                    62 62 64 65 66 67 (+ 57 10))))
+
+  (let longest-seq = (make-large-seq 2048))
+
   (is (== 3 (seq:size short-seq)))
-  (is (== 68 (seq:size longer-seq))))
+  (is (== 68 (seq:size longer-seq)))
+  (is (== 2048 (seq:size longest-seq)))
+  (is (== (Some 1346) (seq:get longest-seq 1346))))
+
+(define-test seq-make-into ()
+  (let my-seq = (seq:make "Hello, world!" (into 3)))
+  (is (== (Some "Hello, world!") (seq:get my-seq 0)))
+  (is (== (Some "3") (seq:get my-seq 1))))

--- a/tests/seq-tests.lisp
+++ b/tests/seq-tests.lisp
@@ -133,8 +133,9 @@ edge all have between MIN-BRANCHING and MAX-BRANCHING subnodes."
     (is (== seq1 seq2))
     (is (not (== seq1 seq3)))))
 
-(cl:defmacro make-large-seq (n)
-  `(seq:make ,@(cl:loop :for x :from 0 :to (cl:1- n) :collect x)))
+(cl:eval-when (:compile-toplevel :load-toplevel :execute)
+  (cl:defmacro make-large-seq (n)
+    `(seq:make ,@(cl:loop :for x :from 0 :to (cl:1- n) :collect x))))
 
 (define-test seq-make ()
   (let short-seq = (the (seq:Seq Integer)


### PR DESCRIPTION
Previously, `seq:make` did not work for more than 1023 elements. Additionally, it could not infer types properly #1322.