### PR TITLE
Add run-free helper function

### DIFF
--- a/library/monad/free.lisp
+++ b/library/monad/free.lisp
@@ -10,7 +10,8 @@
    #:Free
    #:val
    #:liftF
-   #:foldFree))
+   #:foldFree
+   #:run-free))
 
 (in-package #:coalton-library/monad/free)
 
@@ -57,6 +58,18 @@ free monad to a target monad."
     (match fr
       ((Val a) (pure a))
       ((Free fa) (>>= (nat fa) (foldFree nat)))))
+
+  (declare run-free (Functor :f => (:f (Free :f :a) -> Free :f :a) -> Free :f :a -> :a))
+  (define (run-free transf op)
+    "Run a free monad with a function that unwraps a single layer of the functor
+`f` at a time.
+
+References: [here](https://github.com/purescript/purescript-free/blob/v5.1.0/src/Control/Monad/Free.purs#L167)"
+    (match op
+      ((Val a)
+       a)
+      ((Free f-freea)
+       (run-free transf (transf f-freea)))))
 
   ;;
   ;; Instances


### PR DESCRIPTION
Adds a small helper function for writing free monad interpreters. Particularly useful for interpreters that perform side-effects on evaluation.

Example usage:

```lisp
(coalton-toplevel
  (define-class (Monad :m => MonadIoTerm :m)
    (write (Into :a String => :a -> :m Unit))
    (write-line (Into :a String => :a -> :m Unit))
    (read-line (:m String))
    ))

(cl:defmacro derive-monad-io-term (monadT-form)
  "Automatically derive an instance of MonadIoTerm for a monad transformer.

Example:
  (derive-monad-io-term (st:StateT :s :m))"
  `(define-instance (MonadIoTerm :m => MonadIoTerm ,monadT-form)
     (define write (compose lift write))
     (define write-line (compose lift write-line))
     (define read-line (lift read-line))
     ))

;;
;; Std. Library Transformer Instances
;;

(coalton-toplevel
  (derive-monad-io-term (stt:StateT :s :m))
  (derive-monad-io-term (env:EnvT :e :m)))

;;
;; IO Implementation
;;

(coalton-toplevel
  (define-type (IOF :t)
    (WriteF String :t)
    (WriteLineF String :t)
    (ReadLineF (String -> :t))
    )

  (define-instance (Functor IOF)
    (define (map f io)
      (match io
        ((WriteF s next) (WriteF s (f next)))
        ((WriteLineF s next) (WriteLineF s (f next)))
        ((ReadLineF cont) (ReadLineF (map f cont)))
        )))

  (define-type-alias IO (free:Free IOF))

  (define-instance (MonadIoTerm IO)
    (inline)
    (define (write s)
      (free:liftf (WriteF (into s) Unit)))
    (inline)
    (define (write-line s)
      (free:liftf (WriteLineF (into s) Unit)))
    (inline)
    (define read-line
      (free:liftf (ReadLineF id)))
    ))

(coalton-toplevel
  (declare run! (IO :t -> :t))
  (define run!
    (free:run-free
     (fn (iof)
       (match iof
         ((WriteF s next)
          (lisp :a (s)
            (cl:format cl:t "~a" s))
          next)
         ((WriteLineF s next)
          (lisp :a (s)
            (cl:format cl:t "~a~%" s))
          next)
         ((ReadLineF cont)
          (let input = (lisp String ()
                         (cl:read-line)))
          (cont input)))))))

(coalton-toplevel
  (define (run-example)
    (run!
     (do
      (write-line "Please enter your name")
      (name <- read-line)
      (write-line (<> "Hello " name))))))
```