### PR TITLE
Add LiftTo class

### DIFF
--- a/library/monad/classes.lisp
+++ b/library/monad/classes.lisp
@@ -3,6 +3,9 @@
    #:coalton
    #:coalton-library/classes)
   (:export
+   #:LiftTo
+   #:lift-to
+
    #:MonadEnvironment
    #:ask
    #:local
@@ -22,6 +25,18 @@
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
 (coalton-toplevel
+
+  (define-class ((Monad :m) (Monad :r) => LiftTo :m :r)
+     "A monad, :m, which can be lifted to :r. Typically because :m is a MonadTransformer or :m and :r are the same."
+    (lift-to (:m :a -> :r :a)))
+
+  (define-instance (Monad :m => LiftTo :m :m)
+    (inline)
+    (define (lift-to x) x))
+
+  (define-instance ((Monad :m) (Monad (:t :m)) (MonadTransformer :t) => LiftTo :m (:t :m))
+    (inline)
+    (define lift-to lift))
 
   (define-class (Monad :m => MonadEnvironment :env :m (:m -> :env))
     "A monad capable of a function in a computation environment."


### PR DESCRIPTION
Adds a small helper class that allows you to 'lift' a monad to itself or into any transformer stack. The motivating use-case is encoding `MonadUnliftIO`. 

The Haskell library has the surprising and annoying restriction that any function that uses the unlift-io machinery can only _return_ an instance of `MonadUnliftIO`. This is cumbersome because most monads don't have an instance of `MonadUnliftIO`.

For example, [their docs]() give:
```haskell
myWithBinaryFile
    :: MonadUnliftIO m
    => FilePath
    -> IOMode
    -> (Handle -> m a)
    -> m a
```
this example. Notice how the return monad, `m`, has to be a `MonadUnliftIO`! Later, when you're using this, you can lift it after you call the function. If you have something like a `StateT :s (ReaderT :env IO)` stack, this works fine:

```haskell
do
   do-my-stateful-thing
   lift $ myWithBinaryFile ...
   keep-doing-stateful-things
```

But you can't just stick `lift` _into_ `myWithBinaryFile` and then change the return type. If you do, then it can't compile the simple case where `:m = IO`, because IO isn't a monad transformer, so it can't `lift`. My opinion is that `lift` makes monad transformers very hard to use, and it should be made possible to never have to use it outside of library code.

`LiftTo` allows us to say either `lift` or just be yourself. So it allows functions like `myWithBinaryFile` but that can return a separate monad type that does not have to be a MonadUnliftIO:

```lisp
  (declare with-open-file% ((file:File :a) (UnliftIo :r :i) (LiftTo :r :m)
            => file:StreamOptions
            -> ((file:FileStream :a) -> :r (Result file:FileError :b))
            -> :m (Result file:FileError :b)))
  (define (with-open-file% opts k)
    "IO version of FILE:WITH-OPEN-FILE where the continuation returns IO."
    (lift-to
     (with-run-in-io
         (fn (run)
           (lift-io
            (do
             (result? <- (wrap-io (file:with-open-file opts (fn (fs) (Ok (run (k fs)))))))
             (match result?
               ((Err e) (pure (Err e)))
               ((Ok op) op))))))))
```