### PR TITLE
(Vector :a) is now just a (CL:VECTOR CL:T)

### DIFF
--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -60,7 +60,7 @@
   ;; Vector
   ;;
 
-  (repr :native (cl:and (cl:vector cl:t) (cl:not cl:simple-vector)))
+  (repr :native (cl:vector cl:t))
   (define-type (Vector :a))
 
   (inline)


### PR DESCRIPTION
This removes the (NOT SIMPLE-VECTOR) intersection from the Lisp type of (Vector :a). The reason is that a Lisp implementation is allowed to return SIMPLE-VECTOR from MAKE-ARRAY as it pleases. SIMPLE-VECTOR contains, **but is not necessarily limited to**, non-adjustable arrays without fill-pointers. The CLHS spec says:

> If make-array is called with one or more of adjustable,
> fill-pointer, or displaced-to being true, whether the resulting
> array is a simple array is implementation-dependent.

and

> There is no specified way to create an array that is not a simple
> array.

Bug originally reported by @c-kloukinas.