### PR TITLE
OR and AND don't evaluate last expression in tail context

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -251,6 +251,7 @@
                 :components ((:file "lisp-type-tests")))
                (:file "environment-persist-tests")
                (:file "coalton-tests")
+               (:file "shortcut-tailcall-tests")
                (:file "slice-tests")
                (:file "float-tests")
                (:file "dual-tests")

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -452,32 +452,36 @@ Returns a `node'.")
 
     (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
-           (false-value (util:find-symbol "FALSE" coalton-package)))
+           (false-value (util:find-symbol "FALSE" coalton-package))
+           (rev-children (reverse (tc:node-or-nodes expr))))
 
-      (loop :with out-node := (make-node-variable
-                               :type tc:*boolean-type*
-                               :value false-value)
-            :for body-node :in (reverse (tc:node-or-nodes expr)) :do
-              (setf out-node
-                    (make-node-match
-                     :type tc:*boolean-type*
-                     :expr (translate-expression body-node ctx env)
-                     :branches (list
-                                (make-match-branch
-                                 :pattern (make-pattern-constructor
-                                           :type tc:*boolean-type*
-                                           :name true-value
-                                           :patterns nil)
-                                 :body (make-node-variable
-                                        :type tc:*boolean-type*
-                                        :value true-value))
-                                (make-match-branch
-                                 :pattern (make-pattern-constructor
-                                           :type tc:*boolean-type*
-                                           :name false-value
-                                           :patterns nil)
-                                 :body out-node))))
-            :finally (return out-node))))
+      (if (null rev-children)
+          (make-node-variable
+           :type tc:*boolean-type*
+           :value false-value)
+          (loop :with out-node := (translate-expression (car rev-children)
+                                                        ctx env)
+                :for body-node :in (cdr rev-children) :do
+                  (setf out-node
+                        (make-node-match
+                         :type tc:*boolean-type*
+                         :expr (translate-expression body-node ctx env)
+                         :branches (list
+                                    (make-match-branch
+                                     :pattern (make-pattern-constructor
+                                               :type tc:*boolean-type*
+                                               :name true-value
+                                               :patterns nil)
+                                     :body (make-node-variable
+                                            :type tc:*boolean-type*
+                                            :value true-value))
+                                    (make-match-branch
+                                     :pattern (make-pattern-constructor
+                                               :type tc:*boolean-type*
+                                               :name false-value
+                                               :patterns nil)
+                                     :body out-node))))
+                :finally (return out-node)))))
 
   (:method ((expr tc:node-and) ctx env)
     (declare (type pred-context ctx)
@@ -486,32 +490,36 @@ Returns a `node'.")
 
     (let* ((coalton-package (util:find-package "COALTON"))
            (true-value (util:find-symbol "TRUE" coalton-package))
-           (false-value (util:find-symbol "FALSE" coalton-package)))
+           (false-value (util:find-symbol "FALSE" coalton-package))
+           (rev-children (reverse (tc:node-and-nodes expr))))
 
