### PR TITLE
codegen: reuse analysis exhaustiveness checker for fallback matching

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -294,6 +294,7 @@
                 :serial t
                 :components ((:file "cursor-tests")))
                (:file "entry-tests")
+               (:file "codegen-pattern-tests")
                (:file "toplevel-tests")
                (:file "type-inference-tests")
                (:file "fundep-tests")

--- a/tests/codegen-pattern-tests.lisp
+++ b/tests/codegen-pattern-tests.lisp
@@ -1,0 +1,56 @@
+(in-package #:coalton-tests)
+
+(deftest test-patterns-exhaustive-tyvar-head-does-not-crash ()
+  "Constructor-only pattern exhaustiveness checks should return NIL when the
+type head is still a variable, rather than signaling a type error."
+  (let ((ty (tc:make-variable))
+        (pattern
+          (coalton-impl/codegen/pattern:make-pattern-constructor
+           :type (tc:make-variable)
+           :name 'coalton:True
+           :patterns nil)))
+    (is (null (coalton-impl/codegen/pattern:patterns-exhaustive-p
+               (list pattern)
+               ty
+               entry:*global-environment*)))))
+
+(deftest test-patterns-exhaustive-tyvar-head-boolean-signature ()
+  "Constructor signatures should still be recognized when the scrutinee type
+head is a type variable."
+  (let ((ty (tc:make-variable))
+        (true-pattern
+          (coalton-impl/codegen/pattern:make-pattern-constructor
+           :type tc:*boolean-type*
+           :name 'coalton:True
+           :patterns nil))
+        (false-pattern
+          (coalton-impl/codegen/pattern:make-pattern-constructor
+           :type tc:*boolean-type*
+           :name 'coalton:False
+           :patterns nil)))
+    (is (coalton-impl/codegen/pattern:patterns-exhaustive-p
+         (list true-pattern false-pattern)
+         ty
+         entry:*global-environment*))))
+
+(deftest test-patterns-exhaustive-collapse-binding-patterns ()
+  "Codegen exhaustiveness should match analysis behavior for binding patterns."
+  (let ((bound-true-pattern
+          (coalton-impl/codegen/pattern:make-pattern-binding
+           :type tc:*boolean-type*
+           :var (coalton-impl/codegen/pattern:make-pattern-var
+                 :type tc:*boolean-type*
+                 :name 'x)
+           :pattern (coalton-impl/codegen/pattern:make-pattern-constructor
+                     :type tc:*boolean-type*
+                     :name 'coalton:True
+                     :patterns nil)))
+        (false-pattern
+          (coalton-impl/codegen/pattern:make-pattern-constructor
+           :type tc:*boolean-type*
+           :name 'coalton:False
+           :patterns nil)))
+    (is (coalton-impl/codegen/pattern:patterns-exhaustive-p
+         (list bound-true-pattern false-pattern)
+         tc:*boolean-type*
+         entry:*global-environment*))))


### PR DESCRIPTION
The codegen fallback exhaustiveness pass had a separate implementation with different assumptions than analysis-time checking. In particular, it assumed constructor-only matches imply a `TYCON`/`TAPP` scrutinee head. In release codegen this pass can still see `TYVAR` scrutinees, which caused the #1730 failure (`... not of type ... TYCON`) and made behavior diverge from the earlier analysis pass.

Replace the codegen-specific exhaustiveness logic with the analysis checker:
- convert codegen pattern structs into typechecker pattern structs
- collapse binding patterns before checking
- delegate to `analysis-pattern-exhaustiveness:exhaustive-patterns-p`

This removes duplicate logic and keeps fallback emission decisions consistent with analysis semantics.

Add codegen exhaustiveness regression tests for:
- tyvar-head constructor patterns do not crash
- tyvar-head boolean constructor signatures are recognized
- binding patterns are collapsed consistently

Also register `tests/codegen-pattern-tests.lisp` in `coalton.asd`.

Fixes #1730.