### PR TITLE
Add inline attributes for more float operations

### DIFF
--- a/library/math/elementary.lisp
+++ b/library/math/elementary.lisp
@@ -175,6 +175,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
   "Defines the elmentary instances for a lisp floating-point type"
   `(coalton-toplevel
      (define-instance (Trigonometric ,coalton-type)
+       (inline)
        (define (sin x)
          (cond
            ;; CCL signals errors when applying trigonometric functions to NaN and infinity
@@ -188,6 +189,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                  #+ccl ff:with-float-traps-masked #+ccl cl:t
                  (cl:sin x))))))
 
+       (inline)
        (define (cos x)
          (cond
            ;; CCL signals errors when applying trigonometric functions to NaN and infinity
@@ -201,6 +203,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                  #+ccl ff:with-float-traps-masked #+ccl cl:t
                  (cl:cos x))))))
 
+       (inline)
        (define (tan x)
          (cond
            ;; CCL signals errors when applying trigonometric functions to NaN and infinity
@@ -214,6 +217,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                  #+ccl ff:with-float-traps-masked #+ccl cl:t
                  (cl:tan x))))))
 
+       (inline)
        (define (asin x)
          (cond
            ;; CCL signals errors when applying trigonometric functions to NaN and infinity
@@ -229,6 +233,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                      #+ccl ff:with-float-traps-masked #+ccl cl:t
                      (cl:asin x)))))))
 
+       (inline)
        (define (acos x)
          (if (or (nan? x) (> x 1) (< x -1))
              nan
@@ -237,6 +242,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                   #+ccl ff:with-float-traps-masked #+ccl cl:t
                   (cl:acos x)))))
 
+       (inline)
        (define (atan x)
          (cond
            ;; CCL signals errors when applying trigonometric functions to NaN and infinity
@@ -254,6 +260,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
            (cl:coerce cl:pi ',underlying-type))))
 
      (define-instance (Polar ,coalton-type)
+       (inline)
        (define (phase x)
          (lisp ,coalton-type (x)
            (#+(not ccl) cl:progn
@@ -263,6 +270,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
          (Tuple (magnitude x) (phase x))))
 
      (define-instance (Exponentiable ,coalton-type)
+       (inline)
        (define (pow x y)
          (cond
            ((or (nan? x) (nan? y)) nan)
@@ -285,6 +293,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                  #+ccl ff:with-float-traps-masked #+ccl cl:t
                  (cl:expt x y))))))
 
+       (inline)
        (define (exp x)
          (cond
            ;; Allegro signals overflow and underflow errors when using infinity in exponents
@@ -304,6 +313,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                           (cl:realpart res)
                           res)))))))
 
+       (inline)
        (define (log b x)
          (cond
            ((or (nan? b) (nan? x)) nan)
@@ -319,6 +329,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                  (cl:log x b))))
            (True nan)))
 
+       (inline)
        (define (ln x)
          (cond
            ((nan? x) nan)
@@ -332,6 +343,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
            (cl:exp (cl:coerce 1 ',underlying-type)))))
 
      (define-instance (Radical ,coalton-type)
+       (inline)
        (define (sqrt x)
          (if (or (nan? x) (< x 0))
              nan
@@ -339,6 +351,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
                (#+(not ccl) cl:progn
                   #+ccl ff:with-float-traps-masked #+ccl cl:t
                   (cl:sqrt x)))))
+       (inline)
        (define (nth-root n x)
          (canonical-nth-root n x)))
 

--- a/library/math/real.lisp
+++ b/library/math/real.lisp
@@ -161,34 +161,49 @@ Furthermore, `best-approx` returns the simplest fraction, and both functions may
 
 (cl:defmacro %define-native-rationals (type)
   (cl:let
-      ((round (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-ROUND"))))
+      ((round (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-ROUND")))
+       (trunc (cl:intern (cl:concatenate 'cl:string (cl:symbol-name type) "-TRUNCATE"))))
     `(coalton-toplevel
        (define-instance (Quantizable ,type)
+         (inline)
          (define (floor q)
            (lisp Integer (q)
              (cl:nth-value 0 (cl:floor q))))
+         (inline)
          (define (ceiling q)
            (lisp Integer (q)
              (cl:nth-value 0 (cl:ceiling q))))
+         (inline)
          (define (proper q)
            (lisp (Tuple Integer ,type) (q)
              (cl:multiple-value-bind (n r)
                  (cl:truncate q)
                (Tuple n r)))))
 
+       (specialize truncate ,trunc (,type -> Integer))
+       (inline)
+       (declare ,trunc (,type -> Integer))
+       (define (,trunc x)
+         (lisp Integer (x)
+           (cl:nth-value 0 (cl:truncate x))))
+
        (define-instance (Real ,type)
+         (inline)
          (define (real-approx prec x)
            (rational-approx prec x)))
 
        (define-instance (Rational ,type)
+         (inline)
          (define (to-fraction x)
            (lisp Fraction (x)
              (cl:rational x)))
+         (inline)
          (define (best-approx x)
            (lisp Fraction (x)
              (cl:rationalize x))))
 
        (specialize round ,round (,type -> Integer))
+       (inline)
        (declare ,round (,type -> Integer))
        (define (,round x)
          (lisp Integer (x)
@@ -240,11 +255,13 @@ remainders expressed as values of type of X."
         None
         (Some (general/ x y))))
 
+  (inline)
   (declare exact/ (Integer -> Integer -> Fraction))
   (define (exact/ a b)
     "Exactly divide two integers and produce a fraction."
     (general/ a b))
 
+  (inline)
   (declare inexact/ (Integer -> Integer -> Double-Float))
   (define (inexact/ a b)
     "Compute the quotient of integers as a double-precision float.


### PR DESCRIPTION
Adds inline attributes to several float operations. 
Specializes `truncate` on floats to reduce consing.