### PR TITLE
Update optional type with a more efficient runtime representation

### DIFF
--- a/coalton-compiler.asd
+++ b/coalton-compiler.asd
@@ -51,6 +51,7 @@
                (:module "runtime"
                 :serial t
                 :components ((:file "function-entry")
+                             (:file "optional")
                              (:file "package")))
                (:module "typechecker"
                 :serial t

--- a/coalton.asd
+++ b/coalton.asd
@@ -274,6 +274,7 @@
                (:file "call-coalton-from-lisp")
                (:file "vector-tests")
                (:file "string-tests")
+               (:file "optional-tests")
                (:file "recursive-let-tests")
                (:file "class-tests")
                (:file "struct-tests")

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -73,11 +73,6 @@
     (first :a)
     (second :b))
 
-  (define-type (Optional :a)
-    "Represents something that may not have a value."
-    (Some :a)
-    None)
-
   (define-type (Result :bad :good)
     "Represents something that may have failed."
     ;; We write (Result :bad :good) instead of (Result :good :bad)

--- a/library/primitive-types.lisp
+++ b/library/primitive-types.lisp
@@ -40,6 +40,44 @@
     (lisp (List :a) ()
       cl:nil))
 
+  ;; Optional is an early type
+  ;;
+  ;; Defining the following is functionally
+  ;; equivalent to having defined an ADT as
+  ;; (define-type (Optional :a)
+  ;;   (Some :a)
+  ;;   None)
+  (inline)
+  (declare Some (:a -> Optional :a))
+  (define (Some x)
+    "A constructor for the type, `Optional`. This constructor can be used
+like any other algebraic data type constructor, including for pattern
+matching, as in the following example.
+
+```lisp
+(match x
+  ((Some value)
+    value)
+  (_ (error \"Oh, no!\")))
+```"
+    (lisp (Optional :a) (x)
+      (coalton-impl/runtime:cl-some x)))
+
+  (declare None (Optional :a))
+  (define None
+    "A constructor for the type, `Optional`. This constructor can be used
+like any other algebraic data type constructor, including for pattern
+matching, as in the following example.
+
+```lisp
+(match x
+  ((None)
+   \"Fantastic!\")
+  (_ (error \"Oh, no!\")))
+```"
+    (lisp (Optional :a) ()
+      coalton-impl/runtime:cl-none))
+
   (repr :native (cl:unsigned-byte 8))
   (define-type U8
     "Unsigned 8-bit integer capable of storing values in `[0, 255]`. Uses `(unsigned-byte 8)`.")

