### PR TITLE
Additional monoid functions

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -23,7 +23,8 @@
    #:>>
    #:MonadFail #:fail
    #:Alternative #:alt #:empty
-   #:Foldable #:fold #:foldr #:mconcat
+   #:Foldable #:fold #:foldr #:mconcat #:mconcatmap
+   #:mcommute?
    #:Traversable #:traverse
    #:Bifunctor #:bimap #:map-fst #:map-snd
    #:sequence
@@ -227,9 +228,19 @@
     (foldr "A right non-tail-recursive fold."  ((:elt -> :accum -> :accum) -> :accum -> :container :elt -> :accum)))
 
   (declare mconcat ((Foldable :f) (Monoid :a) => :f :a -> :a))
-  (define mconcat
+  (define (mconcat a)
     "Fold a container of monoids into a single element."
-    (fold <> mempty))
+    (fold <> mempty a))
+
+  (declare mconcatmap ((Foldable :f) (Monoid :a) => (:b -> :a) -> :f :b -> :a))
+  (define (mconcatmap f a)
+    "Map a container to a container of monoids, and then fold that container into a single element."
+    (fold (fn (a b) (<> a (f b))) mempty a))
+
+  (declare mcommute? ((Eq :a) (Semigroup :a) => :a -> :a -> Boolean))
+  (define (mcommute? a b)
+    "Does `a <> b` equal `b <> a`?"
+    (== (<> a b) (<> b a)))
 
   (define-class (Traversable :t)
     (traverse (Applicative :f => (:a -> :f :b) -> :t :a -> :f (:t :b))))

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -433,7 +433,7 @@ interleaving. (interleave empty ITER) is equivalent to (id ITER)."
   (declare mconcatmap! ((Monoid :a) => (:b -> :a) -> (Iterator :b) -> :a))
   (define (mconcatmap! func iter)
     "Map an iterator to an iterator of monoids, and then fold that iterator into a single element."
-    ((fold! <> mempty (map func iter))))
+    (fold! <> mempty (map func iter)))
 
   (declare pair-with! ((:key -> :value) -> Iterator :key -> Iterator (Tuple :key :value)))
   (define (pair-with! func keys)

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -42,6 +42,8 @@
    #:take!
    #:flatten!
    #:flat-map!
+   #:mconcat!
+   #:mconcatmap!
    #:chain!
    #:remove-duplicates! ; defined in library/hashtable.lisp
    #:pair-with!
@@ -423,6 +425,15 @@ interleaving. (interleave empty ITER) is equivalent to (id ITER)."
     "Flatten! wrapped around map."
     (flatten! (map func iter)))
 
+  (declare mconcat! ((Monoid :a) => (Iterator :a) -> :a))
+  (define (mconcat! iter)
+    "Fold an iterator of monoids into a single element."
+    (fold! <> mempty iter))
+
+  (declare mconcatmap! ((Monoid :a) => (:b -> :a) -> (Iterator :b) -> :a))
+  (define (mconcatmap! func iter)
+    "Map an iterator to an iterator of monoids, and then fold that iterator into a single element."
+    ((fold! <> mempty (map func iter))))
 
   (declare pair-with! ((:key -> :value) -> Iterator :key -> Iterator (Tuple :key :value)))
   (define (pair-with! func keys)


### PR DESCRIPTION
Added `mconcatmap`, `mcommute?`, `mconcat!` and `mconcatmap!`.

- `mconcatmap` extends `concatmap`, otherwise known as `flat-map`, to any collection that implements `Monoid` and `Foldable`.

- `mcommute?` checks `ab = ba` for types that implement `Eq` and `Semigroup`.

The others are the complements for iterators.

Taken from #1243.