### PR TITLE
Fix Fiasco error reporting from define-test

### DIFF
--- a/src/testing/coalton-native-test-utils.lisp
+++ b/src/testing/coalton-native-test-utils.lisp
@@ -19,26 +19,26 @@ BODY within a `coalton' expression."
   ()
   (:documentation "Signaled when an assertion such as IS is encountered from coalton"))
 
-(cl:define-condition coalton-failure (fiasco::failure)
+(cl:define-condition coalton-failure (fiasco::failed-assertion)
   ()
   (:documentation "Signaled when an assertion such as IS fails from coalton"))
 
 (coalton-toplevel
   (declare %register-assertion (Unit -> Unit))
   (define (%register-assertion _)
-    (progn 
+    (progn
       (lisp :any ()
         (cl:warn 'coalton-test-assertion))
       Unit))
 
   (declare %register-success (Unit -> Unit))
   (define (%register-success _)
-    (progn 
+    (progn
       (lisp :any ()
         (fiasco::register-assertion-was-successful))
       Unit)))
 
-(cl:defmacro is (check cl:&optional (message "")) 
+(cl:defmacro is (check cl:&optional (message ""))
   ;; What I'm doing here is a simplified version of what fiasco does,
   ;; which is check if try to expand one layer of function application
   (cl:check-type message cl:string)
@@ -52,7 +52,7 @@ BODY within a `coalton' expression."
                (name-els (cl:loop :for rand :in (cl:cons rator rands) :collect (cl:list (cl:gensym) rand)))
                (names (cl:mapcar #'cl:first name-els)))
        `(progn
-          (%register-assertion) 
+          (%register-assertion)
           ,@(cl:loop :for (name value) :in name-els
                :collect `(let ,name = ,value))
           (if ,names


### PR DESCRIPTION
When a `(is (== ...))` test fails in `define-test`, Fiasco tries to report the failure (unless it is running all the tests in batch). However, that reporting routine in Fiasco triggers another error, yielding a mysterious error message  "The value NIL is not of type NUMBER", which doesn't help to nail the failure at all.

It was because of the interaction of these three factors

(1) Fiasco reports failed tests with `describe-failed-tests` in suite.lisp,
    which calls `describe-object` on the conditions.
(2) Fiasco specializes `describe-object` method on several internal
    condition types.  What's relevant here is `failed-condition`, which
    is a subclass condition of `failure`, with customized reporter.
(3) Coalton defines `coalton-failure` subclassing `fiasco::failure`
    to represent failure during coalton tests.

The issue is that Fiasco does not specializes `describe-object` on `failure`.  And SBCL does not like that generic function is called on an object without a specialized method.

The user code is not supposed to call `describe-object` directly; it should call `decribe` instead.  So it is partly Fiasco's problem. Nonetheless, to make Fiasco reporting work, we should make `coalton-failure` subclass `fiasco::failed-condition`.