### PR TITLE
Optimize ST operations

### DIFF
--- a/library/monad/state.lisp
+++ b/library/monad/state.lisp
@@ -34,7 +34,7 @@ Represented as a closure from initial state to updated state and value."
   (inline)
   (declare put (:state -> ST :state Unit))
   (define (put state)
-    "A StatefulComputation with state set to be given state. The returned value is Unit."
+    "A StatefulComputation with state set to be the given state. The returned value is Unit."
     (ST (fn (_) (Tuple state Unit))))
 
   (inline)
@@ -69,7 +69,7 @@ Represented as a closure from initial state to updated state and value."
   (inline)
   (declare swap (:state -> ST :state :state))
   (define (swap state)
-    "A StatefulComputation with state set to be given state. The old state is returned."
+    "A StatefulComputation with state set to be the given state. The old state is returned."
     (ST (fn (old-state) (Tuple state old-state))))
 
   (inline)

--- a/library/monad/state.lisp
+++ b/library/monad/state.lisp
@@ -8,6 +8,9 @@
    #:put
    #:get
    #:modify
+   #:modify-get
+   #:swap
+   #:modify-swap
    #:run))
 
 (in-package #:coalton-library/monad/state)
@@ -54,6 +57,27 @@ Represented as a closure from initial state to updated state and value."
     "Modify the state in a StatefulComputation, discarding the old state."
     (ST (fn (state)
           (Tuple (fs->s state) Unit))))
+
+  (inline)
+  (declare modify-get ((:state -> :state) -> ST :state :state))
+  (define (modify-get fs->s)
+    "Modify the state in a StatefulComputation, discarding the old state. Return the new state."
+    (ST (fn (state)
+          (let ((new-state (fs->s state)))
+            (Tuple new-state new-state)))))
+
+  (inline)
+  (declare swap (:state -> ST :state :state))
+  (define (swap state)
+    "A StatefulComputation with state set to be given state. The old state is returned."
+    (ST (fn (old-state) (Tuple state old-state))))
+
+  (inline)
+  (declare modify-swap ((:state -> :state) -> ST :state :state))
+  (define (modify-swap fs->s)
+    "Modify the state in a StatefulComputation, returning the old state."
+    (ST (fn (old-state)
+          (Tuple (fs->s old-state) old-state))))
 
   ;;
   ;; State Monad instances

--- a/library/monad/state.lisp
+++ b/library/monad/state.lisp
@@ -50,11 +50,10 @@ Represented as a closure from initial state to updated state and value."
 
   (inline)
   (declare modify ((:state -> :state) -> ST :state Unit))
-  (define (modify statef)
+  (define (modify fs->s)
     "Modify the state in a StatefulComputation, discarding the old state."
-    (do
-     (state <- get)
-     (put (statef state))))
+    (ST (fn (state)
+          (Tuple (fs->s state) Unit))))
 
   ;;
   ;; State Monad instances


### PR DESCRIPTION
This PR optimizes the state monad `modify` function. It also adds several other similarly optimized primitives.

The old modify function just wrapped existing external operators in `do`:
```lisp
  (declare modify ((:state -> :state) -> ST :state Unit))
  (define (modify statef)
    "Modify the state in a StatefulComputation, discarding the old state."
    (do
     (state <- get)
     (put (statef state))))
```

This results in an unnecessary bind and some unnecessary allocation. The new modify makes use of the ST internals to avoid that:
```lisp
  (inline)
  (declare modify ((:state -> :state) -> ST :state Unit))
  (define (modify fs->s)
    "Modify the state in a StatefulComputation, discarding the old state."
    (ST (fn (state)
          (Tuple (fs->s state) Unit))))
```

The three other new functions are similarly optimized versions of some common ST operations.

For some numbers, here's a little benchmark that generates a list of 4,000,000 random strings. It passes it into a ST function that uses `modify` to pop them one at a time, until they're all popped. (A little overly complicated, but I had the random string code lying around.)
```lisp
(cl:in-package :cl-user)
(defpackage :s-bench
  (:use
   #:coalton
   #:coalton-prelude
   #:coalton-library/monad/state)
  )

(in-package :s-bench)

(named-readtables:in-readtable coalton:coalton)

(cl:defvar *charset* "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
(cl:defvar *rs* (cl:make-random-state cl:t))

(cl:defun select-random-item (seq)
  (cl:elt seq (cl:random (cl:length seq) *rs*)))

(cl:defun random-string_ (cl:&optional (len 16))
  (cl:map 'cl:string
          (cl:lambda (_) (select-random-item *charset*))
          (cl:make-string len)))

(coalton-toplevel
  (declare random-string (Unit -> String))
  (define (random-string)
    (lisp :a ()
      (random-string_)))

  (declare random-strings (Integer -> List String))
  (define (random-strings num)
    (rec % ((n num)
            (result mempty))
      (if (== n 0)
          (reverse result)
          (% (- n 1)
             (Cons (random-string) result)))))

  (declare pop-head (List :a -> List :a))
  (define (pop-head lst)
    (match lst
      ((Nil) Nil)
      ((Cons _ rst)
       rst)))

  (declare pop-strings_ (Unit -> ST (List String) Unit))
  (define (pop-strings_)
    (do
     (modify pop-head)
     (lst <- get)
     (match lst
       ((Nil) (pure Unit))
       (_ (pop-strings_)))))

  (define (pop-strings strs)
    (run (pop-strings_) strs)))

(cl:defmacro bench (func cl:&optional (n 4000000))
  `(coalton
    (let ((strs (random-strings ,n)))
      (lisp :a (strs)
        (cl:time (coalton
                  (let ((strs (lisp (List String) () strs)))
                    (,func strs)))))
      Unit)))

(bench pop-strings)
```
Here is a typical result for the existing code, run in release mode:
```
* (s-bench::bench s-bench::pop-strings)
Evaluation took:
  0.588 seconds of real time
  0.585051 seconds of total run time (0.566989 user, 0.018062 system)
  [ Real times consist of 0.090 seconds GC time, and 0.498 seconds non-GC time. ]
  [ Run times consist of 0.091 seconds GC time, and 0.495 seconds non-GC time. ]
  99.49% CPU
  2,171,184,531 processor cycles
  1,407,975,040 bytes consed
```
and a typical result for the new code:
```
* (s-bench::bench s-bench::pop-strings)
Evaluation took:
  0.445 seconds of real time
  0.442499 seconds of total run time (0.424676 user, 0.017823 system)
  [ Real times consist of 0.074 seconds GC time, and 0.371 seconds non-GC time. ]
  [ Run times consist of 0.072 seconds GC time, and 0.371 seconds non-GC time. ]
  99.33% CPU
  1,642,512,584 processor cycles
  1,023,966,944 bytes consed
```
The new code conses ~28% fewer bytes and completes ~24% faster.