### PR TITLE
Comprehensive documentation overhaul (14 issues)

### DIFF
--- a/docs/cl-style-guide.md
+++ b/docs/cl-style-guide.md
@@ -1,0 +1,183 @@
+# Common Lisp Style Guide for Coalton Compiler Development
+
+This document describes the Common Lisp coding conventions used in the Coalton compiler (`src/`). It is intended for contributors working on the compiler internals, not for users writing Coalton code. For the Coalton standard library style guide, see [style-guide.md](./style-guide.md).
+
+## Variable Binding
+
+### Prefer `let*` over `let`
+
+Use `let*` as the default binding form. Since most bindings depend on previous ones, `let*` avoids the confusion of parallel binding semantics. Use `let` only when parallel binding is specifically needed or when there's a single binding.
+
+```lisp
+;; Preferred
+(let* ((x (compute-something))
+       (y (transform x))
+       (z (finalize y)))
+  (use z))
+
+;; Acceptable for single bindings
+(let ((x 5))
+  (use x))
+```
+
+### Initially-nil variables
+
+Enclose initially-nil variables in explicit parentheses with `nil` rather than using the bare-symbol shorthand, for clarity:
+
+```lisp
+;; Preferred
+(let* ((result nil)
+       (count 0))
+  ...)
+
+;; Avoid
+(let* (result
+       (count 0))
+  ...)
+```
+
+### Predeclared local variables
+
+Predeclared local variables (bound at the top of a function and set later) are acceptable when the control flow makes it awkward to bind them in-line. However, prefer functional style (binding in `let*`) when possible.
+
+## Control Flow
+
+### Prefer `when`/`unless` for one-armed conditionals
+
+Use `when` and `unless` for side-effecting single-branch conditionals. Use `if` only when both branches produce a value.
+
+```lisp
+;; Good — side effect, no else branch
+(when (some-condition)
+  (do-something))
+
+;; Good — value-producing, both branches needed
+(if (some-condition) value-a value-b)
+```
+
+### Use `cond` for multi-way branching
+
+```lisp
+(cond
+  ((null list)
+   (handle-empty))
+  ((= (length list) 1)
+   (handle-singleton list))
+  (t
+   (handle-general list)))
+```
+
+### Early return with `return-from`
+
+Functions that validate preconditions often return early. This is idiomatic:
+
+```lisp
+(defun apply-optimization (node env)
+  (unless (optimization-applicable-p node)
+    (return-from apply-optimization node))
+  ;; ... main logic
+  )
+```
+
+## Expression-Oriented Style
+
+Prefer expression-oriented code where the result flows through binding forms rather than accumulating via mutation:
+
+```lisp
+;; Preferred — expression-oriented
+(let* ((processed (process input))
+       (validated (validate processed))
+       (result (transform validated)))
+  result)
+
+;; Avoid when possible — procedural accumulation
+(let ((result nil))
+  (setf result (process input))
+  (setf result (validate result))
+  (setf result (transform result))
+  result)
+```
+
+Mutation via `setf`, `push`, and `incf` is acceptable in loops and when building up collections.
+
+## Naming Conventions
+
+### Functions
+
+- Use `kebab-case` for all function and variable names
+- Predicates end in `-p`: `node-variable-p`, `coalton-release-p`
+- Constructors use `make-`: `make-node-variable`, `make-ast-substitution`
+- Accessors use `struct-name-field-name`: `node-type`, `node-match-branches`
+
+### Special variables
+
+- Global special variables use earmuffs: `*inliner-max-depth*`, `*coalton-optimize-library*`
+- Constants use `+`: `+macro-expansion-max+`
+
+### Packages
+
+- Implementation packages use the `coalton-impl/` prefix: `coalton-impl/parser`, `coalton-impl/typechecker`
+- Use local nicknames rather than long package prefixes: `(#:tc #:coalton-impl/typechecker)`
+
+## Comments
+
+Follow standard Lisp comment conventions:
+
+- `;;;;` — File-level headers and section separators
+- `;;;` — Section descriptions within a file
+- `;;` — Inline comments explaining the following code block
+- `;` — End-of-line annotations on the same line as code
+
+```lisp
+;;;; src/codegen/optimizer.lisp
+;;;;
+;;;; The optimization pipeline for compiled Coalton code.
+
+;;; Constant Folding
+
+;; We only fold pure operations
+(defun foldable-p (node)
+  (pure-operation-p node))  ; check purity before folding
+```
+
+## Exports and Package Organization
+
+The export list in `defpackage` should annotate each export with its kind:
+
+```lisp
+(:export
+ #:node-variable                ; STRUCT
+ #:make-node-variable           ; CONSTRUCTOR
+ #:node-variable-name           ; ACCESSOR
+ #:parse-expression             ; FUNCTION
+ #:*debug-mode*                 ; VARIABLE
+ #:+max-depth+                  ; CONSTANT
+ )
+```
+
+## Type Declarations
+
+Use `declare` and `declaim` for function signatures to help the CL compiler generate efficient code and to serve as documentation:
+
+```lisp
+(defun process-node (node env)
+  (declare (type node node)
+           (type environment env)
+           (values node &optional))
+  ...)
+```
+
+## Error Handling
+
+- Use `coalton-bug` (from `coalton-impl/util`) for internal compiler errors that indicate a bug
+- Use the condition system (`parse-error`, `tc-error`) for user-facing errors
+- Include enough context in error messages to diagnose the issue
+
+```lisp
+;; Internal bug — should never happen
+(util:coalton-bug "Expected function ~A to have at least ~A args" name (length preds))
+
+;; User-facing parse error
+(parse-error "Malformed expression"
+             (note source form "unexpected dotted list"))
+```

--- a/docs/coalton-documentation-guide.md
+++ b/docs/coalton-documentation-guide.md
@@ -10,8 +10,9 @@ Coalton's `define` form allows for docstrings to go after the variable or functi
 ```
 (coalton-toplevel
 
-  (define *pi* (the Double-Float math:pi)
-    "This is a constant of `pi`, that will always be a `Double-Float`.")
+  (define *pi*
+    "This is a constant of `pi`, that will always be a `Double-Float`."
+    (the Double-Float math:pi))
 
   (define (get-pi)
     "This is a function that returns the `Double-Float` constant `*pi*`."

--- a/docs/coalton-lisp-interop.md
+++ b/docs/coalton-lisp-interop.md
@@ -176,6 +176,55 @@ Here, we used `lisp` to actually construct, type, and return our `RandomState` o
 
 See [`Vector`](https://github.com/coalton-lang/coalton/blob/main/library/vector.lisp) for a more extensive example.
 
+## Promises of `define-struct`
+
+The `define-struct` form creates a single-constructor type with named fields. Its behavior varies by interaction mode:
+
+### Development Mode
+
+In development mode, structs are compiled as CLOS classes. This allows re-definition and interactive development.
+
+```
+(define-struct Point
+  (x Integer)
+  (y Integer))
+```
+
+Generates a CLOS class named `POINT` with:
+- A constructor function `POINT` that takes positional arguments: `(POINT 3 4)`
+- Field accessor functions named `CLASSNAME-FIELDNAME`, e.g., `POINT-X` and `POINT-Y`
+
+### Release Mode
+
+In release mode, structs are compiled as `defstruct` (frozen CL structs) for performance. The generated interface (constructor and accessor names) is the same, but the underlying representation uses CL's `defstruct` with `:read-only t` slots.
+
+### Accessor Naming
+
+**PROMISE**: For a struct defined as `(define-struct Foo (bar T1) (baz T2))`, the following Lisp functions will exist:
+- `FOO`: a constructor function taking positional arguments `(FOO bar-val baz-val)`
+- `FOO-BAR`: a reader function for the `bar` field
+- `FOO-BAZ`: a reader function for the `baz` field
+
+**WARNING**: Struct fields are read-only from Lisp. Coalton does not generate writer functions.
+
+### Using Structs from Lisp
+
+```lisp
+;; After defining a struct in Coalton:
+;;   (define-struct Point (x Integer) (y Integer))
+
+;; Constructing from Lisp:
+(point 3 4)               ; => #<POINT ...>
+
+;; Accessing fields from Lisp:
+(point-x (point 3 4))     ; => 3
+(point-y (point 3 4))     ; => 4
+```
+
+### Parametric Structs
+
+Parametric structs like `(define-struct (Pair :a) (first :a) (second :a))` follow the same accessor naming convention. The constructor and accessors are polymorphic at the Lisp level (they accept any type), so it is the caller's responsibility to ensure type correctness.
+
 ## Promises of `define`
 
 Consider the following definitions:
@@ -259,6 +308,34 @@ Each `<captured-variable>` refers to a lexical variable in the surrounding Coalt
 ```
 
 Here, the values of the parameters `a` and `b` are captured for use inside of the `lisp` form.
