### PR TITLE
Find fixed point when propagating constants with recursive let bindings

### DIFF
--- a/tests/recursive-let-tests.lisp
+++ b/tests/recursive-let-tests.lisp
@@ -68,5 +68,16 @@
       (let ((q (1+ p))
             (p (the UFix 3)))
         q))"
-   '("x" . "UFix")))
+   '("x" . "UFix"))
+
+  (is (= 3 (coalton:coalton (coalton:let ((a b) (b c) (c d) (d 3)) a))))
+
+  (is (= 3 (coalton:coalton (coalton:let ((a (coalton:let ((b c) (c d)) d)) (d 3)) a))))
+
+  (let* ((start (/ (get-internal-real-time) internal-time-units-per-second))
+         (value (eval (read-from-string "(coalton:coalton (coalton:make-list 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0))")))
+         (end (/ (get-internal-real-time) internal-time-units-per-second)))
+
+    (is (< (- end start) 1))
+    (is (equalp value '(1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0)))))
 


### PR DESCRIPTION
Closes #1451.

This PR is an extension of #1449 to find a "fixed point" with respect to constant propagation among recursive `let` bindings.

It also adds a condition for continuing the fixed-point computation which prevents the slow-down in the code generation of `make-list` with many constants.

