### PR TITLE
Fix lisp-type for LispArray of type with multiple tyvars

### DIFF
--- a/src/typechecker/lisp-type.lisp
+++ b/src/typechecker/lisp-type.lisp
@@ -105,6 +105,7 @@ USE-FUNCTION-ENTRIES specifies whether to emit FUNCTION-ENTRY for functions, emi
                 (typep to 'tyvar)
                 ;; (LispArray (Complex :t))
                 (and (typep to 'tapp)
+                     (typep (tapp-from to) 'tycon)
                      (complex-tycon-p (tycon-name (tapp-from to)))
                      (typep (tapp-to to) 'tyvar)))
                `(cl:simple-array cl:* (cl:*)))

--- a/tests/typechecker/lisp-type-tests.lisp
+++ b/tests/typechecker/lisp-type-tests.lisp
@@ -26,6 +26,11 @@
   (declare transparent-type-fn-1 ((TransparentTypeTest IFix) -> IFix))
   (define (transparent-type-fn-1 (TransparentTypeTest x))
     (coalton-library/lisparray:aref x 0))
+
+  (define-type (LispArrayMultiTyvar :a :b))
+  (declare lisp-array-multi-tyvar-fn ((coalton-library/lisparray:LispArray (LispArrayMultiTyvar :a :b)) -> (LispArrayMultiTyvar :a :b)))
+  (define (lisp-array-multi-tyvar-fn x)
+    (coalton-library/lisparray:aref x 0))
   )
 
 (in-package #:coalton-tests)
@@ -64,4 +69,8 @@
                  (lisp-type (coalton-type-of-arg1 'coalton-native-tests::transparent-type-fn))))
       (is (equal '(simple-array fixnum (*))
                  (lisp-type (coalton-type-of-arg1 'coalton-native-tests::transparent-type-fn-1))))
+
+      ;; LispArray with multi-tyvar element type
+      (is (equal '(simple-array coalton-native-tests::LispArrayMultiTyvar (*))
+                 (lisp-type (coalton-type-of-arg1 'coalton-native-tests::lisp-array-multi-tyvar-fn))))
       )))


### PR DESCRIPTION
Compiler failed when LispArray's element type has more than one type variables.

For example, if you want to use something like this:
  (LispArray (T :a :b))

You got an error like:

  The value
    (T #T123)
  is not of type
    COALTON-IMPL/TYPECHECKER/TYPES:TYCON