### PR TITLE
[WIP] Add apples-to-apples benchmark cell vs CL let var

### DIFF
--- a/benchmarks/cell.lisp
+++ b/benchmarks/cell.lisp
@@ -1,0 +1,49 @@
+;;;; cell.lisp
+;;;;
+;;;; Micro benchmarks of cell operations
+
+(cl:in-package #:benchmark-cell)
+
+(cl:defparameter *cell-samples* 150)
+(cl:defparameter *cell-iterations* 2000000)
+
+(define-benchmark cl-lexical-var ()
+  (declare (optimize speed))
+  (loop :repeat *cell-samples*
+        :do (with-benchmark-sampling
+              (benchmark-cell/native::cl-lexical-var *cell-iterations*)))
+  (report trivial-benchmark::*current-timer*))
+
+(define-benchmark coalton-local-cell ()
+  (declare (optimize speed))
+  (loop :repeat *cell-samples*
+        :do (with-benchmark-sampling
+              (benchmark-cell/native::coalton-local-cell *cell-iterations*)))
+  (report trivial-benchmark::*current-timer*))
+
+(cl:in-package #:benchmark-cell/native)
+
+(cl:declaim (cl:optimize (cl:speed 3) (cl:safety 1)))
+
+(coalton-toplevel
+  (declare calculate (UFix -> UFix))
+  (define (calculate x)
+    (mod (^ (1+ x) 2) 123456789)))
+
+;; Benchmark reading and mutating a Common Lisp lexical variable
+(cl:defun cl-lexical-var (iterations)
+  (cl:declare (cl:optimize (cl:speed 3) (cl:safety 1)))
+  (cl:declare (cl:fixnum iterations))
+  (cl:let ((value 0))
+    (cl:dotimes (_ iterations)
+      (cl:setf value (calculate value)))))
+
+;; Benchmark reading and mutating a Coalton cell. To guarantee apples-to-apples
+;; comparison, using CL to use the same loop mechanism as the CL benchamrk.
+(cl:defun coalton-local-cell (iterations)
+  (cl:declare (cl:optimize (cl:speed 3) (cl:safety 1)))
+  (cl:declare (cl:fixnum iterations))
+  (cl:let ((cell (coalton (new 0))))
+    (cl:dotimes (_ iterations)
+      (coalton (write! (lisp :a () cell)
+                       (calculate (read (lisp :a () cell))))))))

--- a/benchmarks/package.lisp
+++ b/benchmarks/package.lisp
@@ -119,6 +119,15 @@
                     (#:arr  #:coalton-library/lisparray))
   )
 
+(define-coalton-benchmark cell
+    ()
+  (:use
+   #:coalton
+   #:coalton-prelude
+   #:coalton-library/cell)
+  (:local-nicknames (#:iter #:coalton-library/iterator))
+  )
+
 (define-coalton-benchmark mapping
     ((:local-nicknames
       (#:hashtable #:coalton-library/hashtable)

--- a/coalton.asd
+++ b/coalton.asd
@@ -207,6 +207,7 @@
                (:file "seq")
                (:file "matrix")
                (:file "mapping")
+               (:file "cell")
                (:module "gabriel-benchmarks"
                 :serial t
                 :components ((:file "tak")


### PR DESCRIPTION
First attempt at adding an apples-to-apples benchmark comparing reading and mutating a Coalton cell vs just mutating a local variable in CL using `setf`. I marked as draft because I'd like to add another benchmark testing a Coalton function that takes a cell as an argument. It's possible that disables some optimizations, and that's a common use case.

Surprisingly, there doesn't seem to be any noticeable difference. Here are the results from two runs, in release mode, on my laptop:

```
Benchmarking BENCHMARK-CELL::COALTON-LOCAL-CELL...
-                SAMPLES  TOTAL      MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION  
REAL-TIME        150      10.800026  0.069999  0.096667  0.073333  0.072     0.002749   
RUN-TIME         150      10.790615  0.071053  0.096522  0.071485  0.071937  0.002223   
USER-RUN-TIME    150      10.790575  0.071048  0.096519  0.071482  0.071937  0.002222   
SYSTEM-RUN-TIME  150      0.000099   0         0.000013  0         0.000001  0.000002   
PAGE-FAULTS      150      0          0         0         0         0         0.0        
GC-RUN-TIME      150      0          0         0         0         0         0.0        
BYTES-CONSED     150      0          0         0         0         0         0.0        
EVAL-CALLS       150      0          0         0         0         0         0.0        
Benchmarking BENCHMARK-CELL::CL-LEXICAL-VAR...
-                SAMPLES  TOTAL      MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION  
REAL-TIME        150      10.510024  0.066665  0.076667  0.07      0.070067  0.001185   
RUN-TIME         150      10.502195  0.069467  0.076697  0.069758  0.070015  0.000764   
USER-RUN-TIME    150      10.502215  0.069467  0.076698  0.069758  0.070015  0.000764   
SYSTEM-RUN-TIME  150      0.000043   0         0.000015  0         0.0       0.000001   
PAGE-FAULTS      150      0          0         0         0         0         0.0        
GC-RUN-TIME      150      0          0         0         0         0         0.0        
BYTES-CONSED     150      0          0         0         0         0         0.0        
EVAL-CALLS       150      0          0         0         0         0         0.0        
done.
* (run-benchmark 'benchmark-cell)
Benchmarking BENCHMARK-CELL::COALTON-LOCAL-CELL...
-                SAMPLES  TOTAL      MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION  
REAL-TIME        150      10.890025  0.069999  0.1       0.073333  0.0726    0.003904   
RUN-TIME         150      10.878115  0.071091  0.101152  0.071541  0.072521  0.003508   
USER-RUN-TIME    150      10.878131  0.07109   0.101145  0.071539  0.072521  0.003508   
SYSTEM-RUN-TIME  150      0.000038   0         0.000006  0         0.0       0.000001   
PAGE-FAULTS      150      0          0         0         0         0         0.0        
GC-RUN-TIME      150      0          0         0         0         0         0.0        
BYTES-CONSED     150      0          0         0         0         0         0.0        
EVAL-CALLS       150      0          0         0         0         0         0.0        
done.
Benchmarking BENCHMARK-CELL::CL-LEXICAL-VAR...
-                SAMPLES  TOTAL      MINIMUM   MAXIMUM   MEDIAN    AVERAGE   DEVIATION  
REAL-TIME        150      10.876692  0.066667  0.090001  0.070001  0.072511  0.004791   
RUN-TIME         150      10.865291  0.069465  0.090759  0.070999  0.072435  0.004533   
USER-RUN-TIME    150      10.865421  0.069466  0.090761  0.070999  0.072436  0.004533   
SYSTEM-RUN-TIME  150      0.000017   0         0.000003  0         0.0       0.0        
PAGE-FAULTS      150      0          0         0         0         0         0.0        
GC-RUN-TIME      150      0          0         0         0         0         0.0        
BYTES-CONSED     150      0          0         0         0         0         0.0        
EVAL-CALLS       150      0          0         0         0         0         0.0        
done.
```