### PR TITLE
Configurably include reexported symbols in docs

### DIFF
--- a/src/doc/environment.lisp
+++ b/src/doc/environment.lisp
@@ -50,25 +50,27 @@
 
 
 (defun find-classes (&key (environment entry:*global-environment*)
-                          (package nil))
+                          (package nil)
+                          (reexported-symbols nil))
   "Return all class definitions in ENVIRONMENT.
 
 By default the global environment is queried.
 If non-nil, restrict to classes defined in PACKAGE."
   (remove-if (lambda (type-entry)
                (and package
-                    (not (exported-symbol-p (tc:ty-class-name type-entry) package t))))
+                    (not (exported-symbol-p (tc:ty-class-name type-entry) package (not reexported-symbols)))))
              (%values (tc:environment-class-environment environment))))
 
 (defun find-types (&key (environment entry:*global-environment*)
-                        (package nil))
+                        (package nil)
+                        (reexported-symbols nil))
   "Return all type definitions in ENVIRONMENT.
 
 By default the global environment is queried.
 If non-nil, restrict to types defined in PACKAGE."
   (remove-if (lambda (type-entry)
                (and package
-                    (not (exported-symbol-p (tc:type-entry-name type-entry) package t))))
+                    (not (exported-symbol-p (tc:type-entry-name type-entry) package (not reexported-symbols)))))
              (%values (tc:environment-type-environment environment))))
 
 (defun find-constructors (&key (environment entry:*global-environment*)
@@ -84,7 +86,8 @@ If non-nil, restrict to constructors defined in PACKAGE."
 
 (defun find-names (&key (environment entry:*global-environment*)
                         (type nil)
-                        (package nil))
+                        (package nil)
+                        (reexported-symbols nil))
   "Return all names in ENVIRONMENT.
 
 By default the global environment is queried.
@@ -93,7 +96,7 @@ If non-nil, restrict to names defined in PACKAGE."
                (or (and type
                         (not (eql type (tc:name-entry-type entry))))
                    (and package
-                        (not (exported-symbol-p (tc:name-entry-name entry) package t)))))
+                        (not (exported-symbol-p (tc:name-entry-name entry) package (not reexported-symbols))))))
              (%values (tc:environment-name-environment environment))))
 
 (defun find-instances (&key (environment entry:*global-environment*)


### PR DESCRIPTION
At a per-package level, allow re-exported symbols to be included in the docs. This works for everything except macros. Defaults to not including reexported symbols, so no existing behavior will change.

Example:
```lisp
(cl:in-package :cl-user)

(ql:quickload "coalton/doc")
(ql:quickload "coalton-io")
(defpackage :io.doc
  (:use :cl))
(in-package :io.doc)

(defun write-docs (&key
                     (pathname "../docs/simple-io.html")
                     (packages (list (coalton/doc/model::make-coalton-package (find-package 'io/simple-io)
                                                                              :reexported-symbols t)
                                     (coalton/doc/model::make-coalton-package (find-package 'io/classes/monad-io-thread))
                                     (coalton/doc/model::make-coalton-package (find-package 'io/thread-exceptions))
                                     )))

  (coalton/doc:write-documentation
    pathname
    packages
    :backend :hugo))

(write-docs)
```