+
+## Accessing Lisp Variables from Coalton
+
+Coalton expressions cannot directly reference Lisp variables. To access a Lisp variable's value from within a `coalton` or `coalton-toplevel` form, you must use the `lisp` escape form and capture the variable explicitly:
+
+```lisp
+;; This does NOT work — x is a Lisp variable, not a Coalton binding:
+;; (let ((x 42))
+;;   (coalton (+ x 1)))  ; ERROR
+
+;; Instead, use the lisp form to bring the value into Coalton:
+(let ((x 42))
+  (coalton
+    (+ (lisp Integer () x) 1)))  ; => 43
+```
+
+The `lisp` form's capture list (the second argument) is for capturing *Coalton* lexical variables. When accessing a *Lisp* variable, leave the capture list empty and reference the variable directly in the Lisp body, since the `lisp` form's body is ordinary Lisp code with access to the surrounding Lisp lexical environment.
+
+For Lisp special (dynamic) variables, the same pattern works:
+
+```lisp
+(defvar *my-config* 100)
+
+(coalton-toplevel
+  (define (get-config)
+    (lisp Integer ()
+      *my-config*)))
+```
 
 ## Soundness of Coalton-Lisp Interop
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,224 @@
+# Collections Guide
+
+Coalton's standard library provides several collection types, each with different trade-offs for mutability, persistence, and performance. This guide helps you choose the right collection for your use case.
+
+## Overview
+
+| Collection | Mutable? | Ordered? | Keyed? | Package |
+|------------|----------|----------|--------|---------|
+| `List` | No | Yes | By position | `coalton/list` |
+| `Vector` | Yes | Yes | By index | `coalton/vector` |
+| `Seq` | No | Yes | By index | `coalton/seq` |
+| `Queue` | Yes | Yes (FIFO) | By position | `coalton/queue` |
+| `Hashtable` | Yes | No | By key | `coalton/hashtable` |
+| `HashMap` | No | No | By key | `coalton/hashmap` |
+| `Cell` | Yes | N/A | N/A | `coalton/cell` |
+| `Slice` | No | Yes | By index | `coalton/slice` |
+
+## List
+
+A singly-linked persistent list. This is the most fundamental collection in Coalton and implements `Functor`, `Applicative`, `Monad`, `Foldable`, `Traversable`, `Semigroup`, `Monoid`, and `Eq`.
+
+**Key characteristics:**
+- Immutable — all operations return new lists
+- O(1) prepend (`Cons`), O(n) append, O(n) access by index
+- Pattern-matchable with `Cons` and `Nil` constructors
+- Every Coalton `List` is also a valid Common Lisp list
+
+```lisp
+(coalton-toplevel
+  (define my-list (make-list 1 2 3 4 5))
+
+  (define first-elem (list:head my-list))      ;; => (Some 1)
+  (define rest-elems (list:tail my-list))       ;; => (Some (2 3 4 5))
+  (define reversed (list:reverse my-list))      ;; => (5 4 3 2 1)
+  (define filtered (list:filter even? my-list)) ;; => (2 4)
+  (define mapped (map (+ 10) my-list)))         ;; => (11 12 13 14 15)
+```
+
+**When to use:** Default choice for sequential data that is consumed by pattern matching, mapping, or folding. Ideal when you build data by prepending elements.
+
+## Vector
+
+A mutable, growable array backed by a Common Lisp adjustable vector with a fill pointer.
+
+**Key characteristics:**
+- Mutable — operations like `push!`, `pop!`, `set!` modify in place
+- O(1) amortized `push!` and `pop!` at the end, O(1) random access by index
+- O(n) for insertion/removal at arbitrary positions
+
+```lisp
+(coalton-toplevel
+  (define (build-squares n)
+    (let ((v (vec:new)))
+      (for i in (iter:up-to n)
+        (vec:push! (* i i) v))
+      v)))
+```
+
+**When to use:** When you need mutable, indexed storage. Good for building collections incrementally with `push!`, for algorithms that need random access, and for interop with Common Lisp code expecting arrays.
+
+## Seq
+
+A persistent (immutable) sequence based on Relaxed Radix Balanced Trees (RRB-Trees).
+
+**Key characteristics:**
+- Immutable — `push` and `put` return new sequences
+- O(log n) random access, update, and append
+- O(log n) `push` (append to end) and `pop` (remove from end)
+- Efficient concatenation with `conc`
+
+```lisp
+(coalton-toplevel
+  (define my-seq (seq:make 1 2 3 4 5))
+
+  (define with-six (seq:push 6 my-seq))   ;; => (Seq 1 2 3 4 5 6)
+  (define third (seq:get 2 my-seq))        ;; => (Some 3)
+  (define updated (seq:put 0 99 my-seq)))  ;; => (Seq 99 2 3 4 5)
+```
+
+**When to use:** When you need a persistent (immutable) sequence with efficient random access and concatenation. Preferred over `List` when you need indexed access or append-heavy workloads without mutation.
+
+## Queue
+
+A mutable FIFO (first-in, first-out) queue.
+
+**Key characteristics:**
+- Mutable — `push!` and `pop!` modify in place
+- O(1) `push!` (enqueue at back) and O(1) `pop!` (dequeue from front)
+- O(1) `peek` at the front element
+
+```lisp
+(coalton-toplevel
+  (define (process-work-items items)
+    (let ((q (queue:new)))
+      (for item in items
+        (queue:push! item q))
+      ;; Process items in FIFO order
+      (while-let (Some item) = (queue:pop! q)
+        (process item)))))
+```
+
+**When to use:** When you need FIFO ordering — task queues, breadth-first search, buffering.
+
+## Hashtable
+
+A mutable hash table mapping keys to values. Keys must implement the `Hash` type class.
+
+**Key characteristics:**
+- Mutable — `set!` and `remove!` modify in place
+- O(1) average-case lookup, insertion, and deletion
+- Keys must implement `Hash` (and `Eq`)
+- Backed by Common Lisp's hash table implementation
+
+```lisp
+(coalton-toplevel
+  (define (word-frequencies words)
+    (let ((ht (hashtable:new)))
+      (for word in words
+        (match (hashtable:get ht word)
+          ((Some count) (hashtable:set! ht word (+ count 1)))
+          ((None) (hashtable:set! ht word 1))))
+      ht)))
+```
+
+**When to use:** When you need fast mutable key-value storage. The go-to choice for caches, frequency counters, and lookup tables that are built once and queried many times.
+
+## HashMap
+
+A persistent (immutable) hash map based on Hash Array Mapped Tries (HAMT).
+
+**Key characteristics:**
+- Immutable — `insert`, `remove`, and `update` return new maps
+- O(log32 n) ≈ O(1) lookup, insertion, and deletion
+- Keys must implement `Hash` (and `Eq`)
+- Supports set operations: `union`, `intersection`, `difference`, `xor`
+
+```lisp
+(coalton-toplevel
+  (define empty-map (hashmap:empty))
+
+  (define my-map
+    (pipe empty-map
+          (hashmap:insert "alice" 42)
+          (hashmap:insert "bob" 37)))
+
+  (define alice-age (hashmap:lookup my-map "alice"))) ;; => (Some 42)
+```
+
+**When to use:** When you need an immutable key-value map. Preferred over `Hashtable` when you need persistence (keeping old versions), structural sharing, or thread safety without locks.
+
+## Cell
+
+A mutable single-value container (a mutable reference).
+
+**Key characteristics:**
+- Mutable — `write!` and `update!` modify the contained value
+- O(1) read and write
+- Used for local mutable state within otherwise-pure code
+
+```lisp
+(coalton-toplevel
+  (define (sum-list lst)
+    (let ((acc (cell:new 0)))
+      (for x in lst
+        (cell:update! (+ x) acc))
+      (cell:read acc))))
+```
+
+**When to use:** When you need a mutable variable in a local scope — loop accumulators, counters, caches. `Cell` is Coalton's equivalent of a mutable reference.
+
+## Slice
+
+An immutable view into a contiguous subsequence of a `Vector`.
+
+**Key characteristics:**
+- Immutable view — does not copy data
+- O(1) creation from a vector, O(1) indexed access within the slice
+
+**When to use:** When you need to work with a subrange of a vector without copying.
+
+## Choosing the Right Collection
+
+**Do you need mutation?**
+- Yes → `Vector` (indexed), `Hashtable` (keyed), `Queue` (FIFO), `Cell` (single value)
+- No → `List` (sequential), `Seq` (indexed), `HashMap` (keyed)
+
+**Do you need key-value lookup?**
+- Mutable → `Hashtable`
+- Immutable → `HashMap`
+
+**Do you need indexed random access?**
+- Mutable → `Vector`
+- Immutable → `Seq`
+
+**Do you need to pattern match on the structure?**
+- Use `List` — it's the only collection with pattern-matchable constructors (`Cons`, `Nil`)
+
+**Do you need FIFO ordering?**
+- Use `Queue`
+
+**Is performance critical?**
+- For tight loops with indexed access → `Vector`
+- For key lookups → `Hashtable` (mutable) or `HashMap` (immutable)
+- For prepend-heavy workloads → `List`
+- For append and concatenation → `Seq`
+
+## Iterators and Collections
+
+All collections can be converted to iterators via the `IntoIterator` type class. This means you can use `for` loops with any collection:
+
+```lisp
+(for x in my-list   (process x))
+(for x in my-vector (process x))
+(for x in my-seq    (process x))
+```
+
+To build a collection from an iterator, use `collect!` with a type annotation:
+
+```lisp
+(the (List Integer)   (iter:collect! my-iterator))
+(the (Vector Integer) (iter:collect! my-iterator))
+```
+
+See the [Iterator Protocol](./iterator-protocol.md) document for details on working with iterators.

--- a/docs/internals/design-docs/typeclasses.md
+++ b/docs/internals/design-docs/typeclasses.md
@@ -44,21 +44,23 @@ Higher kinded types are outside of scope of the initial typeclass implementation
 
 ### Constraints in Class Declarations
 
-_This section is no longer accurate._
-
 Referred to as Decision 9 in Jones 1997.
 
-```lisp
-;; Is not allowed
-(define-class (Test :a)
-  (test (fn (Eq :a) => :a -> :a -> Bool)))
+**Update**: Coalton now allows constraints on class variables in class method signatures. This was previously disallowed to simplify the implementation, but the restriction has since been lifted.
 
-;; Is allowed
+```lisp
+;; Now allowed: constraints on class variable :a in a method signature
+(define-class (Foo :a)
+  (bar (Num :a => :a -> :a)))
+
+;; Also allowed: constraints on non-class variables (always was)
 (define-class (Test :a)
-  (test (fn (Eq :b) => :b -> :b -> Bool)))
+  (test (Eq :b => :b -> :b -> Boolean)))
 ```
 
-Constraints of class variables in class methods are not allowed since this complicates code and will result in the constraint being propogated up to the class, which is already supported by the class definition syntax.
+When a method has a constraint on the class variable, the constraint is effectively propagated to the class context. For example, any call to `bar` above will require both a `Foo` instance and a `Num` instance for the type in question.
+
+This change allows more expressive type class definitions where individual methods may require additional capabilities beyond what the class itself demands.
 
 ### Self Referential Class Definitions
 

--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -757,6 +757,26 @@ Lastly, there's a ratio type called `Fraction`, which is a ratio of two `Integer
 
 Numbers implement the `Num` type class, which has methods `+`, `-`, `*`, and `fromInt`.
 
+### Implicit Numeric Casting with `fromInt`
+
+Integer literals in Coalton are polymorphic. When you write `5` in a context that expects a type with a `Num` instance (such as `Double-Float`, `I32`, or `Fraction`), Coalton implicitly applies `fromInt` to convert the `Integer` into the expected type. This means you can write numeric code without explicit conversions in many cases:
+
+```lisp
+(coalton-toplevel
+  ;; No explicit conversion needed: 5 and 7 are converted to Double-Float
+  ;; via (fromInt 5) and (fromInt 7) implicitly
+  (declare f Double-Float)
+  (define f (+ 5 7)))         ;; f is 12.0d0
+```
+
+If the target type is ambiguous, Coalton will report a type error asking you to clarify. You can always call `fromInt` explicitly if needed:
+
+```lisp
+(coalton-toplevel
+  (declare g (F32 -> F32))
+  (define (g x) (+ x (fromInt 3))))
+```
+
 ### Division, in short
 
 Division is complicated; see the next section. But here are some quick tips.

