### PR TITLE
Add more information to context reduction error

### DIFF
--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -367,7 +367,8 @@ respective superclass predicate is passed to this function."
             ;; There should always be an associated expression
             ;; predicate.
             (when (null expr-pred)
-              (util:coalton-bug "There is no matching expression predicate."))
+              (util:coalton-bug
+                (format nil "No expression predicate matches ~a." pred)))
             ;; So, we create substitutions based on the
             ;; newly-determined types.
             (loop :with expr-pred-tys := (ty-predicate-types expr-pred)


### PR DESCRIPTION
I know it's a bug and you're never *supposed* to see this on compile. But I've seen it a lot recently, and it'd be nice to have more information about what causes it.