### PR TITLE
Fix issues with recompiling Coalton

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -310,6 +310,12 @@ Typical `fail` continuations are:
                      -> (:container :elt)
                      -> :result)))
 
+  (define-instance (Unwrappable (Result :a))
+  (define (unwrap-or-else succeed fail res)
+    (match res
+      ((Ok elt) (succeed elt))
+      ((Err _) (fail)))))
+
   (declare expect ((Unwrappable :container) =>
                    String
                    -> (:container :element)
@@ -331,7 +337,7 @@ Typical `fail` continuations are:
                                                container))))
                     container))
 
-  (declare unwrap-into ((Unwrappable (Result :c)) (TryInto :a :b :c) => :a -> :b))
+  (declare unwrap-into (TryInto :a :b :c => :a -> :b))
   (define (unwrap-into x)
     "Same as `tryInto` followed by `unwrap`."
     (unwrap (tryinto x)))

--- a/library/math/hyperdual.lisp
+++ b/library/math/hyperdual.lisp
@@ -3,7 +3,7 @@
 ;;;; An implementation of Hyperdual numbers for computing second-order
 ;;;; derivatives of compositions of built-in Coalton functions.
 
-(defpackage #:coalton-library/math/hyperdual
+(coalton-library/utils::defstdlib-package #:coalton-library/math/hyperdual
   (:use
    #:coalton
    #:coalton-library/builtin

--- a/library/result.lisp
+++ b/library/result.lisp
@@ -130,12 +130,6 @@
 
   (define-instance (Iso (Result Unit :a) (Optional :a)))
 
-  (define-instance (Unwrappable (Result :a))
-    (define (unwrap-or-else succeed fail res)
-      (match res
-        ((Ok elt) (succeed elt))
-        ((Err _) (fail)))))
-
   (define-instance (iter:IntoIterator (Result :err :elt) :elt)
     (define (iter:into-iter result)
       (match result


### PR DESCRIPTION
1. unlock hyperdual package when defining package.
2. move `(define-instance (Unwrappable (Result :t))...)` to `classes.lisp` for context reduction in `unwrap-into`.