### PR TITLE
Fix test warnings

### DIFF
--- a/src/codegen/codegen-type-definition.lisp
+++ b/src/codegen/codegen-type-definition.lisp
@@ -46,7 +46,8 @@
       `(,(if (settings:coalton-release-p)
              `(defstruct (,(tc:type-definition-name def)
                           (:constructor nil)
-                          (:predicate nil))
+                          (:predicate nil)
+                          (:copier nil))
                 ,@(when (source:docstring def)
                     (list (source:docstring def))))
 

--- a/tests/test-files/define-class.txt
+++ b/tests/test-files/define-class.txt
@@ -6,7 +6,7 @@ Define a class with a single type variable and no methods.
 
 (package coalton-unit-tests)
 
-(define-class (C :a))
+(define-class (C-dc1 :a))
 
 ================================================================================
 2 Define class, two vars
@@ -16,7 +16,7 @@ Define a class with two type variables and no methods.
 
 (package coalton-unit-tests)
 
-(define-class (C1 :a :b))
+(define-class (C1-dc2 :a :b))
 
 ================================================================================
 3 Define class, context
@@ -26,9 +26,9 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C1 :a :b))
+(define-class (C1-dc3 :a :b))
 
-(define-class (C1 :a :b => C2 :a :b))
+(define-class (C1-dc3 :a :b => C2-dc3 :a :b))
 
 ================================================================================
 4 Define class, nested contexts
@@ -36,11 +36,11 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C1 :a :b))
+(define-class (C1-dc4 :a :b))
 
-(define-class (C1 :a :b => C2 :a :b))
+(define-class (C1-dc4 :a :b => C2-dc4 :a :b))
 
-(define-class ((C1 :a :b) (C2 :a :b) => C3 :a :b))
+(define-class ((C1-dc4 :a :b) (C2-dc4 :a :b) => C3-dc4 :a :b))
 
 ================================================================================
 5 Define class, methods
@@ -48,9 +48,9 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C4 :a)
-  (m1 :a)
-  (m2 (:a -> :a)))
+(define-class (C4-dc5 :a)
+  (m1-dc5 :a)
+  (m2-dc5 (:a -> :a)))
 
 ================================================================================
 6 Define class, with methods, docstrings
@@ -58,9 +58,9 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C5 :a)
-  (m3 "Method m3" :a)
-  (m4 (:a -> :a)))
+(define-class (C5-dc6 :a)
+  (m3-dc6 "Method m3" :a)
+  (m4-dc6 (:a -> :a)))
 
 ================================================================================
 7 Define class, with methods, docstrings
@@ -68,9 +68,9 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C6 :a)
-  (m5 :a)
-  (m6 "Method m6" (:a -> :a)))
+(define-class (C6-dc7 :a)
+  (m5-dc7 :a)
+  (m6-dc7 "Method m6" (:a -> :a)))
 
 ================================================================================
 8 Define class, with methods, docstrings
@@ -78,9 +78,9 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C7 :a)
-  (m7 "Method m7" :a)
-  (m8 "Method m8" (:a -> :a)))
+(define-class (C7-dc8 :a)
+  (m7-dc8 "Method m7" :a)
+  (m8-dc8 "Method m8" (:a -> :a)))
 
 ================================================================================
 9 Define class
@@ -88,7 +88,7 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C :a :b (:a -> :a)))
+(define-class (C-dc9 :a :b (:a -> :a)))
 
 ================================================================================
 10 Define class
@@ -96,7 +96,7 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C :a :b :c :d (:a :b -> :c :d)))
+(define-class (C-dc10 :a :b :c :d (:a :b -> :c :d)))
 
 ================================================================================
 11 Define class
@@ -104,7 +104,7 @@ Define a class with a context.
 
 (package coalton-unit-tests)
 
-(define-class (C :a :b (:a -> :b) (:b -> :a)))
+(define-class (C-dc11 :a :b (:a -> :b) (:b -> :a)))
 
 ================================================================================
 12 Define class
@@ -113,7 +113,7 @@ Define a class with a context.
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define-class (Eq :a => (C :a)))
+(define-class (Eq :a => (C-dc12 :a)))
 
 ================================================================================
 13 Define class
@@ -122,7 +122,7 @@ Define a class with a context.
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define-class ((Eq :a) => (C :a)))
+(define-class ((Eq :a) => (C-dc13 :a)))
 
 ================================================================================
 100 Class name must be a symbol

--- a/tests/test-files/define-instance.txt
+++ b/tests/test-files/define-instance.txt
@@ -4,9 +4,9 @@
 
 (package coalton-unit-tests)
 
