### PR TITLE
Added type alias substitution for method definitions

### DIFF
--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -405,10 +405,10 @@
                    :do (loop :for tyvar :in new-tyvars
                              :do (partial-type-env-add-var env tyvar))
 
-                   :collect (multiple-value-bind (ty ksubs_)
+                   :collect (multiple-value-bind (ty_ ksubs_)
                                 (infer-type-kinds ty tc:+kstar+ ksubs env)
                               (setf ksubs ksubs_)
-                              ty))))
+                              (apply-type-alias-substitutions ty_ ty env)))))
 
       (values (make-partial-class :superclasses preds
                                   :method-tys method-tys)

--- a/tests/type-alias-tests.lisp
+++ b/tests/type-alias-tests.lisp
@@ -178,7 +178,7 @@
     (define-class (C :a)
       (m (S -> :a)))
     (define-instance (C Integer)
-    (define (m _) 5))
+      (define (m _) 5))
     (declare s S)
     (define s \"Hello, world!\")
     (define x (the Integer (m s)))"))

--- a/tests/type-alias-tests.lisp
+++ b/tests/type-alias-tests.lisp
@@ -171,4 +171,14 @@
     (define from (.from t))"
 
    '("t" . "(Translation Integer)")
-   '("from" . "(Tuple Integer Integer)")))
+   '("from" . "(Tuple Integer Integer)"))
+
+  (check-coalton-types
+   "(define-type-alias S String)
+    (define-class (C :a)
+      (m (S -> :a)))
+    (define-instance (C Integer)
+    (define (m _) 5))
+    (declare s S)
+    (define s \"Hello, world!\")
+    (define x (the Integer (m s)))"))


### PR DESCRIPTION
Previously, the following block did not compile, because the compiler was expecting type `S` instead of `String`. The type alias substitution was not taking place. This PR fixes that.

```lisp
(coalton-toplevel
  (define-type-alias S String)

  (define-class (C :a)
    (m (S -> :a)))

  (define-instance (C Integer)
    (define (m _) 5))

  (declare s S)
  (define s "Hello, world!")

  (define x (the Integer (m s)))
```