### PR TITLE
Inline functions marked `(inline)` when called from Lisp

### DIFF
--- a/src/codegen/inliner.lisp
+++ b/src/codegen/inliner.lisp
@@ -18,6 +18,7 @@
    #:gentle-heuristic                   ; FUNCTION
    #:aggresive-heuristic                ; FUNCTION
    #:inline-applications                ; FUNCTION
+   #:function-declared-inline-p         ; FUNCTION
    ))
 
 (in-package #:coalton-impl/codegen/inliner)

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -20,6 +20,9 @@
   (:import-from
    #:coalton-impl/codegen/optimizer
    #:optimize-bindings)
+  (:import-from
+   #:coalton-impl/codegen/inliner
+   #:function-declared-inline-p)
   (:local-nicknames
    (#:util #:coalton-impl/util)
    (#:parser #:coalton-impl/parser)
@@ -235,6 +238,11 @@ Example:
              (values ,(tc:lisp-type (node-type (node-abstraction-subexpr node)) env)
                      &optional))
             ,name)))
+
+   ;; Emit inline declamations for functions declared inline at definition-site
+   (loop :for (name . node) :in bindings
+         :if (and (node-abstraction-p node) (function-declared-inline-p name env))
+         :collect `(declaim (inline ,name)))
 
    ;; Compile functions
    (loop :for (name . node) :in bindings


### PR DESCRIPTION
https://github.com/coalton-lang/coalton/issues/1614

This PR just emits `(declaim (inline ,name))` before function definitions if they were marked for inlining by the user.

Before:

```lisp
COALTON-USER> (cl:defun foo () 
                (Some 1))
FOO
COALTON-USER> (disassemble 'foo)
; disassembly for FOO
; Size: 36 bytes. Origin: #x70072ED9FC                        ; FOO
; 9FC:       AA0A40F9         LDR R0, [THREAD, #16]           ; binding-stack-pointer
; A00:       4A0B00F9         STR R0, [CFP, #16]
; A04:       4A0080D2         MOVZ R0, #2
; A08:       D6FDFF58         LDR LEXENV, #x70072ED9C0        ; #<SB-KERNEL:FDEFN SOME>
; A0C:       570080D2         MOVZ NARGS, #2
; A10:       DE9240F8         LDR LR, [LEXENV, #9]
; A14:       DE130091         ADD LR, LR, #4
; A18:       C0031FD6         BR LR
; A1C:       000220D4         BRK #16                         ; Invalid argument count trap
COMMON-LISP:NIL
```

After:

```lisp
COALTON-USER> (cl:defun foo () 
                (Some 1))
FOO
COALTON-USER> (disassemble 'foo)
; disassembly for FOO
; Size: 32 bytes. Origin: #x7005CB012C                        ; FOO
; 2C:       AA0A40F9         LDR R0, [THREAD, #16]            ; binding-stack-pointer
; 30:       4A0B00F9         STR R0, [CFP, #16]
; 34:       4A0080D2         MOVZ R0, #2
; 38:       FB031AAA         MOV CSP, CFP
; 3C:       5A7B40A9         LDP CFP, LR, [CFP]
; 40:       BF0300F1         CMP NULL, #0
; 44:       C0035FD6         RET
; 48:       000220D4         BRK #16                          ; Invalid argument count trap
COMMON-LISP:NIL
```