### PR TITLE
Error message for missing method definitions

### DIFF
--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -152,17 +152,17 @@ of constraint predicates."
                                           method-names))
 
              (method-codegen-inline-p
-               (loop :with alist := ()
-                     :for method-name :in method-names
+               (loop :for method-name :in method-names
                      :for method-codegen-sym :in method-codegen-syms
                      :for method-def := (find method-name (parser:toplevel-define-instance-methods instance)
                                               :key (lambda (method-def)
                                                      (parser:node-variable-name
                                                       (parser:instance-method-definition-name method-def))))
-                     :for method-inline := (parser:instance-method-definition-inline method-def)
-                     ;; Convert from attribute inline to boolean
-                     :do (push (cons method-codegen-sym (if method-inline t nil)) alist)
-                     :finally (return alist)))
+                     :unless (null method-def)
+                       :collect (cons
+                                 method-codegen-sym
+                                 ;; Convert inline attribute to boolean.
+                                 (and (parser:instance-method-definition-inline method-def) t))))
 
              (instance-entry
                (tc:make-ty-class-instance


### PR DESCRIPTION
Fixes #1370.

The error messages for missing methods or unknown methods are already in the code base, so this PR unblocks the code path from reaching those checkpoints.

Unknown method definition:

```lisp
COALTON-USER> (define-class (C :t)
                (m :t))
; No value
COALTON-USER> (define-instance (C String)
                (define n "hi"))
```
```
error: Unknown method
  --> <macroexpansion>:3:4
   |
 3 |       (DEFINE N
   |  _____^
 4 | |       "hi")))
   | |___________^ The method COALTON-USER::N is not part of class COALTON-USER::C
   [Condition of type COALTON-IMPL/TYPECHECKER/BASE:TC-ERROR]
```

Missing method definition:

```lisp
COALTON-USER> (define-class (C :t)
                (m :t))
; No value
COALTON-USER> (define-instance (C String))
```
```
error: Missing method
  --> <macroexpansion>:2:2
   |
 2 |    (DEFINE-INSTANCE (C STRING)))
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The method M is not defined
   [Condition of type COALTON-IMPL/TYPECHECKER/BASE:TC-ERROR]
```