### PR TITLE
Minor math fixes

### DIFF
--- a/library/math/arith.lisp
+++ b/library/math/arith.lisp
@@ -98,7 +98,7 @@ The function `general/` is partial, and will error produce a run-time error if t
   (declare finite? ((Transfinite :a) => :a -> Boolean))
   (define (finite? x)
     "Neither infinite or NaN."
-    (or (infinite? x) (nan? x)))
+    (not (or (infinite? x) (nan? x))))
 
   (declare negative-infinity ((Transfinite :a) (Num :a) => :a))
   (define negative-infinity


### PR DESCRIPTION
This PR does three things.

1. fix bug: add `not` to `finite?` predicate.
2. fix bug: swap `infinity` and `negative-infinity` in `fromInt` method for floats.
3. reduce consing: remove `%optional-coerce` from `fromInt` and `general/` methods for floats.