### PR TITLE
Fix fundep superset bug

### DIFF
--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -359,7 +359,7 @@ respective superclass predicate is passed to this function."
                         ;; We find the expression predicate that is
                         ;; associated with PRED based on KNOWN-TYVARS.
                         (and (eq class-name (ty-predicate-class expr-pred))
-                             (equalp known-indices (known-indices expr-pred))
+                             (subsetp known-indices (known-indices expr-pred))
                              (every #'ty=
                                     (known pred-tys)
                                     (known (ty-predicate-types expr-pred)))))

--- a/tests/fundep-tests.lisp
+++ b/tests/fundep-tests.lisp
@@ -245,3 +245,16 @@
       (coalton-library/types:as-proxy-of (pure Unit)
                                          m-prx))")
   )
+
+(deftest fundep-fundep-identity ()
+  ;; See https://github.com/coalton-lang/coalton/issues/1736
+  (check-coalton-types
+   "(define-class ((Monad :r) (Monad :m) => MonadChain :r :m (:r -> :m)))
+
+    (declare bar (MonadChain :r :m => :r String))
+    (define bar
+      (pure \"bar\"))
+
+    (declare foo (MonadChain :h :h => :h String))
+    (define foo
+      bar)"))


### PR DESCRIPTION
Fix a bug caused when the class constraints of the declaration contained tyvars used in fundeps in more positions than the type of the inferred block.

Fixes #1736