### PR TITLE
A couple of trivial fixes

### DIFF
--- a/library/experimental/loops.lisp
+++ b/library/experimental/loops.lisp
@@ -6,7 +6,6 @@
    #:coalton-library/classes
    #:coalton-library/math/arith)
   (:export
-   #:named-let
    #:repeat
    #:dotimes
    #:everytimes

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -72,7 +72,7 @@ below.")
     "The squared length of a complex number, i.e. re(a)^2 + im(a)^2."
     (let ((r (real-part a))
           (i (imag-part a)))
-       (+ (* r r) (* i i)))
+       (+ (* r r) (* i i))))
 
   (declare ii ((Complex :a) => Complex :a))
   (define ii

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -69,7 +69,7 @@ below.")
   (inline)
   (declare square-magnitude (Complex :a => Complex :a -> :a))
   (define (square-magnitude a)
-    "The length of a complex number."
+    "The squared length of a complex number, i.e. re(a)^2 + im(a)^2."
     (+ (* (real-part a) (real-part a))
        (* (imag-part a) (imag-part a))))
 

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -70,8 +70,9 @@ below.")
   (declare square-magnitude (Complex :a => Complex :a -> :a))
   (define (square-magnitude a)
     "The squared length of a complex number, i.e. re(a)^2 + im(a)^2."
-    (+ (* (real-part a) (real-part a))
-       (* (imag-part a) (imag-part a))))
+    (let ((r (real-part a))
+          (i (imag-part a)))
+       (+ (* r r) (* i i)))
 
   (declare ii ((Complex :a) => Complex :a))
   (define ii


### PR DESCRIPTION
- The docstring of `square-magnitude` lacked "squared".  It was at least confusing.
- The symbol `named-let` was exported from loops but never defined.