### PR TITLE
rename Complex type class to ComplexComponent

### DIFF
--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -1129,7 +1129,7 @@ The following functions all take an optional package parameter.
 
 ## Instance Defaulting
 
-Coalton has a similar [type defaulting system](https://www.haskell.org/onlinereport/decls.html#sect4.3.4) as Haskell. Type defaulting is invoked on implicitly typed definitions and code compiled with the `coalton` macro. Defaulting is applied to a set of ambiguous predicates, with the goal to resolve an ambiguous type variable to a valid type. Coalton will only default if one or more of the predicates is a numeric type class (Num, Quantizable, Reciprocable, Complex, Remainder, Integral). Coalton will default an ambiguous variable to either `Integer`, `F32`, or `F64`; taking the first type that is valid for all predicates referencing that type variable. Coalton will not default when one or more of the predicates containing an ambiguous variable is a multi-parameter type class.
+Coalton has a similar [type defaulting system](https://www.haskell.org/onlinereport/decls.html#sect4.3.4) as Haskell. Type defaulting is invoked on implicitly typed definitions and code compiled with the `coalton` macro. Defaulting is applied to a set of ambiguous predicates, with the goal to resolve an ambiguous type variable to a valid type. Coalton will only default if one or more of the predicates is a numeric type class (`Num`, `Quantizable`, `Reciprocable`, `ComplexComponent`, `Remainder`, `Integral`). Coalton will default an ambiguous variable to either `Integer`, `F32`, or `F64`; taking the first type that is valid for all predicates referencing that type variable. Coalton will not default when one or more of the predicates containing an ambiguous variable is a multi-parameter type class.
 
 
 Differences from Haskell 98. Haskell would consider `Num (List :a)` to be ambiguous, Coalton would default it to `Num Integer`. Haskell would consider (`Num :a` `CustomTypeClass :a`) to be ambiguous, Coalton would default to (`Num Integer` `CustomTypeClass Integer`) assuming `CustomTypeClass Integer` was a valid instance.
@@ -1205,6 +1205,8 @@ Specialization can be listed in the repl with `print-specializations`.
 * To denote anonymous functions, Coalton uses `fn` (*not* `lambda`).
 * Numerical operators like `+` only take 2 arguments.
 * Negation is done with `negate`.  The form `(- x)` is a curried function equivalent to `(fn (z) (- x z))`.
+
+For more details, see the [glossary](./glossary.md).
 
 # Incomplete Features
 

--- a/library/computable-reals/computable-reals.lisp
+++ b/library/computable-reals/computable-reals.lisp
@@ -177,7 +177,7 @@ This threshold is used to ensure `Eq` and `Ord` instances terminate. (In general
 
 (coalton-toplevel
 
-  (define-instance (Complex CReal)
+  (define-instance (complex:ComplexComponent CReal)
     (define (complex a b)
       (complex::%Complex a b))
 
@@ -189,7 +189,7 @@ This threshold is used to ensure `Eq` and `Ord` instances terminate. (In general
       (match z
         ((complex::%Complex _ b) b))))
 
-  (define-instance ((Complex :a) (Into :a CReal) => (Into (Complex :a) (Complex CReal)))
+  (define-instance ((complex:ComplexComponent :a) (Into :a CReal) => (Into (Complex :a) (Complex CReal)))
     (define (Into x)
       (Complex (Into (real-part x))
                (Into (imag-part x))))))

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -110,15 +110,15 @@ component types."
     (define (/ a b)
       (complex-divide a b)))
 
-  (define-instance (ComplexComponent :a => ComplexComponent (Complex :a))
-    (define (complex a b)
-      (%Complex a b))
-    (define (real-part a)
-      (match a
-        ((%Complex a _) a)))
-    (define (imag-part a)
-      (match a
-        ((%Complex _ b) b))))
+  ;; (define-instance (ComplexComponent :a => ComplexComponent (Complex :a))
+  ;;   (define (complex a b)
+  ;;     (%Complex a b))
+  ;;   (define (real-part a)
+  ;;     (match a
+  ;;       ((%Complex a _) a)))
+  ;;   (define (imag-part a)
+  ;;     (match a
+  ;;       ((%Complex _ b) b))))
 
   ;; Below are specializable functions, as class methods cannot be specialized
   ;; This allows us to call out to faster lisp functions for doing arithmetic.

--- a/library/math/elementary.lisp
+++ b/library/math/elementary.lisp
@@ -90,7 +90,9 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
     (sqrt (:a -> :a)))
 
   (define-class ((ComplexComponent :a) (Num :a) => Polar :a)
-    "For a complex number `z = (complex x y)`, the following identities hold:
+    "This type class includes `ComplexComponent` types that admit a magnitude and phase.
+
+For a complex number `z = (complex x y)`, the following identities hold:
 
     z = (* (magnitude z) (exp (* ii (phase z))))
     (polar z) = (Tuple (magnitude z) (phase z))
@@ -100,7 +102,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
     (polar (Complex :a -> (Tuple :a :a))))
 
   (define (magnitude z)
-    "For `z = x + yi`,
+    "The magnitude of a complex number. For `z = x + yi`,
 
 
     (magnitude z) = (sqrt (+ (^ x 2) (^ y 2)))"
@@ -124,27 +126,27 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 
   ;; See http://clhs.lisp.se/Body/f_sinh_.htm
 
-  (declare sinh ((Elementary :f) => :f -> :f))
+  (declare sinh (Elementary :f => :f -> :f))
   (define (sinh x)
     (/ (- (exp x) (exp (negate x))) 2))
 
-  (declare cosh ((Elementary :f) => :f -> :f))
+  (declare cosh (Elementary :f => :f -> :f))
   (define (cosh x)
     (/ (+ (exp x) (exp (negate x))) 2))
 
-  (declare tanh ((Elementary :f) => :f -> :f))
+  (declare tanh (Elementary :f => :f -> :f))
   (define (tanh x)
     (/ (sinh x) (cosh x)))
 
-  (declare asinh ((Elementary :f) => :f -> :f))
+  (declare asinh (Elementary :f => :f -> :f))
   (define (asinh x)
     (ln (+ x (sqrt (+ 1 (pow x 2))))))
 
-  (declare acosh ((Elementary :f) => :f -> :f))
+  (declare acosh (Elementary :f => :f -> :f))
   (define (acosh x)
     (* 2 (ln (+ (sqrt (/ (+ x 1) 2)) (sqrt (/ (- x 1) 2))))))
 
-  (declare atanh ((Elementary :f) => :f -> :f))
+  (declare atanh (Elementary :f => :f -> :f))
   (define (atanh x)
     (/ (- (ln (+ 1 x)) (ln (- 1 x))) (fromInt 2)))
 
@@ -452,21 +454,26 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
     (define pi (Complex pi 0)))
 
   ;; This doesn't have much mathematical meaning
-  (define-instance (Elementary :a => Polar (Complex :a))
-    (define (phase zz)
-      (match (polar zz)
-        ((Tuple _ p) p)))
-    (define (polar zz)
-      (let x = (real-part zz))
-      (let y = (imag-part zz))
-      (let r = (magnitude zz))
-      (let p =
-        (if (== zz 0)
-            0
-            (* 2 (atan (/ y (+ r x))))))
-      (Tuple r p)))
-
-  (define-instance (Elementary :a => Elementary (Complex :a))))
+  ;;
+  ;; We are going to comment this out for now. If downstream code
+  ;; breaks, we can re-enable it.
+  ;;
+  ;; (define-instance (Elementary :a => Polar (Complex :a))
+  ;;   (define (phase zz)
+  ;;     (match (polar zz)
+  ;;       ((Tuple _ p) p)))
+  ;;   (define (polar zz)
+  ;;     (let x = (real-part zz))
+  ;;     (let y = (imag-part zz))
+  ;;     (let r = (magnitude zz))
+  ;;     (let p =
+  ;;       (if (== zz 0)
+  ;;           0
+  ;;           (* 2 (atan (/ y (+ r x))))))
+  ;;     (Tuple r p)))
+  ;;
+  ;; (define-instance (Elementary :a => Elementary (Complex :a)))
+  )
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/MATH/ELEMENTARY")

--- a/library/math/elementary.lisp
+++ b/library/math/elementary.lisp
@@ -89,15 +89,15 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
     (nth-root (Integer -> :a -> :a))
     (sqrt (:a -> :a)))
 
