### PR TITLE
Corrected `infer-impls-binding-types` bug.

### DIFF
--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -2078,7 +2078,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
                        (output-schemes
                          (loop :for ty :in output-qual-tys
-                               :collect (tc:quantify (tc:apply-substitution subs local-tvars) ty)))
+                               :collect (tc:quantify (tc:type-variables (tc:apply-substitution subs local-tvars)) ty)))
 
                        (rewrite-table
                          (loop :with table := (make-hash-table :test #'eq)


### PR DESCRIPTION
A conditional branch of the function `infer-impls-binding-types` did not match the implementation of [THIH](https://web.cecs.pdx.edu/~mpj/thih/thih.pdf) pg. 33, causing errors in some cases.