### PR TITLE
codegen a few known global constants

### DIFF
--- a/library/primitive-types.lisp
+++ b/library/primitive-types.lisp
@@ -9,8 +9,9 @@
 #+coalton-release
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
-;;; XXX: The constants True, False, Unit, and Nil are not codegened
-;;; efficiently. See issue #1410.
+;;; XXX: The "constants" True, False, Unit, and Nil are currently
+;;; treated specially by codegen as being constant; their values are
+;;; looked up at compile-time and emitted directly.
 
 (coalton-toplevel
   (repr :native cl:t)

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -46,7 +46,14 @@
   (:method ((node node-variable) env)
     (declare (type tc:environment env)
              (ignore env))
-    (node-variable-value node))
+    (let ((value (node-variable-value node)))
+      (case value
+        ;; HACK: generate efficient code for known constants.
+        ((coalton:True coalton:False coalton:Nil coalton:Unit)
+         `(quote ,(eval value)))
+        ;; General case: Emit the symbol itself.
+        (otherwise
+         value))))
 
   (:method ((node node-application) env)
     (declare (type tc:environment env))


### PR DESCRIPTION
This partially addresses #1410 in a hacky way by looking up the value at codegen time. This is just a hack that covers the most common language cases, as such, it does not solve #1410.