### PR TITLE
Fix 21 typos in stdlib docstrings

### DIFF
--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -308,11 +308,11 @@ together."
   ;;
 
   (define-class (Into :a :b)
-    "`INTO` imples *every* element of `:a` can be represented by an element of `:b`. This conversion might not be bijective (i.e., there may be elements in `:b` that don't correspond to any in `:a`)."
+    "`INTO` implies *every* element of `:a` can be represented by an element of `:b`. This conversion might not be bijective (i.e., there may be elements in `:b` that don't correspond to any in `:a`)."
     (into (:a -> :b)))
 
   (define-class ((Into :a :b) (Into :b :a) => Iso :a :b)
-    "Opting into this marker typeclass imples that the instances for `(Into :a :b)` and `(Into :b :a)` form a bijection.")
+    "Opting into this marker typeclass implies that the instances for `(Into :a :b)` and `(Into :b :a)` form a bijection.")
 
   (define-instance (Into :a :a)
     (define (into x) x))
@@ -406,7 +406,7 @@ Typical `fail` continuations are:
   (declare defaulting-unwrap ((Unwrappable :container) (Default :element) =>
                               (:container :element) -> :element))
   (define (defaulting-unwrap container)
-    "Unwrap an `unwrappable`, returning `(default)` of the wrapped type on failure. "
+    "Unwrap an `unwrappable`, returning `(default)` of the wrapped type on failure."
     (unwrap-or-else (fn (elt) elt)
                     (fn () (default))
                     container))

