### PR TITLE
Revert "ensure inlining within a single translation unit"

### DIFF
--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -110,17 +110,12 @@ mapping known function names to their arity."
            (type tc:environment env)
            (values binding-list tc:environment))
 
-  ;; Make code and environment data available to the inliner
-  (loop :for (name . node) :in bindings
-        :do (setf env (tc:set-code env name node)))
-  (setf env (update-function-env bindings inline-p-table env))
 
   (let ((bindings (optimize-bindings-initial bindings package env)))
 
     ;; Make code and environment data available to the monomorphizer
     (loop :for (name . node) :in bindings
           :do (setf env (tc:set-code env name node)))
-    (setf env (update-function-env bindings inline-p-table env))
 
     (let* ((manager (make-candidate-manager))
 
@@ -158,19 +153,21 @@ mapping known function names to their arity."
       ;; Update function env
       (setf env (update-function-env bindings inline-p-table env))
 
-      (setf bindings
-            (loop :with function-table := (make-function-table env)
-                  :for (name . node) :in bindings
-                  :collect (cons name (direct-application node function-table))))
 
-      ;; Update code db
-      (loop :for (name . node) :in bindings
-            :do (setf env (tc:set-code env name node)))
+      (let ((function-table (make-function-table env)))
 
-      (loop :for (name . node) :in bindings
-            :do (typecheck-node node env))
+        (setf bindings
+              (loop :for (name . node) :in bindings
+                    :collect (cons name (direct-application node function-table))))
 
-      (values bindings env))))
+        ;; Update code db
+        (loop :for (name . node) :in bindings
+              :do (setf env (tc:set-code env name node)))
+
+        (loop :for (name . node) :in bindings
+              :do (typecheck-node node env))
+
+        (values bindings env)))))
 
 (defun direct-application (node table)
   "Rewrite NODE to use DIRECT-APPLICATIONs when possible. A rewrite is


### PR DESCRIPTION
This reverts commit d060d881b4d947cd11d5110376e4caedb92b38ee.

This seems to have broken inlining, conversion to DIRECT-APPLICATIONs, etc. Needs more investigation and unit tests.