### PR TITLE
Handle case of hoisted dict not in instance environment

### DIFF
--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -417,8 +417,14 @@ speaking, the following kinds of transformations happen:
            (type tc:environment env))
 
   (when (node-variable-p node)
-    (let* ((instance (tc:lookup-instance-by-codegen-sym env (node-variable-value node))))
-      (return-from resolve-compount-superclass (tc:fresh-pred (tc:ty-class-instance-predicate instance)))))
+    (let ((instance (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t)))
+      (cond
+        ((null instance)
+         (return-from resolve-compount-superclass
+           (resolve-compount-superclass (tc:lookup-code env (node-variable-value node)) env)))
+        (t
+         (return-from resolve-compount-superclass
+           (tc:fresh-pred (tc:ty-class-instance-predicate instance)))))))
 
   (let ((rator (node-rator-name node)))
     (unless rator


### PR DESCRIPTION
I ran into an error when attempting to monomorphize a function. The cause of the error is that a hoisted dictionary was not added to the instance environment, so a call to `tc:lookup-instance-by-codegen-sym` failed. This PR fixes this by recursively replacing the hoisted dictionary with its value until the call to `tc:lookup-instance-by-codegen-sym` succeeds. However, I am not sure if this is the correct way to fix the issue.