### PR TITLE
Implement relaxed value restriction with weak type variables

### DIFF
--- a/coalton-compiler.asd
+++ b/coalton-compiler.asd
@@ -65,6 +65,7 @@
                              (:file "unify")
                              (:file "fundeps")
                              (:file "environment")
+                             (:file "variance")
 
                              (:module "redef-detection"
                               :pathname "../redef-detection/"

--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -250,6 +250,91 @@ As suggested, one can replace `y` with `_y`, which tells the Coalton compiler th
 
 One should treat underscore prefixed variables as ignored whenever possible, and use a name not prefixed with `_` if it may be used. Reading from underscore-prefixed variables is permitted so that generated code (e.g., using macros or read-conditionals) may avoid unused variable warnings for variables which will be used in some compilation contexts but not others.
 
+## Polymorphism, Mutation, and the Value Restriction
+
+Coalton infers polymorphic types for `define` and `let` bindings using an ML-style value restriction with a relaxed variance check.
+
+Informally:
+
+- A **non-expansive** expression is value-like (for example: variables, literals, lambdas, and constructor applications over non-expansive arguments).
+- An **expansive** expression may allocate or otherwise depend on effects (for example: calls like `vector:new` or `cell:new`).
+- Expansive bindings introduce **weak** type variables. Weak variables are generalized only when they occur in **covariant** positions.
+
+This keeps polymorphism sound in the presence of mutation while still allowing common covariant expansive expressions to remain polymorphic.
+
+A non-expansive constructor expression can still generalize:
+
+```lisp
+(coalton-toplevel
+  (define wrapped-none (Some None)))
+;; wrapped-none : Optional (Optional :a)
+```
+
+An expansive expression can still generalize when the weak variable is only covariant:
+
+```lisp
+(coalton-toplevel
+  (define wrapped-id
+    ((fn (x) x) None)))
+;; wrapped-id : (Optional :a)
+```
+
+But expansive bindings involving invariant or contravariant occurrences do not generalize. For example, mutable containers such as `Vector` remain monomorphic:
+
+```lisp
+(coalton-toplevel
+  (define wrapped-new
+    (Some (coalton-library/vector:new))))
+;; error: Type is not generalizable
+```
+
+If you hit this, there are two common fixes:
+
+1. Move the allocation into a function body so each call gets fresh state (often via eta-expansion).
+2. Add an explicit top-level type declaration when you intentionally want a monomorphic mutable value.
+
+For example, this is intentionally monomorphic:
+
+```lisp
+(coalton-toplevel
+  (declare int-vec (Vector Integer))
+  (define int-vec (coalton-library/vector:new)))
+```
+
+References:
+
+- [OCaml manual: Polymorphism and its limitations](https://ocaml.org/manual/4.14/polymorphism.html)
+- [Jacques Garrigue, "Relaxing the Value Restriction"](https://caml.inria.fr/pub/papers/garrigue-value_restriction-fiwflp04.pdf)
+- [Andrew K. Wright, "Simple Imperative Polymorphism"](https://doi.org/10.1017/S0956796800001230)
+
+### Variance
+
+Coalton uses type-parameter variance to decide which weak type variables from expansive bindings can still be generalized.
+
+- **Covariant**: the type parameter is only produced (for example, `Optional :a`, `List :a`).
+- **Contravariant**: the type parameter is consumed (for example, function argument position in `:a -> :b`).
+- **Invariant**: both directions are possible, or mutability allows writes (common for mutable containers).
+
+Under the relaxed value restriction, weak variables are generalized only when all observed occurrences are covariant; any invariant or contravariant occurrence keeps them monomorphic.
+
+### Opaque Native Types
+
+For `define-type` forms with no constructors and no alias body (typically used with `repr :native`), Coalton cannot inspect the type's internal structure to infer variance from fields. In those cases, type parameters are treated as invariant by default.
+
+This is conservative by design. For mutable wrappers, invariance is usually required for soundness.
+
+Current parametric opaque stdlib types include:
+
+- `Vector :a`
+- `Cell :a`
+- `Queue :a`
+- `Slice :a`
+- `Hashtable :key :value`
+- `LispArray :t`
+- `FileStream :a`
+
+These are all modeled invariantly; each either exposes mutation directly or mixes read/write capabilities in one type.
+
 ## Data Types
 
 Coalton allows the definition of parametric algebraic data types.
@@ -1502,4 +1587,3 @@ For the time being, the following caveats apply;
 
 
    
-

--- a/examples/small-coalton-programs/src/freecalc.lisp
+++ b/examples/small-coalton-programs/src/freecalc.lisp
@@ -72,14 +72,17 @@ we map over."
   ;; into a State monad. We use a vector of numbers for our inputs.
   ;;
   
-  (define compute-from-vector-inputs
+  ;; Eta-expand this interpreter so the binding is non-expansive and remains
+  ;; generalizable under the value restriction.
+  (define (compute-from-vector-inputs program)
     (free:foldfree
      (fn (arg) (match arg
                  ((AddE x y next) (pure (next (+ x y))))
                  ((SubE x y next) (pure (next (- x y))))
                  ((InputE next)
                   (map (compose next (fn (vec) (defaulting-unwrap (vector:pop! vec))))
-                       st:get))))))
+                       st:get))))
+     program))
 
 
   ;;

