### PR TITLE
Add base Env monad

### DIFF
--- a/tests/monad/environment.lisp
+++ b/tests/monad/environment.lisp
@@ -59,3 +59,35 @@
       2)
      0))
   (is (== 8 result)))
+
+(define-test test-ask-env ()
+  (let result =
+    (m-env:run-env
+     (do
+      (x <- m-env:ask)
+      (pure (+ 10 x)))
+     15))
+  (is (== 25 result)))
+
+(define-test test-asks-env ()
+  (let result =
+    (m-env:run-env
+     (do
+      (x? <- (m-env:asks head))
+      (pure
+       (match x?
+         ((None) 0)
+         ((Some x) (+ 10 x)))))
+     (make-list 10 20 30 40)))
+  (is (== 20 result)))
+
+(define-test test-local-env ()
+  (let result =
+    (m-env:run-env
+     (m-env:local
+      (+ 100)
+      (do
+       (x <- m-env:ask)
+       (pure (+ x 10))))
+     15))
+  (is (== 125 result)))


### PR DESCRIPTION
This PR adds a base `Env :env` monad to `environment.lisp`. Previously `Env :env` was just an alias for `EnvT :env Identity`. Haskell defines `Reader` like this, and they can get away with it. GHC does a *lot* of work behind the scenes to fuse lambda calls, so wrapping the Identity monad is zero-cost at runtime for them. Coalton doesn't have that, so it's not.

Here's a little microbenchmark that takes an Integer as the environment and a list of ints as an argument, and maps adding the environment Integer to all of the ints in the list inside the monad.( It does this very inefficiently, so it binds for every element in the list.)

```lisp
(cl:in-package :cl-user)
(defpackage :bench-env
  (:use
   #:coalton
   #:coalton-prelude
   #:coalton-library/monad/environment
   #:coalton-library/monad/identity
   )
  )

(in-package :bench-env)

(named-readtables:in-readtable coalton:coalton)

(coalton-toplevel
  (define context 100)

  (declare add-env (MonadEnvironment Integer :m => List Integer -> :m (List Integer)))
  (define (add-env ints)
    (rec % ((rem ints)
            (accum Nil))
      (match rem
        ((Nil) (pure (reverse accum)))
        ((Cons x rem)
         (do
          (n <- ask)
          (% rem (Cons (+ n x) accum)))))))


  (declare test-env (List Integer -> Unit))
  (define (test-env ints)
    (run-env (add-env ints) context)
    Unit)

  (declare test-envT (List Integer -> Unit))
  (define (test-envT ints)
    (run-identity (run-envT (add-env ints) context))
    Unit)

  (declare test-both (Unit -> Unit))
  (define (test-both)
    (let ints = (range 0 10000000))
    (lisp :a (ints)
      (cl:time (coalton (test-env (lisp :a () ints)))))
    (lisp :a (ints)
      (cl:time (coalton (test-envT (lisp :a () ints)))))
    Unit)
  )
```

Here are typical results on my machine, compiled in release mode:
```
Evaluation took:
  1.186 seconds of real time
  1.182656 seconds of total run time (1.007186 user, 0.175470 system)
  [ Real times consist of 0.547 seconds GC time, and 0.639 seconds non-GC time. ]
  [ Run times consist of 0.543 seconds GC time, and 0.640 seconds non-GC time. ]
  99.75% CPU
  4,382,138,882 processor cycles
  1,919,869,824 bytes consed
  
Evaluation took:
  1.226 seconds of real time
  1.220518 seconds of total run time (1.082556 user, 0.137962 system)
  [ Real times consist of 0.356 seconds GC time, and 0.870 seconds non-GC time. ]
  [ Run times consist of 0.357 seconds GC time, and 0.864 seconds non-GC time. ]
  99.59% CPU
  4,527,260,615 processor cycles
  2,719,164,848 bytes consed
```
The base `Env` runs ~3.26% faster than the `EnvT`' which actually surprised me that it was so close. I'm not good enough at optimizing CL/Coalton to really know why that might be, other than speculating that the EnvT & Identity monads really don't do that much.
The base `Env` did cons ~29% fewer bytes than the `EnvT` version did, which is in line with what I would have expected. Also curious, the base version actually spent more time in GC, but I suspect that's just noise or a bad test setup on my part.