### PR TITLE
Add `string:upcase` and `string:downcase` functions to the standard library

### DIFF
--- a/library/string.lisp
+++ b/library/string.lisp
@@ -25,7 +25,9 @@
    #:ref-unchecked
    #:substring-index
    #:substring?
-   #:chars))
+   #:chars
+   #:upcase
+   #:downcase))
 
 
 (in-package #:coalton-library/string)
@@ -142,6 +144,18 @@ does not have that suffix."
   (define (chars str)
     "Returns an iterator over the characters in `str`."
     (iter:into-iter str))
+
+  (declare upcase (String -> String))
+  (define (upcase str)
+    "Returns a new string with uppercase characters."
+    (lisp String (str)
+      (cl:string-upcase str)))
+
+  (declare downcase (String -> String))
+  (define (downcase str)
+    "Returns a new string with lowercase characters."
+    (lisp String (str)
+      (cl:string-downcase str)))
 
   ;;
   ;; Instances

--- a/tests/string-tests.lisp
+++ b/tests/string-tests.lisp
@@ -76,3 +76,12 @@
   (let has-empty? = (string:substring? ""))
   (is (has-empty? ""))
   (is (has-empty? "foo")))
+
+(define-test string-case-conversion ()
+  (let down  = "hello world!")
+  (let up    = "HELLO WORLD!")
+  (let mixed = "Hello World!")
+  (is (== down (string:downcase up)))
+  (is (== down (string:downcase mixed)))
+  (is (== up (string:upcase down)))
+  (is (== up (string:upcase mixed))))


### PR DESCRIPTION
These simply call `cl:string-upcase` and `cl:string-downcase` respectively.  I am thinking it might also be worth adding a function that wraps `cl:string-equal` for case-insensitive equality testing, but I'm not sure what it should be named.