-(define-class (C :a))
+(define-class (C-di1 :a))
 
-(define-instance (C :a))
+(define-instance (C-di1 :a))
 
 ================================================================================
 2 Define instance
@@ -14,9 +14,9 @@
 
 (package coalton-unit-tests)
 
-(define-class (C :a :b))
+(define-class (C-di2 :a :b))
 
-(define-instance (C :a :b))
+(define-instance (C-di2 :a :b))
 
 ================================================================================
 3 Define instance
@@ -24,11 +24,11 @@
 
 (package coalton-unit-tests)
 
-(define-class (C :a))
+(define-class (C-di3 :a))
 
-(define-class (C2 :a :b))
+(define-class (C2-di3 :a :b))
 
-(define-instance (C :a => C2 :a :b))
+(define-instance (C-di3 :a => C2-di3 :a :b))
 
 ================================================================================
 4 Define instance
@@ -36,11 +36,11 @@
 
 (package coalton-unit-tests)
 
-(define-class (C :a))
+(define-class (C-di4 :a))
 
-(define-class (C2 :a :b))
+(define-class (C2-di4 :a :b))
 
-(define-instance ((C :a) (C :b) => C2 :a :b))
+(define-instance ((C-di4 :a) (C-di4 :b) => C2-di4 :a :b))
 
 ================================================================================
 5 Define instance
@@ -49,11 +49,11 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define-class (M :a)
-  (f (:a -> UFix)))
+(define-class (M-di5 :a)
+  (f-di5 (:a -> UFix)))
 
-(define-instance (M :a)
-  (define (f x) 1))
+(define-instance (M-di5 :a)
+  (define (f-di5 x) 1))
 
 ================================================================================
 6 Define instance
@@ -62,13 +62,13 @@
 (package coalton-unit-tests/define-instance-6
   (import coalton-prelude))
 
-(define-class (C :a)
-  (f (:a -> :a))
-  (g :a))
+(define-class (C-di6 :a)
+  (f-di6 (:a -> :a))
+  (g-di6 :a))
 
-(define-instance (Num :a => C :a)
-  (define (f x) 1)
-  (define g 1))
+(define-instance (Num :a => C-di6 :a)
+  (define (f-di6 x) 1)
+  (define g-di6 1))
 
 ================================================================================
 7 Define instance
@@ -76,9 +76,9 @@
 
 (package coalton-unit-tests)
 
-(define-class (C :a))
+(define-class (C-di7 :a))
 
-(define-instance (C :a => (C (List :a))))
+(define-instance (C-di7 :a => (C-di7 (List :a))))
 
 ================================================================================
 8 Define instance
@@ -86,9 +86,9 @@
 
 (package coalton-unit-tests)
 
-(define-class (C :a))
+(define-class (C-di8 :a))
 
-(define-instance ((C :a) => (C (List :a))))
+(define-instance ((C-di8 :a) => (C-di8 (List :a))))
 
 ================================================================================
 9 Define instance
@@ -97,9 +97,9 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define-type C X Y Z)
+(define-type C-di9 X-di9 Y-di9 Z-di9)
 
-(define-instance (Eq C)
+(define-instance (Eq C-di9)
   (define (== _ _) True))
 
 ================================================================================
@@ -110,12 +110,12 @@
 
 ;; see issue #1340
 
-(define-type (T :a))
-(define-class (P :a))
-(define-class (C :a :b))
-(define-class ((P :a) (C :b :a) => PC :b :a))
-(define-instance (C (T :a) :a))
-(define-instance (P :a => PC (T :a) :a))
+(define-type (T-di10 :a))
+(define-class (P-di10 :a))
+(define-class (C-di10 :a :b))
+(define-class ((P-di10 :a) (C-di10 :b :a) => PC-di10 :b :a))
+(define-instance (C-di10 (T-di10 :a) :a))
+(define-instance (P-di10 :a => PC-di10 (T-di10 :a) :a))
 
 ================================================================================
 11 Define instance with inline
@@ -124,9 +124,9 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define-type D X Y Z)
+(define-type D-di11 X-di11 Y-di11 Z-di11)
 
