### PR TITLE
Additional try-into functions

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -332,9 +332,9 @@ Typical `fail` continuations are:
                     container))
 
   (declare unwrap-into ((Unwrappable (Result :c)) (TryInto :a :b :c) => :a -> :b))
-  (define unwrap-into
+  (define (unwrap-into x)
     "Same as `tryInto` followed by `unwrap`."
-    (fn (x) (unwrap (tryinto x))))
+    (unwrap (tryinto x)))
 
   (declare with-default ((Unwrappable :container) =>
                          :element

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -31,7 +31,7 @@
    #:Into
    #:TryInto
    #:Iso
-   #:Unwrappable #:unwrap-or-else #:with-default #:unwrap #:expect #:as-optional
+   #:Unwrappable #:unwrap-or-else #:with-default #:unwrap #:unwrap-into #:expect #:as-optional
    #:default #:defaulting-unwrap #:default?))
 
 (in-package #:coalton-library/classes)
@@ -330,6 +330,11 @@ Typical `fail` continuations are:
                                     (cl:format cl:nil "Unexpected ~a in UNWRAP"
                                                container))))
                     container))
+
+  (declare unwrap-into ((Unwrappable (Result :c)) (TryInto :a :b :c) => :a -> :b))
+  (define unwrap-into
+    "Same as `tryInto` followed by `unwrap`."
+    (fn (x) (unwrap (tryinto x))))
 
   (declare with-default ((Unwrappable :container) =>
                          :element

--- a/src/language-macros.lisp
+++ b/src/language-macros.lisp
@@ -29,6 +29,64 @@ Note that this may copy the object or allocate memory."
              `(fn (,lexpr)
                 (the ,type (,into ,lexpr)))))))
 
+(cl:defmacro try-as (type cl:&optional (expr cl:nil expr-supplied-p))
+  "A syntactic convenience for type casting.
+
+    (try-as <type> <expr>)
+
+is equivalent to
+
+    (the (Result :_ <type>) (tryInto <expr>))
+
+and
+
+    (try-as <type>)
+
+is equivalent to
+
+    (fn (expr) (the (Result :_ <type>) (tryInto expr))).
+
+Note that this may copy the object or allocate memory."
+
+  (cl:let ((try-into (cl:ignore-errors (cl:find-symbol "TRYINTO" "COALTON-LIBRARY/CLASSES")))
+           (Result (cl:ignore-errors (cl:find-symbol "RESULT" "COALTON-LIBRARY/CLASSES"))))
+    (cl:assert try-into () "`try-as` macro does not have access to `try-into` yet.")
+    (cl:assert Result () "`try-as` macro does not have access to `Result` yet.")
+    (cl:if expr-supplied-p
+           `(the (,Result :_ ,type) (,try-into ,expr))
+           (alexandria:with-gensyms (lexpr)
+             `(fn (,lexpr)
+                (the (,Result :_ ,type) (,try-into ,lexpr)))))))
+
+(cl:defmacro unwrap-as (type cl:&optional (expr cl:nil expr-supplied-p))
+  "A syntactic convenience for type casting.
+
+    (unwrap-as <type> <expr>)
+
+is equivalent to
+
+    (the <type> (uwrap (tryInto <expr>)))
+
+and
+
+    (unwrap-as <type>)
+
+is equivalent to
+
+    (fn (expr) (the <type> (unwrap (tryInto expr)))).
+
+Note that this may copy the object or allocate memory."
+
+  (cl:let ((try-into (cl:ignore-errors (cl:find-symbol "TRYINTO" "COALTON-LIBRARY/CLASSES")))
+           (unwrap (cl:ignore-errors (cl:find-symbol "UNWRAP" "COALTON-LIBRARY/CLASSES"))))
+    (cl:assert try-into () "`try-as` macro does not have access to `try-into` yet.")
+    (cl:assert unwrap () "`unwrap` macro does not have access to `unwrap` yet.")
+    (cl:if expr-supplied-p
+           `(the ,type (,unwrap (,try-into ,expr)))
+           (alexandria:with-gensyms (lexpr)
+             `(fn (,lexpr)
+                (the ,type (,unwrap (,try-into ,lexpr))))))))
+
 (cl:defmacro nest (cl:&rest items)
   "A syntactic convenience for function application. Transform
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -89,6 +89,8 @@
    #:or
    #:cond
    #:as
+   #:try-as
+   #:unwrap-as
    #:nest
    #:pipe
    #:.<


### PR DESCRIPTION
Added `unwrap-into` function, `try-as` macro, and `unwrap-as` macro.

Example:

```lisp
COALTON-USER> (coalton (the U32 (unwrap-into (the Integer 5))))
5
COALTON-USER> (coalton (try-as U32 (the Integer 5)))
#.(OK 5)
COALTON-USER> (coalton (unwrap-as U32 (the Integer 5)))
5
```

The macros also support currying such as `(try-as U32)` and `(unwrap-as U16)`.

Taken from #1243.