### PR TITLE
allow continuing from an orphan error

### DIFF
--- a/src/typechecker/base.lisp
+++ b/src/typechecker/base.lisp
@@ -14,6 +14,7 @@
    #:*pprint-variable-symbol-code*
    #:*pprint-variable-symbol-suffix*
    #:tc-error                           ; CONDITION, FUNCTION
+   #:tc-cerror                          ; FUNCTION
    #:tc-location
    #:tc-secondary-location
    #:tc-note
@@ -91,6 +92,11 @@ This requires a valid PPRINT-VARIABLE-CONTEXT")
   "Signal a typechecker error with MESSAGE, and optional NOTES that label source locations."
   (declare (type string message))
   (error 'tc-error :message message :notes notes))
+
+(defun tc-cerror (message &rest notes)
+  "Signal a continuable typechecker error with MESSAGE, and optional NOTES that label source locations."
+  (declare (type string message))
+  (cerror "Ignore and continue anyway." 'tc-error :message message :notes notes))
 
 (define-condition coalton-internal-type-error (error)
   ()

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -370,6 +370,7 @@
                  :append (mapcar #'parser:tycon-name (parser:collect-referenced-types type))))))
 
     (unless (find *package* instance-syms :key #'symbol-package)
-      (tc-error "Invalid orphan instance"
-                (tc-location (parser:toplevel-define-instance-head-location instance)
-                             "instances must be defined in the same package as their class or reference one or more types in their defining package")))))
+      (tc-cerror "Invalid orphan instance"
+                 (tc-location (parser:toplevel-define-instance-head-location instance)
+                              "instances must be defined in the same package as their class or reference one or more types in their defining package"))
+      (return-from check-for-orphan-instance))))


### PR DESCRIPTION
When we have an orphan instance error, allow the programmer to continue, ignoring the error.