### PR TITLE
Add :documentation strings to stdlib and compiler packages

### DIFF
--- a/library/big-float/package.lisp
+++ b/library/big-float/package.lisp
@@ -3,6 +3,7 @@
 ;;;; Big float package for various implementations
 
 (coalton/utils:defstdlib-package #:coalton/big-float
+  (:documentation "Arbitrary-precision floating-point arithmetic (implementation-specific: uses SB-MPFR on SBCL).")
   (:use #:coalton
         #:coalton/classes
         #:coalton/functions

--- a/library/bits.lisp
+++ b/library/bits.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/bits
+  (:documentation "Bitwise operations (and, or, xor, shift, rotate) on fixed-width integer types.")
   (:shadow
      #:and
      #:or

--- a/library/boolean.lisp
+++ b/library/boolean.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/boolean
+  (:documentation "Boolean type class instances (Eq, Ord, Hash) and Show.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/builtin.lisp
+++ b/library/builtin.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/builtin
+  (:documentation "Built-in utilities: error, unreachable, undefined, and boolean logic operators.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/cell.lisp
+++ b/library/cell.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/cell
+  (:documentation "Mutable single-value containers (mutable references) for local state.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/char.lisp
+++ b/library/char.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/char
+  (:documentation "Character classification, case conversion, and Unicode code-point operations.")
   (:use
    #:coalton
    #:coalton/classes

--- a/library/classes.lisp
+++ b/library/classes.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/classes
+  (:documentation "Core type classes: Eq, Ord, Num, Semigroup, Monoid, Functor, Applicative, Monad, Into, and more.")
   (:use
    #:coalton)
   (:local-nicknames

--- a/library/computable-reals/computable-reals.lisp
+++ b/library/computable-reals/computable-reals.lisp
@@ -3,6 +3,7 @@
 ;;;; Reals library using computable-reals (https://github.com/stylewarning/computable-reals)
 
 (defpackage #:coalton/computable-reals
+  (:documentation "Coalton interface to computable-reals: exact real arithmetic with lazy, on-demand precision.")
   (:nicknames #:coalton-library/computable-reals)
   (:use #:coalton
         #:coalton-prelude

--- a/library/functions.lisp
+++ b/library/functions.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/functions
+  (:documentation "Higher-order function combinators: composition, currying, fixpoints, and debugging utilities.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/hash.lisp
+++ b/library/hash.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/hash
+  (:documentation "Hash combining utilities and the define-sxhash-hasher macro for implementing Hash instances.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/hashmap.lisp
+++ b/library/hashmap.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/hashmap
+  (:documentation "Persistent (immutable) hash maps based on Hash Array Mapped Tries, with set operations.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/hashtable.lisp
+++ b/library/hashtable.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/hashtable
+  (:documentation "Mutable hash tables mapping keys (with Hash instances) to values.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/iterator.lisp
+++ b/library/iterator.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/iterator
+  (:documentation "Lazy forward-only iterators for sequential data traversal, transformation, and aggregation.")
   (:shadow #:empty)
   (:use
    #:coalton

--- a/library/lisparray.lisp
+++ b/library/lisparray.lisp
@@ -3,6 +3,7 @@
 ;;;; An interface to Common Lisp rank-1 SIMPLE-ARRAYs.
 
 (coalton/utils:defstdlib-package #:coalton/lisparray
+  (:documentation "Low-level interface to Common Lisp rank-1 simple-arrays with element-type specialization.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/list.lisp
+++ b/library/list.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/list
+  (:documentation "Operations on singly-linked persistent lists: traversal, search, transformation, and set operations.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/arith.lisp
+++ b/library/math/arith.lisp
@@ -3,6 +3,7 @@
 ;;;; Number types and basic arithmetic.
 
 (coalton/utils:defstdlib-package #:coalton/math/arith
+  (:documentation "Core arithmetic: Reciprocable, Dividable, Fraction type, and numeric conversions.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/bounded.lisp
+++ b/library/math/bounded.lisp
@@ -3,6 +3,7 @@
 ;;;; Numerical types with fixed bounds
 
 (coalton/utils:defstdlib-package #:coalton/math/bounded
+  (:documentation "Bounded type class: minBound and maxBound for fixed-width numeric types.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/complex.lisp
+++ b/library/math/complex.lisp
@@ -3,6 +3,7 @@
 ;;;; Complex numbers
 
 (coalton/utils:defstdlib-package #:coalton/math/complex
+    (:documentation "Complex number type and the ComplexComponent class for extracting real/imaginary parts.")
     (:use #:coalton
           #:coalton/classes
           #:coalton/utils

--- a/library/math/conversions.lisp
+++ b/library/math/conversions.lisp
@@ -3,6 +3,7 @@
 ;;;; Conversions between primitive numerical types
 
 (coalton/utils:defstdlib-package #:coalton/math/conversions
+  (:documentation "Safe (Into) and fallible (TryInto) conversions between primitive numeric types.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/dual.lisp
+++ b/library/math/dual.lisp
@@ -4,6 +4,7 @@
 ;;;; of compositions of built-in Coalton functions.
 
 (coalton/utils:defstdlib-package #:coalton/math/dual
+  (:documentation "Dual numbers for automatic first-order forward-mode differentiation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/dyadic.lisp
+++ b/library/math/dyadic.lisp
@@ -4,6 +4,7 @@
 ;;; It is not exported into the math package as it is a niche numeric type
 
 (coalton/utils::defstdlib-package #:coalton/math/dyadic
+    (:documentation "Dyadic rationals (a * 2^n): a niche numeric type used internally for big-float arithmetic.")
     (:use
      #:coalton
      #:coalton/builtin

--- a/library/math/elementary.lisp
+++ b/library/math/elementary.lisp
@@ -3,6 +3,7 @@
 ;;;; Elementary/algebraic functions and transcendental numbers
 
 (coalton/utils::defstdlib-package #:coalton/math/elementary
+    (:documentation "Elementary and transcendental functions: trigonometric, exponential, logarithmic, and constants pi and ee.")
     (:use
      #:coalton
      #:coalton/builtin

--- a/library/math/fraction.lisp
+++ b/library/math/fraction.lisp
@@ -3,6 +3,7 @@
 ;;;; Reduced ratios of integers
 
 (coalton/utils:defstdlib-package #:coalton/math/fraction
+  (:documentation "Fraction type: reduced ratios of integers with numerator/denominator access.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/hyperdual.lisp
+++ b/library/math/hyperdual.lisp
@@ -4,6 +4,7 @@
 ;;;; derivatives of compositions of built-in Coalton functions.
 
 (coalton/utils::defstdlib-package #:coalton/math/hyperdual
+  (:documentation "Hyperdual numbers for automatic second-order forward-mode differentiation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/math/integral.lisp
+++ b/library/math/integral.lisp
@@ -3,6 +3,7 @@
 ;;;; Integral domains and operations on integers
 
 (coalton/utils::defstdlib-package #:coalton/math/integral
+  (:documentation "Integral type class and integer operations: division, modular arithmetic, GCD, and primality testing.")
   (:use
    #:coalton
    #:coalton/classes

--- a/library/math/num.lisp
+++ b/library/math/num.lisp
@@ -3,6 +3,7 @@
 ;;;; Instances for primitive numerical types
 
 (coalton/utils:defstdlib-package #:coalton/math/num
+  (:documentation "Num, Eq, Ord, Hash, Into, and other fundamental instances for all primitive numeric types.")
   (:use
    #:coalton
    #:coalton/math/num-defining-macros)

--- a/library/math/real.lisp
+++ b/library/math/real.lisp
@@ -3,6 +3,7 @@
 ;;;; Numbers that exist on the real number line
 
 (coalton/utils::defstdlib-package #:coalton/math/real
+    (:documentation "Real number classes: Quantizable (floor, ceiling) and Rational for types on the real number line.")
     (:use
      #:coalton
      #:coalton/math/arith

--- a/library/monad/classes.lisp
+++ b/library/monad/classes.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/classes
+  (:documentation "Monad effect classes: MonadState, MonadEnvironment, MonadError, and the LiftTo transformer lifting interface.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/monad/environment.lisp
+++ b/library/monad/environment.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/environment
+  (:documentation "Environment (reader) monad transformer: thread read-only configuration through computations.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/monad/free.lisp
+++ b/library/monad/free.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/monad/free
+  (:documentation "Free monad: build monadic computations from any Functor without choosing an interpretation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/freet.lisp
+++ b/library/monad/freet.lisp
@@ -1,4 +1,5 @@
 (coalton/utils::defstdlib-package #:coalton/monad/freet
+  (:documentation "Free monad transformer: layer free-monadic effects over an existing monad.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/identity.lisp
+++ b/library/monad/identity.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/identity
+  (:documentation "Identity monad: trivial wrapper used as the base case for monad transformer stacks.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/optionalt.lisp
+++ b/library/monad/optionalt.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/optionalt
+  (:documentation "Optional monad transformer: add short-circuiting failure to a monad stack.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/monad/resultt.lisp
+++ b/library/monad/resultt.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/resultt
+  (:documentation "Result monad transformer: add error handling with typed errors to a monad stack.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/monad/state.lisp
+++ b/library/monad/state.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/state
+  (:documentation "Pure state monad: get, put, modify, and run operations over threaded state.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/monad/statet.lisp
+++ b/library/monad/statet.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/monad/statet
+  (:documentation "State monad transformer: thread mutable state through a monad stack.")
   (:use
    #:coalton
    #:coalton/functions

--- a/library/optional.lisp
+++ b/library/optional.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/optional
+  (:documentation "Utilities for Optional values: extracting, testing, and converting.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/ordmap.lisp
+++ b/library/ordmap.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package :coalton/ordmap
+  (:documentation "Immutable ordered maps backed by balanced binary trees, keyed by Ord-constrained types.")
   (:use
    :coalton
    :coalton/classes

--- a/library/ordtree.lisp
+++ b/library/ordtree.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package :coalton/ordtree
+  (:documentation "Immutable ordered sets backed by weight-balanced binary trees.")
   (:use
    #:coalton
    #:coalton/classes

--- a/library/queue.lisp
+++ b/library/queue.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/queue
+  (:documentation "Mutable FIFO queues with O(1) push and pop operations.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/randomaccess.lisp
+++ b/library/randomaccess.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/randomaccess
+  (:documentation "Type class for random-access containers with indexed reads, writes, and rotation.")
   (:use
    #:coalton
    #:coalton/classes)

--- a/library/result.lisp
+++ b/library/result.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/result
+  (:documentation "Utilities for Result values: testing, mapping errors, and converting to Optional.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/seq.lisp
+++ b/library/seq.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/seq
+  (:documentation "Persistent sequences based on Relaxed Radix Balanced Trees, with efficient random access and concatenation.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/slice.lisp
+++ b/library/slice.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/slice
+  (:documentation "Mutable sub-range views into Vectors, with bounds-checked and unchecked element access.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/string.lisp
+++ b/library/string.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/string
+  (:documentation "Unicode string operations: splitting, joining, searching, and conversion.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/system.lisp
+++ b/library/system.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/system
+  (:documentation "System utilities: timing, memory profiling, garbage collection, sleep, Lisp condition handling, and command-line arguments.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/tuple.lisp
+++ b/library/tuple.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/tuple
+  (:documentation "Tuple types (2-element and 3-element) with accessors, destructuring, and instances.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/library/types.lisp
+++ b/library/types.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/types
+  (:documentation "Runtime type representation: Proxy types, LispType mappings, and RuntimeRepr.")
   (:use
    #:coalton)
   (:export

--- a/library/vector.lisp
+++ b/library/vector.lisp
@@ -1,4 +1,5 @@
 (coalton/utils:defstdlib-package #:coalton/vector
+  (:documentation "Mutable growable arrays backed by Common Lisp adjustable vectors with fill pointers.")
   (:use
    #:coalton
    #:coalton/builtin

--- a/src/codegen/package.lisp
+++ b/src/codegen/package.lisp
@@ -1,4 +1,17 @@
 (uiop:define-package #:coalton-impl/codegen
+  (:documentation "The Coalton code generator translates typed AST into Common Lisp forms.
+
+The pipeline: typed AST -> codegen AST -> optimization -> CL code generation.
+
+Key stages:
+- Translation (translate-expression.lisp): converts typechecker AST to codegen AST,
+  inserting type class dictionary passing and constructor applications.
+- Optimization (optimizer.lisp): inlining, constant folding, direct application,
+  match compilation, and tail-call optimization.
+- Monomorphization (monomorphize.lisp): specializes polymorphic functions for
+  concrete types, eliminating dictionary-passing overhead.
+- Code generation (codegen-expression.lisp): emits Common Lisp forms from the
+  optimized codegen AST.")
   (:import-from
    #:coalton-impl/codegen/codegen-expression
    #:codegen-expression)

--- a/src/parser/package.lisp
+++ b/src/parser/package.lisp
@@ -1,4 +1,16 @@
 (uiop:define-package #:coalton-impl/parser
+  (:documentation "The Coalton parser transforms s-expressions into a typed AST.
+
+Parsing proceeds in two phases: first, Coalton source forms (from COALTON-TOPLEVEL
+or the Coalton reader) are parsed into an untyped CST (concrete syntax tree).
+Then the renamer resolves names and produces the final parse tree that the
+typechecker consumes.
+
+Key concepts:
+- Expressions, patterns, and types each have their own node types.
+- Top-level forms (define, define-type, define-class, etc.) are parsed by toplevel.lisp.
+- The collect protocol provides generic traversal for gathering sub-nodes.
+- The binding and type-definition protocols abstract over definition forms.")
   (:mix-reexport
    #:coalton-impl/parser/base
    #:coalton-impl/parser/reader

--- a/src/typechecker/package.lisp
+++ b/src/typechecker/package.lisp
@@ -1,4 +1,18 @@
 (uiop:define-package #:coalton-impl/typechecker
+  (:documentation "The Coalton type checker implements Hindley-Milner type inference
+extended with type classes (following 'Typing Haskell in Haskell' by Mark P. Jones).
+
+The typechecker takes an untyped parse tree and produces a typed AST annotated
+with inferred types, resolved type class dictionaries, and specialization
+information. Key subsystems include:
+
+- Type inference (define.lisp) via constraint generation and unification
+- Kind inference (parse-type.lisp) for higher-kinded types
+- Type class resolution (context-reduction.lisp, define-class.lisp, define-instance.lisp)
+- Functional dependencies (fundeps.lisp) for multi-parameter type classes
+- Specialization (specialize.lisp) for performance-critical type class dispatch
+- Variance checking (variance.lisp) for type parameters
+- Environment management (environment.lisp, tc-env.lisp) for the global type database")
   (:mix-reexport
    #:coalton-impl/typechecker/stage-1
    #:coalton-impl/typechecker/base


### PR DESCRIPTION
## Summary
- Add one-line `:documentation` strings to `defpackage` forms across 49 library packages
- Add multi-line descriptions to 3 compiler umbrella packages (codegen, parser, typechecker)
- These strings are accessible at runtime via `(documentation (find-package :coalton/foo) t)`

Each string describes the package's purpose and key contents at a glance — useful for IDE tooltips, `describe`, and programmatic documentation generators.

Fixes #578

## AI Disclaimer
AI was used to help draft these descriptions. All strings have been manually reviewed against the source code for accuracy.

## Test plan
- [ ] Verify the project builds cleanly (`make`)
- [ ] Spot-check a few packages with `(documentation (find-package :coalton/list) t)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)