### PR TITLE
Add inlining for boolean functions

### DIFF
--- a/library/boolean.lisp
+++ b/library/boolean.lisp
@@ -25,7 +25,6 @@
         (cl:eq x y))))
 
   (define-instance (Ord Boolean)
-    (inline)
     (define (<=> x y)
       (match x
         ((True)

--- a/library/boolean.lisp
+++ b/library/boolean.lisp
@@ -19,11 +19,13 @@
   ;;
 
   (define-instance (Eq Boolean)
+    (inline)
     (define (== x y)
-        (lisp Boolean (x y)
-              (cl:eq x y))))
+      (lisp Boolean (x y)
+        (cl:eq x y))))
 
   (define-instance (Ord Boolean)
+    (inline)
     (define (<=> x y)
       (match x
         ((True)
@@ -36,6 +38,7 @@
            ((False) EQ))))))
 
   (define-instance (Default Boolean)
+    (inline)
     (define (default) False)))
 
 (define-sxhash-hasher Boolean)

--- a/library/builtin.lisp
+++ b/library/builtin.lisp
@@ -26,18 +26,24 @@
      (cl:error ,datum ,@arguments)))
 
 (coalton-toplevel
+  (inline)
   (define (undefined _)
     "A function which can be used in place of any value, throwing an error at runtime."
     (error "Undefined"))
 
-  (define not
+  (inline)
+  (declare not (Boolean -> Boolean))
+  (define (not x)
     "Synonym for `boolean-not`."
-    boolean-not)
+    (boolean-not x))
 
-  (define xor
+  (inline)
+  (declare xor (Boolean -> Boolean -> Boolean))
+  (define (xor x y)
     "Synonym for `boolean-xor`."
-    boolean-xor)
+    (boolean-xor x y))
 
+  (inline)
   (declare boolean-not (Boolean -> Boolean))
   (define (boolean-not x)
     "The logical negation of `x`. Is `x` false?"
@@ -45,6 +51,7 @@
       ((True) False)
       ((False) True)))
 
+  (inline)
   (declare boolean-or (Boolean -> Boolean -> Boolean))
   (define (boolean-or x y)
     "Is either `x` or `y` true? Note that this is a *function* which means both `x` and `y` will be evaluated. Use the `or` macro for short-circuiting behavior."
@@ -52,6 +59,7 @@
       ((True) True)
       ((False) y)))
 
+  (inline)
   (declare boolean-and (Boolean -> Boolean -> Boolean))
   (define (boolean-and x y)
     "Are both `x` and `y` true? Note that this is a *function* which means both `x` and `y` will be evaluated. Use the `and` macro for short-circuiting behavior."
@@ -59,6 +67,7 @@
       ((True) y)
       ((False) False)))
 
+  (inline)
   (declare boolean-xor (Boolean -> Boolean -> Boolean))
   (define (boolean-xor x y)
     "Are `x` or `y` true, but not both?"

--- a/library/builtin.lisp
+++ b/library/builtin.lisp
@@ -26,7 +26,6 @@
      (cl:error ,datum ,@arguments)))
 
 (coalton-toplevel
-  (inline)
   (define (undefined _)
     "A function which can be used in place of any value, throwing an error at runtime."
     (error "Undefined"))
@@ -47,25 +46,22 @@
   (declare boolean-not (Boolean -> Boolean))
   (define (boolean-not x)
     "The logical negation of `x`. Is `x` false?"
-    (match x
-      ((True) False)
-      ((False) True)))
+    (lisp Boolean (x)
+      (cl:not x)))
 
   (inline)
   (declare boolean-or (Boolean -> Boolean -> Boolean))
   (define (boolean-or x y)
     "Is either `x` or `y` true? Note that this is a *function* which means both `x` and `y` will be evaluated. Use the `or` macro for short-circuiting behavior."
-    (match x
-      ((True) True)
-      ((False) y)))
+    (lisp Boolean (x y)
+      (cl:or x y)))
 
   (inline)
   (declare boolean-and (Boolean -> Boolean -> Boolean))
   (define (boolean-and x y)
     "Are both `x` and `y` true? Note that this is a *function* which means both `x` and `y` will be evaluated. Use the `and` macro for short-circuiting behavior."
-    (match x
-      ((True) y)
-      ((False) False)))
+    (lisp Boolean (x y)
+      (cl:and x y)))
 
   (inline)
   (declare boolean-xor (Boolean -> Boolean -> Boolean))


### PR DESCRIPTION
Adds `(inline)` attributes in `library/builtin.lisp` and `library/boolean.lisp`.
Also adds type declarations for `not` and `xor`.