### PR TITLE
Ensure CL can handle recursive inlining properly

### DIFF
--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -95,7 +95,8 @@
 
   (:method ((expr node-locally) env)
     (declare (type tc:environment env))
-    (codegen-expression (node-locally-subexpr expr) env))
+    `(locally (declare (notinline ,@(node-locally-noinline-functions expr)))
+       ,(codegen-expression (node-locally-subexpr expr) env)))
 
   (:method ((expr node-lisp) env)
     (declare (type tc:environment env))


### PR DESCRIPTION
As discussed in https://github.com/coalton-lang/coalton/issues/1631, SBCL handles recursive inlining, but unrolls deeper than I would expect.  This change should ensure that any CL implementation will work with recursively inlined functions and gives the programmer control over the amount of inlining CL actually does.

At the same point where Coalton decides to stop inlining, it emits the following:

```lisp
(locally (declare (notinline ,@noinline-funcs))
  ...)
```


Currently calling an inlined factorial function emits a function of 20764 bytes and 52 calls to `==`.

With this PR, it emits a function of 964 bytes and 2 calls to `==`.

Setting `*max-unroll*` inliner parameter to 5 causes it to emit a function of 2140 bytes and 5 calls to `==`.