### PR TITLE
Do not declare dynamic extent when a match expression is captured

### DIFF
--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -510,8 +510,10 @@ when possible."
              ;; pattern, then it can escape the match branches scope,
              ;; and thus cannot be safely stack allocated.
              (loop :for branch :in (node-match-branches node)
-                   :when (typep (match-branch-pattern branch) 'pattern-var) :do
-                     (return-from apply-lift nil))
+                   :for pattern := (match-branch-pattern branch)
+                   :when (or (pattern-var-p pattern)
+                             (pattern-binding-p pattern))
+                     :do (return-from apply-lift nil))
 
              (let ((expr (node-match-expr node)))
                (unless (or (node-direct-application-p expr)


### PR DESCRIPTION
Addresses cases like the following, for which the match expression should not be declared to have dynamic extent.
```lisp
(match (Tuple x y)
  ((= v (Tuple x y))
   (print x)
   (print y)
   v))
```