-  (define-class ((Complex :a) (Num :a) => Polar :a)
+  (define-class ((ComplexComponent :a) (Num :a) => Polar :a)
     "For a complex number `z = (complex x y)`, the following identities hold:
 
     z = (* (magnitude z) (exp (* ii (phase z))))
     (polar z) = (Tuple (magnitude z) (phase z))
     (phase z) = (atan2 y x)
 "
-    (phase ((Complex :a) -> :a))
-    (polar ((Complex :a) -> (Tuple :a :a))))
+    (phase (Complex :a -> :a))
+    (polar (Complex :a -> (Tuple :a :a))))
 
   (define (magnitude z)
     "For `z = x + yi`,
@@ -106,7 +106,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
     (magnitude z) = (sqrt (+ (^ x 2) (^ y 2)))"
     (sqrt (square-magnitude z)))
 
-  (declare cis ((Trigonometric :a) (Complex :a) => :a -> (Complex :a)))
+  (declare cis ((Trigonometric :a) (ComplexComponent :a) => :a -> Complex :a))
   (define (cis z)
     "A point on the complex unit circle:
 
@@ -360,9 +360,10 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
 (%define-real-float-elementary F32 cl:single-float)
 (%define-real-float-elementary F64 cl:double-float)
 
+;;; FIXME: duplicate macro from complex.lisp
 (cl:defmacro %define-standard-complex-instances (type)
   `(coalton-toplevel
-     (define-instance (Complex ,type)
+     (define-instance (ComplexComponent ,type)
        (define (complex a b)
          (%Complex a b))
        (define (real-part a)
@@ -373,7 +374,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
            ((%Complex _ b) b))))))
 
 (coalton-toplevel
-  (define-instance ((Elementary :a) => Exponentiable (Complex :a))
+  (define-instance (Elementary :a => Exponentiable (Complex :a))
     (define (ln z)
       ;; The principal natural log of a complex number
       (match (polar z)
@@ -393,7 +394,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
       (/ (ln x) (ln b)))
     (define ee (Complex ee 0)))
 
-  (define-instance ((Elementary :a) => Radical (Complex :a))
+  (define-instance (Elementary :a => Radical (Complex :a))
     (define (sqrt z)
       (match (polar z)
         ((Tuple r theta)
@@ -410,7 +411,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
          ;; sqrt(z) = sqrt(r) (cos theta/2 + i sin theta/2)
          (complex (* nth-root-r (cos phi)) (* nth-root-r (sin phi)))))))
 
-  (define-instance ((Elementary :a) => Trigonometric (Complex :a))
+  (define-instance (Elementary :a => Trigonometric (Complex :a))
     (define (sin z)
       (let ((x (real-part z))
             (y (imag-part z))
@@ -451,7 +452,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
     (define pi (Complex pi 0)))
 
   ;; This doesn't have much mathematical meaning
-  (define-instance ((Elementary :a) => Polar (Complex :a))
+  (define-instance (Elementary :a => Polar (Complex :a))
     (define (phase zz)
       (match (polar zz)
         ((Tuple _ p) p)))
@@ -465,7 +466,7 @@ as (atan (/ y x)) when defined and accounting for the quadrant of the (x,y)."
             (* 2 (atan (/ y (+ r x))))))
       (Tuple r p)))
 
-  (define-instance ((Elementary :a) => Elementary (Complex :a))))
+  (define-instance (Elementary :a => Elementary (Complex :a))))
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON-LIBRARY/MATH/ELEMENTARY")

--- a/library/math/hyperdual.lisp
+++ b/library/math/hyperdual.lisp
@@ -186,7 +186,7 @@ Note: See identity (1) in the description of this package (`coalton-library/math
                  (+ (+ (* ax dy) (* dx ay)) (+ (* bx cy) (* cx by)))))
     (define (fromInt x) (Hyperdual (fromInt x) 0 0 0)))
 
