### PR TITLE
Fix Nested Instances with Functional Dependencies Bug

### DIFF
--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -31,7 +31,6 @@
 ;; Context reduction
 ;;
 
-
 (defun true (x)
   (if x
       t
@@ -294,7 +293,10 @@ the type variables of the class D.
           :with preds      := (expand preds)
           :with subs       := nil
           :for pred :in preds
-          :for new-subs := (fundep-entail% env expr-preds pred known-tyvars)
+          :for new-subs :=
+            (if (entail env expr-preds pred)
+                '()
+                (fundep-entail% env expr-preds pred known-tyvars))
           :do (setf subs (compose-substitution-lists subs new-subs))
           :finally (return subs))))
 


### PR DESCRIPTION
I encountered a bug in nested instances of a class with functional dependencies. When one type would contain an instance of a class, and then it used that contained instance's instance to supply its own instance of the class, then it would fail to compile.

The issue was that define-instance removes the class constraints before checking the types of the instance methods. Normally that's not a problem because they're entailed. But `fundep-entail%` checks for structural similarity, not entailment. To fix it, I had `fundep-entail` skip `fundep-entail%` for any predicate that was entailed by the environment.

The tests pass, and I included a regression test that failed with the fix removed and passes now.

Edit: The fix is in src/typechecker/context-reduction.lisp:fundep-entail, L296