### PR TITLE
Preliminary fix for node-do code generation in release mode

### DIFF
--- a/src/codegen/pattern.lisp
+++ b/src/codegen/pattern.lisp
@@ -187,6 +187,12 @@ CONSTRUCTOR of type TYPE?"
   (when (endp pattern-constructors)
     (return-from pattern-constructors-exhaustive-p nil))
 
+  (loop :with subs        := nil
+        :for pattern      :in pattern-constructors
+        :for pattern-type := (pattern-type pattern)
+        :do (setf subs (tc:unify subs pattern-type type))
+        :finally (setf type (tc:apply-substitution subs type)))
+
   ;; If we got this far, then PATTERN-CONSTRUCTORS is NOT empty,
   ;; which means we do have a list of constructors, and we can
   ;; assume that TYPE is a TYCON or a TAPP.


### PR DESCRIPTION
In release mode, we only emit an extra branch after checking that a match is indeed not exhaustive. This is done by flattening the type of the expression and comparing the tycon symbol with the pattern symbols. When a `do` statement is compiled, it is turned into a node-application which is then translated to include match statements. Somewhere in this process, it seems that type information is lost about the match expression type in some cases, as in the case reported by @Jason94. This commit fixes that issue, but it does not address the source of the typechecking error.

I'm keeping this in `draft` mode while I continue investigating. See the original post from [here](https://discord.com/channels/888196168067199046/1451618690662400192/1451618690662400192).