-  (define-instance (Complex :t => Complex (Hyperdual :t))
+  (define-instance (ComplexComponent :t => ComplexComponent (Hyperdual :t))
     (define (complex a b)
       (complex::%Complex a b))
     (define (real-part a)
@@ -196,7 +196,7 @@ Note: See identity (1) in the description of this package (`coalton-library/math
       (match a
         ((complex::%Complex _ b) b))))
 
-  (define-instance ((Complex :t) (Into :t (Hyperdual :t)) => Into (Complex :t) (Complex (Hyperdual :t)))
+  (define-instance ((ComplexComponent :t) (Into :t (Hyperdual :t)) => Into (Complex :t) (Complex (Hyperdual :t)))
     (define (into z) (complex (into (real-part z)) (into (imag-part z)))))
 
   (define-instance (Reciprocable :t => Reciprocable (Hyperdual :t))

--- a/tests/float-tests.lisp
+++ b/tests/float-tests.lisp
@@ -27,7 +27,7 @@
                  (^ (math:reciprocal 2) (math:div (big-float:get-precision) 2)))
               (== a b) ))))
 
-  (define-instance ((LooseCompare :a) (Complex :a) => LooseCompare (Complex :a))
+  (define-instance ((LooseCompare :a) (math:ComplexComponent :a) => LooseCompare (Complex :a))
     (define (~ a b)
       (and (~ (real-part a) (real-part b))
            (~ (imag-part a) (imag-part b)))))


### PR DESCRIPTION
Partially addresses #1488.

This PR also removes some instances that don't seem useful, like `ComplexComponent (Complex :t)` etc.