### PR TITLE
Check that symbol doesn't name a macro in type-of

### DIFF
--- a/src/debug.lisp
+++ b/src/debug.lisp
@@ -171,7 +171,9 @@
 
 (defun coalton:type-of (symbol)
   "Lookup the type of value SYMBOL in the global environment"
-  (tc:lookup-value-type entry:*global-environment* symbol))
+  (if (macro-function symbol)
+      ':macro
+      (tc:lookup-value-type entry:*global-environment* symbol)))
 
 (defun coalton:describe-type-of (symbol)
   "Lookup the type of value SYMBOL in the global environment. Prints the type and type aliases."


### PR DESCRIPTION
Addresses #1549 

Or something like this.

@garlic0x1 @stylewarning @YarinHeffes 