-(define-instance (Eq D)
+(define-instance (Eq D-di11)
   (inline)
   (define (== _ _) True))
 

--- a/tests/test-files/define-type-alias.txt
+++ b/tests/test-files/define-type-alias.txt
@@ -4,7 +4,7 @@
 
 (package coalton-unit-tests)
 
-(define-type-alias Index Integer)
+(define-type-alias Index-dta1 Integer)
 
 ================================================================================
 2 Define type alias
@@ -36,13 +36,13 @@
 
 (package coalton-unit-tests)
 
-(define-type-alias Index Integer)
+(define-type-alias Index-dta5 Integer)
 
-(define-type-alias MyIndex Index)
+(define-type-alias MyIndex-dta5 Index-dta5)
 
-(define-type-alias (Collection :a) (List :a))
+(define-type-alias (Collection-dta5 :a) (List :a))
 
-(define-type-alias MyIndices (Collection MyIndex))
+(define-type-alias MyIndices-dta5 (Collection-dta5 MyIndex-dta5))
 
 ================================================================================
 6 Define type alias

--- a/tests/test-files/define-type.txt
+++ b/tests/test-files/define-type.txt
@@ -4,7 +4,7 @@
 
 (package coalton-unit-tests)
 
-(define-type T)
+(define-type T-dt1)
 
 ================================================================================
 2 Define type
@@ -12,7 +12,7 @@
 
 (package coalton-unit-tests)
 
-(define-type (T :a))
+(define-type (T-dt2 :a))
 
 ================================================================================
 3 Define type
@@ -20,7 +20,7 @@
 
 (package coalton-unit-tests)
 
-(define-type T T1)
+(define-type T-dt3 T1-dt3)
 
 ================================================================================
 4 Define type
@@ -28,9 +28,9 @@
 
 (package coalton-unit-tests/define-type-4)
 
-(define-type (T :a :b :c)
-  (T1 :a)
-  (T2 :b :c))
+(define-type (T-dt4 :a :b :c)
+  (T1-dt4 :a)
+  (T2-dt4 :b :c))
 
 ================================================================================
 5 Define type
@@ -39,7 +39,7 @@
 (package coalton-unit-tests)
 
 (repr :native cl:t)
-(define-type T)
+(define-type T-dt5)
 
 ================================================================================
 6 Define type
@@ -48,10 +48,10 @@
 (package coalton-unit-tests)
 
 (repr :enum)
-(define-type T
-  First
-  Second
-  Third)
+(define-type T-dt6
+  First-dt6
+  Second-dt6
+  Third-dt6)
 
 
 ================================================================================
@@ -60,10 +60,10 @@
 
 (package coalton-unit-tests)
 
-(define-type (T :a)
-  T1         "This is an empty constructor"
-  (T2 :a)    "This is a constructor"
-  (T3 :a :a) "This is a well-nourished constructor"))
+(define-type (T-dt7 :a)
+  T1-dt7         "This is an empty constructor"
+  (T2-dt7 :a)    "This is a constructor"
+  (T3-dt7 :a :a) "This is a well-nourished constructor"))
 
 ================================================================================
 100 Malformed type definition

--- a/tests/test-files/parse-expression.txt
+++ b/tests/test-files/parse-expression.txt
@@ -4,7 +4,7 @@
 
 (package coalton-unit-tests)
 
-(define f 5)
+(define f-parse1 5)
 
 ================================================================================
 2 Parse expression
@@ -12,7 +12,7 @@
 
 (package coalton-unit-tests)
 
-(define (f _x) 5)
+(define (f-parse2 _x) 5)
 
 ================================================================================
 3 Parse expression
@@ -20,7 +20,7 @@
 
 (package coalton-unit-tests)
 
-(define (f _x _y) 5)
+(define (f-parse3 _x _y) 5)
 
 ================================================================================
 4 Parse expression
@@ -29,7 +29,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define f
+(define f-parse4
   (fn (x)
     (+ x x)))
 
@@ -40,7 +40,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define f
+(define f-parse5
   (fn ()
     (+ 1 2)))
 
