### PR TITLE
Inline runtume-repr and fix a couple file bugs

### DIFF
--- a/library/types.lisp
+++ b/library/types.lisp
@@ -23,16 +23,19 @@
     "Proxy holds no data, but has a phantom type parameter."
     Proxy)
 
+  (inline)
   (declare proxy-of (:a -> Proxy :a))
   (define (proxy-of _)
     "Returns a Proxy containing the type of the parameter."
     Proxy)
 
+  (inline)
   (declare as-proxy-of (:a -> Proxy :a -> :a))
   (define (as-proxy-of x _)
     "Returns the parameter, forcing the proxy to have the same type as the parameter."
     x)
 
+  (inline)
   (declare proxy-inner (Proxy (:a :b) -> Proxy :b))
   (define (proxy-inner _)
     Proxy)
@@ -49,6 +52,7 @@
 The compiler will auto-generate instances of `RuntimeRepr` for all defined types."
     (runtime-repr (Proxy :a -> LispType)))
 
+  (inline)
   (declare runtime-repr-of (RuntimeRepr :a => :a -> LispType))
   (define (runtime-repr-of x)
     "Returns the runtime representation of the type of the given value."
@@ -57,38 +61,47 @@ The compiler will auto-generate instances of `RuntimeRepr` for all defined types
   ;; Additional RuntimeRepr instances for early-defined types
 
   (define-instance (RuntimeRepr Boolean)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:boolean)))
 
   (define-instance (RuntimeRepr Char)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:character)))
 
   (define-instance (RuntimeRepr Integer)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:integer)))
 
   (define-instance (RuntimeRepr Single-Float)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:single-float)))
 
   (define-instance (RuntimeRepr Double-Float)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:double-float)))
 
   (define-instance (RuntimeRepr String)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:string)))
 
   (define-instance (RuntimeRepr Fraction)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:rational)))
 
   (define-instance (RuntimeRepr (:a -> :b))
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'coalton-impl/runtime/function-entry:function-entry)))
 
   (define-instance (RuntimeRepr (List :a))
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () 'cl:list)))
 
@@ -96,10 +109,12 @@ The compiler will auto-generate instances of `RuntimeRepr` for all defined types
   ;; types defined in this file to avoid circular dependencies.
   
   (define-instance (RuntimeRepr LispType)
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () '(cl:or cl:symbol cl:list))))
 
   (define-instance (RuntimeRepr (Proxy :a))
+    (inline)
     (define (runtime-repr _)
       (lisp LispType () '(cl:member 'proxy/proxy)))))
 

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -21,6 +21,7 @@
    #:make-attribute-monomorphize                 ; CONSTRUCTOR
    #:attribute-repr                              ; STRUCT
    #:make-attribute-repr                         ; CONSTRUCTOR
+   #:make-attribute-inline                       ; CONSTRUCTOR
    #:attribute-repr-type                         ; ACCESSOR
    #:attribute-repr-arg                          ; ACCESSOR
    #:constructor                                 ; STRUCT

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -563,7 +563,9 @@
                                    :var-names nil
                                    :body (list (util:runtime-quote (type-definition-runtime-type type)))))
                 :location location
-                :inline nil))
+                ;; Always inline RUNTIME-REPR so that other
+                ;; optimizations can kick off.
+                :inline (parser:make-attribute-inline :location location)))
      :location location
      :head-location location
      :compiler-generated t)))


### PR DESCRIPTION
This inlines `runtime-repr` and also fixes some bugs in the file module.

We inline `runtime-repr` to allow the various array operations to know their element type at compile-time.

The file module had 2 bugs:

1. vectors were given an element type (which was also an improper element type; we needed two `proxy-inner`s) when `Vector` only refers to CL vectors whose element type is `cl:t`.
2. `read-sequence` may not read as many elements as expected, so we must continue reading until we've done so. This ensures there are no uninitialized array values.