### PR TITLE
Derive Recursive Types

### DIFF
--- a/library/derivers.lisp
+++ b/library/derivers.lisp
@@ -4,12 +4,11 @@
    (#:tc #:coalton-impl/typechecker)
    (#:classes #:coalton-library/classes)
    (#:parser #:coalton-impl/parser)
-   (#:source #:coalton-impl/source)
-   (#:derive #:coalton-impl/typechecker/derive)))
+   (#:source #:coalton-impl/source)))
 
 (in-package #:coalton-library/derivers)
 
-(defmethod derive:derive-methods ((class (eql 'classes:eq)) def env)
+(defmethod tc:derive-methods ((class (eql 'classes:eq)) def env)
   "Deriver implementation for class `Eq'."
   (let ((location (source:location def)))
     (list

--- a/library/derivers.lisp
+++ b/library/derivers.lisp
@@ -1,6 +1,7 @@
 (defpackage #:coalton-library/derivers
   (:use #:cl)
   (:local-nicknames
+   (#:tc #:coalton-impl/typechecker)
    (#:classes #:coalton-library/classes)
    (#:parser #:coalton-impl/parser)
    (#:source #:coalton-impl/source)

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -36,7 +36,7 @@
 
         (env *global-environment*))
 
-    (multiple-value-bind (type-definitions derivations instances env)
+    (multiple-value-bind (type-definitions instances env)
         (tc:toplevel-define-type (parser:program-types program)
                                  (parser:program-structs program)
                                  (parser:program-type-aliases program)
@@ -48,7 +48,11 @@
             (tc:toplevel-define-class (parser:program-classes program)
                                       env)
 
-          (let ((all-instances (append all-instances (tc:derive-class-instances derivations env)))) 
+          (let ((all-instances
+                  (append all-instances
+                          (tc:derive-class-instances (parser:program-types program)
+                                                     (parser:program-structs program)
+                                                     env)))) 
 
             (multiple-value-bind (ty-instances env)
                 (tc:toplevel-define-instance all-instances env)

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -25,6 +25,8 @@
 
 (defvar *global-environment* (tc:make-default-environment))
 
+(defparameter *ty-instances* nil)
+
 (defun entry-point (program)
   (declare (type parser:program program))
 
@@ -34,7 +36,7 @@
 
         (env *global-environment*))
 
-    (multiple-value-bind (type-definitions instances env)
+    (multiple-value-bind (type-definitions derivations instances env)
         (tc:toplevel-define-type (parser:program-types program)
                                  (parser:program-structs program)
                                  (parser:program-type-aliases program)
@@ -46,62 +48,65 @@
             (tc:toplevel-define-class (parser:program-classes program)
                                       env)
 
-          (multiple-value-bind (ty-instances env)
-              (tc:toplevel-define-instance all-instances env)
+          (let ((all-instances (append all-instances (tc:derive-class-instances derivations env)))) 
 
-            (multiple-value-bind (toplevel-definitions env)
-                (tc:toplevel-define (parser:program-defines program)
-                                    (parser:program-declares program)
-                                    env)
+            (multiple-value-bind (ty-instances env)
+                (tc:toplevel-define-instance all-instances env)
 
-              (multiple-value-bind (toplevel-instances)
-                  (tc:toplevel-typecheck-instance ty-instances
-                                                  all-instances
-                                                  env)
 
-                (setf env (tc:toplevel-specialize (parser:program-specializations program) env))
+              (multiple-value-bind (toplevel-definitions env)
+                  (tc:toplevel-define (parser:program-defines program)
+                                      (parser:program-declares program)
+                                      env)
 
-                (let ((monomorphize-table (make-hash-table :test #'eq))
+                (multiple-value-bind (toplevel-instances)
+                    (tc:toplevel-typecheck-instance ty-instances
+                                                    all-instances
+                                                    env)
 
-                      (inline-p-table (make-hash-table :test #'eq))
+                  (setf env (tc:toplevel-specialize (parser:program-specializations program) env))
 
-                      (translation-unit
-                        (tc:make-translation-unit
-                         :types type-definitions
-                         :definitions toplevel-definitions
-                         :classes class-definitions
-                         :instances toplevel-instances
-                         :lisp-forms (parser:program-lisp-forms program)
-                         :package *package*)))
+                  (let ((monomorphize-table (make-hash-table :test #'eq))
 
-                  (loop :for define :in (parser:program-defines program)
-                        :when (parser:toplevel-define-monomorphize define)
-                          :do (setf (gethash (parser:node-variable-name (parser:toplevel-define-name define))
-                                             monomorphize-table)
-                                    t)
-                        :when (parser:toplevel-define-inline define)
-                          :do (setf (gethash (parser:node-variable-name (parser:toplevel-define-name define))
-                                             inline-p-table)
-                                    t))
+                        (inline-p-table (make-hash-table :test #'eq))
 
-                  (loop :for declare :in (parser:program-declares program)
-                        :when (parser:toplevel-declare-monomorphize declare)
-                          :do (setf (gethash (parser:identifier-src-name (parser:toplevel-declare-name declare))
-                                             monomorphize-table)
-                                    t)
-                        :when (parser:toplevel-declare-inline declare)
-                          :do (setf (gethash (parser:identifier-src-name (parser:toplevel-declare-name declare))
-                                             inline-p-table)
-                                    t))
+                        (translation-unit
+                          (tc:make-translation-unit
+                           :types type-definitions
+                           :definitions toplevel-definitions
+                           :classes class-definitions
+                           :instances toplevel-instances
+                           :lisp-forms (parser:program-lisp-forms program)
+                           :package *package*)))
 
-                  (loop :for ty-instance :in ty-instances
-                        :for method-codegen-inline-p := (tc:ty-class-instance-method-codegen-inline-p ty-instance)
-                        :do (loop :for (method-codegen-sym . inline-p) :in method-codegen-inline-p
-                                  :do (when inline-p (setf (gethash method-codegen-sym inline-p-table) t))))
+                    (loop :for define :in (parser:program-defines program)
+                          :when (parser:toplevel-define-monomorphize define)
+                            :do (setf (gethash (parser:node-variable-name (parser:toplevel-define-name define))
+                                               monomorphize-table)
+                                      t)
+                          :when (parser:toplevel-define-inline define)
+                            :do (setf (gethash (parser:node-variable-name (parser:toplevel-define-name define))
+                                               inline-p-table)
+                                      t))
 
-                  (analysis:analyze-translation-unit translation-unit env)
+                    (loop :for declare :in (parser:program-declares program)
+                          :when (parser:toplevel-declare-monomorphize declare)
+                            :do (setf (gethash (parser:identifier-src-name (parser:toplevel-declare-name declare))
+                                               monomorphize-table)
+                                      t)
+                          :when (parser:toplevel-declare-inline declare)
+                            :do (setf (gethash (parser:identifier-src-name (parser:toplevel-declare-name declare))
+                                               inline-p-table)
+                                      t))
 
-                  (codegen:compile-translation-unit translation-unit monomorphize-table inline-p-table env))))))))))
+                    (loop :for ty-instance :in ty-instances
+                          :for method-codegen-inline-p := (tc:ty-class-instance-method-codegen-inline-p ty-instance)
+                          :do (loop :for (method-codegen-sym . inline-p) :in method-codegen-inline-p
+                                    :do (when inline-p (setf (gethash method-codegen-sym inline-p-table) t))))
+
+                    (analysis:analyze-translation-unit translation-unit env)
+
+                    (codegen:compile-translation-unit translation-unit monomorphize-table inline-p-table env)))))))))))
 
 
 (defun expression-entry-point (node)

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -25,8 +25,6 @@
 
 (defvar *global-environment* (tc:make-default-environment))
 
-(defparameter *ty-instances* nil)
-
 (defun entry-point (program)
   (declare (type parser:program program))
 

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -64,6 +64,7 @@
    #:toplevel-define-struct-derive               ; ACCESSOR
    #:toplevel-define-struct-head-location        ; ACCESSOR
    #:toplevel-define-struct-list                 ; TYPE
+   #:toplevel-define-type-or-struct              ; TYPE
    #:toplevel-declare                            ; STRUCT
    #:make-toplevel-declare                       ; CONSTRUCTOR
    #:toplevel-declare-name                       ; ACCESSOR
@@ -347,6 +348,9 @@
 
 (deftype toplevel-define-struct-list ()
   '(satisfies toplevel-define-struct-list-p))
+
+(deftype toplevel-define-type-or-struct ()
+  '(or toplevel-define-type toplevel-define-struct))
 
 (defstruct (toplevel-declare
             (:copier nil))

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -28,6 +28,30 @@
 
 (in-package #:coalton-impl/typechecker/define-instance)
 
+(defun expand-constraint (constraint env)
+  (declare (type tc:ty-predicate constraint)
+           (type tc:environment env)
+           (values tc:ty-predicate-list &optional))
+
+  (labels ((f (constraint env base)
+             (multiple-value-bind (inst subs) (tc:lookup-class-instance env constraint :no-error t)
+               (if inst
+                   (mapcan (alexandria:rcurry #'f env base)
+                           (mapcar (alexandria:curry #'tc:apply-substitution subs)
+                                   (remove-if (alexandria:curry #'tc:type-predicate= base)
+                                              (tc:ty-class-instance-constraints inst))))
+                   (list constraint)))))
+    (f constraint env constraint)))
+
+(defun expand-context (context env)
+  (declare (type tc:ty-predicate-list context)
+           (type tc:environment env)
+           (values tc:ty-predicate-list &optional))
+
+  (remove-duplicates
+   (mapcan (alexandria:rcurry #'expand-constraint env) context)
+   :test #'tc:type-predicate=))
+
 (defun toplevel-define-instance (instances env)
   (declare (type parser:toplevel-define-instance-list instances)
            (type tc:environment env)
@@ -161,6 +185,9 @@
         (loop :for method-name :in method-names
               :for method-codegen-sym :in method-codegen-syms :do
                 (setf env (tc:set-method-inline env method-name instance-codegen-sym method-codegen-sym)))
+
+        (setf (tc:ty-class-instance-constraints instance-entry)
+              (expand-context context env))
 
         (values instance-entry env)))))
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -38,7 +38,8 @@ to write an instance with signature `(Eq A => Eq A)'."
            (values tc:ty-predicate-list &optional))
 
   (labels ((f (constraint env)
-             (multiple-value-bind (inst subs) (tc:lookup-class-instance env constraint :no-error t)
+             (multiple-value-bind (inst subs)
+                 (tc:lookup-class-instance env constraint :no-error t)
                (if inst
                    (mapcan (a:rcurry #'f env)
                            (mapcar (a:curry #'tc:apply-substitution subs)

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -68,7 +68,10 @@ to write an instance with signature `(Eq A => Eq A)'."
                               (define-instance-in-environment instance env)
                             (setf env env_)
                             instance))
-         :do (setf (tc:ty-class-instance-constraints instance)
+         :do
+            ;; Expand the constraints, perhaps it should be done in a
+            ;; different stage but this works.
+            (setf (tc:ty-class-instance-constraints instance)
                    (expand-context (tc:ty-class-instance-constraints instance) env))
          :collect instance)
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -72,7 +72,7 @@ to write an instance with signature `(Eq A => Eq A)'."
             ;; Expand the constraints, perhaps it should be done in a
             ;; different stage but this works.
             (setf (tc:ty-class-instance-constraints instance)
-                   (expand-context (tc:ty-class-instance-constraints instance) env))
+                  (expand-context (tc:ty-class-instance-constraints instance) env))
          :collect instance)
 
    env))

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -28,20 +28,20 @@
 
 (in-package #:coalton-impl/typechecker/define-instance)
 
-(defun expand-constraint (constraint env)
-  (declare (type tc:ty-predicate constraint)
+(defun expand-constraint (base-constraint env)
+  (declare (type tc:ty-predicate base-constraint)
            (type tc:environment env)
            (values tc:ty-predicate-list &optional))
 
-  (labels ((f (constraint env base)
+  (labels ((f (constraint env)
              (multiple-value-bind (inst subs) (tc:lookup-class-instance env constraint :no-error t)
                (if inst
-                   (mapcan (alexandria:rcurry #'f env base)
+                   (mapcan (alexandria:rcurry #'f env)
                            (mapcar (alexandria:curry #'tc:apply-substitution subs)
-                                   (remove-if (alexandria:curry #'tc:type-predicate= base)
+                                   (remove-if (alexandria:curry #'tc:type-predicate= base-constraint)
                                               (tc:ty-class-instance-constraints inst))))
                    (list constraint)))))
-    (f constraint env constraint)))
+    (f base-constraint env)))
 
 (defun expand-context (context env)
   (declare (type tc:ty-predicate-list context)

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -59,11 +59,15 @@
            (values tc:ty-class-instance-list tc:environment))
 
   (values
-   (loop :for instance :in instances
-         :collect (multiple-value-bind (instance env_)
-                      (define-instance-in-environment instance env)
-                    (setf env env_)
-                    instance))
+   (loop :for instance :in 
+           (loop :for instance :in instances
+                 :collect (multiple-value-bind (instance env_)
+                              (define-instance-in-environment instance env)
+                            (setf env env_)
+                            instance))
+         :do (setf (tc:ty-class-instance-constraints instance)
+                   (expand-context (tc:ty-class-instance-constraints instance) env))
+         :collect instance)
 
    env))
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -30,6 +30,9 @@
 (in-package #:coalton-impl/typechecker/define-instance)
 
 (defun expand-constraint (base-constraint env)
+  "This was implemented as a hack to make `derive' work on recursive
+types.  It gets rid of recursive constraints in class instances, allowing you
+to write an instance with signature `(Eq A => Eq A)'."
   (declare (type tc:ty-predicate base-constraint)
            (type tc:environment env)
            (values tc:ty-predicate-list &optional))
@@ -190,9 +193,6 @@
         (loop :for method-name :in method-names
               :for method-codegen-sym :in method-codegen-syms :do
                 (setf env (tc:set-method-inline env method-name instance-codegen-sym method-codegen-sym)))
-
-        (setf (tc:ty-class-instance-constraints instance-entry)
-              (expand-context context env))
 
         (values instance-entry env)))))
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -16,6 +16,7 @@
    #:make-tc-env
    #:infer-expl-binding-type)
   (:local-nicknames
+   (#:a #:alexandria)
    (#:settings #:coalton-impl/settings)
    (#:source #:coalton-impl/source)
    (#:util #:coalton-impl/util)
@@ -36,9 +37,9 @@
   (labels ((f (constraint env)
              (multiple-value-bind (inst subs) (tc:lookup-class-instance env constraint :no-error t)
                (if inst
-                   (mapcan (alexandria:rcurry #'f env)
-                           (mapcar (alexandria:curry #'tc:apply-substitution subs)
-                                   (remove-if (alexandria:curry #'tc:type-predicate= base-constraint)
+                   (mapcan (a:rcurry #'f env)
+                           (mapcar (a:curry #'tc:apply-substitution subs)
+                                   (remove-if (a:curry #'tc:type-predicate= base-constraint)
                                               (tc:ty-class-instance-constraints inst))))
                    (list constraint)))))
     (f base-constraint env)))
@@ -49,7 +50,7 @@
            (values tc:ty-predicate-list &optional))
 
   (remove-duplicates
-   (mapcan (alexandria:rcurry #'expand-constraint env) context)
+   (a:mappend (a:rcurry #'expand-constraint env) context)
    :test #'tc:type-predicate=))
 
 (defun toplevel-define-instance (instances env)
@@ -118,7 +119,7 @@
            (context (tc:apply-ksubstitution ksubs context)))
 
       (let* ((instance-codegen-sym
-               (alexandria:format-symbol
+               (a:format-symbol
                 *package*
                 "INSTANCE/~A"
                 (with-output-to-string (s)
@@ -130,9 +131,9 @@
                                    (tc:ty-class-unqualified-methods class)))
 
              (method-codegen-syms (mapcar (lambda (method-name)
-                                            (alexandria:format-symbol *package* "~A-~S"
-                                                                      instance-codegen-sym
-                                                                      method-name))
+                                            (a:format-symbol *package* "~A-~S"
+                                                             instance-codegen-sym
+                                                             method-name))
                                           method-names))
 
              (method-codegen-inline-p
@@ -250,7 +251,7 @@
 
     (check-duplicates
      (parser:toplevel-define-instance-methods unparsed-instance)
-     (alexandria:compose #'parser:node-variable-name #'parser:instance-method-definition-name)
+     (a:compose #'parser:node-variable-name #'parser:instance-method-definition-name)
      (lambda (first second)
        (tc-error "Duplicate method definition"
                  (tc-note first "first definition here")
@@ -271,8 +272,8 @@
     ;; Ensure each method is defined
     (loop :for name :being :the :hash-keys :of method-table
           :for method := (find name (parser:toplevel-define-instance-methods unparsed-instance)
-                               :key (alexandria:compose #'parser:node-variable-name
-                                                        #'parser:instance-method-definition-name))
+                               :key (a:compose #'parser:node-variable-name
+                                               #'parser:instance-method-definition-name))
           :unless method
             :do (tc-error "Missing method"
                           (tc-note unparsed-instance "The method ~S is not defined" name)))

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -87,7 +87,7 @@
            (type parser:toplevel-define-struct-list structs)
            (type parser:toplevel-define-type-alias-list type-aliases)
            (type tc:environment env)
-           (values type-definition-list derive:toplevel-derivation-list parser:toplevel-define-instance-list tc:environment))
+           (values type-definition-list parser:toplevel-define-instance-list tc:environment))
 
   ;; Ensure that all types are defined in the current package
   (check-package (append types structs type-aliases)
@@ -211,14 +211,6 @@
 
                             :do (setf env (update-env-for-type-definition type vars parser-type env))
                             :finally (return type-definitions))))
-     (loop :for type :in (append types structs)
-           :for derive := (parser:type-definition-derive type)
-           :for classes := (and derive (parser:attribute-derive-classes derive))
-           :when classes
-             :nconc (loop :for class :in (cst:raw classes)
-                          :collect (derive:make-toplevel-derivation
-                                    :type-definition type
-                                    :class class)))
      instances
      env)))
 

--- a/src/typechecker/derive.lisp
+++ b/src/typechecker/derive.lisp
@@ -80,10 +80,11 @@ EQL-specialize on symbol `class'."))
   (loop :for type :in (append types structs)
         :for derive := (parser:type-definition-derive type)
         :for classes := (and derive (parser:attribute-derive-classes derive))
-        :when classes :nconc (loop :for class :in (cst:raw classes)
-                                   :collect (make-toplevel-derivation
-                                             :type-definition type
-                                             :class class))))
+        :unless (null classes)
+          :nconc (loop :for class :in (cst:raw classes)
+                       :collect (make-toplevel-derivation
+                                 :type-definition type
+                                 :class class))))
 
 (defun derive-class-instances (types structs env)
   "Entrypoint for deriver implementations.  Given a list of types and

--- a/src/typechecker/derive.lisp
+++ b/src/typechecker/derive.lisp
@@ -15,12 +15,9 @@
 
 (in-package #:coalton-impl/typechecker/derive)
 
-(deftype parser-definition ()
-  '(or parser:toplevel-define-type parser:toplevel-define-struct))
-
 (defstruct toplevel-derivation
-  (type-definition (util:required 'type-definition) :type parser-definition :read-only t)
-  (class           (util:required 'class)           :type symbol            :read-only t))
+  (type-definition (util:required 'type-definition) :type parser:toplevel-define-type-or-struct :read-only t)
+  (class           (util:required 'class)           :type symbol                                :read-only t))
 
 (defun toplevel-derivation-list-p (x)
   (and (alexandria:proper-list-p x)
@@ -30,7 +27,7 @@
   '(satisfies toplevel-derivation-list-p))
 
 (defun parser-definition-type-constraints (def class)
-  (declare (type parser-definition def)
+  (declare (type parser:toplevel-define-type-or-struct def)
            (type symbol class)
            (values parser:ty-predicate-list &optional))
 
@@ -45,7 +42,7 @@
                               (parser:type-definition-ctors def))))
 
 (defun parser-definition-type-signature (def)
-  (declare (type parser-definition def)
+  (declare (type parser:toplevel-define-type-or-struct def)
            (values parser:ty &optional))
 
   (labels ((apply-type-argument-list (ty args)

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -719,7 +719,7 @@
 ;;;
 
 (defstruct ty-class-instance
-  (constraints             (util:required 'constraints)             :type ty-predicate-list :read-only t)
+  (constraints             (util:required 'constraints)             :type ty-predicate-list :read-only nil)
   (predicate               (util:required 'predicate)               :type ty-predicate      :read-only t)
   (codegen-sym             (util:required 'codegen-sym)             :type symbol            :read-only t)
   (method-codegen-syms     (util:required 'method-codegen-syms)     :type util:symbol-list  :read-only t)

--- a/src/typechecker/package.lisp
+++ b/src/typechecker/package.lisp
@@ -11,6 +11,7 @@
    #:coalton-impl/typechecker/partial-type-env
    #:coalton-impl/typechecker/parse-type
    #:coalton-impl/typechecker/define-type
+   #:coalton-impl/typechecker/derive
    #:coalton-impl/typechecker/define-class
    #:coalton-impl/typechecker/tc-env
    #:coalton-impl/typechecker/define

--- a/tests/deriver-tests.lisp
+++ b/tests/deriver-tests.lisp
@@ -34,27 +34,26 @@
 (define-test derive-basic-test ()
   "Ensure `Eq' can be derived for structs and types."
   (is (== Nothing (The (DerivingThing U8) Nothing)))
-  (is (not (== Nothing (Something 12))))
+  (is (/= Nothing (Something 12)))
   (is (== (Something "hi") (Something "hi")))
   (is (== (Something 12) (Something 12)))
 
   (is (== (DerivingPerson 1 "a" (vector:make (Something "computer")))
           (DerivingPerson 1 "a" (vector:make (Something "computer")))))
-  (is (not (== (DerivingPerson 1 "a" (vector:make (Something "computer")))
-               (DerivingPerson 1 "a" (vector:make (Something "sardine")))))))
+  (is (/= (DerivingPerson 1 "a" (vector:make (Something "computer")))
+          (DerivingPerson 1 "a" (vector:make (Something "sardine"))))))
 
 (define-test derive-recursive-test ()
   "Ensure deriving works for single recursive types."
   (is (== (the (DeriveTree UFix) DeriveLeaf) DeriveLeaf))
-  (is (not (== DeriveLeaf (the (DeriveTree UFix) (DeriveNode 1 DeriveLeaf DeriveLeaf)))))
-  (is (== (the (DeriveTree UFix) (DeriveNode 1 DeriveLeaf DeriveLeaf)) (DeriveNode 1 DeriveLeaf DeriveLeaf)))
-  )
+  (is (/= DeriveLeaf (the (DeriveTree UFix) (DeriveNode 1 DeriveLeaf DeriveLeaf))))
+  (is (== (the (DeriveTree UFix) (DeriveNode 1 DeriveLeaf DeriveLeaf)) (DeriveNode 1 DeriveLeaf DeriveLeaf))))
 
 (define-test derive-mutually-recursive-test ()
   "Ensure deriving works for mutually recursive types."
   (is (== B0 B0))
   (is (== (Bn (An B0)) (Bn (An B0))))
-  (is (not (== B0 (Bn (An B0))))))
+  (is (/= B0 (Bn (An B0)))))
 
 
 (in-package #:coalton-tests)

--- a/tests/deriver-tests.lisp
+++ b/tests/deriver-tests.lisp
@@ -14,6 +14,23 @@
     (name String)
     (things (vector:Vector (DerivingThing :a)))))
 
+(coalton-toplevel
+  (derive Eq)
+  (define-type (DeriveTree :t)
+    DeriveLeaf
+    (DeriveNode :t (DeriveTree :t) (DeriveTree :t))))
+
+(coalton-toplevel
+  (derive Eq)
+  (define-type A
+    A0
+    (An B))
+
+  (derive Eq)
+  (define-type B
+    B0
+    (Bn A)))
+
 (define-test derive-basic-test ()
   "Ensure `Eq' can be derived for structs and types."
   (is (== Nothing (The (DerivingThing U8) Nothing)))
@@ -25,6 +42,19 @@
           (DerivingPerson 1 "a" (vector:make (Something "computer")))))
   (is (not (== (DerivingPerson 1 "a" (vector:make (Something "computer")))
                (DerivingPerson 1 "a" (vector:make (Something "sardine")))))))
+
+(define-test derive-recursive-test ()
+  "Ensure deriving works for single recursive types."
+  (is (== (the (DeriveTree UFix) DeriveLeaf) DeriveLeaf))
+  (is (not (== DeriveLeaf (the (DeriveTree UFix) (DeriveNode 1 DeriveLeaf DeriveLeaf)))))
+  (is (== (the (DeriveTree UFix) (DeriveNode 1 DeriveLeaf DeriveLeaf)) (DeriveNode 1 DeriveLeaf DeriveLeaf)))
+  )
+
+(define-test derive-mutually-recursive-test ()
+  "Ensure deriving works for mutually recursive types."
+  (is (== B0 B0))
+  (is (== (Bn (An B0)) (Bn (An B0))))
+  (is (not (== B0 (Bn (An B0))))))
 
 
 (in-package #:coalton-tests)

--- a/tests/test-files/define-type.txt
+++ b/tests/test-files/define-type.txt
@@ -422,3 +422,30 @@ error: Malformed derive attribute
    |
  3 |  (derive coalton-library/classes:Eq 1)
    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected class arguments
+
+================================================================================
+119 Derive recursive type
+================================================================================
+
+(package test-package)
+
+(derive coalton-library/classes:Eq)
+(define-type (Tree%% :a)
+  Leaf%%
+  (Node :a (Tree%% :a) (Tree%% :a)))
+
+
+================================================================================
+119 Derive mutually recursive types
+================================================================================
+
+(package test-package)
+
+(derive coalton-library/classes:Eq)
+(define-type AA
+  AA0
+  (AAn BB))
+(derive coalton-library/classes:Eq)
+(define-type BB
+  BB0
+  (BBn AA))

--- a/tests/test-files/define-type.txt
+++ b/tests/test-files/define-type.txt
@@ -365,7 +365,7 @@ help: remove additional docstring
   --> test:5:0
    |
  5 |   (derive Quuxableness)
-   |   ^^^^^^^^^^^^^^^^^^^^^ Class QUUXABLENESS does not exist
+   |   ^^^^^^^^^^^^^^^^^^^^^ Deriver for class QUUXABLENESS is not implemented
  6 |   (define-struct Point
    |  _^
  7 | |   (x UFix)


### PR DESCRIPTION
This fixes https://github.com/coalton-lang/coalton/issues/1517 by expanding instance constraints and excluding recursive predicates.

Now this is possible, whereas it would have caused a stack overflow before due to infinitely resolving the constraint:
```lisp
COALTON-USER> (coalton-toplevel 
                (define-type Foo (Foo UFix))
                (define-instance (Eq Foo => Eq Foo)
                  (define (== (Foo a) (Foo b))
                    (== a b))))
; No values
COALTON-USER> (coalton (== (Foo 1) (Foo 1)))
COMMON-LISP:T
```

With a recursive type, there is still a bug where the `coalton-toplevel` needs to be evaluated twice, so I need to fix that before merge.