### PR TITLE
ensure proper error message for overapplied functions

### DIFF
--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -366,7 +366,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                    (setf preds (append preds preds_))
                                    (setf accessors (append accessors accessors_))
                                    (setf subs subs_)
-                                   (setf fun-ty_ (tc:function-type-to fun-ty_))
+                                   (setf fun-ty_ (tc:apply-substitution subs (tc:function-type-to fun-ty_)))
 
                                    node_))
 


### PR DESCRIPTION
This PR begins to address #1395.

The error message for `(max 1.0 2.0 3.0)` is fixed.

However, the error message for cases like `(max 1 2 3)` for which the types of the arguments are not fully resolved at the point at which the arity is checked are not fixed.  We check arity by reading an expression such as `(max 1.0 2.0 3.0)` as `((((max) 1.0) 2.0) 3.0)` and checking after each application if we have a function type. The issue remains that we cannot determine if `(max 1 2)` is a function type at this point, since it just has type `Num :a => :a` and `:a` which may be a function type.

This will be more complicated. It would be resolved by simply removing this block
https://github.com/coalton-lang/coalton/blob/main/src/typechecker/define.lisp#L374-L393

But I am not sure what adverse consequences my arise thereafter. It will require further investigation.