### PR TITLE
move Num-related macros to its own file

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -46,6 +46,7 @@
                (:file "types")
                (:file "primitive-types")
                (:file "classes")
+               (:file "hash-defining-macros")
                (:file "hash")
                (:file "builtin")
                (:file "functions")
@@ -54,6 +55,7 @@
                (:module "math"
                 :serial t
                 :components ((:file "arith")
+                             (:file "num-defining-macros")
                              (:file "num")
                              (:file "bounded")
                              (:file "conversions")

--- a/library/boolean.lisp
+++ b/library/boolean.lisp
@@ -38,9 +38,9 @@
 
   (define-instance (Default Boolean)
     (inline)
-    (define (default) False)))
+    (define (default) False))
 
-(define-sxhash-hasher Boolean)
+  (define-sxhash-hasher Boolean))
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/BOOLEAN")

--- a/library/char.lisp
+++ b/library/char.lisp
@@ -145,9 +145,10 @@
      (iter:range-increasing
       1
       (char-code start)
-      (+ 1 (char-code end))))))
+      (+ 1 (char-code end)))))
 
-(define-sxhash-hasher Char)
+  (define-sxhash-hasher Char))
+
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/CHAR")

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -10,6 +10,7 @@
    #:Optional #:Some #:None
    #:Result #:Ok #:Err
    #:Eq #:==
+   #:Hash
    #:Ord #:LT #:EQ #:GT
    #:<=> #:> #:< #:>= #:<=
    #:max
@@ -106,6 +107,32 @@
  
   (define-instance (Eq Unit)
     (define (== _ _) True))
+
+  ;;
+  ;; Hash
+  ;;
+
+  #+sbcl
+  (repr :native (cl:unsigned-byte 62))
+
+  #+allegro
+  (repr :native (cl:unsigned-byte 0 32))
+
+  ;; https://github.com/Clozure/ccl/blob/ff51228259d9dbc8a9cc7bbb08858ef4aa9fe8d0/level-0/l0-hash.lisp#L1885
+  #+ccl
+  (repr :native (cl:and cl:fixnum cl:unsigned-byte))
+
+  #-(or sbcl allegro ccl)
+  #.(cl:error "hashing is not supported on ~A" (cl:lisp-implementation-type))
+
+  (define-type Hash
+    "Implementation dependent hash code.")
+
+  (define-class (Eq :a => Hash :a)
+    "Types which can be hashed for storage in hash tables.
+
+The hash function must satisfy the invariant that `(== left right)` implies `(== (hash left) (hash right))`."
+    (hash (:a -> Hash)))
 
   ;;
   ;; Ord