--- a/src/typechecker/package.lisp
+++ b/src/typechecker/package.lisp
@@ -10,6 +10,7 @@
    #:coalton-impl/typechecker/accessor
    #:coalton-impl/typechecker/partial-type-env
    #:coalton-impl/typechecker/parse-type
+   #:coalton-impl/typechecker/variance
    #:coalton-impl/typechecker/define-type
    #:coalton-impl/typechecker/derive
    #:coalton-impl/typechecker/define-class

--- a/src/typechecker/stage-1.lisp
+++ b/src/typechecker/stage-1.lisp
@@ -10,5 +10,6 @@
    #:coalton-impl/typechecker/unify
    #:coalton-impl/typechecker/fundeps
    #:coalton-impl/typechecker/environment
+   #:coalton-impl/typechecker/variance
    #:coalton-impl/typechecker/lisp-type
    #:coalton-impl/typechecker/context-reduction))

--- a/src/typechecker/variance.lisp
+++ b/src/typechecker/variance.lisp
@@ -1,0 +1,170 @@
+(defpackage #:coalton-impl/typechecker/variance
+  (:use
+   #:cl
+   #:coalton-impl/typechecker/kinds
+   #:coalton-impl/typechecker/types
+   #:coalton-impl/typechecker/environment)
+  (:export
+   #:variance                            ; TYPE
+   #:variance-list                       ; TYPE
+   #:variance-p                          ; FUNCTION
+   #:variance-covariant-p                ; FUNCTION
+   #:variance-flip                       ; FUNCTION
+   #:variance-compose                    ; FUNCTION
+   #:variance-join                       ; FUNCTION
+   #:collect-tyvar-variances             ; FUNCTION
+   #:tyvar-variance                      ; FUNCTION
+   #:make-env-variance-resolver          ; FUNCTION
+   ))
+
+(in-package #:coalton-impl/typechecker/variance)
+
+;;;
+;;; Variance
+;;;
+;;; This module computes type-variable variance observations used by the
+;;; relaxed value restriction in DEFINE.LISP.
+;;;
+;;; References:
+;;;   - Jacques Garrigue, "Relaxing the Value Restriction" (2004)
+;;;   - OCaml manual section "Polymorphism and its limitations"
+;;;
+;;; Design note:
+;;;   We prefer conservative answers when information is missing. Unknown,
+;;;   underspecified, or opaque type constructors are treated as invariant.
+;;;   This may reject some programs but avoids unsound generalization.
+;;;
+
+(deftype variance ()
+  '(member :covariant :contravariant :invariant))
+
+(defun variance-p (x)
+  (typep x 'variance))
+
+(defun variance-covariant-p (variance)
+  (declare (type (or variance (eql :absent)) variance)
+           (values boolean &optional))
+  (eq variance ':covariant))
+
+(defun variance-flip (variance)
+  (declare (type variance variance)
+           (values variance &optional))
+  (ecase variance
+    (:covariant ':contravariant)
+    (:contravariant ':covariant)
+    (:invariant ':invariant)))
+
+(defun variance-compose (outer inner)
+  "Compose variances through nested type positions.
+
+OUTER is the variance of the current position; INNER is the variance of the
+child position relative to the current node."
+  (declare (type variance outer inner)
+           (values variance &optional))
+  (ecase outer
+    (:invariant ':invariant)
+    (:covariant inner)
+    (:contravariant (variance-flip inner))))
+
+(defun variance-join (left right)
+  "Join two variance observations for the same type variable.
+
+`:absent` means there was no observation in that branch. Conflicting
+covariant/contravariant observations collapse to invariant."
+  (declare (type (or variance (eql :absent)) left right)
+           (values (or variance (eql :absent)) &optional))
+  (cond
+    ((eq left ':absent) right)
+    ((eq right ':absent) left)
+    ((or (eq left ':invariant)
+         (eq right ':invariant))
+     ':invariant)
+    ((eq left right) left)
+    (t ':invariant)))
+
+(defun make-env-variance-resolver (env)
+  "Return a resolver for constructor variances in ENV.
+
+The returned function accepts a type constructor name and the observed arity in
+the current type application.
+
+Missing, underspecified, or opaque entries are treated as invariant."
+  (declare (type environment env)
+           (values function &optional))
+  (lambda (tycon-name arity)
+    (declare (type symbol tycon-name)
+             (type alexandria:non-negative-fixnum arity)
+             (values variance-list &optional))
+    (let ((fallback (make-list arity :initial-element ':invariant)))
+      (alexandria:if-let (entry (lookup-type env tycon-name :no-error t))
+        (let ((variances (type-entry-variances entry)))
+          (if (>= (length variances) arity)
+              (subseq variances 0 arity)
+              (append variances
+                      (make-list (- arity (length variances))
+                                 :initial-element ':invariant))))
+        fallback))))
+
+(defun tyvar-variance (table tyvar)
+  "Return TYVAR's variance in TABLE, or `:absent` if unseen."
+  (declare (type hash-table table)
+           (type tyvar tyvar)
+           (values (or variance (eql :absent)) &optional))
+  (or (gethash (tyvar-id tyvar) table)
+      ':absent))
+
+(defun collect-tyvar-variances (type resolver &key (position ':covariant) (table (make-hash-table :test #'eql)))
+  "Collect type-variable variances for TYPE into TABLE.
+
+TYPE may be a type or a list of types. RESOLVER must return a list of
+variances for a type constructor name and application arity.
+
+The walk composes variance through nested type constructors. Unknown
+applications (for example higher-kinded heads without a resolved TYCON) are
+treated as invariant to preserve soundness."
+  (declare (type (or ty list) type)
+           (type function resolver)
+           (type variance position)
+           (type hash-table table)
+           (values hash-table &optional))
+  (labels ((record (tyvar variance)
+             (declare (type tyvar tyvar)
+                      (type variance variance))
+             (let* ((id (tyvar-id tyvar))
+                    (old (or (gethash id table) ':absent))
+                    (new (variance-join old variance)))
+               (unless (eq old new)
+                 (setf (gethash id table) new))))
+           (walk (node variance)
+             (declare (type t node)
+                      (type variance variance))
+             (typecase node
+               (null nil)
+               (list
+                 (dolist (entry node)
+                   (walk entry variance)))
+               (tyvar
+                 (record node variance))
+               (tapp
+                 (let* ((flattened (flatten-type node))
+                        (head (first flattened))
+                        (args (rest flattened)))
+                   (if (typep head 'tycon)
+                       (let ((arg-variances
+                               (funcall resolver
+                                        (tycon-name head)
+                                        (length args))))
+                         (loop :for arg :in args
+                               :for i :from 0
+                               :for arg-variance := (or (nth i arg-variances)
+                                                        ':invariant)
+                               :do (walk arg (variance-compose variance arg-variance))))
+                       ;; Conservative fallback for higher-kinded applications:
+                       ;; unknown applications are treated as invariant.
+                       (progn
+                         (walk (tapp-from node) (variance-compose variance ':invariant))
+                         (walk (tapp-to node) (variance-compose variance ':invariant))))))
+               ((or tycon tgen ty)
+                nil))))
+    (walk type position)
+    table))


### PR DESCRIPTION
Adopt OCaml-style weak type variables to prevent unsound generalization for expansive bindings while preserving safe polymorphism.

- Treat expansive `define`/`let` bindings as weak and generalize only covariant weak variables.
- Add a variance analysis pass (`typechecker/variance`) and thread variance metadata through type environment entries.
- Infer type-parameter variance across `define-type` SCCs; default opaque native types to invariant when structure is unavailable.
- Keep top-level unresolved weak vars as an explicit "Type is not generalizable" error with a fix hint.
- Expand type-inference tests for covariant/contravariant/invariant cases, mutable containers (`Vector`, `Cell`, `Queue`), and opaque constructors.
- Document value restriction, weak variables, variance, and opaque native type behavior in the intro and typechecker docs.

Fixes #84.