--- a/docs/iterator-protocol.md
+++ b/docs/iterator-protocol.md
@@ -1,0 +1,262 @@
+# Iterator Protocol
+
+Coalton's iterators provide a lazy, forward-only traversal of sequences of values. They are the primary abstraction for looping and data transformation in Coalton.
+
+## The Iterator Type
+
+An `Iterator :elt` is defined as a function that, when called, returns either `(Some value)` for the next element or `None` when the sequence is exhausted:
+
+```lisp
+;; The Iterator type (simplified)
+(define-type (Iterator :elt)
+  (%Iterator (Unit -> (Optional :elt)) (Optional UFix)))
+```
+
+The second field is an optional size hint that some operations use for pre-allocation.
+
+## Creating Iterators
+
+### From Collections
+
+Any type that implements `IntoIterator` can be converted into an iterator with `into-iter`:
+
+```lisp
+(coalton-toplevel
+  (define list-iter (iter:into-iter (make-list 1 2 3)))
+  (define vec-iter  (iter:into-iter (vec:make 10 20 30)))
+  (define str-iter  (iter:into-iter "hello")))
+```
+
+### Range Iterators
+
+```lisp
+(coalton-toplevel
+  ;; 0, 1, 2, ..., 9
+  (define ten (iter:up-to 10))
+
+  ;; 0, 1, 2, ..., 10 (inclusive)
+  (define eleven (iter:up-through 10))
+
+  ;; Custom step: 0, 2, 4, 6, 8
+  (define evens (iter:range-increasing 2 0 10))
+
+  ;; Counting down: 10, 8, 6, 4, 2
+  (define countdown (iter:range-decreasing 2 10 0)))
+```
+
+### Other Constructors
+
+```lisp
+(coalton-toplevel
+  ;; Repeat a single value forever
+  (define ones (iter:repeat 1))
+
+  ;; Repeat a value a fixed number of times
+  (define five-zeros (iter:repeat-for 5 0))
+
+  ;; Yield a single element
+  (define just-one (iter:once 42))
+
+  ;; Empty iterator
+  (define nothing iter:empty)
+
+  ;; Count forever: 0, 1, 2, 3, ...
+  (define naturals (iter:count-forever))
+
+  ;; Build from a function
+  (define custom (iter:new (fn () (Some 1)))))
+```
+
+## Consuming Iterators
+
+Iterators are consumed by calling `next!` repeatedly. Most users will not call `next!` directly, but instead use higher-level consumers.
+
+**Important:** Consuming operations are destructive — they advance the iterator and the consumed elements are gone. An iterator can only be traversed once.
+
+### Collecting into a Container
+
+```lisp
+;; Collect into a list
+(the (List Integer) (iter:collect! (iter:up-to 5)))
+;; => (0 1 2 3 4)
+
+;; Collect into a vector
+(the (Vector Integer) (iter:collect! (iter:up-to 5)))
+```
+
+### Folding
+
+```lisp
+;; Sum via fold
+(iter:fold! + 0 (iter:up-to 10))  ;; => 45
+
+;; Specialized sum
+(iter:sum! (iter:up-to 10))  ;; => 45
+```
+
+### Looping with `for`
+
+```lisp
+(for x in (iter:up-to 5)
+  (traceobject "x" x))
+```
+
+### Searching
+
+```lisp
+;; Find the first even number
+(iter:find! even? (iter:into-iter (make-list 1 3 4 5)))
+;; => (Some 4)
+
+;; Find the index of an element
+(iter:index-of! (== 3) (iter:into-iter (make-list 1 2 3 4)))
+;; => (Some 2)
+```
+
+### Aggregation
+
+```lisp
+(iter:count!  (iter:up-to 10))               ;; => 10
+(iter:every!  positive? (iter:up-to 10))      ;; => False (0 is not positive)
+(iter:any!    even? (iter:up-to 10))          ;; => True
+(iter:max!    (iter:into-iter (make-list 3 1 4 1 5)))  ;; => (Some 5)
+(iter:min!    (iter:into-iter (make-list 3 1 4 1 5)))  ;; => (Some 1)
+```
+
+## Transforming Iterators
+
+Transformations create new iterators that lazily apply operations as elements are consumed. They do not process any elements until something downstream consumes the result.
+
+### Mapping and Filtering
+
+```lisp
+;; Map a function over elements
+(iter:collect! (map (* 2) (iter:up-to 5)))
+;; => (0 2 4 6 8)
+
+;; Filter elements
+(iter:collect! (iter:filter! even? (iter:up-to 10)))
+;; => (0 2 4 6 8)
+
+;; Combined map and filter
+(iter:collect! (iter:filter-map! (fn (x) (if (even? x) (Some (* x x)) None))
+                                 (iter:up-to 10)))
+;; => (0 4 16 36 64)
+```
+
+### Taking and Chaining
+
+```lisp
+;; Take the first n elements
+(iter:collect! (iter:take! 3 (iter:count-forever)))
+;; => (0 1 2)
+
+;; Chain two iterators
+(iter:collect!
+  (iter:chain! (iter:up-to 3) (iter:up-to 3)))
+;; => (0 1 2 0 1 2)
+```
+
+### Zipping
+
+```lisp
+;; Zip two iterators into pairs
+(iter:collect!
+  (iter:zip! (iter:up-to 3)
+             (iter:into-iter (make-list "a" "b" "c"))))
+;; => ((Tuple 0 "a") (Tuple 1 "b") (Tuple 2 "c"))
+
+;; Zip with a custom combiner
+(iter:collect!
+  (iter:zip-with! + (iter:up-to 3) (iter:up-to 3)))
+;; => (0 2 4)
+
+;; Enumerate: pair each element with its index
+(iter:collect! (iter:enumerate! (iter:into-iter "abc")))
+;; => ((Tuple 0 #\a) (Tuple 1 #\b) (Tuple 2 #\c))
+```
+
+### Flattening
+
+```lisp
+;; Flatten nested iterators
+(iter:collect!
+  (iter:flatten! (map (fn (x) (iter:up-to x))
+                      (iter:into-iter (make-list 1 2 3)))))
+;; => (0 0 1 0 1 2)
+
+;; Flat-map (map then flatten)
+(iter:collect!
+  (iter:flat-map! (fn (x) (iter:repeat-for 2 x))
+                  (iter:into-iter (make-list 1 2 3))))
+;; => (1 1 2 2 3 3)
+```
+
+## Protocol Guarantees and Caveats
+
+### Once-only Traversal
+
+An iterator can only be traversed once. After `next!` returns `None`, subsequent calls to `next!` should also return `None`, but this behavior is not strictly enforced by all iterator constructors.
+
+### Behavior After Exhaustion
+
+The behavior of calling `next!` on an exhausted iterator (one that has already returned `None`) is currently unspecified. Most standard library iterators will continue to return `None`, but consumers should not rely on this. Best practice: stop consuming after the first `None`.
+
+### Thread Safety
+
+Iterators are not thread-safe. Calling `next!` from multiple threads concurrently on the same iterator without external synchronization is undefined behavior.
+
+### Draining
+
+Functions like `collect!`, `fold!`, and `for-each!` fully drain an iterator. Functions like `find!` and `any!` may stop early (short-circuit) and leave the iterator partially consumed.
+
+### Laziness
+
+Transformations like `map`, `filter!`, and `take!` are lazy — they do not process elements until the resulting iterator is consumed. This means you can build chains of transformations without allocating intermediate collections:
+
+```lisp
+;; No intermediate lists are created here
+(iter:sum!
+  (map (* 2)
+    (iter:filter! odd?
+      (iter:up-to 1000))))
+```
+
+## Common Patterns
+
+### Pipeline Style
+
+```lisp
+(coalton-toplevel
+  (define (sum-of-even-squares n)
+    (pipe (iter:up-to n)
+          (iter:filter! even?)
+          (map (fn (x) (* x x)))
+          iter:sum!)))
+```
+
+### Building Collections from Iterators
+
+Use the `FromIterator` type class via `collect!`:
+
+```lisp
+(coalton-toplevel
+  ;; Type annotation determines the output collection type
+  (declare evens-list (List Integer))
+  (define evens-list
+    (iter:collect! (iter:filter! even? (iter:up-to 20)))))
+```
+
+### Mutable Accumulation
+
+```lisp
+(coalton-toplevel
+  (define (group-by-parity n)
+    (let ((evens (vec:new))
+          (odds  (vec:new)))
+      (for i in (iter:up-to n)
+        (if (even? i)
+            (vec:push! i evens)
+            (vec:push! i odds)))
+      (Tuple evens odds))))
+```

--- a/docs/optimization-guide.md
+++ b/docs/optimization-guide.md
@@ -1,0 +1,151 @@
+# Optimization Guide
+
+Coalton compiles to Common Lisp, which in turn compiles to native machine code via the host CL implementation (e.g., SBCL). This gives Coalton access to mature optimizing compilers. This guide covers Coalton-specific optimization features that can help you write faster code.
+
+## Inlining
+
+Inlining replaces a function call with the function's body at the call site, eliminating call overhead and enabling further optimizations like constant folding.
+
+### Declaring a Function Inline
+
+Use `declare` with the `inline` property to mark a function for inlining:
+
+```lisp
+(coalton-toplevel
+  (declare add1 (Integer -> Integer))
+  (declare add1 inline)
+  (define (add1 x)
+    (+ x 1)))
+```
+
+When `add1` is called, the compiler will substitute the function body directly at the call site rather than emitting a function call.
+
+### When to Inline
+
+Inlining is most effective for:
+- **Small utility functions** — functions with a few arithmetic operations or a simple pattern match
+- **Wrapper functions** — thin wrappers around other operations
+- **Hot inner loops** — functions called in tight loops where call overhead matters
+
+Avoid inlining large functions, as this increases code size ("code bloat") and can hurt instruction cache performance.
+
+### Heuristic Inlining
+
+Even without an explicit `inline` declaration, Coalton's compiler applies heuristic inlining for sufficiently small functions. The default "gentle" heuristic inlines functions with at most 4 applications and 8 AST nodes. This happens automatically and does not require any annotation.
+
+The heuristic can be configured at the CL level:
+- `coalton-impl/codegen/inliner:*inliner-heuristic*` — the heuristic function (default: `'gentle-heuristic`)
+- `coalton-impl/codegen/inliner:*inliner-max-depth*` — maximum inlining depth (default: 16)
+- `coalton-impl/codegen/inliner:*inliner-max-unroll*` — maximum recursive unroll depth (default: 3)
+
+## Monomorphization
+
+Coalton functions that use type class constraints are compiled as functions that take *dictionary* arguments at runtime. For example:
+
+```lisp
+(declare double (Num :a => :a -> :a))
+(define (double x) (+ x x))
+```
+
+At the CL level, `double` receives a dictionary argument for `Num` and dispatches `+` through it. This adds overhead compared to a function that directly uses fixnum or float addition.
+
+**Monomorphization** eliminates this overhead by creating specialized copies of a function for the concrete types it is called with.
+
+### Using `(monomorphize)`
+
+Annotate a definition with the `(monomorphize)` attribute:
+
+```lisp
+(coalton-toplevel
+  (monomorphize)
+  (declare double (Num :a => :a -> :a))
+  (define (double x) (+ x x)))
+```
+
+When the compiler encounters a call like `(double 5)` (where `5` is an `Integer`), it generates a specialized version `double<Integer>` that directly calls integer addition, with no dictionary passing.
+
+### How It Works
+
+The monomorphizer traverses the call graph starting from monomorphized entry points. At each call site, if the type class dictionaries are statically known (i.e., the concrete types are determined), it creates a specialized copy of the called function with those dictionaries inlined. This process is recursive — if the specialized function itself calls other generic functions with known dictionaries, those are specialized too.
+
+### Trade-offs
+
+- **Pro:** Eliminates dictionary-passing overhead, enables further inlining and optimization
+- **Con:** Can increase code size if a function is called with many different type combinations
+- **Con:** Increases compile time proportional to the number of specializations generated
+
+Monomorphization is most valuable for numeric code and other performance-critical inner loops where dictionary dispatch is a measurable bottleneck.
+
+## Specialization
+
+Specialization lets you manually provide an optimized implementation of a generic function for a specific type, without modifying the original function.
+
+### Declaring a Specialization
+
+```lisp
+(coalton-toplevel
+  ;; Generic function
+  (declare sum-list (Num :a => List :a -> :a))
+  (define (sum-list lst)
+    (fold + 0 lst))
+
+  ;; Optimized version for Integer
+  (declare sum-list/integer (List Integer -> Integer))
+  (define (sum-list/integer lst)
+    (lisp Integer (lst)
+      (cl:loop :for x :in lst :sum x)))
+
+  ;; Tell the compiler to use sum-list/integer when sum-list is called on Integer lists
+  (specialize sum-list sum-list/integer (List Integer -> Integer)))
+```
+
+When the compiler encounters `(sum-list my-integer-list)`, it will substitute the call with `(sum-list/integer my-integer-list)`, bypassing dictionary dispatch entirely.
+
+### When to Use Specialization
+
+- When you have a generic function that has a much faster implementation for a specific type
+- When you want to use CL-native operations (via `lisp`) for specific types without sacrificing the generic API
+- When monomorphization alone isn't sufficient because you need a fundamentally different algorithm for certain types
+
+## Efficient Numerical Code
+
+### Use Specific Numeric Types
+
+Polymorphic numeric code (using `Num :a`) incurs dictionary dispatch. When performance matters, use concrete types:
+
+```lisp
+;; Polymorphic — dictionary dispatch on every + and *
+(declare slow-square (Num :a => :a -> :a))
+(define (slow-square x) (* x x))
+
+;; Monomorphic — compiles directly to fixnum multiplication
+(declare fast-square (IFix -> IFix))
+(define (fast-square x) (* x x))
+```
+
+The fixed-width types `IFix`, `UFix`, `I32`, `U32`, `I64`, `U64`, `F32`, and `F64` map directly to their CL counterparts and compile to efficient machine instructions.
+
+### Avoid Unnecessary Polymorphism
+
+If a function only ever operates on one type, declare it with that type instead of using a type class constraint. The compiler can then generate specialized machine code without dictionary overhead.
+
+### Combine with Monomorphization
+
+For library code that must be polymorphic, use `(monomorphize)` to get the best of both worlds — a generic API with specialized code generation:
+
+```lisp
+(coalton-toplevel
+  (monomorphize)
+  (declare dot-product (Num :a => List :a -> List :a -> :a))
+  (define (dot-product xs ys)
+    (fold + 0 (zipWith * xs ys))))
+```
+
+### Interaction with Common Lisp Optimization
+
+Coalton respects CL optimization declarations. In release mode, the standard library is compiled with high optimization settings. You can control this via:
+
+- `COALTON_ENV=release` — enables release mode globally
+- Release mode applies `(optimize (speed 3) (safety 1))` (or similar) to generated code
+
+The host CL compiler (e.g., SBCL) then applies its own optimizations — type inference, unboxing, SIMD, etc. — to the generated code.

