### PR TITLE
accept superclass-only vars during class kind inference

### DIFF
--- a/tests/fundep-tests.lisp
+++ b/tests/fundep-tests.lisp
@@ -246,6 +246,24 @@
                                          m-prx))")
   )
 
+(deftest fundep-superclass-determined-var-regression ()
+  ;; See https://github.com/coalton-lang/coalton/issues/1716
+  (check-coalton-types
+   "(define-class (HasA :t :a (:t -> :a))
+      (get-a (coalton/types:Proxy :t -> :a)))
+
+    (define-class (HasA :t :a => WrapsHasA :w :t (:w -> :t))
+      (get-two-as (:w -> Tuple :a :a)))"))
+
+(deftest fundep-superclass-determined-var-workaround-regression ()
+  ;; See https://github.com/coalton-lang/coalton/issues/1716
+  (check-coalton-types
+   "(define-class (HasA :t :a (:t -> :a))
+      (get-a (coalton/types:Proxy :t -> :a)))
+
+    (define-class (HasA :t :a => WrapsHasA :w :t :a (:w -> :t))
+      (get-two-as (:w -> Tuple :a :a)))"))
+
 (deftest fundep-catch-inferred-dict-regression ()
   ;; See https://github.com/coalton-lang/coalton/issues/1719
   (is (null


### PR DESCRIPTION
Classes with fundeps and superclass constraints could fail. The failure happened because `infer-class-kinds` kind-inferred superclass predicates before adding superclass-only type vars to the partial type environment. Fix by collecting type vars from superclass predicates and pre-registering any vars not present in the class head before `infer-predicate-kinds`.

Fixes #1716.