### PR TITLE
Some notes on AST and Environment

### DIFF
--- a/src/algorithm/tarjan-scc.lisp
+++ b/src/algorithm/tarjan-scc.lisp
@@ -1,37 +1,92 @@
 (defpackage #:coalton-impl/algorithm/tarjan-scc
   (:use #:cl)
   (:export
-   #:tarjan-scc ; FUNCTION
-   ))
+   #:tarjan-scc))
 
 (in-package #:coalton-impl/algorithm/tarjan-scc)
+
+;;;;
+;;;; Tarjan's Strongly Connected Components Algorithm
+;;;;
+;;;; This module implements Robert Tarjan's algorithm for finding
+;;;; strongly connected components (SCCs) in a directed graph.
+;;;; Coalton uses SCCs for:
+;;;;
+;;;; - Dependency analysis of mutually recursive types
+;;;;
+;;;;   For example:
+;;;;
+;;;;     (define-type (Tree :a) (Node :a (Forest :a)))
+;;;;     (define-type (Forest :a) (List (Tree :a)))
+;;;;
+;;;; - Calculating value-binding dependencies: functions that call
+;;;;   each other must be compiled together to handle mutual
+;;;;   recursion. SCCs determine which functions can be compiled
+;;;;   independently vs. which must be grouped.
+;;;;
+;;;; - Detecting cyclic superclass dependencies and determining the
+;;;;   order of class processing.
+;;;;
+;;;; - Compilation ordering: the topological order of SCCs expresses
+;;;;   that dependencies come before dependents.
+;;;;
+;;;; The algorithm performs a depth-first search, while maintaining:
+;;;;
+;;;; - A "discovery index" for when each vertex is first visited
+;;;; - A "low-link value" tracking the lowest-numbered vertex reachable
+;;;; - A stack of vertices in the current path
+;;;;
+;;;; When a vertex's low-link equals its discovery index, it's an SCC
+;;;; root, and all vertices above it on the stack form a single
+;;;; strongly connected component.
+;;;;
+;;;; Time complexity: O(V + E) where V is vertices and E is edges.
+;;;; Space complexity: O(V) for the auxiliary data structures.
+;;;;
+;;;; See: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+;;;;
 
 (defstruct tarjan-node
   (index    nil :type (or null integer))
   (low-link nil :type integer)
   (on-stack nil :type boolean))
 
-(defun tarjan-scc (dag)
-  "Perform Tarjan's strongly-connected component algorithm on DAG.
+(declaim (ftype (function (list) list) tarjan-scc))
+(defun tarjan-scc (graph)
+  "Find strongly connected components in a directed graph using Tarjan's algorithm.
 
-DAG is of format ((node-name dependency*)
-                  (...)
-                 )
-where all names and dependencies are symbols"
+GRAPH is a list of vertices and their dependencies in the format:
+  ((vertex-name dependency-1 dependency-2 ...)
+   (vertex-name-2 dependency-a dependency-b ...)
+   ...)
+
+Where all vertex names and dependencies are symbols.
+
+Returns a list of SCCs, where each SCC is a list of mutually dependent vertices.
+The SCCs are returned in reverse topological order, meaning that if SCC-A depends
+on vertices in SCC-B, then SCC-B will appear before SCC-A in the result list.
+
+Example:
+  (tarjan-scc '((a b c) (b c) (c)))
+  => ((C) (B) (A))  ; C has no deps, B depends on C, A depends on B and C
+
+With mutually recursive definitions:
+  (tarjan-scc '((f g) (g f) (h)))  
+  => ((H) (F G))    ; H is independent, F and G are mutually recursive"
   (let ((symbol-to-index (make-hash-table))
-        (edge-vector (make-array (length dag))))
-    ;; Populate table mapping dag vertices to indices
-    (loop :for (vertex . edges) :in dag
+        (edge-vector (make-array (length graph))))
+    ;; Populate table mapping graph vertices to indices
+    (loop :for (vertex . edges) :in graph
           :for i :from 0
           :do (setf (gethash vertex symbol-to-index) i
                     (aref edge-vector i) edges))
     (let ((index 0)
           (stack nil)
-          (node-data (make-array (length dag)))
+          (node-data (make-array (length graph)))
           (sccs nil))
 
       ;; Initialize our node-data vector
-      (dotimes (i (length dag))
+      (dotimes (i (length graph))
         (setf (aref node-data i)
               (make-tarjan-node :index nil
                                 :low-link 0
@@ -85,6 +140,6 @@ where all names and dependencies are symbols"
                                    (push item new-scc))
                              :while (not (eql vertex item)))
                        (push new-scc sccs))))))
-        (dolist (vertex dag)
+        (dolist (vertex graph)
           (visit (car vertex)))
-        sccs))))
+        (nreverse sccs)))))

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -144,6 +144,18 @@
    #:node-properties                    ; FUNCTION
    ))
 