-      (loop :with out-node := (make-node-variable
-                               :type tc:*boolean-type*
-                               :value true-value)
-            :for body-node :in (reverse (tc:node-and-nodes expr)) :do
-              (setf out-node
-                    (make-node-match
-                     :type tc:*boolean-type*
-                     :expr (translate-expression body-node ctx env)
-                     :branches (list
-                                (make-match-branch
-                                 :pattern (make-pattern-constructor
-                                           :type tc:*boolean-type*
-                                           :name false-value
-                                           :patterns nil)
-                                 :body (make-node-variable
-                                        :type tc:*boolean-type*
-                                        :value false-value))
-                                (make-match-branch
-                                 :pattern (make-pattern-constructor
-                                           :type tc:*boolean-type*
-                                           :name true-value
-                                           :patterns nil)
-                                 :body out-node))))
-            :finally (return out-node))))
+      (if (null rev-children)
+          (make-node-variable
+           :type tc:*boolean-type*
+           :value true-value)
+          (loop :with out-node := (translate-expression (car rev-children)
+                                                        ctx env)
+                :for body-node :in (cdr rev-children) :do
+                  (setf out-node
+                        (make-node-match
+                         :type tc:*boolean-type*
+                         :expr (translate-expression body-node ctx env)
+                         :branches (list
+                                    (make-match-branch
+                                     :pattern (make-pattern-constructor
+                                               :type tc:*boolean-type*
+                                               :name false-value
+                                               :patterns nil)
+                                     :body (make-node-variable
+                                            :type tc:*boolean-type*
+                                            :value false-value))
+                                    (make-match-branch
+                                     :pattern (make-pattern-constructor
+                                               :type tc:*boolean-type*
+                                               :name true-value
+                                               :patterns nil)
+                                     :body out-node))))
+                :finally (return out-node)))))
 
   (:method ((expr tc:node-if) ctx env)
     (declare (type pred-context ctx)

--- a/tests/shortcut-tailcall-tests.lisp
+++ b/tests/shortcut-tailcall-tests.lisp
@@ -1,0 +1,15 @@
+(cl:in-package #:coalton-native-tests)
+
+(coalton-toplevel
+  (declare and-tailcall (Integer -> Boolean))
+  (define (and-tailcall n) (and (> n 0) (and-tailcall (1- n))))
+
+  (declare or-tailcall (Integer -> Boolean))
+  (define (or-tailcall n) (or (== n 0) (or-tailcall (1- n))))
+  )
+
+(define-test test-shortcut-tailcall ()
+  ;; This causes stack overflow with buggy compiler
+  (is (== False (and-tailcall 1000000)))
+  (is (== True (or-tailcall 1000000)))
+  )


### PR DESCRIPTION
This prevents tail-recursive call involving `and`/`or` from TCO-ed, and causes stack overflow.

```
COALTON-USER> (define (f n) (and (> n 0) (f (1- n))))
;; F :: ∀ A. (ORD A) (NUM A) ⇒ (A → BOOLEAN)
; No value
COALTON-USER> (f 100000)
INFO: Control stack guard page unprotected
Control stack guard page temporarily disabled: proceed with caution
; Evaluation aborted on #<SB-KERNEL::CONTROL-STACK-EXHAUSTED {7007C3F163}>.
```

Notably, this makes `iter:every!` fail if the iterator has lots of elements.

This PR fixes it.  Tests are included.

For the reference, this is the codegen of previous code:

```
COALTON-USER> (coalton-codegen (define (f n) (and (> n 0) (f (1- n)))))
;; F :: ∀ A. (ORD A) (NUM A) ⇒ (A → BOOLEAN)
(COMMON-LISP:PROGN
 (COMMON-LISP:LOCALLY
  (COMMON-LISP:DECLARE (COMMON-LISP:OPTIMIZE (SB-C::TYPE-CHECK 0)))
  (COALTON-IMPL/GLOBAL-LEXICAL:DEFINE-GLOBAL-LEXICAL F
                                                     COALTON-IMPL/RUNTIME/FUNCTION-ENTRY:FUNCTION-ENTRY)
  (COMMON-LISP:DEFUN F (#:DICT4656 #:DICT4657 N-4084)
    (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:DICT4656 #:DICT4657 N-4084))
    (COMMON-LISP:LET ((#:MATCH4660
                       (> #:DICT4656 N-4084 (FROMINT #:DICT4657 0))))
      (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:MATCH4660))
      (COMMON-LISP:LOCALLY
       (COMMON-LISP:DECLARE
        (SB-EXT:MUFFLE-CONDITIONS SB-EXT:CODE-DELETION-NOTE))
       (COMMON-LISP:COND
        ((COMMON-LISP:EQL 'COMMON-LISP:NIL #:MATCH4660) 'COMMON-LISP:NIL)
        ((COMMON-LISP:EQL 'COMMON-LISP:T #:MATCH4660)
         (COMMON-LISP:LET ((#:MATCH4661
                            (F #:DICT4656 #:DICT4657
                             (COMMON-LISP:LET ((#:NUM-2404659 N-4084))
                               (COMMON-LISP:DECLARE
                                (COMMON-LISP:IGNORABLE #:NUM-2404659))
                               (COMMON-LISP:LET ((#:DICT6734658 #:DICT4657))
                                 (COMMON-LISP:DECLARE
                                  (COMMON-LISP:IGNORABLE #:DICT6734658))
                                 (- #:DICT6734658 #:NUM-2404659
                                    (FROMINT #:DICT6734658 1)))))))
           (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:MATCH4661))
           (COMMON-LISP:LOCALLY
            (COMMON-LISP:DECLARE
             (SB-EXT:MUFFLE-CONDITIONS SB-EXT:CODE-DELETION-NOTE))
            (COMMON-LISP:COND
             ((COMMON-LISP:EQL 'COMMON-LISP:NIL #:MATCH4661) 'COMMON-LISP:NIL)
             ((COMMON-LISP:EQL 'COMMON-LISP:T #:MATCH4661) 'COMMON-LISP:T)
             (COMMON-LISP:T
              (COMMON-LISP:ERROR "Pattern match not exhaustive error"))))))
        (COMMON-LISP:T
         (COMMON-LISP:ERROR "Pattern match not exhaustive error"))))))
  (COMMON-LISP:SETF F (COALTON-IMPL/RUNTIME/FUNCTION-ENTRY::F3 #'F))
  (COMMON-LISP:SETF (COMMON-LISP:DOCUMENTATION 'F 'COMMON-LISP:VARIABLE)
                      "F :: ∀ A. (ORD A) (NUM A) ⇒ (A → BOOLEAN)")
  (COMMON-LISP:SETF (COMMON-LISP:DOCUMENTATION 'F 'COMMON-LISP:FUNCTION)
                      "F :: ∀ A. (ORD A) (NUM A) ⇒ (A → BOOLEAN)"))
 (COMMON-LISP:VALUES))
```

And this is the fixed version:

```
COALTON-USER> (coalton-codegen (define (f n) (and (> n 0) (f (1- n)))))
;; F :: ∀ A. (ORD A) (NUM A) ⇒ (A → BOOLEAN)
(COMMON-LISP:PROGN
 (COMMON-LISP:LOCALLY
  (COMMON-LISP:DECLARE (COMMON-LISP:OPTIMIZE (SB-C::TYPE-CHECK 0)))
  (COALTON-IMPL/GLOBAL-LEXICAL:DEFINE-GLOBAL-LEXICAL F
                                                     COALTON-IMPL/RUNTIME/FUNCTION-ENTRY:FUNCTION-ENTRY)
  (COMMON-LISP:DEFUN F (#:DICT4636 #:DICT4637 N-4084)
    (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:DICT4636 #:DICT4637 N-4084))
    (COMMON-LISP:LET ((#:MATCH4640
                       (> #:DICT4636 N-4084 (FROMINT #:DICT4637 0))))
      (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:MATCH4640))
      (COMMON-LISP:LOCALLY
       (COMMON-LISP:DECLARE
        (SB-EXT:MUFFLE-CONDITIONS SB-EXT:CODE-DELETION-NOTE))
       (COMMON-LISP:COND
        ((COMMON-LISP:EQL 'COMMON-LISP:NIL #:MATCH4640) 'COMMON-LISP:NIL)
        ((COMMON-LISP:EQL 'COMMON-LISP:T #:MATCH4640)
         (F #:DICT4636 #:DICT4637
          (COMMON-LISP:LET ((#:NUM-2404639 N-4084))
            (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:NUM-2404639))
            (COMMON-LISP:LET ((#:DICT6724638 #:DICT4637))
              (COMMON-LISP:DECLARE (COMMON-LISP:IGNORABLE #:DICT6724638))
              (- #:DICT6724638 #:NUM-2404639 (FROMINT #:DICT6724638 1))))))
        (COMMON-LISP:T
         (COMMON-LISP:ERROR "Pattern match not exhaustive error"))))))
  (COMMON-LISP:SETF F (COALTON-IMPL/RUNTIME/FUNCTION-ENTRY::F3 #'F))
  (COMMON-LISP:SETF (COMMON-LISP:DOCUMENTATION 'F 'COMMON-LISP:VARIABLE)
                      "F :: ∀ A. (ORD A) (NUM A) ⇒ (A → BOOLEAN)")
  (COMMON-LISP:SETF (COMMON-LISP:DOCUMENTATION 'F 'COMMON-LISP:FUNCTION)
                      "F :: ∀ A. (ORD A) (NUM A) ⇒ (A → BOOLEAN)"))
 (COMMON-LISP:VALUES))
```