@@ -51,7 +51,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define (f)
+(define (f-parse6)
   (let ((x (the UFix 1))
         (declare y (Unit -> UFix))
         (y (fn () (+ 1 2))))
@@ -64,7 +64,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define (f a b c)
+(define (f-parse7 a b c)
   (lisp Integer (a b c)
     (cl:+ a b c)))
 
@@ -75,11 +75,11 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(declare f ((Default :a) => (Optional :a) -> :a))
-  (define (f x)
-    (match x
-      ((Some y) y)
-      (_ (default))))
+(declare f-parse8 ((Default :a) => (Optional :a) -> :a))
+(define (f-parse8 x)
+  (match x
+    ((Some y) y)
+    (_ (default))))
 
 ================================================================================
 9 Parse expression
@@ -88,10 +88,10 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define (f)
-    (let x = 1)
-    (let ((y (from-some "invalid y" (Some 2))))
-      (+ x y)))
+(define (f-parse9)
+  (let x = 1)
+  (let ((y (from-some "invalid y" (Some 2))))
+    (+ x y)))
 
 ================================================================================
 10 Parse expression
@@ -100,7 +100,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define f
+(define f-parse10
   (the String "value"))
 
 ================================================================================
@@ -109,7 +109,7 @@
 
 (package coalton-unit-tests)
 
-(define (x) (return))
+(define (x--parse11) (return))
 
 ================================================================================
 12 Parse expression
@@ -117,7 +117,7 @@
 
 (package coalton-unit-tests)
 
-(define (y) (return 5))
+(define (y--parse12) (return 5))
 
 ================================================================================
 13 Parse expression
@@ -126,7 +126,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define z (+ 1 (+ 2 (* 3 5))))
+(define z-parse13 (+ 1 (+ 2 (* 3 5))))
 
 ================================================================================
 14 Parse expression
@@ -135,10 +135,10 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define (f)
+(define (f-parse14)
   (progn
     (let x = 1)
-    (f x)
+    (f-parse14 x)
     (let y = 2)
     (+ x y)))
 
@@ -149,7 +149,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define (f x y)
+(define (f--parse15 x y)
   (if (== x y)
     1
     2))
@@ -161,7 +161,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define (f x y)
+(define (f--parse16 x y)
   (when (== x y)
     (let _z = 3)
     (print "hello"))
@@ -176,7 +176,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define (f ax bx)
+(define (f-parse17 ax bx)
   (do
    (a <- ax)
    (b <- bx)
@@ -190,7 +190,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define x
+(define x--parse18
   (cond 
     (True 1)
     ((> 2 3) 2)))
@@ -202,7 +202,7 @@
 (package coalton-unit-tests/prelude
   (import coalton-prelude))
 
-(define x
+(define x-parse19
   (fn ((Tuple x _y)) x))
 
 ================================================================================

--- a/tests/test-files/parse-method.txt
+++ b/tests/test-files/parse-method.txt
@@ -2,7 +2,7 @@
 100 Malformed method definition
 ================================================================================
 
-(package test)
+(package test/method-def)
 
 (define-class (Greetable :a)
   (Greet :a Unit))
@@ -21,7 +21,7 @@ error: Malformed method definition
 101 Malformed method definition
 ================================================================================
 
-(package test)
+(package test/method-def)
 
 (define-class (Oops :a)
   (Ouch "This method stubbed its toe" :a Unit))

--- a/tests/test-files/parse-return.txt
+++ b/tests/test-files/parse-return.txt
@@ -4,7 +4,7 @@
 
 (package coalton-unit-tests)
 
-(define (f)
+(define (f-return-test)
   (return))
 
 ================================================================================

--- a/tests/test-files/toplevel-progn.txt
+++ b/tests/test-files/toplevel-progn.txt
@@ -6,10 +6,10 @@
 
 (progn
   (repr :transparent)
-  (define-type T
-    (T Integer))
+  (define-type TPrognTest
+    (TPrognTest Integer))
 
-  (define (f x) x))
+  (define (f-progn-test x) x))
 
 ================================================================================
 100 Invalid attribute for progn

--- a/tests/test-files/unused-variables.txt
+++ b/tests/test-files/unused-variables.txt
@@ -89,7 +89,7 @@ help: prefix the variable with '_' to declare it unused
 (package coalton-unit-tests/unused-variables
   (import coalton-prelude))
 
-(define (f) 5)
+(define (f-hidden1) 5)
 
 --------------------------------------------------------------------------------
 
@@ -100,6 +100,6 @@ help: prefix the variable with '_' to declare it unused
 (package coalton-unit-tests/unused-variables
   (import coalton-prelude))
 
-(define f (fn () 5))
+(define f-hidden2 (fn () 5))
 
 --------------------------------------------------------------------------------

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -119,6 +119,7 @@ Returns (values SOURCE-PATHNAME COMPILED-PATHNAME)."
 
 (defun run-test-file (pathname)
   "Run the test file at PATHNAME."
+  (format t "~&;; --- Running test file: ~A~%" pathname)
   (let ((file (test-file pathname))
         (coalton-impl/settings:*coalton-print-unicode* nil))
     (loop :for (line number flags description program expected-error)


### PR DESCRIPTION
fix naming collisions in tests
    
This doesn't fix #1495 but temporarily mitigates its effects.
    
This fixes #1471.