### PR TITLE
disable precise FTYPE declarations for struct readers/ctors

### DIFF
--- a/src/codegen/struct-or-class.lisp
+++ b/src/codegen/struct-or-class.lisp
@@ -59,6 +59,16 @@ regardless of Coalton's release mode."
        (:struct
         (append
          ;; Declare the types of the constructor and readers:
+         ;;
+         ;; XXX: These seem to cause bugs because they overwrite or
+         ;; disagree with SBCL's own conception of the types of these
+         ;; functions. Maybe we can re-enable or revise later, hence
+         ;; we'll keep the code.
+         ;;
+         ;; As a specific example, readers are inferred to be
+         ;; (FUNCTION (T) ...) as opposed to (FUNCTION (STRUCT-TYPE)
+         ;; ...).
+         #+#:broken-on-sbcl
          (when settings:*emit-type-annotations*
            (list*
             `(declaim (ftype (function


### PR DESCRIPTION
These disagree with SBCL's inferred type in minor (but what I believe to be compatible) ways, but it appears to wreak havoc in SBCL's checking on whether struct definitions are getting clobbered, etc. So, for now, we disable it.

For example

```
(define-struct A (B F64))
```

would produce the ftype

```
   (COMMON-LISP:FTYPE
    (COMMON-LISP:FUNCTION (A/A)
                          (COMMON-LISP:VALUES COMMON-LISP:DOUBLE-FLOAT COMMON-LISP:&OPTIONAL))
    A/A-_0)
```

but SBCL took that as a clobber, maybe because SBCL thinks it's

```
CL-USER> (describe #'A/A-_0)
#<FUNCTION A/A-_0>
  [compiled function]


An accessor for COMMON-LISP-USER::A/A
Lambda-list: (INSTANCE)
Derived type: (FUNCTION (T) (VALUES DOUBLE-FLOAT &OPTIONAL))
Inline proclamation: INLINE (no inline expansion available)
Source file: ~/Scratch/bug.lisp
```

Note the `T` vs `A/A`.

Maybe it's not legal to declaim FTYPEs on struct-generated functions?