### PR TITLE
Add StateT monad transformer

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -101,8 +101,10 @@
                (:file "queue")
                (:module "monad"
                 :serial t
-                :components ((:file "identity")
+                :components ((:file "classes")
+                             (:file "identity")
                              (:file "state")
+                             (:file "statet")
                              (:file "environment")
                              (:file "resultt")
                              (:file "optionalt")
@@ -326,7 +328,8 @@
                 :serial t
                 :components ((:file "optionalt")
                              (:file "resultt")
-                             (:file "environment")))
+                             (:file "environment")
+                             (:file "statet")))
                (:module "algorithms-tests"
                 :serial t
                 :components ((:file "fft-tests")))))

--- a/library/monad/classes.lisp
+++ b/library/monad/classes.lisp
@@ -1,0 +1,51 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/monad/classes
+  (:use
+   #:coalton
+   #:coalton-library/classes)
+  (:export
+   #:MonadEnvironment
+   #:ask
+   #:local
+   #:asks
+
+   #:MonadState
+   #:get
+   #:put
+   #:modify
+   ))
+
+(in-package #:coalton-library/monad/classes)
+
+(named-readtables:in-readtable coalton:coalton)
+
+#+coalton-release
+(cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
+
+(coalton-toplevel
+
+  (define-class (Monad :m => MonadEnvironment :env :m (:m -> :env))
+    "A monad capable of a function in a computation environment."
+    (ask
+     "Retrieves the computation environment."
+     (:m :env))
+    (local
+     "Run a computation in a modified environment."
+     ((:env -> :env) -> :m :a -> :m :a))
+    (asks
+     "Retrieve an aspect of the computation environment."
+     ((:env -> :a) -> :m :a)))
+
+  (define-class (Monad :m => MonadState :s :m (:m -> :s))
+    "A monad capable of tracking state in a computation."
+    (get
+     "Retrieve the computation state."
+     (:m :s))
+    (put
+     "Set the state to a given value."
+     (:s -> :m Unit))
+    (modify
+     "Modify the computation state, discarding the old state."
+     ((:s -> :s) -> :m Unit))))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/MONAD/CLASSES")

--- a/library/monad/statet.lisp
+++ b/library/monad/statet.lisp
@@ -1,0 +1,138 @@
+(coalton-library/utils:defstdlib-package #:coalton-library/monad/statet
+  (:use
+   #:coalton
+   #:coalton-library/functions
+   #:coalton-library/classes
+   #:coalton-library/monad/classes)
+  (:export
+   #:StateT
+   #:run-stateT
+   #:map-stateT
+
+   #:lift-stateT
+
+   #:put-stateT
+   #:get-stateT
+   #:modify-stateT
+
+   ;; Re-export MonadState
+   #:MonadState
+   #:get
+   #:put
+   #:modify))
+
+(in-package #:coalton-library/monad/statet)
+
+(named-readtables:in-readtable coalton:coalton)
+
+#+coalton-release
+(cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
+
+(coalton-toplevel
+
+  ;;
+  ;; StateT Definition
+  ;;
+
+  (repr :transparent)
+  (define-type (StateT :s :m :a)
+    "A monadic computation that tracks state of type :s."
+    (StateT (:s -> :m (Tuple :s :a))))
+
+  (inline)
+  (declare put-stateT (Applicative :m => :s -> StateT :s :m Unit))
+  (define (put-stateT state)
+    "A stateful computation with state set to the given state. The returned value is Unit."
+    (StateT (const (pure (Tuple state Unit)))))
+
+  (inline)
+  (declare get-stateT (Applicative :m => StateT :s :m :s))
+  (define get-stateT
+    "A stateful computation which returns the current state as the value."
+    (StateT (fn (s)
+              (pure (Tuple s s)))))
+
+  (inline)
+  (declare run-stateT (Applicative :m => StateT :s :m :a -> :s -> :m (Tuple :s :a)))
+  (define (run-stateT (StateT fs->msa) s)
+    (fs->msa s))
+
+  (inline)
+  (declare modify-stateT (Applicative :m => (:s -> :s) -> StateT :s :m Unit))
+  (define (modify-stateT fs->s)
+    "Modify the computation state, discarding the old state."
+    (StateT
+     (fn (s)
+       (pure (Tuple (fs->s s) Unit)))))
+
+  ;;
+  ;; StateT Instances
+  ;;
+
+  (inline)
+  (declare map-stateT ((:m (Tuple :s :a) -> :n (Tuple :s :b)) -> StateT :s :m :a -> StateT :s :n :b))
+  (define (map-stateT fma->nb (StateT fs->msa))
+    "Map the return value, the final state, and the execution context."
+    (StateT (fn (s)
+              (fma->nb (fs->msa s)))))
+
+  (inline)
+  (declare lift-stateT (Functor :m => :m :a -> StateT :s :m :a))
+  (define (lift-stateT m)
+    "Lift a stateless computation into a stateful context."
+    (StateT (fn (s)
+              (map (fn (a)
+                     (Tuple s a))
+                   m))))
+
+  (define-instance (Functor :m => Functor (StateT :s :m))
+    (inline)
+    (define (map fa->b (StateT fs->msa))
+      (StateT (fn (s)
+                (map (fn ((Tuple s2 a))
+                       (Tuple s2 (fa->b a)))
+                     (fs->msa s))))))
+
+  (define-instance (Applicative :m => Applicative (StateT :s :m))
+    (inline)
+    (define (pure a)
+      (lift-stateT (pure a)))
+    (inline)
+    (define (liftA2 fa->b->c (StateT fs->msa) (StateT fs->msb))
+      (StateT (fn (s)
+                (liftA2 (fn ((Tuple _ a) (Tuple _ b))
+                          (Tuple s (fa->b->c a b)))
+                        (fs->msa s)
+                        (fs->msb s))))))
+
+  (define-instance (Monad :m => Monad (StateT :s :m))
+    (inline)
+    (define (>>= (StateT fs->msa) fa->st-msb)
+      (StateT (fn (s)
+                (>>= (fs->msa s)
+                     (fn ((Tuple s2 a))
+                       (match (fa->st-msb a)
+                         ((StateT fs->msb)
+                          (fs->msb s2)))))))))
+
+  (define-instance (MonadTransformer (StateT :s))
+    (inline)
+    (define lift lift-stateT))
+
+  (define-instance (Monad :m => MonadState :s (StateT :s :m))
+    (define get get-stateT)
+    (define put put-stateT)
+    (define modify modify-stateT)))
+
+;;;
+;;; StateT Instances for other Transformers
+;;;
+
+(coalton-toplevel
+  (define-instance (MonadEnvironment :e :m => (MonadEnvironment :e (StateT :s :m)))
+    (define ask (lift ask))
+    (define asks (compose lift asks))
+    (define local (compose map-stateT local))))
+
+#+sb-package-locks
+(sb-ext:lock-package "COALTON-LIBRARY/MONAD/STATET")

--- a/tests/monad/statet.lisp
+++ b/tests/monad/statet.lisp
@@ -1,0 +1,49 @@
+(in-package #:coalton-native-tests)
+
+(named-readtables:in-readtable coalton:coalton)
+
+(coalton-toplevel
+  (define-type-alias TestM (m-env:EnvT Integer
+                                       (m-stt:StateT (List Integer)
+                                                     m-id:Identity)))
+
+  (define (runM env init-state m)
+    (m-id:run-identity
+     (m-stt:run-stateT
+      (m-env:run-envT m env)
+      init-state)))
+
+  (declare just-get (TestM Integer))
+  (define just-get
+    (do
+     (ints <- m-stt:get)
+     (match ints
+       ((Nil) (pure 0))
+       ((Cons x _) (pure x)))))
+
+  (declare just-put (TestM Unit))
+  (define just-put
+    (do
+     (x <- m-env:ask)
+     (m-stt:put (make-list x))))
+
+  (declare just-modify (TestM Unit))
+  (define just-modify
+    (do
+     (x <- m-env:ask)
+     (m-stt:modify (map (+ x))))))
+
+(define-test test-statet-get ()
+  (let (Tuple state result) = (runM 100 (make-list 1 2 3) just-get))
+  (is (== (make-list 1 2 3) state))
+  (is (== 1 result)))
+
+(define-test test-statet-put ()
+  (let (Tuple state result) = (runM 100 (make-list 1 2 3) just-put))
+  (is (== (make-list 100) state))
+  (is (== Unit result)))
+
+(define-test test-statet-modify ()
+  (let (Tuple state result) = (runM 100 (make-list 1 2 3) just-modify))
+  (is (== (make-list 101 102 103) state))
+  (is (== Unit result)))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -44,9 +44,11 @@
    (#:file #:coalton-library/file)
    (#:experimental #:coalton-library/experimental)
    (#:st #:coalton-library/monad/state)
+   (#:m-id #:coalton-library/monad/identity)
    (#:m-opt #:coalton-library/monad/optionalt)
    (#:m-res #:coalton-library/monad/resultt)
    (#:m-env #:coalton-library/monad/environment)
+   (#:m-stt #:coalton-library/monad/statet)
    (#:fft #:coalton-library/algorithms/fft)))
 
 (in-package #:coalton-native-tests)


### PR DESCRIPTION
This PR adds the StateT monad transformer. It also fixes the type signature of the `Environment:local`function and reorganizes the MTL typeclasses a little bit.

Notably, I chose to introduce the `MonadState` typeclass here that I backed out of the previous PR adding some of the other transformers. That's because there were some type inference problems that broke too much existing code. (namely, #1656 ). This PR adds `MonadState` but it's in totally separate packages from the non-transformer `ST` monad. When the bugs get fixed, it can cover `ST` as well. In the meantime, I think it's worth adding because:
1. It's a huge pain to use transformers without it, frankly.
2. It won't break any existing code.
3. It's not that hard, if it does break when it shouldn't, to just keep adding `lift` until it compiles.

An interesting note on performance. `StateT` is transparent, so each "pass" through it has to allocate (1) some closures and (2) some tuples. _Apparently_ there's a church-encoded StateT monad, which doesn't have to allocate tuples. But it requires GADT's, so we can't use that for now. However, I think I saw on the discord that there's some optimization work being done to make Tuples zero-cost? (I think `Optional` is already like this?) In that case, I think that the current, simpler, implementation is actually more performant than the church encoding, which has some inefficiencies of its own. That's why Haskell, which is very good at optimizing away all sorts of intermediate data structures, uses this encoding and not the church one. So the upshot is that if we do get the tuples optimization in soon this will magically become faster, and there shouldn't be any reason to change it.