--- a/library/types.lisp
+++ b/library/types.lisp
@@ -105,6 +105,13 @@ The compiler will auto-generate instances of `RuntimeRepr` for all defined types
     (define (runtime-repr _)
       (lisp LispType () 'cl:list)))
 
+  (define-instance (RuntimeRepr (Optional :a))
+    (inline)
+    (define (runtime-repr _)
+      ;; If using `cl:t` proves to be inefficient we could try to
+      ;; improve this, perhaps using proxy-inner.
+      (lisp LispType () 'cl:t)))
+
   ;; The compiler will not auto-generate RuntimeRepr instances for
   ;; types defined in this file to avoid circular dependencies.
   

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -313,11 +313,16 @@
                           (values list &optional))
                 setf-accessor))
 (defun setf-accessor (ctor-ent nth-slot instance)
-  (if (eq (tc:constructor-entry-name ctor-ent) 'coalton:Cons)
-      (ecase nth-slot
-        (0 `(car ,instance))
-        (1 `(cdr ,instance)))
-      `(slot-value ,instance ',(constructor-slot-name ctor-ent nth-slot))))
+  (case (tc:constructor-entry-name ctor-ent)
+    ((coalton:Cons)
+     (ecase nth-slot
+       (0 `(car ,instance))
+       (1 `(cdr ,instance))))
+    ((coalton:Some)
+     (ecase nth-slot
+       (0 `(rt:unwrap-cl-some ,instance))))
+    (otherwise
+     `(slot-value ,instance ',(constructor-slot-name ctor-ent nth-slot)))))
 
 (defun codegen-let (node sccs local-vars env)
   (declare (type node-let node)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -62,7 +62,8 @@
    #:String
    #:Fraction
    #:Arrow
-   #:List #:Cons #:Nil)
+   #:List #:Cons #:Nil
+   #:Optional #:Some #:None)
 
   ;; Primitive Syntax
   (:export

--- a/src/runtime/optional.lisp
+++ b/src/runtime/optional.lisp
@@ -1,0 +1,98 @@
+;;;; optional.lisp
+;;;;
+;;;; This package contains the underlying implementation of the
+;;;; Optional type for Coalton. The idea is to avoid unnecessary
+;;;; boxing by defining a structure that represents None nested in N
+;;;; Somes. Consider the general case of the type (Optional^M :t). In
+;;;; this case, we have exactly M+1 possible cases to match
+;;;; against. We have the cases (Some^N (None)) for N from 0 to M-1
+;;;; and we have the case (Some^M x) where x is of type :t. Therefore,
+;;;; by defining a struct CL-OPTIONAL with one slot, DEPTH, we can
+;;;; always represent (Optional^M :t) as either an element of type :t
+;;;; or as a CL-OPTIONAL with a depth between 0 and M-1.
+;;;;
+;;;; For example, (lisp (Optional (Optional :t)) () 5) is
+;;;; unambiguously equal to (Some (Some 5)).
+
+(defpackage #:coalton-impl/runtime/optional
+  (:use
+   #:cl)
+  (:export
+   #:cl-none
+   #:cl-none-p
+   #:cl-some
+   #:cl-some-p
+   #:unwrap-cl-some))
+
+(in-package #:coalton-impl/runtime/optional)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (declaim (inline make-cl-optional))
+  (defstruct (cl-optional (:constructor make-cl-optional (depth)))
+    "A CL-OPTIONAL represents of DEPTH N represents the Coalton
+value (Some^N None)."
+    (depth 0 :type (unsigned-byte 16) :read-only t))
+
+  ;; SBCL generates the load form by default, but CCL
+  ;; does not, so we generate it here regardless.
+  (defmethod make-load-form ((obj cl-optional) &optional env)
+    (make-load-form-saving-slots obj :environment env)))
+
+#+sbcl
+(cl:declaim (sb-ext:freeze-type cl-optional))
+
+(defmethod print-object ((opt cl-optional) stream)
+  (let ((depth (cl-optional-depth opt)))
+    (format stream "#.")
+    (loop :repeat depth :do (format stream "(~S " 'coalton:Some))
+    (format stream "~S" 'coalton:None)
+    (loop :repeat depth :do (format stream ")"))))
+
+(alexandria:define-constant +cl-optional-cache-size+ 8)
+
+(declaim (type (simple-vector 8) cl-optional-cache))
+(alexandria:define-constant cl-optional-cache
+    (make-array +cl-optional-cache-size+
+                :initial-contents
+                (loop :for depth :below +cl-optional-cache-size+
+                      :collect (make-cl-optional depth)))
+  :test 'equalp)
+
+(alexandria:define-constant cl-none (aref cl-optional-cache 0) :test 'equalp)
+
+(declaim (inline cl-none-p))
+(defun cl-none-p (x)
+  ;; This would ideally be EQ instead of EQUALP,
+  ;; however, we need to make sure the logic
+  ;; compiles with the standard. For example,
+  ;; if this were EQ, then
+  ;; (CL-NONE-P (READ-FROM-STRING "#.NONE"))
+  ;; would evaluate to false.
+  (equalp x cl-none))
+
+(declaim (inline cl-some))
+(defun cl-some (x)
+  (typecase x
+    (cl-optional
+     (let ((new-depth (1+ (cl-optional-depth x))))
+       (if (< new-depth +cl-optional-cache-size+)
+           (aref cl-optional-cache new-depth)
+           (make-cl-optional new-depth))))
+    (otherwise
+     x)))
+
+(declaim (inline cl-some-p))
+(defun cl-some-p (x)
+  (not (cl-none-p x)))
+
+(declaim (inline unwrap-cl-some))
+(defun unwrap-cl-some (x)
+  (typecase x
+    (cl-optional
+     (let ((new-depth (1- (cl-optional-depth x))))
+       (if (< new-depth +cl-optional-cache-size+)
+           (aref cl-optional-cache new-depth)
+           (make-cl-optional new-depth))))
+    (otherwise
+     x)))
+

--- a/src/runtime/package.lisp
+++ b/src/runtime/package.lisp
@@ -1,3 +1,4 @@
 (uiop:define-package #:coalton-impl/runtime
   (:mix-reexport
-   #:coalton-impl/runtime/function-entry))
+   #:coalton-impl/runtime/function-entry
+   #:coalton-impl/runtime/optional))

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -417,7 +417,19 @@
             :explicit-repr '(:native cl:list)
             :enum-repr nil
             :newtype nil
-            :docstring "Homogeneous list of objects represented as a Common Lisp `list`.")))))
+            :docstring "Homogeneous list of objects represented as a Common Lisp `list`."))
+
+          ('coalton:Optional
+           (make-type-entry
+            :name 'coalton:Optional
+            :runtime-type 'cl:t
+            :type *optional-type*
+            :tyvars (list (make-variable))
+            :constructors '(coalton:Some coalton:None)
+            :explicit-repr '(:native cl:t)
+            :enum-repr nil
+            :newtype nil
+            :docstring "Represents something that may not have a value.")))))
 
 ;;;
 ;;; Constructor environment
@@ -500,6 +512,24 @@
             :constructs 'coalton:List
             :classname nil
             :docstring "`Nil` represents an empty `List`."
+            :compressed-repr 'nil))
+
+          ('coalton:Some
+           (make-constructor-entry
+            :name 'coalton:Some
+            :arity 1
+            :constructs 'coalton:Optional
+            :classname nil
+            :docstring "`Some` expresses the presence of a meaningful value."
+            :compressed-repr 'nil))
+
+          ('coalton:None
+           (make-constructor-entry
+            :name 'coalton:None
+            :arity 0
+            :constructs 'coalton:Optional
+            :classname nil
+            :docstring "`None` expresses the absence of a meaningful value."
             :compressed-repr 'nil)))))
 
 #+(and sbcl coalton-release)

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -48,6 +48,7 @@
    #:*fraction-type*                    ; VARIABLE
    #:*arrow-type*                       ; VARIABLE
    #:*list-type*                        ; VARIABLE
+   #:*optional-type*                    ; VARIABLE
    #:push-type-alias                    ; FUNCTION
    #:flatten-type                       ; FUNCTION
    #:apply-type-argument                ; FUNCTION
@@ -265,6 +266,7 @@
 (defvar *fraction-type*     (make-tycon :name 'coalton:Fraction     :kind +kstar+))
 (defvar *arrow-type*        (make-tycon :name 'coalton:Arrow        :kind (make-kfun :from +kstar+ :to (make-kfun :from +kstar+ :to +kstar+))))
 (defvar *list-type*         (make-tycon :name 'coalton:List         :kind (make-kfun :from +kstar+ :to +kstar+)))
+(defvar *optional-type*     (make-tycon :name 'coalton:Optional     :kind (make-kfun :from +kstar+ :to +kstar+)))
 
 ;;;
 ;;; Operations on Types

--- a/tests/optional-tests.lisp
+++ b/tests/optional-tests.lisp
@@ -1,0 +1,32 @@
+(cl:in-package #:coalton-native-tests)
+
+(define-test test-optional ()
+
+  (let ((x 5)
+        (n (the (Optional Integer) None))
+        (s (fn (x) (Some x)))
+        (u (fn (x) (unwrap x))))
+    (is (== x
+            (nest u u u
+                  s s s
+                  x)))
+    (is (== x
+            (nest u u u u u u u u u u u u u u u u u
+                  s s s s s s s s s s s s s s s s s
+                  x)))
+    (is (== (nest s s s s x)
+            (nest u u u u u u u u u u u u u
+                  s s s s s s s s s s s s s s s s s
+                  x)))
+    (is (== n
+            (nest u u u
+                  s s s
+                  n)))
+    (is (== n
+            (nest u u u u u u u u u u u u u u u u u
+                  s s s s s s s s s s s s s s s s s
+                  n)))
+    (is (== (nest s s s s n)
+            (nest u u u u u u u u u u u u u
+                  s s s s s s s s s s s s s s s s s
+                  n)))))


### PR DESCRIPTION
Closes #1480.

Based entirely on @stylewarning's sketch here: https://github.com/coalton-lang/coalton/issues/1480#issuecomment-3028152370

As a bonus, the optional is still printable and readable in a convenient way

```lisp
COALTON-USER> (coalton (Some None))
#.(SOME NONE)

COALTON-USER> (coalton (Some 5))
5

COALTON-USER> (coalton-toplevel
                (define x
                  (lisp (Optional (Optional Integer)) () 
                    (cl:read-from-string "#.(SOME NONE)"))))
; No value

COALTON-USER> x
#.(SOME NONE)

COALTON-USER> (type-of 'x)
(OPTIONAL (OPTIONAL INTEGER))

COALTON-USER> (coalton-toplevel
                (define x
                  (lisp (Optional Integer) () 
                    (cl:read-from-string "5"))))
; No value

COALTON-USER> x
5

COALTON-USER> (type-of 'x)
(OPTIONAL INTEGER)
```