### PR TITLE
Rename bound variables when inlining

### DIFF
--- a/src/codegen/ast-substitutions.lisp
+++ b/src/codegen/ast-substitutions.lisp
@@ -41,18 +41,24 @@ is true."
            (type node node)
            (type boolean rename-bound-variables)
            (values node &optional))
+
+  ;; In the case that `rename-bound-variables` is `t`, we keep track
+  ;; of bound variable renaming in `new-subs`.  Otherwise, `new-subs`
+  ;; will remain `nil` throughout the traversal.
   (traverse
    node
    (list
-    (action (:after node-variable node subs)
+    (action (:after node-variable node new-subs)
       (alexandria:when-let
-          ((res (find (node-variable-value node) subs :key #'ast-substitution-from)))
+          ((res (or (find (node-variable-value node) subs :key #'ast-substitution-from)
+                    (find (node-variable-value node) new-subs :key #'ast-substitution-from))))
         (ast-substitution-to res)))
-    (action (:after node-lisp node subs)
+    (action (:after node-lisp node new-subs)
       (multiple-value-bind (let-bindings lisp-var-bindings)
           (loop :for (lisp-var . coalton-var) :in (node-lisp-vars node)
                 :for new-var := (gensym (symbol-name coalton-var))
-                :for res := (find coalton-var subs :key #'ast-substitution-from)
+                :for res := (or (find coalton-var subs :key #'ast-substitution-from)
+                                (find coalton-var new-subs :key #'ast-substitution-from))
                 :if (and res (node-variable-p (ast-substitution-to res)))
                   :collect (cons lisp-var (node-variable-value (ast-substitution-to res)))
                     :into lisp-var-bindings
@@ -73,12 +79,19 @@ is true."
                :type (node-type node)
                :bindings let-bindings
                :subexpr new-lisp-node)))))
-    (action (:before node-direct-application node subs)
+    (action (:before node-direct-application node new-subs)
       (when (find (node-direct-application-rator node) subs :key #'ast-substitution-from)
         (util:coalton-bug
          "Failure to apply ast substitution on variable ~A to node-direct-application"
-         (node-direct-application-rator node))))
-    (action (:traverse node-let node subs)
+         (node-direct-application-rator node)))
+      (alexandria:when-let
+          ((res (find (node-direct-application-rator node) new-subs :key #'ast-substitution-from)))
+        (make-node-direct-application
+         :type (node-type node)
+         :rator-type (node-direct-application-rator-type node)
+         :rator (node-variable-value (ast-substitution-to res))
+         :rands (node-direct-application-rands node))))
+    (action (:traverse node-let node new-subs)
       (loop :for (name . expr) :in (node-let-bindings node)
             :do (when (find name subs :key #'ast-substitution-from)
                   (util:coalton-bug
@@ -90,7 +103,7 @@ is true."
                          :to (make-node-variable
                               :type (node-type expr)
                               :value (gensym (symbol-name name))))
-                        subs)))
+                        new-subs)))
       (make-node-let
        :type (node-type node)
        :bindings
@@ -99,8 +112,8 @@ is true."
              (cons (if rename-bound-variables
                        (node-variable-value
                         (ast-substitution-to
-                         (find name subs :key #'ast-substitution-from)))
+                         (find name new-subs :key #'ast-substitution-from)))
                        name)
-                   (funcall *traverse* node subs)))
-       :subexpr (funcall *traverse* (node-let-subexpr node) subs))))
-   subs))
+                   (funcall *traverse* node new-subs)))
+       :subexpr (funcall *traverse* (node-let-subexpr node) new-subs))))
+   nil))

--- a/src/codegen/ast-substitutions.lisp
+++ b/src/codegen/ast-substitutions.lisp
@@ -5,6 +5,7 @@
   (:import-from
    #:coalton-impl/codegen/traverse
    #:action
+   #:*traverse*
    #:traverse)
   (:local-nicknames
    (#:parser #:coalton-impl/parser)
@@ -31,21 +32,23 @@
 (deftype ast-substitution-list ()
   '(satisfies ast-substitution-list-p))
 
-(defun apply-ast-substitution (subs node)
+(defun apply-ast-substitution (subs node &optional (rename-bound-variables nil))
   "Substitute variables in the tree of `node` with other nodes specified
 in `subs`. Throw an error if a variable to be substituted is bound in
-a subtree of `node`."
+a subtree of `node`. Also rename all bound variables if `rename-bound-variables`
+is true."
   (declare (type ast-substitution-list subs)
            (type node node)
+           (type boolean rename-bound-variables)
            (values node &optional))
   (traverse
    node
    (list
-    (action (:after node-variable node)
+    (action (:after node-variable node subs)
       (alexandria:when-let
           ((res (find (node-variable-value node) subs :key #'ast-substitution-from)))
         (ast-substitution-to res)))
-    (action (:after node-lisp node)
+    (action (:after node-lisp node subs)
       (multiple-value-bind (let-bindings lisp-var-bindings)
           (loop :for (lisp-var . coalton-var) :in (node-lisp-vars node)
                 :for new-var := (gensym (symbol-name coalton-var))
@@ -70,14 +73,34 @@ a subtree of `node`."
                :type (node-type node)
                :bindings let-bindings
                :subexpr new-lisp-node)))))
-    (action (:before node-direct-application node)
+    (action (:before node-direct-application node subs)
       (when (find (node-direct-application-rator node) subs :key #'ast-substitution-from)
         (util:coalton-bug
          "Failure to apply ast substitution on variable ~A to node-direct-application"
          (node-direct-application-rator node))))
-    (action (:before node-let node)
-      (loop :for (name . _) :in (node-let-bindings node)
+    (action (:traverse node-let node subs)
+      (loop :for (name . expr) :in (node-let-bindings node)
             :do (when (find name subs :key #'ast-substitution-from)
                   (util:coalton-bug
                    "Failure to apply ast substitution on variable ~A to node-let"
-                   name)))))))
+                   name))
+            :do (when rename-bound-variables
+                  (push (make-ast-substitution
+                         :from name
+                         :to (make-node-variable
+                              :type (node-type expr)
+                              :value (gensym (symbol-name name))))
+                        subs)))
+      (make-node-let
+       :type (node-type node)
+       :bindings
+       (loop :for (name . node) :in (node-let-bindings node)
+             :collect
+             (cons (if rename-bound-variables
+                       (node-variable-value
+                        (ast-substitution-to
+                         (find name subs :key #'ast-substitution-from)))
+                       name)
+                   (funcall *traverse* node subs)))
+       :subexpr (funcall *traverse* (node-let-subexpr node) subs))))
+   subs))

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -406,7 +406,7 @@ requires direct constructor calls."
                                       ;; inadvertently unified
                                       ;; across substitutions.
                                       (rename-type-variables
-                                       (apply-ast-substitution subs body)))))))
+                                       (apply-ast-substitution subs body t)))))))
 
            (try-inline (node call-stack)
              "Attempt to perform an inlining of the application node NODE. The

--- a/tests/inliner-tests.lisp
+++ b/tests/inliner-tests.lisp
@@ -6,3 +6,17 @@
   ;; See gh #1202
   (is (== 1 (1+
              ((fn (x) (return x)) 0)))))
+
+(in-package #:coalton-tests)
+
+;; See gh #1293
+(deftest test-inliner-rename-bound-variables ()
+  (check-coalton-types
+   "(declare f (Integer -> Integer))
+    (define (f n)
+      (when (== n 0)
+        (return 0))
+      (when (== n 1)
+        (return 1))
+      (+ (f (- n 1))
+         (f (- n 2))))"))


### PR DESCRIPTION
This is a continuation of #1295. See also #1293.

This PR fixes the CI test failure in #1295 by separating the bound variable substitutions from the call-site-given AST substitutions and treating them separately.