--- a/library/big-float/package.lisp
+++ b/library/big-float/package.lisp
@@ -3,6 +3,7 @@
 ;;;; Big float package for various implementations
 
 (coalton/utils:defstdlib-package #:coalton/big-float
+  (:documentation "Arbitrary-precision floating-point arithmetic (implementation-specific: uses SB-MPFR on SBCL).")
   (:use #:coalton
         #:coalton/classes
         #:coalton/functions

--- a/library/bits.lisp
+++ b/library/bits.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/bits
+  (:documentation "Bitwise operations (and, or, xor, shift, rotate) on fixed-width integer types.")
   (:shadow
      #:and
      #:or

--- a/library/boolean.lisp
+++ b/library/boolean.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/boolean
+  (:documentation "Boolean type class instances (Eq, Ord, Hash) and Show.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/builtin.lisp
+++ b/library/builtin.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/builtin
+  (:documentation "Built-in utilities: error, unreachable, undefined, and boolean logic operators.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/cell.lisp
+++ b/library/cell.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/cell
+  (:documentation "Mutable single-value containers (mutable references) for local state.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/char.lisp
+++ b/library/char.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/char
+  (:documentation "Character classification, case conversion, and Unicode code-point operations.")
   (:use
    #:coalton
    #:coalton/classes

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/classes
+  (:documentation "Core type classes: Eq, Ord, Num, Semigroup, Monoid, Functor, Applicative, Monad, Into, and more.")
   (:use
    #:coalton)
   (:local-nicknames
@@ -86,7 +87,12 @@
   ;;
 
   (define-class (Eq :a)
-    "Types which have equality defined."
+    "Types which have equality defined.
+
+Instances must satisfy:
+- Reflexivity: `(== a a)` is `True`
+- Symmetry: `(== a b)` implies `(== b a)`
+- Transitivity: `(== a b)` and `(== b c)` implies `(== a c)`"
     (== (:a -> :a -> Boolean)))
 
   (define-instance (Eq types:LispType)
@@ -95,7 +101,15 @@
         (cl:equalp a b))))
 
   (define-class (Eq :a => Num :a)
-    "Types which have numeric operations defined."
+    "Types which have numeric operations defined.
+
+Instances must satisfy:
+- Commutativity of `+`: `(+ a b)` equals `(+ b a)`
+- Associativity of `+`: `(+ (+ a b) c)` equals `(+ a (+ b c))`
+- Associativity of `*`: `(* (* a b) c)` equals `(* a (* b c))`
+- `(fromInt 0)` is the additive identity: `(+ a (fromInt 0))` equals `a`
+- `(fromInt 1)` is the multiplicative identity: `(* a (fromInt 1))` equals `a`
+- `(- a a)` equals `(fromInt 0)`"
     (+ (:a -> :a -> :a))
     (- (:a -> :a -> :a))
     (* (:a -> :a -> :a))
@@ -163,7 +177,13 @@ The hash function must satisfy the invariant that `(== left right)` implies `(==
         ((Tuple (GT) (GT)) EQ))))
 
   (define-class (Eq :a => Ord :a)
-    "Types whose values can be ordered. Requires `Eq`."
+    "Types whose values can be totally ordered. Requires `Eq`.
+
+Instances must satisfy:
+- Reflexivity: `(<=> a a)` is `EQ`
+- Antisymmetry: if `(<=> a b)` is `LT` then `(<=> b a)` is `GT`
+- Transitivity: if `(<=> a b)` is `LT` and `(<=> b c)` is `LT` then `(<=> a c)` is `LT`
+- Consistency with `Eq`: `(<=> a b)` is `EQ` if and only if `(== a b)` is `True`"
     (<=>
      "Given two objects, return their comparison (as an `Ord` object)."
      (:a -> :a -> Ord)))
@@ -215,24 +235,45 @@ The hash function must satisfy the invariant that `(== left right)` implies `(==
   ;;
 
   (define-class (Semigroup :a)
-    "Types with an associative binary operation defined."
+    "Types with an associative binary operation defined.
+
+Instances must satisfy:
+- Associativity: `(<> (<> a b) c)` equals `(<> a (<> b c))`"
     (<> (:a -> :a -> :a)))
 
   (define-class (Semigroup :a => Monoid :a)
-    "Types with an associative binary operation and identity defined."
+    "Types with an associative binary operation and identity defined.
+
+Instances must satisfy:
+- Left identity: `(<> mempty a)` equals `a`
+- Right identity: `(<> a mempty)` equals `a`"
     (mempty :a))
 
   (define-class (Functor :f)
-    "Types which can map an inner type where the mapping adheres to the identity and composition laws."
+    "Types which can map an inner type where the mapping adheres to the identity and composition laws.
+
+Instances must satisfy:
+- Identity: `(map id x)` equals `x`
+- Composition: `(map (compose f g) x)` equals `(map f (map g x))`"
     (map ((:a -> :b) -> :f :a -> :f :b)))
 
   (define-class (Functor :f => Applicative :f)
-    "Types which are a functor which can embed pure expressions and sequence operations."
+    "Types which are a functor which can embed pure expressions and sequence operations.
+
+Instances must satisfy:
+- Identity: `(liftA2 id (pure id) v)` equals `v`
+- Homomorphism: `(liftA2 id (pure f) (pure x))` equals `(pure (f x))`
+- Interchange: `(liftA2 id u (pure y))` equals `(liftA2 id (pure (fn (f) (f y))) u)`"
     (pure (:a -> (:f :a)))
     (liftA2 ((:a -> :b -> :c) -> :f :a -> :f :b -> :f :c)))
 
   (define-class (Applicative :m => Monad :m)
-    "Types which are monads as defined in Haskell. See https://wiki.haskell.org/Monad for more information."
+    "Types which are monads as defined in Haskell. See https://wiki.haskell.org/Monad for more information.
+
+Instances must satisfy:
+- Left identity: `(>>= (pure a) f)` equals `(f a)`
+- Right identity: `(>>= m pure)` equals `m`
+- Associativity: `(>>= (>>= m f) g)` equals `(>>= m (fn (x) (>>= (f x) g)))`"
     (>>= (:m :a -> (:a -> :m :b) -> :m :b)))
 
   (define-class (MonadTransformer :t)
@@ -308,7 +349,11 @@ together."
   ;;
 
   (define-class (Into :a :b)
-    "`INTO` imples *every* element of `:a` can be represented by an element of `:b`. This conversion might not be bijective (i.e., there may be elements in `:b` that don't correspond to any in `:a`)."
+    "`INTO` implies *every* element of `:a` can be represented by an element of `:b`. This conversion might not be bijective (i.e., there may be elements in `:b` that don't correspond to any in `:a`).
+
+Instances must satisfy:
+- Totality: `into` must be defined for all values of `:a` (never error or diverge)
+- If an `(Into :b :a)` instance also exists and both form an `Iso`, then `(into (into x))` must equal `x`"
     (into (:a -> :b)))
 
   (define-class ((Into :a :b) (Into :b :a) => Iso :a :b)
@@ -406,7 +451,7 @@ Typical `fail` continuations are:
   (declare defaulting-unwrap ((Unwrappable :container) (Default :element) =>
                               (:container :element) -> :element))
   (define (defaulting-unwrap container)
-    "Unwrap an `unwrappable`, returning `(default)` of the wrapped type on failure. "
+    "Unwrap an `unwrappable`, returning `(default)` of the wrapped type on failure."
     (unwrap-or-else (fn (elt) elt)
                     (fn () (default))
                     container))

--- a/library/computable-reals/computable-reals.lisp
+++ b/library/computable-reals/computable-reals.lisp
@@ -3,6 +3,7 @@
 ;;;; Reals library using computable-reals (https://github.com/stylewarning/computable-reals)
 
 (defpackage #:coalton/computable-reals
+  (:documentation "Coalton interface to computable-reals: exact real arithmetic with lazy, on-demand precision.")
   (:nicknames #:coalton-library/computable-reals)
   (:use #:coalton
         #:coalton-prelude

--- a/library/experimental/loops.lisp
+++ b/library/experimental/loops.lisp
@@ -308,11 +308,11 @@ COALTON::UNIT/UNIT
   `(%sometimes ,count (fn (,variable) ,@body)))
 
 (defmacro sumtimes ((variable count) cl:&body body)
-  "The sum of `body` for `variable` bount to every `UFix` in [0, `count`)."
+  "The sum of `body` for `variable` bound to every `UFix` in [0, `count`)."
   `(%sumtimes ,count (fn (,variable) ,@body)))
 
 (defmacro prodtimes ((variable count) cl:&body body)
-  "The product of `body` for `variable` bount to every `UFix` in [0, `count`)."
+  "The product of `body` for `variable` bound to every `UFix` in [0, `count`)."
   `(%prodtimes ,count (fn (,variable) ,@body)))
 
 (defmacro collecttimes ((variable count) cl:&body body)
@@ -320,7 +320,7 @@ COALTON::UNIT/UNIT
   `(%collecttimes ,count (fn (,variable) ,@body)))
 
 (defmacro besttimes ((variable count better?) cl:&body body)
-  "The result of evaluating `body` with `variable` bound to a `UFix` in [0, `count`) that is `better?` than the result of evaluating `body` with `variable` bound to the rest of the `UFix`s in [0, `count`).."
+  "The result of evaluating `body` with `variable` bound to a `UFix` in [0, `count`) that is `better?` than the result of evaluating `body` with `variable` bound to the rest of the `UFix`s in [0, `count`)."
   `(%besttimes ,count ,better? (fn (,variable) ,@body)))
 
 (defmacro argbesttimes ((variable count better?) cl:&body body)

--- a/library/functions.lisp
+++ b/library/functions.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/functions
+  (:documentation "Higher-order function combinators: composition, currying, fixpoints, and debugging utilities.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/hash.lisp
+++ b/library/hash.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/hash
+  (:documentation "Hash combining utilities and the define-sxhash-hasher macro for implementing Hash instances.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/hashmap.lisp
+++ b/library/hashmap.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/hashmap
+  (:documentation "Persistent (immutable) hash maps based on Hash Array Mapped Tries, with set operations.")
   (:use
    #:coalton
    #:coalton/builtin
@@ -693,19 +694,19 @@ new value, if the key was found."
   ;; API
   (declare keys (Hash :k => HashMap :k :v -> (iter:Iterator :k)))
   (define (keys hm)
-    "Returns an interator to iterate over all the keys in a hashmap hm."
+    "Returns an iterator over all the keys in a hashmap hm."
     (iter:new (->generator hm (fn (k _) k))))
 
   ;; API
   (declare values (Hash :k => HashMap :k :v -> (iter:Iterator :v)))
   (define (values hm)
-    "Returns an interator to iterate over all the values in a hashmap hm."
+    "Returns an iterator over all the values in a hashmap hm."
     (iter:new (->generator hm (fn (_ v) v))))
 
   ;; API
   (declare entries (Hash :k => HashMap :k :v -> (iter:Iterator (Tuple :k :v))))
   (define (entries hm)
-    "Returns an interator to iterate over all entries in hashmap hm."
+    "Returns an iterator over all entries in hashmap hm."
     (iter:new (->generator hm Tuple)))
   )
 
@@ -767,12 +768,12 @@ The entries from A remains in the result."
 
   (declare difference (Hash :k => HashMap :k :v -> HashMap :k :v -> HashMap :k :v))
   (define (difference a b)
-    "Raturns a HashMap that contains mappings in `a` but not in `b`."
+    "Returns a HashMap that contains mappings in `a` but not in `b`."
     (iter:fold! (fn (m (Tuple k _v)) (remove m k)) a (iter:into-iter b)))
 
   (declare xor (Hash :k => HashMap :k :v -> HashMap :k :v -> HashMap :k :v))
   (define (xor a b)
-    "Raturns a HashMap that contains mappings either in `a` or in `b`,
+    "Returns a HashMap that contains mappings either in `a` or in `b`,
 but not in both."
     (iter:fold! (fn (m (Tuple k v))
                   (fst (update m k

--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/hashtable
+  (:documentation "Mutable hash tables mapping keys (with Hash instances) to values.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/iterator
+  (:documentation "Lazy forward-only iterators for sequential data traversal, transformation, and aggregation.")
   (:shadow #:empty)
   (:use
    #:coalton
@@ -304,7 +305,7 @@ Equivalent to reversing `range-increasing`"
 
   (declare interleave! (Iterator :a -> Iterator :a -> Iterator :a))
   (define (interleave! left right)
-    "Return an interator of interleaved elements from LEFT and RIGHT which terminates as soon as both LEFT and RIGHT do.
+    "Return an iterator of interleaved elements from LEFT and RIGHT which terminates as soon as both LEFT and RIGHT do.
 
 If one iterator terminates before the other, elements from the longer iterator will be yielded without
 interleaving. (interleave empty ITER) is equivalent to (id ITER)."
@@ -350,7 +351,7 @@ interleaving. (interleave empty ITER) is equivalent to (id ITER)."
 
   (declare filter! ((:elt -> Boolean) -> Iterator :elt -> Iterator :elt))
   (define (filter! keep? iter)
-    "Return an iterator over the elements from ITER for which KEEP?returns true."
+    "Return an iterator over the elements from ITER for which KEEP? returns true."
     (let ((filter-iter (fn (u)
                          (match (next! iter)
                            ((None) None)

--- a/library/lisparray.lisp
+++ b/library/lisparray.lisp
@@ -3,6 +3,7 @@
 ;;;; An interface to Common Lisp rank-1 SIMPLE-ARRAYs.
 
 (coalton/utils:defstdlib-package #:coalton/lisparray
+  (:documentation "Low-level interface to Common Lisp rank-1 simple-arrays with element-type specialization.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/list
+  (:documentation "Operations on singly-linked persistent lists: traversal, search, transformation, and set operations.")
   (:use
    #:coalton
    #:coalton/builtin
@@ -108,7 +109,7 @@
 
   (declare car (List :a -> :a))
   (define (car x)
-    "Return the traditional car of a list. This function is partial"
+    "Return the traditional car of a list. This function is partial."
     (match x
       ((Cons x _) x)
       ((Nil) (error "there is no first element"))))
@@ -425,7 +426,7 @@
 
   (declare difference (Eq :a => ((List :a) -> (List :a) -> (List :a))))
   (define (difference xs ys)
-    "Returns a new list with the first occurence of each element in `ys` removed from `xs`."
+    "Returns a new list with the first occurrence of each element in `ys` removed from `xs`."
     (fold (fn (a b) (remove b a)) xs ys))
 
   (declare zipWith ((:a -> :b -> :c) -> (List :a) -> (List :b) -> (List :c)))
@@ -662,7 +663,7 @@
 
   (declare combs (List :a -> (List (List :a))))
   (define (combs l)
-    "Compute a list of all combinations of elements of `l`. This function is sometimes goes by the name \"power set\" or \"subsets\".
+    "Compute a list of all combinations of elements of `l`. This function sometimes goes by the name \"power set\" or \"subsets\".
 
 The ordering of elements of `l` is preserved in the ordering of elements in each list produced by this function."
     (match l

--- a/library/math/arith.lisp
+++ b/library/math/arith.lisp
@@ -3,6 +3,7 @@
 ;;;; Number types and basic arithmetic.
 
 (coalton/utils:defstdlib-package #:coalton/math/arith
+  (:documentation "Core arithmetic: Reciprocable, Dividable, Fraction type, and numeric conversions.")
   (:use
    #:coalton
    #:coalton/builtin
@@ -168,7 +169,7 @@ The function `general/` is partial, and will error produce a run-time error if t
   (inline)
   (declare ash (Integer -> Integer -> Integer))
   (define (ash x n)
-    "Compute the \"arithmetic shift\" of `x` by `n`. "
+    "Compute the \"arithmetic shift\" of `x` by `n`."
     (lisp Integer (x n) (cl:ash x n)))
 
   (inline)

--- a/library/math/bounded.lisp
+++ b/library/math/bounded.lisp
@@ -3,6 +3,7 @@
 ;;;; Numerical types with fixed bounds
 
 (coalton/utils:defstdlib-package #:coalton/math/bounded
+  (:documentation "Bounded type class: minBound and maxBound for fixed-width numeric types.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -3,6 +3,7 @@
 ;;;; Complex numbers
 
 (coalton/utils:defstdlib-package #:coalton/math/complex
+    (:documentation "Complex number type and the ComplexComponent class for extracting real/imaginary parts.")
     (:use #:coalton
           #:coalton/classes
           #:coalton/utils

--- a/library/math/conversions.lisp
+++ b/library/math/conversions.lisp
@@ -3,6 +3,7 @@
 ;;;; Conversions between primitive numerical types
 
 (coalton/utils:defstdlib-package #:coalton/math/conversions
+  (:documentation "Safe (Into) and fallible (TryInto) conversions between primitive numeric types.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/dual.lisp
+++ b/library/math/dual.lisp
@@ -4,6 +4,7 @@
 ;;;; of compositions of built-in Coalton functions.
 
 (coalton/utils:defstdlib-package #:coalton/math/dual
+  (:documentation "Dual numbers for automatic first-order forward-mode differentiation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/dyadic.lisp
+++ b/library/math/dyadic.lisp
@@ -4,6 +4,7 @@
 ;;; It is not exported into the math package as it is a niche numeric type
 
 (coalton/utils::defstdlib-package #:coalton/math/dyadic
+    (:documentation "Dyadic rationals (a * 2^n): a niche numeric type used internally for big-float arithmetic.")
     (:use
      #:coalton
      #:coalton/builtin

--- a/library/math/elementary.lisp
+++ b/library/math/elementary.lisp
@@ -3,6 +3,7 @@
 ;;;; Elementary/algebraic functions and transcendental numbers
 
 (coalton/utils::defstdlib-package #:coalton/math/elementary
+    (:documentation "Elementary and transcendental functions: trigonometric, exponential, logarithmic, and constants pi and ee.")
     (:use
      #:coalton
      #:coalton/builtin
@@ -175,7 +176,7 @@ For a complex number `z = (complex x y)`, the following identities hold:
     (Tuple r theta)))
 
 (cl:defmacro %define-real-float-elementary (coalton-type underlying-type)
-  "Defines the elmentary instances for a lisp floating-point type"
+  "Defines the elementary instances for a lisp floating-point type."
   `(coalton-toplevel
      (define-instance (Trigonometric ,coalton-type)
        (inline)

--- a/library/math/fraction.lisp
+++ b/library/math/fraction.lisp
@@ -3,6 +3,7 @@
 ;;;; Reduced ratios of integers
 
 (coalton/utils:defstdlib-package #:coalton/math/fraction
+  (:documentation "Fraction type: reduced ratios of integers with numerator/denominator access.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/hyperdual.lisp
+++ b/library/math/hyperdual.lisp
@@ -4,6 +4,7 @@
 ;;;; derivatives of compositions of built-in Coalton functions.
 
 (coalton/utils::defstdlib-package #:coalton/math/hyperdual
+  (:documentation "Hyperdual numbers for automatic second-order forward-mode differentiation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/integral.lisp
+++ b/library/math/integral.lisp
@@ -3,6 +3,7 @@
 ;;;; Integral domains and operations on integers
 
 (coalton/utils::defstdlib-package #:coalton/math/integral
+  (:documentation "Integral type class and integer operations: division, modular arithmetic, GCD, and primality testing.")
   (:use
    #:coalton
    #:coalton/classes

--- a/library/math/num.lisp
+++ b/library/math/num.lisp
@@ -3,6 +3,7 @@
 ;;;; Instances for primitive numerical types
 
 (coalton/utils:defstdlib-package #:coalton/math/num
+  (:documentation "Num, Eq, Ord, Hash, Into, and other fundamental instances for all primitive numeric types.")
   (:use
    #:coalton
    #:coalton/math/num-defining-macros)

--- a/library/math/real.lisp
+++ b/library/math/real.lisp
@@ -3,6 +3,7 @@
 ;;;; Numbers that exist on the real number line
 
 (coalton/utils::defstdlib-package #:coalton/math/real
+    (:documentation "Real number classes: Quantizable (floor, ceiling) and Rational for types on the real number line.")
     (:use
      #:coalton
      #:coalton/math/arith

--- a/library/monad/classes.lisp
+++ b/library/monad/classes.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/classes
+  (:documentation "Monad effect classes: MonadState, MonadEnvironment, MonadError, and the LiftTo transformer lifting interface.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/monad/environment.lisp
+++ b/library/monad/environment.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/environment
+  (:documentation "Environment (reader) monad transformer: thread read-only configuration through computations.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/monad/free.lisp
+++ b/library/monad/free.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/monad/free
+  (:documentation "Free monad: build monadic computations from any Functor without choosing an interpretation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/freet.lisp
+++ b/library/monad/freet.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/monad/freet
+  (:documentation "Free monad transformer: layer free-monadic effects over an existing monad.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/identity.lisp
+++ b/library/monad/identity.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/identity
+  (:documentation "Identity monad: trivial wrapper used as the base case for monad transformer stacks.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/optionalt.lisp
+++ b/library/monad/optionalt.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/optionalt
+  (:documentation "Optional monad transformer: add short-circuiting failure to a monad stack.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/monad/resultt.lisp
+++ b/library/monad/resultt.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/resultt
+  (:documentation "Result monad transformer: add error handling with typed errors to a monad stack.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/monad/state.lisp
+++ b/library/monad/state.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/state
+  (:documentation "Pure state monad: get, put, modify, and run operations over threaded state.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/statet.lisp
+++ b/library/monad/statet.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/statet
+  (:documentation "State monad transformer: thread mutable state through a monad stack.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/optional.lisp
+++ b/library/optional.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/optional
+  (:documentation "Utilities for Optional values: extracting, testing, and converting.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/ordmap.lisp
+++ b/library/ordmap.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package :coalton/ordmap
+  (:documentation "Immutable ordered maps backed by balanced binary trees, keyed by Ord-constrained types.")
   (:use
    :coalton
    :coalton/classes
@@ -273,14 +274,14 @@ The resulting values are from `a`."
 
   (declare difference (Ord :key => OrdMap :key :value -> OrdMap :key :value -> OrdMap :key :value))
   (define (difference a b)
-    "Raturns an OrdMap that contains mappings in `a` but not in `b`."
+    "Returns an OrdMap that contains mappings in `a` but not in `b`."
     (let (%Map ta) = a)
     (let (%Map tb) = b)
     (%Map (tree:difference ta tb)))
 
   (declare xor (Ord :key => OrdMap :key :value -> OrdMap :key :value -> OrdMap :key :value))
   (define (xor a b)
-    "Raturns an OrdMap that contains mappings either in `a` or in `b`,
+    "Returns an OrdMap that contains mappings either in `a` or in `b`,
 but not in both."
     (let (%Map ta) = a)
     (let (%Map tb) = b)

--- a/library/ordtree.lisp
+++ b/library/ordtree.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package :coalton/ordtree
+  (:documentation "Immutable ordered sets backed by weight-balanced binary trees.")
   (:use
    #:coalton
    #:coalton/classes

--- a/library/queue.lisp
+++ b/library/queue.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/queue
+  (:documentation "Mutable FIFO queues with O(1) push and pop operations.")
   (:use
    #:coalton
    #:coalton/builtin
@@ -190,7 +191,7 @@
 
   (declare items! (Queue :a -> iter:Iterator :a))
   (define (items! q)
-    "Returns an interator over the items of `q`, removing items as they are returned."
+    "Returns an iterator over the items of `q`, removing items as they are returned."
     (iter:with-size
         (fn ()
           (pop! q))

--- a/library/randomaccess.lisp
+++ b/library/randomaccess.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/randomaccess
+  (:documentation "Type class for random-access containers with indexed reads, writes, and rotation.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/result.lisp
+++ b/library/result.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/result
+  (:documentation "Utilities for Result values: testing, mapping errors, and converting to Optional.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/seq.lisp
+++ b/library/seq.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/seq
+  (:documentation "Persistent sequences based on Relaxed Radix Balanced Trees, with efficient random access and concatenation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/slice
+  (:documentation "Mutable sub-range views into Vectors, with bounds-checked and unchecked element access.")
   (:use
    #:coalton
    #:coalton/builtin
@@ -100,7 +101,7 @@
 
   (declare iter-sliding ((Sliceable (:b :a)) => UFix -> :b :a -> iter:Iterator (Slice :a)))
   (define (iter-sliding size s)
-    "Returns an iterator that yeilds a series of overlapping slices of length `size`."
+    "Returns an iterator that yields a series of overlapping slices of length `size`."
     (let length = (%length s))
     (let offset_ = (cell:new 0))
     (iter:with-size 

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/string
+  (:documentation "Unicode string operations: splitting, joining, searching, and conversion.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/system.lisp
+++ b/library/system.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/system
+  (:documentation "System utilities: timing, memory profiling, garbage collection, sleep, Lisp condition handling, and command-line arguments.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/tuple.lisp
+++ b/library/tuple.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/tuple
+  (:documentation "Tuple types (2-element and 3-element) with accessors, destructuring, and instances.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/types.lisp
+++ b/library/types.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/types
+  (:documentation "Runtime type representation: Proxy types, LispType mappings, and RuntimeRepr.")
   (:use
    #:coalton)
   (:export

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/vector
+  (:documentation "Mutable growable arrays backed by Common Lisp adjustable vectors with fill pointers.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/src/analysis/analysis.lisp
+++ b/src/analysis/analysis.lisp
@@ -1,3 +1,11 @@
+;;;; analysis.lisp
+;;;;
+;;;; The top-level analysis driver. After type checking, the analysis pass
+;;;; runs static checks on the typed AST: pattern exhaustiveness (are all
+;;;; match cases covered?), unused variables (are any bindings dead?), and
+;;;; underapplied values (are partially-applied constructors used as values
+;;;; where a full application was likely intended?).
+
 (defpackage #:coalton-impl/analysis/analysis
   (:use
    #:cl

--- a/src/analysis/unused-variables.lisp
+++ b/src/analysis/unused-variables.lisp
@@ -1,3 +1,11 @@
+;;;; unused-variables.lisp
+;;;;
+;;;; Detects unused variable bindings in typed definitions. Walks the
+;;;; typed AST to collect variable references, then checks each parameter
+;;;; and let-binding against the set of used variables, emitting warnings
+;;;; for any that are unreferenced (excluding variables whose names start
+;;;; with underscore, which are conventionally unused).
+
 (defpackage #:coalton-impl/analysis/unused-variables
   (:use
    #:cl)

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -1,3 +1,18 @@
+;;;; ast.lisp
+;;;;
+;;;; The codegen AST (abstract syntax tree): a lower-level intermediate
+;;;; representation used during code generation. Unlike the typechecker's
+;;;; AST which mirrors the source language, the codegen AST is closer to
+;;;; Common Lisp and includes nodes for:
+;;;;
+;;;; - Direct function application (bypassing FUNCALL)
+;;;; - Explicit type class dictionary passing
+;;;; - Struct field access and mutation
+;;;; - Loop constructs (while, for, break, continue)
+;;;; - Lisp escape nodes for FFI
+;;;;
+;;;; Each node carries its inferred type for use during optimization.
+
 (defpackage #:coalton-impl/codegen/ast
   (:use
    #:cl

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -1,3 +1,12 @@
+;;;; codegen-expression.lisp
+;;;;
+;;;; The final code generation stage: transforms the optimized codegen AST
+;;;; into Common Lisp forms that can be compiled by the host CL compiler.
+;;;; Handles translation of Coalton constructs into their CL equivalents:
+;;;; pattern matching into TYPECASE/IF chains, closures into LAMBDA forms,
+;;;; type class dispatch into structure slot access, and loop constructs
+;;;; into TAGBODY/GO forms.
+
 (defpackage #:coalton-impl/codegen/codegen-expression
   (:use
    #:cl

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -1,3 +1,19 @@
+;;;; optimizer.lisp
+;;;;
+;;;; The codegen optimizer transforms the codegen AST to improve the
+;;;; quality of generated Common Lisp code. Optimizations include:
+;;;;
+;;;; - Direct application: eliminates FUNCALL overhead by recognizing
+;;;;   known-function calls and emitting direct CL function calls.
+;;;; - Inlining: replaces calls to inline-declared functions with their
+;;;;   bodies, specializing for the call site.
+;;;; - Monomorphization: generates type-specialized copies of polymorphic
+;;;;   functions, eliminating dictionary-passing overhead.
+;;;; - Constant folding and dead code elimination.
+;;;; - Match compilation: optimizes nested pattern matches.
+;;;;
+;;;; The optimizer runs after translation and before final CL codegen.
+
 (defpackage #:coalton-impl/codegen/optimizer
   (:use
    #:cl

--- a/src/codegen/package.lisp
+++ b/src/codegen/package.lisp
@@ -1,4 +1,17 @@
 (uiop:define-package #:coalton-impl/codegen
+  (:documentation "The Coalton code generator translates typed AST into Common Lisp forms.
+
+The pipeline: typed AST -> codegen AST -> optimization -> CL code generation.
+
+Key stages:
+- Translation (translate-expression.lisp): converts typechecker AST to codegen AST,
+  inserting type class dictionary passing and constructor applications.
+- Optimization (optimizer.lisp): inlining, constant folding, direct application,
+  match compilation, and tail-call optimization.
+- Monomorphization (monomorphize.lisp): specializes polymorphic functions for
+  concrete types, eliminating dictionary-passing overhead.
+- Code generation (codegen-expression.lisp): emits Common Lisp forms from the
+  optimized codegen AST.")
   (:import-from
    #:coalton-impl/codegen/codegen-expression
    #:codegen-expression)

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -1,3 +1,17 @@
+;;;; program.lisp
+;;;;
+;;;; The top-level code generation driver. Orchestrates the full pipeline
+;;;; from a typed translation unit to compiled Common Lisp forms:
+;;;;
+;;;; 1. Translate type definitions into CL struct/class definitions
+;;;; 2. Translate type class definitions into CL class hierarchies
+;;;; 3. Translate value definitions through the codegen pipeline
+;;;; 4. Optimize the codegen AST (inline, monomorphize, etc.)
+;;;; 5. Generate final CL forms and update the global environment
+;;;;
+;;;; The *codegen-hook* variable allows external tools (e.g., the docs
+;;;; generator) to observe the generated CL forms.
+
 (defpackage #:coalton-impl/codegen/program
   (:use
    #:cl

--- a/src/doc/html.lisp
+++ b/src/doc/html.lisp
@@ -388,6 +388,12 @@ summary{cursor:pointer;font-weight:600;padding:6px 0}
                       :label "Macros"
                       :header-html-class "macros-header"
                       :content-html-class "macros-content"))
+      (:raw
+       (write-section backend objects
+                      :type 'coalton-operator
+                      :label "Operators"
+                      :header-html-class "operators-header"
+                      :content-html-class "operators-content"))
       )))
 
 (defun write-section (backend objects &key type label header-html-class content-html-class)
@@ -495,6 +501,9 @@ summary{cursor:pointer;font-weight:600;padding:6px 0}
     (:raw (doc-html object))))
 
 (defmethod write-object-body ((backend html-backend) (object coalton-macro))
+  (doc-html object))
+
+(defmethod write-object-body ((backend html-backend) (object coalton-operator))
   (doc-html object))
 
 (defun doc-html (object)

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -104,7 +104,8 @@
       (write-section 'coalton-struct "Structs")
       (write-section 'coalton-class "Classes")
       (write-section 'coalton-value "Values")
-      (write-section 'coalton-macro "Macros"))))
+      (write-section 'coalton-macro "Macros")
+      (write-section 'coalton-operator "Operators"))))
 
 (defun write-instances (backend object)
   (let ((instances (object-instances object)))
@@ -221,6 +222,11 @@
 ;;; coalton-macro
 
 (defmethod write-object-body ((backend markdown-backend) (object coalton-macro))
+  (write-doc backend object))
+
+;;; coalton-operator
+
+(defmethod write-object-body ((backend markdown-backend) (object coalton-operator))
   (write-doc backend object))
 
 ;;; Methods for TO-MARKDOWN

--- a/src/doc/model.lisp
+++ b/src/doc/model.lisp
@@ -59,6 +59,10 @@
    #:coalton-macro
    #:coalton-macro-name
 
+   #:coalton-operator
+   #:coalton-operator-name
+   #:coalton-operator-kind
+
    #:coalton-package
    #:package-objects
    #:sort-objects
@@ -350,12 +354,13 @@
       (tc:type-entry-name type-entry)))
 
 (defun stdlib-p (symbol)
-  "A standard library package is any package with the exact name 'coalton' or whose name starts with 'coalton/'."
+  "A standard library package is any package with the exact name 'coalton', 'coalton-prelude', or whose name starts with 'coalton/'."
   (let ((pkg (symbol-package symbol)))
     (if (null pkg)
         nil
         (let ((name (package-name pkg)))
           (or (string-equal name "COALTON")
+              (string-equal name "COALTON-PRELUDE")
               (eql 0 (search "COALTON/" name)))))))
 
 ;;; class coalton-macro
@@ -437,6 +442,65 @@
            (package-name (symbol-package (coalton-macro-name x)))
            (symbol-name (coalton-macro-name x)))))
 
+;;; class coalton-operator
+
+(defclass coalton-operator (coalton-object)
+  ((name :initarg :name :reader coalton-operator-name)
+   (kind :initarg :kind :reader coalton-operator-kind
+         :documentation "Either :TOPLEVEL or :EXPRESSION.")))
+
+(defun symbol-names-coalton-operator-p (s)
+  (get s ':coalton-operator))
+
+(defun find-operators (&key (package nil package-provided-p))
+  (let ((operators nil))
+    (cond
+      ((not package-provided-p)
+       (do-all-symbols (v operators)
+         (when (and (symbol-exported-p v)
+                    (symbol-names-coalton-operator-p v))
+           (push (make-instance 'coalton-operator
+                   :name v
+                   :kind (get v ':coalton-operator))
+                 operators))))
+      (t
+       (do-external-symbols (v package operators)
+         (when (symbol-names-coalton-operator-p v)
+           (push (make-instance 'coalton-operator
+                   :name v
+                   :kind (get v ':coalton-operator))
+                 operators)))))))
+
+(defun has-operators-p (package)
+  (do-external-symbols (v package nil)
+    (when (symbol-names-coalton-operator-p v)
+      (return-from has-operators-p t))))
+
+(defmethod object-name ((x coalton-operator))
+  (let ((*print-pretty* nil)
+        (*print-circle* nil))
+    (with-output-to-string (s)
+      (format s "~A " (coalton-operator-name x))
+      (print-lambda-list s (get (coalton-operator-name x) ':coalton-operator-lambda-list)))))
+
+(defmethod object-type ((x coalton-operator))
+  (if (eq (coalton-operator-kind x) ':toplevel)
+      "TOPLEVEL OPERATOR"
+      "OPERATOR"))
+
+(defmethod object-location ((x coalton-operator))
+  nil)
+
+(defmethod object-docstring ((x coalton-operator))
+  (documentation (coalton-operator-name x) 'function))
+
+(defmethod object-aname ((x coalton-operator))
+  (substitute
+   #\- #\/
+   (format nil "~(~A-~A-operator~)"
+           (package-name (symbol-package (coalton-operator-name x)))
+           (symbol-name (coalton-operator-name x)))))
+
 ;;; Public API
 
 (defun has-values-p (package)
@@ -480,24 +544,78 @@
   (or (has-types-p package)
       (has-values-p package)
       (has-classes-p package)
-      (has-macros-p package)))
+      (has-macros-p package)
+      (has-operators-p package)))
 
 (defun find-objects (&key package reexported-symbols)
-  "Find all Coalton OBJECTS, optionally retstricting to objects defined in PACKAGE."
+  "Find all Coalton objects, optionally restricting to objects defined in PACKAGE."
   (append (find-types :package package :reexported-symbols reexported-symbols)
           (find-values :package package :reexported-symbols reexported-symbols)
           (find-classes :package package :reexported-symbols reexported-symbols)
-          (find-macros :package package)))
+          (find-macros :package package)
+          (find-operators :package package)))
+
+(defun symbols-covered-by-p (impl umbrella)
+  "Return T if every external symbol of IMPL is also external in UMBRELLA."
+  (do-external-symbols (sym impl t)
+    (multiple-value-bind (found status)
+        (find-symbol (symbol-name sym) umbrella)
+      (unless (and (eq found sym) (eq status ':external))
+        (return-from symbols-covered-by-p nil)))))
+
+(defun stdlib-package-p (package)
+  "T if PACKAGE is a standard library package."
+  (let ((name (package-name package)))
+    (or (string-equal name "COALTON")
+        (eql 0 (search "COALTON/" name)))))
+
+(defun find-umbrella-packages ()
+  "Return an alist of (umbrella-package . covered-packages) for user-facing umbrella packages."
+  (let ((result nil))
+    (dolist (name '("COALTON-PRELUDE" "COALTON/MATH"))
+      (let ((umbrella (find-package name)))
+        (when umbrella
+          (let ((covered nil))
+            ;; Find implementation packages whose symbols are fully re-exported
+            (dolist (pkg (list-all-packages))
+              (when (and (not (eq pkg umbrella))
+                         (stdlib-package-p pkg)
+                         (has-objects-p pkg)
+                         (symbols-covered-by-p pkg umbrella))
+                (push pkg covered)))
+            (push (cons umbrella covered) result)))))
+    result))
 
 (defun find-packages ()
-  "Return the list of packages in the standard library."
-  (let ((packages nil))
+  "Return the list of packages in the standard library.
+
+Prefers user-facing umbrella packages (COALTON-PRELUDE, COALTON/MATH) over
+their implementation sub-packages when the umbrella fully re-exports a
+sub-package's symbols."
+  (let* ((umbrella-alist (find-umbrella-packages))
+         (covered (mapcan #'copy-list (mapcar #'cdr umbrella-alist)))
+         (packages nil))
+    ;; Add umbrella packages with reexported-symbols enabled
+    (dolist (entry umbrella-alist)
+      (let ((umbrella (car entry)))
+        (when (has-objects-p umbrella)
+          (push (make-coalton-package umbrella :reexported-symbols t) packages))))
+    ;; Add remaining stdlib packages that aren't covered by an umbrella
     (do-all-symbols (symbol)
       (when (stdlib-p symbol)
-        (pushnew (symbol-package symbol) packages)))
-    (sort-objects
-     (mapcar #'make-coalton-package
-             (remove-if-not #'has-objects-p packages)))))
+        (let ((pkg (symbol-package symbol)))
+          (unless (or (member pkg covered :test #'eq)
+                      (assoc pkg umbrella-alist :test #'eq))
+            (pushnew pkg packages :test (lambda (a b)
+                                          (if (typep b 'coalton-package)
+                                              (eq a (lisp-package b))
+                                              (eq a b))))))))
+    ;; Convert remaining raw packages to coalton-package objects
+    (setf packages
+          (mapcar (lambda (p)
+                    (if (typep p 'coalton-package) p (make-coalton-package p)))
+                  packages))
+    (sort-objects (remove-if-not (lambda (p) (has-objects-p (lisp-package p))) packages))))
 
 ;;; Source-name lookup utilities
 

--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -21,20 +21,26 @@
 (defmacro define-coalton-toplevel-editor-macro (name lambda-list &optional (docstring ""))
   "Define a macro so that Emacs and SLIME see it nicely, and so the forms indent properly. Not intended for actual use in Lisp code."
   (check-type docstring string)
-  `(defmacro ,name ,lambda-list
-     ,docstring
-     (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
-                                   lambda-list)))
-     (error-coalton-toplevel-only ',name)))
+  `(progn
+     (cl:setf (cl:get ',name ':coalton-operator) ':toplevel
+              (cl:get ',name ':coalton-operator-lambda-list) ',lambda-list)
+     (defmacro ,name ,lambda-list
+       ,docstring
+       (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
+                                     lambda-list)))
+       (error-coalton-toplevel-only ',name))))
 
 (defmacro define-coalton-editor-macro (name lambda-list &optional (docstring ""))
   "Define a macro so that Emacs and SLIME see it nicely, and so the forms indent properly. Not intended for actual use in Lisp code."
   (check-type docstring string)
-  `(defmacro ,name ,lambda-list
-     ,docstring
-     (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
-                                   lambda-list)))
-     (error-coalton-only ',name)))
+  `(progn
+     (cl:setf (cl:get ',name ':coalton-operator) ':expression
+              (cl:get ',name ':coalton-operator-lambda-list) ',lambda-list)
+     (defmacro ,name ,lambda-list
+       ,docstring
+       (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
+                                     lambda-list)))
+       (error-coalton-only ',name))))
 
 
 ;;; Top-Level Forms
@@ -91,6 +97,10 @@
   "A lambda abstraction callable within coalton."
   (rt:construct-function-entry `(lambda ,vars ,@form) (length vars)))
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (setf (get 'coalton:fn ':coalton-operator) ':expression
+        (get 'coalton:fn ':coalton-operator-lambda-list) '(vars &body form)))
+
 (define-coalton-editor-macro coalton:throw (exception)
     "Throw an exception.")
 
@@ -121,30 +131,44 @@
 (define-coalton-editor-macro coalton:the (type expr)
   "Declare that EXPR is of type TYPE.")
 
-(define-coalton-editor-macro coalton:or (&rest args))
+(define-coalton-editor-macro coalton:or (&rest args)
+  "Short-circuit logical disjunction. Evaluates arguments left-to-right, returning the first truthy value or False if all are False.")
 
-(define-coalton-editor-macro coalton:and (&rest args))
+(define-coalton-editor-macro coalton:and (&rest args)
+  "Short-circuit logical conjunction. Evaluates arguments left-to-right, returning False on the first False value, or the last value if all are truthy.")
 
-(define-coalton-editor-macro coalton:if (expr then else))
+(define-coalton-editor-macro coalton:if (expr then else)
+  "Conditional expression. Evaluates EXPR; if True, evaluates and returns THEN, otherwise evaluates and returns ELSE. Both branches must have the same type.")
 
-(define-coalton-editor-macro coalton:when (expr &body body))
+(define-coalton-editor-macro coalton:when (expr &body body)
+  "Evaluate BODY for side effects when EXPR is True. Returns Unit.")
 
-(define-coalton-editor-macro coalton:unless (expr &body body))
+(define-coalton-editor-macro coalton:unless (expr &body body)
+  "Evaluate BODY for side effects when EXPR is False. Returns Unit.")
 
-(define-coalton-editor-macro coalton:cond (&rest clauses))
+(define-coalton-editor-macro coalton:cond (&rest clauses)
+  "Multi-way conditional. Each clause is (TEST BODY). Clauses are evaluated in order; the body of the first clause whose test is True is returned. The last clause's test is typically True as a default.")
 
-(define-coalton-editor-macro coalton:do (&body body))
+(define-coalton-editor-macro coalton:do (&body body)
+  "Monadic do notation. Binds the results of monadic computations using left-arrow syntax (x <- expr) and sequences them. The final expression determines the result type. Operates within a monadic context inferred from the bindings.")
 
-(define-coalton-editor-macro coalton:return (&optional value))
+(define-coalton-editor-macro coalton:return (&optional value)
+  "Monadic return. Wraps VALUE in the current monadic context. Equivalent to calling `pure`.")
 
-(define-coalton-editor-macro coalton:loop (&body body))
+(define-coalton-editor-macro coalton:loop (&body body)
+  "Infinite loop. Repeatedly evaluates BODY until terminated by `break`. Supports an optional loop label keyword for nested loop control.")
 
-(define-coalton-editor-macro coalton:while (test &body body))
+(define-coalton-editor-macro coalton:while (test &body body)
+  "Conditional loop. Evaluates BODY repeatedly as long as TEST is True. Supports `break`, `continue`, and an optional loop label keyword.")
 
-(define-coalton-editor-macro coalton:while-let (pattern = test &body body))
+(define-coalton-editor-macro coalton:while-let (pattern = test &body body)
+  "Pattern-matching loop. Evaluates TEST each iteration; if it matches PATTERN, binds the pattern variables and evaluates BODY. Terminates when the pattern does not match. Supports `break`, `continue`, and an optional loop label keyword.")
 
-(define-coalton-editor-macro coalton:for (pattern in iter &body body))
+(define-coalton-editor-macro coalton:for (pattern in iter &body body)
+  "Iterator loop. Evaluates ITER (which must implement IntoIterator), then for each element matching PATTERN, evaluates BODY. Supports `break`, `continue`, and an optional loop label keyword.")
 
-(define-coalton-editor-macro coalton:break (&optional label))
+(define-coalton-editor-macro coalton:break (&optional label)
+  "Terminate the enclosing loop immediately. If LABEL is provided, terminates the loop with that label, allowing break from nested loops.")
 
-(define-coalton-editor-macro coalton:continue (&optional label))
+(define-coalton-editor-macro coalton:continue (&optional label)
+  "Skip the rest of the current loop iteration and start the next one. If LABEL is provided, continues the loop with that label.")

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -234,7 +234,7 @@ Rebound to NIL parsing an anonymous FN.")
 ;;;;             | node-abstraction
 ;;;;             | node-let
 ;;;;             | node-rec
-;;;;             | node-lisp 
+;;;;             | node-lisp
 ;;;;             | node-match
 ;;;;             | node-progn
 ;;;;             | node-the
@@ -247,6 +247,12 @@ Rebound to NIL parsing an anonymous FN.")
 ;;;;             | node-unless
 ;;;;             | node-cond
 ;;;;             | node-do
+;;;;             | node-loop
+;;;;             | node-while
+;;;;             | node-while-let
+;;;;             | node-for
+;;;;             | node-break
+;;;;             | node-continue
 ;;;;
 ;;;; node-bind := "(" "let" pattern "=" expression ")"
 ;;;;
@@ -299,6 +305,20 @@ Rebound to NIL parsing an anonymous FN.")
 ;;;;                       | node-do-bind
 ;;;;
 ;;;; node-do := node-do-body-element* expression
+;;;;
+;;;; label := <a keyword symbol>
+;;;;
+;;;; node-loop := "(" "loop" label? body ")"
+;;;;
+;;;; node-while := "(" "while" label? expression body ")"
+;;;;
+;;;; node-while-let := "(" "while-let" label? pattern "=" expression body ")"
+;;;;
+;;;; node-for := "(" "for" label? pattern "in" expression body ")"
+;;;;
+;;;; node-break := "(" "break" label? ")"
+;;;;
+;;;; node-continue := "(" "continue" label? ")"
 
 (defstruct (node
             (:constructor nil)

--- a/src/parser/package.lisp
+++ b/src/parser/package.lisp
@@ -1,4 +1,16 @@
 (uiop:define-package #:coalton-impl/parser
+  (:documentation "The Coalton parser transforms s-expressions into a typed AST.
+
+Parsing proceeds in two phases: first, Coalton source forms (from COALTON-TOPLEVEL
+or the Coalton reader) are parsed into an untyped CST (concrete syntax tree).
+Then the renamer resolves names and produces the final parse tree that the
+typechecker consumes.
+
+Key concepts:
+- Expressions, patterns, and types each have their own node types.
+- Top-level forms (define, define-type, define-class, etc.) are parsed by toplevel.lisp.
+- The collect protocol provides generic traversal for gathering sub-nodes.
+- The binding and type-definition protocols abstract over definition forms.")
   (:mix-reexport
    #:coalton-impl/parser/base
    #:coalton-impl/parser/reader

--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -1,3 +1,17 @@
+;;;; context-reduction.lisp
+;;;;
+;;;; Type class context reduction: simplifies the set of type class
+;;;; constraints that a definition requires. After type inference, a
+;;;; function may accumulate many redundant or entailed constraints
+;;;; (e.g., both Eq :a and Ord :a, where Ord implies Eq). Context
+;;;; reduction removes redundant constraints and splits them into
+;;;; "deferred" (still polymorphic) and "retained" (can be resolved
+;;;; now) sets.
+;;;;
+;;;; Also implements defaulting: when a type variable appears only in
+;;;; Num constraints and has no other constraints, it can be defaulted
+;;;; to Integer, similar to Haskell's defaulting rules.
+
 (defpackage #:coalton-impl/typechecker/context-reduction
   (:use
    #:cl

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -1,3 +1,19 @@
+;;;; environment.lisp
+;;;;
+;;;; The global type environment: the central database that stores all type
+;;;; information accumulated during compilation. This includes:
+;;;;
+;;;; - Type definitions (algebraic types, structs, type aliases)
+;;;; - Type class definitions and their instances
+;;;; - Value bindings and their inferred type schemes
+;;;; - Constructor entries mapping data constructors to their parent types
+;;;; - Specialization entries for optimized type class dispatch
+;;;; - Source names for preserving user-written names through compilation
+;;;;
+;;;; The environment is an immutable data structure backed by FSET maps.
+;;;; Each compilation unit produces a new environment by extending the
+;;;; previous one, enabling incremental compilation.
+
 (defpackage #:coalton-impl/typechecker/environment
   (:use
    #:cl

--- a/src/typechecker/kinds.lisp
+++ b/src/typechecker/kinds.lisp
@@ -1,3 +1,17 @@
+;;;; kinds.lisp
+;;;;
+;;;; The kind system classifies types by their arity. Just as types
+;;;; classify values, kinds classify type constructors:
+;;;;
+;;;;   * (KSTAR) — the kind of concrete types (Integer, Boolean, etc.)
+;;;;   * -> * (KFUN) — the kind of type constructors taking one argument
+;;;;                    (List, Optional, etc.)
+;;;;   (* -> *) -> * — higher-kinded types (like Functor's argument)
+;;;;
+;;;; Kind checking ensures that type constructors are applied to the
+;;;; correct number of arguments (e.g., List needs one argument,
+;;;; Hashtable needs two).
+
 (defpackage #:coalton-impl/typechecker/kinds
   (:use
    #:cl

--- a/src/typechecker/package.lisp
+++ b/src/typechecker/package.lisp
@@ -1,4 +1,18 @@
 (uiop:define-package #:coalton-impl/typechecker
+  (:documentation "The Coalton type checker implements Hindley-Milner type inference
+extended with type classes (following 'Typing Haskell in Haskell' by Mark P. Jones).
+
+The typechecker takes an untyped parse tree and produces a typed AST annotated
+with inferred types, resolved type class dictionaries, and specialization
+information. Key subsystems include:
+
+- Type inference (define.lisp) via constraint generation and unification
+- Kind inference (parse-type.lisp) for higher-kinded types
+- Type class resolution (context-reduction.lisp, define-class.lisp, define-instance.lisp)
+- Functional dependencies (fundeps.lisp) for multi-parameter type classes
+- Specialization (specialize.lisp) for performance-critical type class dispatch
+- Variance checking (variance.lisp) for type parameters
+- Environment management (environment.lisp, tc-env.lisp) for the global type database")
   (:mix-reexport
    #:coalton-impl/typechecker/stage-1
    #:coalton-impl/typechecker/base

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -1,3 +1,16 @@
+;;;; predicate.lisp
+;;;;
+;;;; Type class predicates and related structures. A predicate like
+;;;; (Eq :a) constrains a type variable to belong to a type class.
+;;;; This module defines:
+;;;;
+;;;; - TY-PREDICATE: a class name applied to type arguments
+;;;; - TY-CLASS: a type class definition (superclasses, methods, fundeps)
+;;;; - TY-CLASS-INSTANCE: a concrete implementation of a class for a type
+;;;; - QUALIFIED-TY: a type with class constraints (e.g., Eq :a => :a -> :a -> Boolean)
+;;;;
+;;;; These form the constraint language that drives type class resolution.
+
 (defpackage #:coalton-impl/typechecker/predicate
   (:use
    #:cl

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -1,3 +1,13 @@
+;;;; scheme.lisp
+;;;;
+;;;; Type schemes (universally quantified types). A type scheme like
+;;;; ∀ :a. Eq :a => :a -> :a -> Boolean represents a polymorphic type
+;;;; that can be instantiated with fresh type variables at each use site.
+;;;;
+;;;; Quantification (QUANTIFY) closes over free type variables in a type,
+;;;; producing a scheme. Instantiation (INSTANTIATE) replaces the bound
+;;;; variables with fresh ones for each use, enabling let-polymorphism.
+
 (defpackage #:coalton-impl/typechecker/scheme
   (:use
    #:cl

--- a/src/typechecker/substitutions.lisp
+++ b/src/typechecker/substitutions.lisp
@@ -1,3 +1,15 @@
+;;;; substitutions.lisp
+;;;;
+;;;; Type substitutions: mappings from type variables to types. During type
+;;;; inference, constraints between types are solved by building up a
+;;;; substitution that, when applied to all types in scope, makes them
+;;;; consistent.
+;;;;
+;;;; A substitution list is composed and applied left-to-right. The key
+;;;; operations are COMPOSE-SUBSTITUTION-LISTS (combine two substitutions)
+;;;; and APPLY-SUBSTITUTION (replace type variables in a type according to
+;;;; the substitution).
+
 (defpackage #:coalton-impl/typechecker/substitutions
   (:use
    #:cl

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -1,3 +1,19 @@
+;;;; types.lisp
+;;;;
+;;;; The core type representation. Types in Coalton are represented as a
+;;;; tree of structs:
+;;;;
+;;;;   TY (abstract base)
+;;;;   ├── TYVAR   — type variable (e.g., :a), identified by a unique integer ID
+;;;;   ├── TYCON   — type constructor (e.g., Integer, List), named by a symbol
+;;;;   └── TAPP    — type application (e.g., (List Integer)), combining FROM and TO
+;;;;
+;;;; Function types like (:a -> :b) are represented as TAPP chains using
+;;;; the built-in Arrow type constructor.
+;;;;
+;;;; This module also provides the pretty-printer for types, which maps
+;;;; internal type variable IDs to human-readable names (:A, :B, ...).
+
 (defpackage #:coalton-impl/typechecker/types
   (:use
    #:cl

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -1,3 +1,14 @@
+;;;; unify.lisp
+;;;;
+;;;; Type unification: the core algorithm that determines whether two types
+;;;; can be made equal by finding a substitution (mapping of type variables
+;;;; to types). Unification is the engine of type inference—each use of a
+;;;; variable or function generates constraints that are solved by unification.
+;;;;
+;;;; UNIFY finds the most general unifier (MGU) of two types, while MATCH
+;;;; finds a one-way substitution (type1 can be specialized to type2).
+;;;; Both operate on types and on type class predicates.
+
 (defpackage #:coalton-impl/typechecker/unify
   (:use
    #:cl


### PR DESCRIPTION
## Summary

This PR addresses **14 open documentation issues** with changes spanning 80 files (1,480 additions). The changes fall into four categories: user-facing docs, stdlib documentation, docs generator improvements, and compiler internal documentation.

### User-Facing Guides (4 new docs, 4 updated)
- **New** `docs/collections.md` — choosing the right collection type (#1303)
- **New** `docs/iterator-protocol.md` — iterator creation, consumption, and protocol guarantees (#884)
- **New** `docs/optimization-guide.md` — inlining, monomorphization, and specialization (#1367)
- **New** `docs/cl-style-guide.md` — CL coding style guide for compiler contributors (#777)
- **Updated** intro-to-coalton.md — implicit `fromInt` numeric casting (#1244)
- **Updated** coalton-lisp-interop.md — `define-struct` promises + accessing CL variables (#1457, #961, #629)
- **Updated** typeclasses.md design doc — constrained methods now allowed (#1520)
- **Updated** coalton-documentation-guide.md — fixed docstring ordering example (#898)

### Standard Library Documentation
- **Package docs** (#578): Added `:documentation` strings to all 40+ stdlib packages (classes, list, vector, iterator, hashtable, hashmap, seq, queue, cell, string, char, optional, result, functions, boolean, system, tuple, slice, bits, hash, builtin, types, lisparray, randomaccess, ordmap, ordtree, big-float, computable-reals, all math/*, all monad/*)
- **Type class invariants** (#498): Documented algebraic laws for Eq, Num, Ord, Semigroup, Monoid, Functor, Applicative, Monad, and Into in their class definitions
- **Faux macro docstrings** (#1282): Added docstrings to all 14 undocumented faux macros (or, and, if, when, unless, cond, do, return, loop, while, while-let, for, break, continue)
- **EBNF grammar** (#1593): Added loop forms to the parser grammar comments
- **Docstring typos** (#898): Fixed 23 typos/formatting issues across the stdlib (interator→iterator, Raturns→Returns, yeilds→yields, occurence→occurrence, elmentary→elementary, bount→bound, missing periods, trailing spaces, grammar fix)

### Docs Generator Improvements
- **Language operators in reference** (#1592): Tagged faux macros with `:coalton-operator` property and added "Operators" section to markdown, HTML, and Hugo backends
- **User-facing package names** (#886): Docs generator now prefers umbrella packages (COALTON-PRELUDE, COALTON/MATH) over implementation sub-packages when the umbrella fully re-exports a sub-package's symbols

### Compiler Internal Documentation (#1502)
- Added module preambles to 15 critical compiler files explaining their purpose and key concepts:
  - Parser: package.lisp (pipeline overview)
  - Typechecker: package.lisp, types.lisp, kinds.lisp, predicate.lisp, scheme.lisp, substitutions.lisp, unify.lisp, environment.lisp, context-reduction.lisp
  - Codegen: package.lisp, ast.lisp, optimizer.lisp, codegen-expression.lisp, program.lisp
  - Analysis: analysis.lisp, unused-variables.lisp
- Added `:documentation` strings to parser, typechecker, and codegen aggregate packages

## Issues Addressed

Fixes #1244, #1520, #1282, #1457, #961, #629, #1593, #498, #578, #898, #1303, #884, #1367, #777
Ref #1592, #886, #1502 (partially addressed)

## Test plan

- [ ] Verify `(asdf:load-system "coalton")` loads without errors
- [ ] Verify `(asdf:test-system "coalton")` passes
- [ ] Verify `(coalton/doc:write-stdlib-documentation-to-file "/tmp/test.md")` generates reference including the new Operators section
- [ ] Review new guide docs for accuracy against source code
- [ ] Verify package `:documentation` strings appear in `(describe (find-package "COALTON/LIST"))` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)