--- a/library/hash-defining-macros.lisp
+++ b/library/hash-defining-macros.lisp
@@ -1,0 +1,27 @@
+;;;; hash-defining-macros.lisp
+;;;;
+;;;; Ordinarily we would like to interleave these macros definitions
+;;;; with LISP-TOPLEVEL in Coalton code. However, due to issue #1408,
+;;;; nuances of when things get evaluated and whether they persist in
+;;;; FASLs linger. In the mean time, we define the Lisp macros
+;;;; separately before being used by Coalton.
+;;;;
+;;;; See also num-defining-macros.lisp
+;;;;
+;;;; NOTE: This package is not intended to be used by users.
+
+(defpackage #:coalton-library/math/hash-defining-macros
+  (:use
+   #:coalton
+   #:coalton-library/classes)
+  (:export
+   #:define-sxhash-hasher))
+
+(in-package #:coalton-library/math/hash-defining-macros)
+
+(cl:defmacro define-sxhash-hasher (type)
+  "Define an instance of Hash for the Coalton type TYPE using CL:SXHASH."
+  `(define-instance (Hash ,type)
+     (define (hash item)
+       (lisp Hash (item)
+         (cl:sxhash item)))))

--- a/library/hash-defining-macros.lisp
+++ b/library/hash-defining-macros.lisp
@@ -22,6 +22,7 @@
 (cl:defmacro define-sxhash-hasher (type)
   "Define an instance of Hash for the Coalton type TYPE using CL:SXHASH."
   `(define-instance (Hash ,type)
+     (inline)
      (define (hash item)
        (lisp Hash (item)
          (cl:sxhash item)))))

--- a/library/hash.lisp
+++ b/library/hash.lisp
@@ -2,8 +2,9 @@
   (:use
    #:coalton
    #:coalton-library/classes)
+  (:import-from #:coalton-library/math/hash-defining-macros
+                #:define-sxhash-hasher)
   (:export
-   #:Hash
    #:combine-hashes
    #:combine-hashes-order-independent
    #:define-sxhash-hasher))
@@ -15,29 +16,9 @@
 #+coalton-release
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
+;; NOTE: Both the Hash class and Hash type are defined in classes.lisp.
+
 (coalton-toplevel
-  #+sbcl
-  (repr :native (cl:unsigned-byte 62))
-
-  #+allegro
-  (repr :native (cl:unsigned-byte 0 32))
-
-  ;; https://github.com/Clozure/ccl/blob/ff51228259d9dbc8a9cc7bbb08858ef4aa9fe8d0/level-0/l0-hash.lisp#L1885
-  #+ccl
-  (repr :native (cl:and cl:fixnum cl:unsigned-byte)) 
-
-  #+(not (or sbcl allegro ccl))
-  #.(cl:error "hashing is not supported on ~A" (cl:lisp-implementation-type))
-
-  (define-type Hash
-    "Implementation dependent hash code")
-
-  (define-class (Eq :a => Hash :a)
-    "Types which can be hashed for storage in hash tables.
-
-The hash function must satisfy the invariant that `(== left right)` implies `(== (hash left) (hash right))`."
-    (hash (:a -> Hash)))
-
   (declare combine-hashes (Hash -> Hash -> Hash))
   (define (combine-hashes lhs rhs)
     (lisp Hash (lhs rhs)
@@ -86,16 +67,9 @@ The hash function must satisfy the invariant that `(== left right)` implies `(==
   (define-instance (Default Hash)
     (define (default)
       (lisp Hash ()
-        0))))
+        0)))
 
-(cl:defmacro define-sxhash-hasher (type)
-  `(coalton-toplevel
-     (define-instance (Hash ,type)
-       (define (hash item)
-         (lisp Hash (item)
-           (cl:sxhash item))))))
-
-(define-sxhash-hasher Hash)
+  (define-sxhash-hasher Hash))
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/HASH")

--- a/library/math/num-defining-macros.lisp
+++ b/library/math/num-defining-macros.lisp
@@ -1,0 +1,367 @@
+;;;; num-defining-macros.lisp
+;;;;
+;;;; Ordinarily we would like to interleave these macros definitions
+;;;; with LISP-TOPLEVEL in Coalton code. However, due to issue #1408,
+;;;; nuances of when things get evaluated and whether they persist in
+;;;; FASLs linger. In the mean time, we define the Lisp macros
+;;;; separately before being used by Coalton.
+;;;;
+;;;; See also hash-defining-macros.lisp
+;;;;
+;;;; NOTE: This package is not intended to be used by users.
+
+(defpackage #:coalton-library/math/num-defining-macros
+  (:use
+   #:coalton
+   #:coalton-library/builtin
+   #:coalton-library/classes
+   #:coalton-library/functions
+   #:coalton-library/utils
+   #:coalton-library/math/arith)
+  (:local-nicknames
+   (#:ff #:float-features)
+   (#:bits #:coalton-library/bits))
+  (:export
+   #:+fixnum-bits+
+   #:+unsigned-fixnum-bits+
+   #:define-eq
+   #:define-ord
+   #:define-num-checked
+   #:%handle-8bit-overflow
+   #:%handle-16bit-overflow
+   #:%handle-32bit-overflow
+   #:%handle-64bit-overflow
+   #:%handle-fixnum-overflow
+   #:define-num-wrapping
+   #:define-num-float
+   #:define-float-fraction-conversion
+   #:define-reciprocable-float
+   #:define-dividable-float
+   #:define-bits-checked
+   #:define-bits-wrapping
+   #:define-default-num))
+
+(in-package #:coalton-library/math/num-defining-macros)
+
+(cl:eval-when (:compile-toplevel :load-toplevel :execute)
+  (cl:defconstant +fixnum-bits+
+    #+sbcl sb-vm:n-fixnum-bits
+    #-sbcl (cl:1+ (cl:floor (cl:log cl:most-positive-fixnum 2))))
+  (cl:defconstant +unsigned-fixnum-bits+
+    (cl:1- +fixnum-bits+)))
+
+
+;;; Utilities to define Eq types.
+(cl:defmacro define-eq (type)
+  `(define-instance (Eq ,type)
+     (inline)
+     (define (== a b)
+       (lisp Boolean (a b)
+         ;; Use cl:= so that (== 0.0 -0.0) => True
+         (cl:= a b)))))
+
+
+;;; Utilities to define Ord types.
+(cl:defmacro define-ord (type)
+  (cl:let ((>-spec (alexandria:format-symbol cl:*package* "~A->" type))
+           (>=-spec (alexandria:format-symbol cl:*package* "~A->=" type))
+           (<-spec (alexandria:format-symbol cl:*package* "~A-< type" type))
+           (<=-spec (alexandria:format-symbol cl:*package* "~A-<=" type)))
+
+    ;; Generates the instance and specializations to use more direct
+    ;; comparison functions when possible.
+
+    `(progn
+       (define-instance (Ord ,type)
+         (inline)
+         (define (<=> a b)
+           (lisp Ord (a b)
+             (cl:cond
+               ((cl:< a b)
+                LT)
+               ((cl:> a b)
+                GT)
+               (cl:t
+                EQ)))))
+
+       (specialize > ,>-spec (,type -> ,type -> Boolean))
+       (inline)
+       (declare ,>-spec (,type -> ,type -> Boolean))
+       (define (,>-spec a b)
+         (lisp Boolean (a b)
+           (to-boolean (cl:> a b))))
+
+       (specialize >= ,>=-spec (,type -> ,type -> Boolean))
+       (inline)
+       (declare ,>=-spec (,type -> ,type -> Boolean))
+       (define (,>=-spec a b)
+         (lisp Boolean (a b)
+           (to-boolean (cl:>= a b))))
+
+       (specialize < ,<-spec (,type -> ,type -> Boolean))
+       (inline)
+       (declare ,<-spec (,type -> ,type -> Boolean))
+       (define (,<-spec a b)
+         (lisp Boolean (a b)
+           (to-boolean (cl:< a b))))
+
+       (specialize <= ,<=-spec (,type -> ,type -> Boolean))
+       (inline)
+       (declare ,<=-spec (,type -> ,type -> Boolean))
+       (define (,<=-spec a b)
+         (lisp Boolean (a b)
+           (to-boolean (cl:<= a b)))))))
+
+
+;;; Utilities to define integer overflow and wrapping Num instances.
+(cl:declaim (cl:inline %unsigned->signed))
+(cl:defun %unsigned->signed (bits x)
+  ;; This is the two's complement conversion of X (interpreted as BITS
+  ;; bits) to a signed integer (as a Lisp object).
+  (cl:-
+   (cl:ldb (cl:byte (cl:1- bits) 0) x)
+   (cl:dpb 0 (cl:byte (cl:1- bits) 0) x)))
+
+(cl:defmacro %define-overflow-handler (name bits)
+  `(cl:progn
+     (cl:declaim (cl:inline ,name))
+     (cl:defun ,name (value)
+       (cl:typecase value
+         ((cl:signed-byte ,bits) value)
+         (cl:otherwise
+          (cl:cerror "Continue, wrapping around."
+                     ,(cl:format cl:nil "Signed value overflowed ~D bits." bits))
+          (%unsigned->signed ,bits (cl:mod value ,(cl:expt 2 bits))))))))
+
+
+(%define-overflow-handler %handle-8bit-overflow 8)
+(%define-overflow-handler %handle-16bit-overflow 16)
+(%define-overflow-handler %handle-32bit-overflow 32)
+(%define-overflow-handler %handle-64bit-overflow 64)
+(%define-overflow-handler %handle-fixnum-overflow #.+fixnum-bits+)
+
+(cl:defmacro define-num-checked (type overflow-handler)
+  "Define a `Num' instance for TYPE which signals on overflow."
+  `(define-instance (Num ,type)
+     (inline)
+     (define (+ a b)
+       (lisp ,type (a b)
+         (,overflow-handler (cl:+ a b))))
+
+     (inline)
+     (define (- a b)
+       (lisp ,type (a b)
+         (,overflow-handler (cl:- a b))))
+
+     (inline)
+     (define (* a b)
+       (lisp ,type (a b)
+         (,overflow-handler (cl:* a b))))
+
+     (inline)
+     (define (fromInt x)
+       (lisp ,type (x)
+         (,overflow-handler x)))))
+
+(cl:defmacro define-num-wrapping (type bits)
+  "Define a `Num' instance for TYPE which wraps on overflow."
+  `(define-instance (Num ,type)
+     (inline)
+     (define (+ a b)
+       (lisp ,type (a b)
+         (cl:values (cl:mod (cl:+ a b) ,(cl:expt 2 bits)))))
+
+     (inline)
+     (define (- a b)
+       (lisp ,type (a b)
+         (cl:values (cl:mod (cl:- a b) ,(cl:expt 2 bits)))))
+
+     (inline)
+     (define (* a b)
+       (lisp ,type (a b)
+         (cl:values (cl:mod (cl:* a b) ,(cl:expt 2 bits)))))
+
+     (inline)
+     (define (fromInt x)
+       (lisp ,type (x)
+         (cl:values (cl:mod x ,(cl:expt 2 bits)))))))
+
+
+;;; Float Num instances.
+(cl:defmacro define-num-float (type lisp-type)
+  "Define `Num' for the float type TYPE."
+
+  ;;
+  ;; CCL has a tendency to re-enable float traps. The explicit float
+  ;; trap masking keeps the test suite working during interactive
+  ;; development.
+  ;;
+  ;; Allegro appears to have some checks that make some arithmetic
+  ;; functions error on some inputs. The explicit checks in division
+  ;; keep the behavior consistent with IEEE 754.
+  ;;
+
+  `(define-instance (Num ,type)
+     (inline)
+     (define (+ a b)
+       (lisp ,type (a b)
+         (#+(not ccl) cl:progn
+            #+ccl ff:with-float-traps-masked #+ccl cl:t
+            (cl:+ a b))))
+
+     (inline)
+     (define (- a b)
+       (lisp ,type (a b)
+         (#+(not ccl) cl:progn
+            #+ccl ff:with-float-traps-masked #+ccl cl:t
+            (cl:- a b))))
+
+     (inline)
+     (define (* a b)
+       (lisp ,type (a b)
+         (#+(not ccl) cl:progn
+            #+ccl ff:with-float-traps-masked #+ccl cl:t
+            (cl:* a b))))
+
+     (inline)
+     (define (fromInt x)
+       (lisp ,type (x)
+         (cl:or (cl:ignore-errors (cl:coerce x ',lisp-type))
+                (cl:if (cl:< x 0)
+                       (coalton (the ,type negative-infinity))
+                       (coalton (the ,type infinity))))))))
+
+
+;;; Utility to define type -> Fraction conversions.
+(cl:defmacro define-float-fraction-conversion (type)
+  `(define-instance (TryInto ,type Fraction String)
+     (define (tryInto x)
+       (if (finite? x)
+           (Ok (lisp Fraction (x) (cl:rational x)))
+           (Err "Could not convert NaN or infinity into a Fraction")))))
+
+
+;;; Utility to define Reciprocable instances on floats.
+(cl:defmacro define-reciprocable-float (type)
+  `(define-instance (Reciprocable ,type)
+     (inline)
+     (define (/ x y)
+       (cond
+         #+allegro
+         ((or (nan? x)
+              (nan? y))
+          nan)
+
+         #+allegro
+         ((and (== x 0) (== y 0))
+          nan)
+
+         #+allegro
+         ((and (positive? x) (== y 0))
+          infinity)
+
+         #+allegro
+         ((and (negative? x) (== y 0))
+          negative-infinity)
+
+         (True
+          (lisp ,type (x y)
+            (#+(not ccl) cl:progn
+               #+ccl ff:with-float-traps-masked #+ccl cl:t
+               (cl:/ x y))))))
+
+     (inline)
+     (define (reciprocal x)
+       (cond
+         #+allegro
+         ((== x 0)
+          infinity)
+
+         (True
+          (lisp ,type (x)
+            (#+(not ccl) cl:progn
+               #+ccl ff:with-float-traps-masked #+ccl cl:t
+               (cl:/ x))))))))
+
+(cl:defmacro define-dividable-float (type lisp-type)
+  `(define-instance (Dividable Integer ,type)
+     (inline)
+     (define (general/ x y)
+       (if (== y 0)
+           (/ (fromInt x) (fromInt y))
+           (lisp ,type (x y)
+             (cl:or (cl:ignore-errors (cl:coerce (cl:/ x y) ',lisp-type))
+                    (cl:if (cl:eq (cl:< x 0) (cl:< y 0))
+                           (coalton (the ,type infinity))
+                           (coalton (the ,type negative-infinity)))))))))
+
+
+;;; Utilities to define Bits instances.
+(cl:defmacro define-bits-checked (type handle-overflow)
+  `(define-instance (bits:Bits ,type)
+     (inline)
+     (define (bits:and a b)
+       (lisp ,type (a b)
+         (cl:logand a b)))
+
+     (inline)
+     (define (bits:or a b)
+       (lisp ,type (a b)
+         (cl:logior a b)))
+
+     (inline)
+     (define (bits:xor a b)
+       (lisp ,type (a b)
+         (cl:logxor a b)))
+
+     (inline)
+     (define (bits:not x)
+       (lisp ,type (x)
+         (cl:lognot x)))
+
+     (inline)
+     (define (bits:shift amount bits)
+       (lisp ,type (amount bits)
+         (,handle-overflow (cl:ash bits amount))))))
+
+(cl:declaim (cl:inline unsigned-lognot))
+(cl:defun unsigned-lognot (int n-bits)
+  (cl:declare (cl:type cl:unsigned-byte int)
+              (cl:type cl:unsigned-byte n-bits)
+              (cl:values cl:unsigned-byte))
+
+  (cl:- (cl:ash 1 n-bits) int 1))
+
+(cl:defmacro define-bits-wrapping (type width)
+  `(define-instance (bits:Bits ,type)
+     (inline)
+     (define (bits:and a b)
+       (lisp ,type (a b)
+         (cl:logand a b)))
+
+     (inline)
+     (define (bits:or a b)
+       (lisp ,type (a b)
+         (cl:logior a b)))
+
+     (inline)
+     (define (bits:xor a b)
+       (lisp ,type (a b)
+         (cl:logxor a b)))
+
+     (inline)
+     (define (bits:not x)
+       (lisp ,type (x)
+         (unsigned-lognot x ,width)))
+
+     (inline)
+     (define (bits:shift amount bits)
+       (lisp ,type (amount bits)
+         (cl:logand (cl:ash bits amount)
+                    ,(cl:1- (cl:ash 1 width)))))))
+
+;;; Utility to define Default instances.
+(cl:defmacro define-default-num (type)
+  `(define-instance (Default ,type)
+     (inline)
+     (define (default) 0)))

--- a/library/prelude.lisp
+++ b/library/prelude.lisp
@@ -9,12 +9,6 @@
    #:coalton-library/functions)
 
   (:import-from
-   #:coalton-library/hash
-   #:hash)
-  (:export
-   #:hash)
-
-  (:import-from
    #:coalton-library/math/arith
    #:Reciprocable #:/
    #:Fraction

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -234,9 +234,10 @@ does not have that suffix."
                  (Ok z))))))
 
   (define-instance (Default String)
-    (define (default) "")))
+    (define (default) ""))
 
-(define-sxhash-hasher String)
+  (define-sxhash-hasher String))
+
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/STRING")


### PR DESCRIPTION
These macros were moved due to the variety of issues present in the LISP-TOPLEVEL form. See issue #1408 and #1402 for details.

This commit also makes `define-sxhash-hasher` a proper Coalton macro.