### PR TITLE
Propagate constants among recursive let bindings.

### DIFF
--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -87,6 +87,14 @@ If not, returns NIL"
                            (t
                             (push (cons var propagated-value-node)
                                   nonconstant-bindings))))
+
+               ;; propagate new constant bindings into the values of
+               ;; the remaining nonconstant bindings.
+               (loop :for binding :in nonconstant-bindings
+                     :for value := (cdr binding)
+                     :for new-value := (funcall *traverse* value new-constant-bindings)
+                     :do (setf (cdr binding) new-value))
+
                (let ((inner-constant-bindings (append new-constant-bindings constant-bindings)))
                  (if nonconstant-bindings
                      (make-node-let

--- a/tests/recursive-let-tests.lisp
+++ b/tests/recursive-let-tests.lisp
@@ -53,3 +53,20 @@
                                  (loop-times (- n 1)))))))
         (loop-times 100)))"
    '("foo" . "Unit")))
+
+(deftest recursive-let-constant-propagation ()
+  "Test that constant let bindings are propagated to the other bindings. See GitHub issue #1442."
+  (check-coalton-types
+   "(define x
+      (let ((p (the UFix 3))
+            (q (1+ p)))
+        q))"
+   '("x" . "UFix"))
+
+  (check-coalton-types
+   "(define x
+      (let ((q (1+ p))
+            (p (the UFix 3)))
+        q))"
+   '("x" . "UFix")))
+


### PR DESCRIPTION
Closes #1442.

After propagating known constant bindings and separating constant and non-constant `let` bindings, this PR adds the propagation of the collected constant bindings into the values of the remaining non-constant bindings before generating a new `let` expression and propagating the constants into the body of the expression.