### PR TITLE
fix list:union conditional

### DIFF
--- a/library/list.lisp
+++ b/library/list.lisp
@@ -341,7 +341,7 @@
           ((Nil) acc)
           ((Cons x xs)
            (if (or (member x ys)
-                   (member x ys))
+                   (member x acc))
                (f xs acc)
                (f xs (Cons x acc)))))))))
 

--- a/tests/list-tests.lisp
+++ b/tests/list-tests.lisp
@@ -79,6 +79,9 @@
   (is (== (list:union (list:append x x) x) x))
   (is (== (list:union Nil (list:append (Cons 4 x) x)) (Cons 4 x)))
 
+  (is (set== (list:union x (make-list 4 4)) (make-list 1 2 3 4)))
+  (is (set== (list:union (make-list 4 4) x) (make-list 1 2 3 4)))
+
   (is (set== (list:intersection x x) x))
   (is (set== (list:intersection (list:append x (make-list 0 9 8 7)) (Cons 4 x)) x)))
 


### PR DESCRIPTION
Fixes issue #1414.<br><br>In line 343, the if expression checks, for each xs item, only if it is a member of ys, when building the accumulator of xs items for later including ys remaining unique items to the union.<br>That causes repeated items in xs that are not in ys to be ignored.<br><br>Fix: check if each xs item is also already not in the current accumulator.<br><br>Added two assertions to cover lists with repeated items (the second of which fails) https://github.com/coalton-lang/coalton/blob/44d9e2facb571c3fea5cf4b7caac16d08575181a/library/list.lisp#L332-L346