### PR TITLE
Fix declare faux-macro to optimize for CL editing

### DIFF
--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -57,8 +57,7 @@
 (define-coalton-toplevel-editor-macro coalton:define-resumption (name constructor)
     "Create a new resumption with its single constructor. (Coalton top-level operator.)")
 
-;; the `&body` below is purely for the purpose editor indentation display.
-(define-coalton-toplevel-editor-macro coalton:declare (var &body type)
+(define-coalton-toplevel-editor-macro coalton:declare (var type)
     "Declare the type of a variable. (Coalton top-level operator.)")
 
 (define-coalton-toplevel-editor-macro coalton:define-class (class &body method-signatures)


### PR DESCRIPTION
Reverts this commit: https://github.com/coalton-lang/coalton/commit/39ca00c38e48ab02237fbc9eb768610b0eccb019

Making `declare` use `&body` improves indentation in Coalton type declarations, but makes it worse for CL declarations.  In my opinion it is more annoying than it is helpful, and I would like to undo this change.