+;;;;
+;;;; Codegen AST - Typed Expression Nodes  
+;;;;
+;;;; This module defines the Abstract Syntax Tree structures used during code
+;;;; generation, after type checking. These nodes include complete type information
+;;;; and are optimized for translation to Common Lisp code.
+;;;;
+;;;; This is the SECOND of two AST systems in the Coalton compiler:
+;;;; 1. Parser AST (parser/expression.lisp): Untyped nodes from parsing
+;;;; 2. Codegen AST (this module): Typed nodes for code generation
+;;;;
+
 (in-package #:coalton-impl/codegen/ast)
 
 ;;;
@@ -382,10 +394,9 @@ call to (break)."
   (declare (type binding-list bindings))
 
   (let ((binding-names (mapcar #'car bindings)))
-    (reverse
-     (algo:tarjan-scc
-      (loop :for (name . node) :in bindings
-            :collect (cons name (intersection binding-names (node-variables node))))))))
+    (algo:tarjan-scc
+     (loop :for (name . node) :in bindings
+           :collect (cons name (intersection binding-names (node-variables node)))))))
 
 (defun node-rands (node)
   (declare (type (or node-application node-direct-application))

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -182,6 +182,18 @@
    #:parse-variable                     ; FUNCTION
    ))
 
+;;;;
+;;;; Parser AST - Untyped Expression Nodes
+;;;;
+;;;; This module defines the Abstract Syntax Tree structures used during parsing,
+;;;; before type checking. These nodes represent the syntactic structure of Coalton
+;;;; code as parsed from source text.
+;;;;
+;;;; This is the first of two AST systems in the Coalton compiler:
+;;;; 1. Parser AST (this module): Untyped nodes used during parsing/syntax analysis
+;;;; 2. Codegen AST (codegen/ast.lisp): Typed nodes used during code generation
+;;;;
+
 (in-package #:coalton-impl/parser/expression)
 
 (defvar *macro-expansion-count* 0)

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -18,6 +18,14 @@
    #:toplevel-define-class              ; FUNCTION
    ))
 
+;;;;
+;;;; Type Class Definition Processing with SCC-Based Dependency Resolution
+;;;;
+;;;; This module handles toplevel define-class forms and ensures that type class
+;;;; hierarchies are processed in the correct dependency order using strongly
+;;;; connected components (SCCs).
+;;;;
+
 (in-package #:coalton-impl/typechecker/define-class)
 
 (defstruct partial-class
@@ -115,7 +123,7 @@
 
                  :collect (cons class-name deps)))
 
-         (sccs (reverse (algo:tarjan-scc class-dependencies)))
+         (sccs (algo:tarjan-scc class-dependencies))
 
          (classes-by-scc
            (loop :for scc :in sccs

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -1,9 +1,3 @@
-;;;;
-;;;; Handling of toplevel define-type forms. Types are split apart by
-;;;; SCC and then type usage in constructors is used to infer the
-;;;; kinds of all type variables.
-;;;;
-
 (defpackage #:coalton-impl/typechecker/define-type
   (:use
    #:cl
@@ -39,6 +33,15 @@
    #:type-definition-docstring          ; ACCESSOR
    #:type-definition-list               ; TYPE
    ))
+
+;;;;
+;;;; Type Definition Processing
+;;;;
+;;;; This module handles toplevel define-type forms and performs kind
+;;;; inference for user-defined algebraic data types. Mutually
+;;;; recursive types must be processed together as strongly connected
+;;;; components (SCCs) to correctly infer their kinds.
+;;;;
 
 (in-package #:coalton-impl/typechecker/define-type)
 
@@ -165,7 +168,7 @@
                  :finally (return table)))
 
          (types-by-scc
-           (loop :for scc :in (reverse sccs)
+           (loop :for scc :in sccs
                  :collect (loop :for name :in scc
                                 :collect (gethash name type-table))))
 

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -1901,7 +1901,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
 
          (impl-binding-nodes
            ;; Infer the types of implicit bindings on scc at a time
-           (loop :for scc :in (reverse sccs)
+           (loop :for scc :in sccs
                  :for bindings
                    := (loop :for name :in scc
                             :collect (gethash name impl-bindings))

--- a/tests/tarjan-scc-tests.lisp
+++ b/tests/tarjan-scc-tests.lisp
@@ -7,9 +7,9 @@
   ;; Can we detect a basic scc
   (is (sccs-equalp
        (coalton-impl/algorithm::tarjan-scc
-        '((a b)
+        '((c a)
           (b c)
-          (c a)))
+          (a b)))
        '((a b c))))
 
   ;; Can we detect an isolated scc
@@ -18,8 +18,8 @@
         '((a a)
           (b c)
           (c b)))
-       '((b c)
-         (a))))
+       '((a)
+         (b c))))
 
   ;; Can we produce a topological sorting of sccs
   (is (sccs-equalp
@@ -29,8 +29,8 @@
           (c a d)
           (d e)
           (e d)))
-       '((a b c)
-         (d e))))
+       '((d e)
+         (a b c))))
 
   ;; Can we out wiki the pedia (https://commons.wikimedia.org/wiki/File:Scc-1.svg)
   (is (sccs-equalp
@@ -43,9 +43,9 @@
           (f g)
           (g f)
           (h d g)))
-       '((a b e)
+       '((f g)
          (c d h)
-         (f g))))
+         (a b e))))
 
   ;; Wikipedia example 2 (https://commons.wikimedia.org/wiki/File:Graph_Condensation.svg)
   (is (sccs-equalp
@@ -66,9 +66,9 @@
           (n o p)
           (o m)
           (p o k)))
-       '((a b c d e)
-         (m n o p)
-         (f)
-         (l k)
+       '((j)
          (g h i)
-         (j)))))
+         (l k)
+         (f)
+         (m n o p)
+         (a b c d e)))))


### PR DESCRIPTION
This is a contribution towards https://github.com/coalton-lang/coalton/issues/1502 with some notes on typechecking environment and roles of the dual ASTs (parser, code generator) -- it would benefit from review for terminological correctness.

Also, there is an incompatible change to the return value of tarjar-scc: almost invariably, the returned SCC list is immediately reversed, since it's so strongly bound up with compilation dependency ordering. I found this confusing on first seeing it: my feeling is that it's more intuitive to return values in least-to-most dependent order.

Also, changed 'dag' to 'graph' in the SCC routing, since that was also a bit of a red herring.