### PR TITLE
Ensure printing of constructors iff exported

### DIFF
--- a/src/doc/environment.lisp
+++ b/src/doc/environment.lisp
@@ -77,10 +77,10 @@ If non-nil, restrict to types defined in PACKAGE."
 
 By default the global environment is queried.
 If non-nil, restrict to constructors defined in PACKAGE."
-  (remove-if-not (lambda (constructor-entry)
-                   (and package
-                        (not (exported-symbol-p (tc:constructor-entry-name constructor-entry) package t))))
-                 (%values (tc:environment-constructor-environment environment))))
+  (remove-if (lambda (constructor-entry)
+               (and package
+                    (not (exported-symbol-p (tc:constructor-entry-name constructor-entry) package t))))
+             (%values (tc:environment-constructor-environment environment))))
 
 (defun find-names (&key (environment entry:*global-environment*)
                         (type nil)

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -179,13 +179,14 @@
             :for ctor-docstring := (source:docstring ctor)
             :do (let ((args (type-constructor-args object ctor-type)))
                   (cond (args
-                         (format stream "- <code>(~A~{ ~A~} ~A)</code>~%"
+                         (format stream "- <code>(~A~{ ~A~})</code>~A~%"
                                  (html-entities:encode-entities (symbol-name ctor-name))
                                  (mapcar #'to-markdown args)
-                                 (or ctor-docstring "")))
+                                 (if (null ctor-docstring) "" (format nil "~%  - ~A" ctor-docstring))))
                         (t
-                         (format stream "- <code>~A</code>~%"
-                                 (html-entities:encode-entities (symbol-name ctor-name))))))))
+                         (format stream "- <code>~A</code> ~A~%"
+                                 (html-entities:encode-entities (symbol-name ctor-name))
+                                 (if (null ctor-docstring) "" (format nil "~%  - ~A" ctor-docstring))))))))
     (write-doc backend object)
     (write-instances backend object)))
 


### PR DESCRIPTION
Closes #1486.

Example of print formatting for exported constructors:

<img width="454" height="188" alt="image" src="https://github.com/user-attachments/assets/55e00d8a-ec0b-40d1-a17d-fa733f603e83" />

Example of omitted constructors:

<img width="558" height="156" alt="image" src="https://github.com/user-attachments/assets/ed5d8953-cae3-40af-ac73-2d0a0118525f" />
