### PR TITLE
Fix running tests in slime

### DIFF
--- a/tests/entry-tests.lisp
+++ b/tests/entry-tests.lisp
@@ -4,10 +4,11 @@
   (test-file "examples/small-coalton-programs/src/fact-fib.coal"))
 
 (defun source-forms (string)
-  (with-input-from-string (stream string)
-    (loop :for form := (read stream nil nil)
-          :while form
-          :collect form)))
+  (let ((*readtable* (copy-readtable nil)))
+    (with-input-from-string (stream string)
+      (loop :for form := (read stream nil nil)
+            :while form
+            :collect form))))
 
 (deftest test-compile-to-lisp ()
   "Test that the Coalton compiler compiles a test file into something that looks like Lisp source."
@@ -28,7 +29,8 @@
       (fmakunbound fact)
       (setf entry:*global-environment* (tc:unset-function entry:*global-environment* fact)))
     (let ((file (source:make-source-file (compile-test-file) :name "test")))
-      (entry:compile file :load t)
+      (let ((*readtable* (copy-readtable nil)))
+        (entry:compile file :load t))
       (let ((fact (test-sym)))
         (is (fboundp fact)
             "Test function was bound as side effect of loading fasl")

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -121,7 +121,8 @@ Returns (values SOURCE-PATHNAME COMPILED-PATHNAME)."
   "Run the test file at PATHNAME."
   (format t "~&;; --- Running test file: ~A~%" pathname)
   (let ((file (test-file pathname))
-        (coalton-impl/settings:*coalton-print-unicode* nil))
+        (coalton-impl/settings:*coalton-print-unicode* nil)
+        (*readtable* (copy-readtable nil)))
     (loop :for (line number flags description program expected-error)
             :in (coalton-tests/loader:load-test-file file)
           :unless (position :disable flags)


### PR DESCRIPTION
With Slime REPL, running tests fails on the second time and after.
Emacs 29.3, Slime-20251122.1352 (installed from melpa), SBCL 2.5.10.

```
; SLIME
CL-USER> (ql:quickload :coalton)
...
CL-USER> (asdf:test-system :coalton/tests)
...
; compilation unit finished
;   caught 1 STYLE-WARNING condition
;   printed 152 notes
T
CL-USER> (asdf:test-system :coalton/tests)
COALTON-TESTS (Suite)
  TEST-CHAR-POSITION-STREAM...............................................[ OK ]
  TEST-LOCATION...........................................................[ OK ]
  TEST-SOURCE-NAMES-ARE-PRESERVED.........................................[ OK ]
  TEST-TARJAN-SCC.........................................................[ OK ]
  TEST-UNINTERNED-SYMBOLS.................................................[ OK ]
  READ-EVAL-ERROR.........................................................[ OK ]
  TEST-ERROR..............................................................[ OK ]
  TEST-COMPILE-TO-LISP
;
; compilation unit aborted
;   caught 1 fatal ERROR condition
; Evaluation aborted on #<FIASCO::FAILED-ASSERTION "Missing expected ~A form in generated code" {120B073703}>.
CL-USER>
```

This doesn't happen when running SBCL directly from the shell.  Probably it won't in other environments (e.g. Sly).

I narrowed it that it is something to do with the readtable.  After the full test is run, somehow Slime uses Coalton's readtable as the default when interacting with inferior-lisp process.   In some tests, a compiled result (CL forms) are repeatedly `read` to check its vailidity.  With that messed up state, only the first form is read and the next read yields EOF.

The proper fix may be in Slime side, or there can be workaround in Coalton's readtable  code.  Meanwhile, since this issue is extremely annoying, this PR makes the tests run.