### PR TITLE
Removed re-evaluation of last coalton form

### DIFF
--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -1047,7 +1047,7 @@ Rebound to NIL parsing an anonymous FN.")
   (let ((nodes (mapcar (lambda (form) (parse-expression form source)) forms)))
     (make-node-progn
      :body (make-node-body
-            :nodes nodes
+            :nodes (nreverse (rest (reverse nodes)))
             :last-node (first (last nodes)))
      :location (source:make-location
                 source

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -1047,7 +1047,7 @@ Rebound to NIL parsing an anonymous FN.")
   (let ((nodes (mapcar (lambda (form) (parse-expression form source)) forms)))
     (make-node-progn
      :body (make-node-body
-            :nodes (nreverse (rest (reverse nodes)))
+            :nodes (butlast nodes)
             :last-node (first (last nodes)))
      :location (source:make-location
                 source


### PR DESCRIPTION
Previously, the last form in a `coalton` expression with more than one form would be evaluated twice. This PR fixes that.