### PR TITLE
New Vector Operations

### DIFF
--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -147,7 +147,7 @@
   (inline)
   (declare kill! (Vector :a -> UFix -> UFix -> Vector :a))
   (define (kill! v start end)
-    "Destructively kills subsequence in a vector bounded by given indices."
+    "Destructively kills a subsequence in a vector bounded by given indices."
     (let ((real-start (max 0 (min start end)))
           (real-end (min (length v) (max start end)))
           (new-size (- (length v) (- real-end real-start))))

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -18,11 +18,13 @@
    #:with-initial-element
    #:singleton
    #:length
+   #:subseq
    #:capacity
    #:empty?
    #:singleton?
    #:copy
    #:set-capacity!
+   #:kill!
    #:clear!
    #:push!
    #:pop!
@@ -95,6 +97,16 @@
       (cl:length v)))
 
   (inline)
+  (declare subseq (Vector :a -> UFix -> UFix -> Vector :a))
+  (define (subseq v start end)
+    "Compute a subseq of a vector bounded by given indices."
+    (let ((real-start (max 0 (min start end)))
+          (real-end (min (length v) (max start end))))
+      (lisp (Vector :a) (real-start real-end v)
+        (cl:let ((result (cl:make-array (cl:- real-end real-start) :adjustable cl:t))) 
+          (cl:replace result v :start2 real-start)))))
+
+  (inline)
   (declare capacity (Vector :a -> UFix))
   (define (capacity v)
     "Returns the number of elements that `v` can store without resizing."
@@ -131,6 +143,18 @@
       ;; fill pointer
       (cl:adjust-array v new-capacity :fill-pointer shrinking)
       Unit))
+
+  (inline)
+  (declare kill! (Vector :a -> UFix -> UFix -> Vector :a))
+  (define (kill! v start end)
+    "Destructively kills subsequence in a vector bounded by given indices."
+    (let ((real-start (max 0 (min start end)))
+          (real-end (min (length v) (max start end)))
+          (new-size (- (length v) (- real-end real-start))))
+      (lisp (Vector :a) (real-start real-end v)
+        (cl:replace v v :start1 real-start :start2 real-end))
+      (set-capacity! new-size v)
+      v))
 
   (inline)
   (declare clear! (Vector :a -> Unit))

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -24,7 +24,7 @@
    #:singleton?
    #:copy
    #:set-capacity!
-   #:kill!
+   #:resect!
    #:clear!
    #:push!
    #:pop!
@@ -99,7 +99,9 @@
   (inline)
   (declare subseq (Vector :a -> UFix -> UFix -> Vector :a))
   (define (subseq v start end)
-    "Compute a subseq of a vector bounded by given indices."
+    "Compute a subseq of a vector bounded by given indices.
+
+`start` index is inclusive and `end` index is exclusive."
     (let ((real-start (min start end))
           (real-end (min (length v) (max start end))))
       (lisp (Vector :a) (real-start real-end v)
@@ -145,16 +147,17 @@
       Unit))
 
   (inline)
-  (declare kill! (Vector :a -> UFix -> UFix -> Vector :a))
-  (define (kill! v start end)
-    "Destructively kills a subsequence in a vector bounded by given indices."
+  (declare resect! (Vector :a -> UFix -> UFix -> Unit))
+  (define (resect! v start end)
+    "Destructively kills a subsequence in a vector bounded by given indices.
+
+`start` index is inclusive and `end` index is exclusive."
     (let ((real-start (min start end))
           (real-end (min (length v) (max start end)))
           (new-size (- (length v) (- real-end real-start))))
       (lisp (Vector :a) (real-start real-end v)
         (cl:replace v v :start1 real-start :start2 real-end))
-      (set-capacity! new-size v)
-      v))
+      (set-capacity! new-size v)))
 
   (inline)
   (declare clear! (Vector :a -> Unit))

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -100,7 +100,7 @@
   (declare subseq (Vector :a -> UFix -> UFix -> Vector :a))
   (define (subseq v start end)
     "Compute a subseq of a vector bounded by given indices."
-    (let ((real-start (max 0 (min start end)))
+    (let ((real-start (min start end))
           (real-end (min (length v) (max start end))))
       (lisp (Vector :a) (real-start real-end v)
         (cl:let ((result (cl:make-array (cl:- real-end real-start) :adjustable cl:t))) 

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -148,7 +148,7 @@
   (declare kill! (Vector :a -> UFix -> UFix -> Vector :a))
   (define (kill! v start end)
     "Destructively kills a subsequence in a vector bounded by given indices."
-    (let ((real-start (max 0 (min start end)))
+    (let ((real-start (min start end))
           (real-end (min (length v) (max start end)))
           (new-size (- (length v) (- real-end real-start))))
       (lisp (Vector :a) (real-start real-end v)

--- a/tests/vector-tests.lisp
+++ b/tests/vector-tests.lisp
@@ -72,3 +72,17 @@
   (is (== False (vector:singleton? (vector:new))))
   (is (== True (vector:singleton? (vector:make 1))))
   )
+
+(define-test test-vector-kill ()
+  (let v = (vector:make 0 1 2 3 4 5 6))
+  (vector:kill! v 2 4)
+  (is (== v (vector:make 0 1 4 5 6)))
+
+  (let v = (vector:make 0 1 2 3 4 5 6))
+  (vector:kill! v 0 400)
+  (is (== v (vector:make))))
+
+(define-test test-vector-subseq ()
+  (let v = (vector:make 0 1 2 3 4 5 6))
+  (is (== (vector:make 2 3) (vector:subseq v 2 4)))
+  (is (== v (vector:subseq v 0 1000))))

--- a/tests/vector-tests.lisp
+++ b/tests/vector-tests.lisp
@@ -70,16 +70,15 @@
 
   (is (== False (vector:singleton? vec2)))
   (is (== False (vector:singleton? (vector:new))))
-  (is (== True (vector:singleton? (vector:make 1))))
-  )
+  (is (== True (vector:singleton? (vector:make 1)))))
 
-(define-test test-vector-kill ()
+(define-test test-vector-resect ()
   (let v = (vector:make 0 1 2 3 4 5 6))
-  (vector:kill! v 2 4)
+  (vector:resect! v 2 4)
   (is (== v (vector:make 0 1 4 5 6)))
 
   (let v = (vector:make 0 1 2 3 4 5 6))
-  (vector:kill! v 0 400)
+  (vector:resect! v 0 400)
   (is (== v (vector:make))))
 
 (define-test test-vector-subseq ()


### PR DESCRIPTION
`vec:subseq` is the same as `string:substr`, and `vec:kill!` kills a range in a vector.