### PR TITLE
Remove Num instance from Optional type

### DIFF
--- a/library/optional.lisp
+++ b/library/optional.lisp
@@ -67,12 +67,6 @@
         ((Tuple (None) (None))
          Eq))))
 
-  (define-instance (Num :a => Num (Optional :a))
-    (define (+ a b) (liftA2 + a b))
-    (define (- a b) (liftA2 - a b))
-    (define (* a b) (liftA2 * a b))
-    (define (fromInt x) (pure (fromInt x))))
-
   (define-instance (Semigroup :a => Semigroup (Optional :a))
     (define (<> a b)
       (match (Tuple a b)

--- a/library/system.lisp
+++ b/library/system.lisp
@@ -140,7 +140,7 @@ A garbage collection will be forced prior to invoking `f`."
     (let start = (monotonic-bytes-consed))
     (let value = (f))
     (let end   = (monotonic-bytes-consed))
-    (Tuple value (- end start)))
+    (Tuple value (liftA2 - end start)))
 
   (define-struct (MeteredResult :a)
     "Function output with space and timing metedata."
@@ -168,7 +168,7 @@ Garbage collection will be performed before profiling is performed."
     (MeteredResult
      value
      (- end-real-time start-real-time)
-     (- end-bytes-consed start-bytes-consed))))
+     (liftA2 - end-bytes-consed start-bytes-consed))))
 
 
 ;;;

--- a/tests/list-tests.lisp
+++ b/tests/list-tests.lisp
@@ -44,7 +44,7 @@
   (is (== (list:take 2 x) (make-list 1 2))))
 
 (define-test test-search ()
-  (is (== (list:find even? x)  (Some 2)))
+  (is (== (list:find even? x) (Some (the Integer 2))))
   (is (== (list:find (< 10) x) None))
 
   (is (== (list:filter odd? x) (make-list 1 3)))
@@ -57,9 +57,9 @@
   (is (== (list:nth-cdr 3 (make-list 1 2 3 4 5 6 7)) (make-list 4 5 6 7)))
   (is (== (list:nth-cdr 4 (make-list 1 2 3)) nil))
 
-  (is (== (list:elemIndex 2 x) 1))
+  (is (== (list:elemIndex 2 x) (Some 1)))
 
-  (is (== (list:findIndex even? x) 1))
+  (is (== (list:findIndex even? x) (Some 1)))
 
   (is (== (list:length x) 3)))
 

--- a/tests/monad/optionalt.lisp
+++ b/tests/monad/optionalt.lisp
@@ -30,7 +30,7 @@
   (declare split-positive-state (st:ST (Optional Integer) :a
                                  -> Result (Optional Integer) (Optional Integer)))
   (define (split-positive-state stateful-calculation)
-    (let (Tuple state _) = (st:run stateful-calculation 0))
+    (let (Tuple state _) = (st:run stateful-calculation (Some 0)))
     (match state
       ((None) (Err None))
       ((Some x)

--- a/tests/runtime-tests.lisp
+++ b/tests/runtime-tests.lisp
@@ -106,7 +106,7 @@
 
 ;; Test defaulting and context reduction
 (define-test test-defaulting ()
-  (is (== (+ (Some (Some (the Integer 1))) (Some (Some 2))) (Some (Some 3)))))
+  (is (== (liftA2 (liftA2 +) (Some (Some (the Integer 1))) (Some (Some 2))) (Some (Some 3)))))
 
 
 ;; Test that explicit type declarations in let bindings work


### PR DESCRIPTION
https://github.com/coalton-lang/coalton/issues/1492

We might want to change the name of `test-defaulting` in `runtime-tests.lisp` since it doesn't test defaulting.