--- a/library/experimental/loops.lisp
+++ b/library/experimental/loops.lisp
@@ -308,11 +308,11 @@ COALTON::UNIT/UNIT
   `(%sometimes ,count (fn (,variable) ,@body)))
 
 (defmacro sumtimes ((variable count) cl:&body body)
-  "The sum of `body` for `variable` bount to every `UFix` in [0, `count`)."
+  "The sum of `body` for `variable` bound to every `UFix` in [0, `count`)."
   `(%sumtimes ,count (fn (,variable) ,@body)))
 
 (defmacro prodtimes ((variable count) cl:&body body)
-  "The product of `body` for `variable` bount to every `UFix` in [0, `count`)."
+  "The product of `body` for `variable` bound to every `UFix` in [0, `count`)."
   `(%prodtimes ,count (fn (,variable) ,@body)))
 
 (defmacro collecttimes ((variable count) cl:&body body)
@@ -320,7 +320,7 @@ COALTON::UNIT/UNIT
   `(%collecttimes ,count (fn (,variable) ,@body)))
 
 (defmacro besttimes ((variable count better?) cl:&body body)
-  "The result of evaluating `body` with `variable` bound to a `UFix` in [0, `count`) that is `better?` than the result of evaluating `body` with `variable` bound to the rest of the `UFix`s in [0, `count`).."
+  "The result of evaluating `body` with `variable` bound to a `UFix` in [0, `count`) that is `better?` than the result of evaluating `body` with `variable` bound to the rest of the `UFix`s in [0, `count`)."
   `(%besttimes ,count ,better? (fn (,variable) ,@body)))
 
 (defmacro argbesttimes ((variable count better?) cl:&body body)

--- a/library/hashmap.lisp
+++ b/library/hashmap.lisp
@@ -693,19 +693,19 @@ new value, if the key was found."
   ;; API
   (declare keys (Hash :k => HashMap :k :v -> (iter:Iterator :k)))
   (define (keys hm)
-    "Returns an interator to iterate over all the keys in a hashmap hm."
+    "Returns an iterator over all the keys in a hashmap hm."
     (iter:new (->generator hm (fn (k _) k))))
 
   ;; API
   (declare values (Hash :k => HashMap :k :v -> (iter:Iterator :v)))
   (define (values hm)
-    "Returns an interator to iterate over all the values in a hashmap hm."
+    "Returns an iterator over all the values in a hashmap hm."
     (iter:new (->generator hm (fn (_ v) v))))
 
   ;; API
   (declare entries (Hash :k => HashMap :k :v -> (iter:Iterator (Tuple :k :v))))
   (define (entries hm)
-    "Returns an interator to iterate over all entries in hashmap hm."
+    "Returns an iterator over all entries in hashmap hm."
     (iter:new (->generator hm Tuple)))
   )
 
@@ -767,12 +767,12 @@ The entries from A remains in the result."
 
   (declare difference (Hash :k => HashMap :k :v -> HashMap :k :v -> HashMap :k :v))
   (define (difference a b)
-    "Raturns a HashMap that contains mappings in `a` but not in `b`."
+    "Returns a HashMap that contains mappings in `a` but not in `b`."
     (iter:fold! (fn (m (Tuple k _v)) (remove m k)) a (iter:into-iter b)))
 
   (declare xor (Hash :k => HashMap :k :v -> HashMap :k :v -> HashMap :k :v))
   (define (xor a b)
-    "Raturns a HashMap that contains mappings either in `a` or in `b`,
+    "Returns a HashMap that contains mappings either in `a` or in `b`,
 but not in both."
     (iter:fold! (fn (m (Tuple k v))
                   (fst (update m k

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -304,7 +304,7 @@ Equivalent to reversing `range-increasing`"
 
   (declare interleave! (Iterator :a -> Iterator :a -> Iterator :a))
   (define (interleave! left right)
-    "Return an interator of interleaved elements from LEFT and RIGHT which terminates as soon as both LEFT and RIGHT do.
+    "Return an iterator of interleaved elements from LEFT and RIGHT which terminates as soon as both LEFT and RIGHT do.
 
 If one iterator terminates before the other, elements from the longer iterator will be yielded without
 interleaving. (interleave empty ITER) is equivalent to (id ITER)."
@@ -350,7 +350,7 @@ interleaving. (interleave empty ITER) is equivalent to (id ITER)."
 
   (declare filter! ((:elt -> Boolean) -> Iterator :elt -> Iterator :elt))
   (define (filter! keep? iter)
-    "Return an iterator over the elements from ITER for which KEEP?returns true."
+    "Return an iterator over the elements from ITER for which KEEP? returns true."
     (let ((filter-iter (fn (u)
                          (match (next! iter)
                            ((None) None)

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -108,7 +108,7 @@
 
   (declare car (List :a -> :a))
   (define (car x)
-    "Return the traditional car of a list. This function is partial"
+    "Return the traditional car of a list. This function is partial."
     (match x
       ((Cons x _) x)
       ((Nil) (error "there is no first element"))))
@@ -425,7 +425,7 @@
 
   (declare difference (Eq :a => ((List :a) -> (List :a) -> (List :a))))
   (define (difference xs ys)
-    "Returns a new list with the first occurence of each element in `ys` removed from `xs`."
+    "Returns a new list with the first occurrence of each element in `ys` removed from `xs`."
     (fold (fn (a b) (remove b a)) xs ys))
 
   (declare zipWith ((:a -> :b -> :c) -> (List :a) -> (List :b) -> (List :c)))
@@ -662,7 +662,7 @@
 
   (declare combs (List :a -> (List (List :a))))
   (define (combs l)
-    "Compute a list of all combinations of elements of `l`. This function is sometimes goes by the name \"power set\" or \"subsets\".
+    "Compute a list of all combinations of elements of `l`. This function sometimes goes by the name \"power set\" or \"subsets\".
 
 The ordering of elements of `l` is preserved in the ordering of elements in each list produced by this function."
     (match l

--- a/library/math/arith.lisp
+++ b/library/math/arith.lisp
@@ -168,7 +168,7 @@ The function `general/` is partial, and will error produce a run-time error if t
   (inline)
   (declare ash (Integer -> Integer -> Integer))
   (define (ash x n)
-    "Compute the \"arithmetic shift\" of `x` by `n`. "
+    "Compute the \"arithmetic shift\" of `x` by `n`."
     (lisp Integer (x n) (cl:ash x n)))
 
   (inline)

--- a/library/math/elementary.lisp
+++ b/library/math/elementary.lisp
@@ -175,7 +175,7 @@ For a complex number `z = (complex x y)`, the following identities hold:
     (Tuple r theta)))
 
 (cl:defmacro %define-real-float-elementary (coalton-type underlying-type)
-  "Defines the elmentary instances for a lisp floating-point type"
+  "Defines the elementary instances for a lisp floating-point type."
   `(coalton-toplevel
      (define-instance (Trigonometric ,coalton-type)
        (inline)

--- a/library/ordmap.lisp
+++ b/library/ordmap.lisp
@@ -273,14 +273,14 @@ The resulting values are from `a`."
 
   (declare difference (Ord :key => OrdMap :key :value -> OrdMap :key :value -> OrdMap :key :value))
   (define (difference a b)
-    "Raturns an OrdMap that contains mappings in `a` but not in `b`."
+    "Returns an OrdMap that contains mappings in `a` but not in `b`."
     (let (%Map ta) = a)
     (let (%Map tb) = b)
     (%Map (tree:difference ta tb)))
 
   (declare xor (Ord :key => OrdMap :key :value -> OrdMap :key :value -> OrdMap :key :value))
   (define (xor a b)
-    "Raturns an OrdMap that contains mappings either in `a` or in `b`,
+    "Returns an OrdMap that contains mappings either in `a` or in `b`,
 but not in both."
     (let (%Map ta) = a)
     (let (%Map tb) = b)

--- a/library/queue.lisp
+++ b/library/queue.lisp
@@ -190,7 +190,7 @@
 
   (declare items! (Queue :a -> iter:Iterator :a))
   (define (items! q)
-    "Returns an interator over the items of `q`, removing items as they are returned."
+    "Returns an iterator over the items of `q`, removing items as they are returned."
     (iter:with-size
         (fn ()
           (pop! q))

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -100,7 +100,7 @@
 
   (declare iter-sliding ((Sliceable (:b :a)) => UFix -> :b :a -> iter:Iterator (Slice :a)))
   (define (iter-sliding size s)
-    "Returns an iterator that yeilds a series of overlapping slices of length `size`."
+    "Returns an iterator that yields a series of overlapping slices of length `size`."
     (let length = (%length s))
     (let offset_ = (cell:new 0))
     (iter:with-size 


### PR DESCRIPTION
## Summary
- Fix spelling errors and trailing whitespace in docstrings across 10 library files
- Pure typo corrections — no behavioral or semantic changes

### Changes
| File | Fix |
|------|-----|
| `library/experimental/loops.lisp` | "bount" → "bound" (×2), ".." → "." |
| `library/hashmap.lisp` | "interator" → "iterator" (×3), "Raturns" → "Returns" (×2) |
| `library/iterator.lisp` | "interator" → "iterator", "KEEP?returns" → "KEEP? returns" |
| `library/list.lisp` | missing period, "occurence" → "occurrence", "is sometimes goes" → "sometimes goes" |
| `library/math/arith.lisp` | trailing space |
| `library/math/elementary.lisp` | "elmentary" → "elementary" |
| `library/ordmap.lisp` | "Raturns" → "Returns" (×2) |
| `library/queue.lisp` | "interator" → "iterator" |
| `library/slice.lisp` | "yeilds" → "yields" |
| `library/classes.lisp` | "imples" → "implies" (×2), trailing space |

Fixes #898

## AI Disclaimer
AI was used to help identify these typos. All changes have been manually reviewed against the source code.

## Test plan
- [ ] Verify the project builds cleanly (`make`)
- [ ] Spot-check docstrings render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)