### PR TITLE
Monad extension

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -20,7 +20,7 @@
    #:Functor #:map
    #:Applicative #:pure #:liftA2
    #:Monad #:>>=
-   #:>>
+   #:>> #:join
    #:MonadFail #:fail
    #:Alternative #:alt #:empty
    #:Foldable #:fold #:foldr #:mconcat #:mconcatmap
@@ -212,7 +212,13 @@
 
   (declare >> (Monad :m => (:m :a) -> (:m :b) -> (:m :b)))
   (define (>> a b)
+    "Equivalent to `(>>= a (fn (_) b))`."
     (>>= a (fn (_) b)))
+
+  (declare join (Monad :m => :m (:m :a) -> :m :a))
+  (define (join m)
+    "Equivalent to `(>>= m id)`."
+    (>>= m (fn (x) x)))
 
   (define-class (Monad :m => MonadFail :m)
     (fail (String -> :m :a)))

--- a/library/functions.lisp
+++ b/library/functions.lisp
@@ -160,7 +160,14 @@
   ;;
 
   (define-instance (Functor (Arrow :a))
-    (define map compose)))
+    (define map compose))
+
+  (define-instance (Applicative (Arrow :a))
+    (define (pure x) (fn (_) x))
+    (define (liftA2 f g h) (fn (x) (f (g x) (h x)))))
+
+  (define-instance (Monad (Arrow :a))
+    (define (>>= f g) (fn (x) (g (f x) x)))))
 
 ;;;
 ;;; Bracket pattern


### PR DESCRIPTION
Added `join` and implemented `Applicative (Arrow :a)` and `Monad (Arrow :a)`.

Taken from #1243.

The original motivation for this was to enable `(join bimap)`.