### PR TITLE
Add operators section and umbrella package resolution to docs generator

### DIFF
--- a/src/doc/html.lisp
+++ b/src/doc/html.lisp
@@ -388,6 +388,12 @@ summary{cursor:pointer;font-weight:600;padding:6px 0}
                       :label "Macros"
                       :header-html-class "macros-header"
                       :content-html-class "macros-content"))
+      (:raw
+       (write-section backend objects
+                      :type 'coalton-operator
+                      :label "Operators"
+                      :header-html-class "operators-header"
+                      :content-html-class "operators-content"))
       )))
 
 (defun write-section (backend objects &key type label header-html-class content-html-class)
@@ -495,6 +501,9 @@ summary{cursor:pointer;font-weight:600;padding:6px 0}
     (:raw (doc-html object))))
 
 (defmethod write-object-body ((backend html-backend) (object coalton-macro))
+  (doc-html object))
+
+(defmethod write-object-body ((backend html-backend) (object coalton-operator))
   (doc-html object))
 
 (defun doc-html (object)

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -104,7 +104,8 @@
       (write-section 'coalton-struct "Structs")
       (write-section 'coalton-class "Classes")
       (write-section 'coalton-value "Values")
-      (write-section 'coalton-macro "Macros"))))
+      (write-section 'coalton-macro "Macros")
+      (write-section 'coalton-operator "Operators"))))
 
 (defun write-instances (backend object)
   (let ((instances (object-instances object)))
@@ -221,6 +222,11 @@
 ;;; coalton-macro
 
 (defmethod write-object-body ((backend markdown-backend) (object coalton-macro))
+  (write-doc backend object))
+
+;;; coalton-operator
+
+(defmethod write-object-body ((backend markdown-backend) (object coalton-operator))
   (write-doc backend object))
 
 ;;; Methods for TO-MARKDOWN

--- a/src/doc/model.lisp
+++ b/src/doc/model.lisp
@@ -59,6 +59,10 @@
    #:coalton-macro
    #:coalton-macro-name
 
+   #:coalton-operator
+   #:coalton-operator-name
+   #:coalton-operator-kind
+
    #:coalton-package
    #:package-objects
    #:sort-objects
@@ -350,12 +354,13 @@
       (tc:type-entry-name type-entry)))
 
 (defun stdlib-p (symbol)
-  "A standard library package is any package with the exact name 'coalton' or whose name starts with 'coalton/'."
+  "A standard library package is any package with the exact name 'coalton', 'coalton-prelude', or whose name starts with 'coalton/'."
   (let ((pkg (symbol-package symbol)))
     (if (null pkg)
         nil
         (let ((name (package-name pkg)))
           (or (string-equal name "COALTON")
+              (string-equal name "COALTON-PRELUDE")
               (eql 0 (search "COALTON/" name)))))))
 
 ;;; class coalton-macro
@@ -437,6 +442,65 @@
            (package-name (symbol-package (coalton-macro-name x)))
            (symbol-name (coalton-macro-name x)))))
 
+;;; class coalton-operator
+
+(defclass coalton-operator (coalton-object)
+  ((name :initarg :name :reader coalton-operator-name)
+   (kind :initarg :kind :reader coalton-operator-kind
+         :documentation "Either :TOPLEVEL or :EXPRESSION.")))
+
+(defun symbol-names-coalton-operator-p (s)
+  (get s ':coalton-operator))
+
+(defun find-operators (&key (package nil package-provided-p))
+  (let ((operators nil))
+    (cond
+      ((not package-provided-p)
+       (do-all-symbols (v operators)
+         (when (and (symbol-exported-p v)
+                    (symbol-names-coalton-operator-p v))
+           (push (make-instance 'coalton-operator
+                   :name v
+                   :kind (get v ':coalton-operator))
+                 operators))))
+      (t
+       (do-external-symbols (v package operators)
+         (when (symbol-names-coalton-operator-p v)
+           (push (make-instance 'coalton-operator
+                   :name v
+                   :kind (get v ':coalton-operator))
+                 operators)))))))
+
+(defun has-operators-p (package)
+  (do-external-symbols (v package nil)
+    (when (symbol-names-coalton-operator-p v)
+      (return-from has-operators-p t))))
+
+(defmethod object-name ((x coalton-operator))
+  (let ((*print-pretty* nil)
+        (*print-circle* nil))
+    (with-output-to-string (s)
+      (format s "~A " (coalton-operator-name x))
+      (print-lambda-list s (get (coalton-operator-name x) ':coalton-operator-lambda-list)))))
+
+(defmethod object-type ((x coalton-operator))
+  (if (eq (coalton-operator-kind x) ':toplevel)
+      "TOPLEVEL OPERATOR"
+      "OPERATOR"))
+
+(defmethod object-location ((x coalton-operator))
+  nil)
+
+(defmethod object-docstring ((x coalton-operator))
+  (documentation (coalton-operator-name x) 'function))
+
+(defmethod object-aname ((x coalton-operator))
+  (substitute
+   #\- #\/
+   (format nil "~(~A-~A-operator~)"
+           (package-name (symbol-package (coalton-operator-name x)))
+           (symbol-name (coalton-operator-name x)))))
+
 ;;; Public API
 
 (defun has-values-p (package)
@@ -480,24 +544,78 @@
   (or (has-types-p package)
       (has-values-p package)
       (has-classes-p package)
-      (has-macros-p package)))
+      (has-macros-p package)
+      (has-operators-p package)))
 
 (defun find-objects (&key package reexported-symbols)
-  "Find all Coalton OBJECTS, optionally retstricting to objects defined in PACKAGE."
+  "Find all Coalton objects, optionally restricting to objects defined in PACKAGE."
   (append (find-types :package package :reexported-symbols reexported-symbols)
           (find-values :package package :reexported-symbols reexported-symbols)
           (find-classes :package package :reexported-symbols reexported-symbols)
-          (find-macros :package package)))
+          (find-macros :package package)
+          (find-operators :package package)))
+
+(defun symbols-covered-by-p (impl umbrella)
+  "Return T if every external symbol of IMPL is also external in UMBRELLA."
+  (do-external-symbols (sym impl t)
+    (multiple-value-bind (found status)
+        (find-symbol (symbol-name sym) umbrella)
+      (unless (and (eq found sym) (eq status ':external))
+        (return-from symbols-covered-by-p nil)))))
+
+(defun stdlib-package-p (package)
+  "T if PACKAGE is a standard library package."
+  (let ((name (package-name package)))
+    (or (string-equal name "COALTON")
+        (eql 0 (search "COALTON/" name)))))
+
+(defun find-umbrella-packages ()
+  "Return an alist of (umbrella-package . covered-packages) for user-facing umbrella packages."
+  (let ((result nil))
+    (dolist (name '("COALTON-PRELUDE" "COALTON/MATH"))
+      (let ((umbrella (find-package name)))
+        (when umbrella
+          (let ((covered nil))
+            ;; Find implementation packages whose symbols are fully re-exported
+            (dolist (pkg (list-all-packages))
+              (when (and (not (eq pkg umbrella))
+                         (stdlib-package-p pkg)
+                         (has-objects-p pkg)
+                         (symbols-covered-by-p pkg umbrella))
+                (push pkg covered)))
+            (push (cons umbrella covered) result)))))
+    result))
 
 (defun find-packages ()
-  "Return the list of packages in the standard library."
-  (let ((packages nil))
+  "Return the list of packages in the standard library.
+
+Prefers user-facing umbrella packages (COALTON-PRELUDE, COALTON/MATH) over
+their implementation sub-packages when the umbrella fully re-exports a
+sub-package's symbols."
+  (let* ((umbrella-alist (find-umbrella-packages))
+         (covered (mapcan #'copy-list (mapcar #'cdr umbrella-alist)))
+         (packages nil))
+    ;; Add umbrella packages with reexported-symbols enabled
+    (dolist (entry umbrella-alist)
+      (let ((umbrella (car entry)))
+        (when (has-objects-p umbrella)
+          (push (make-coalton-package umbrella :reexported-symbols t) packages))))
+    ;; Add remaining stdlib packages that aren't covered by an umbrella
     (do-all-symbols (symbol)
       (when (stdlib-p symbol)
-        (pushnew (symbol-package symbol) packages)))
-    (sort-objects
-     (mapcar #'make-coalton-package
-             (remove-if-not #'has-objects-p packages)))))
+        (let ((pkg (symbol-package symbol)))
+          (unless (or (member pkg covered :test #'eq)
+                      (assoc pkg umbrella-alist :test #'eq))
+            (pushnew pkg packages :test (lambda (a b)
+                                          (if (typep b 'coalton-package)
+                                              (eq a (lisp-package b))
+                                              (eq a b))))))))
+    ;; Convert remaining raw packages to coalton-package objects
+    (setf packages
+          (mapcar (lambda (p)
+                    (if (typep p 'coalton-package) p (make-coalton-package p)))
+                  packages))
+    (sort-objects (remove-if-not (lambda (p) (has-objects-p (lisp-package p))) packages))))
 
 ;;; Source-name lookup utilities
 

--- a/src/faux-macros.lisp
+++ b/src/faux-macros.lisp
@@ -21,20 +21,26 @@
 (defmacro define-coalton-toplevel-editor-macro (name lambda-list &optional (docstring ""))
   "Define a macro so that Emacs and SLIME see it nicely, and so the forms indent properly. Not intended for actual use in Lisp code."
   (check-type docstring string)
-  `(defmacro ,name ,lambda-list
-     ,docstring
-     (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
-                                   lambda-list)))
-     (error-coalton-toplevel-only ',name)))
+  `(progn
+     (cl:setf (cl:get ',name ':coalton-operator) ':toplevel
+              (cl:get ',name ':coalton-operator-lambda-list) ',lambda-list)
+     (defmacro ,name ,lambda-list
+       ,docstring
+       (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
+                                     lambda-list)))
+       (error-coalton-toplevel-only ',name))))
 
 (defmacro define-coalton-editor-macro (name lambda-list &optional (docstring ""))
   "Define a macro so that Emacs and SLIME see it nicely, and so the forms indent properly. Not intended for actual use in Lisp code."
   (check-type docstring string)
-  `(defmacro ,name ,lambda-list
-     ,docstring
-     (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
-                                   lambda-list)))
-     (error-coalton-only ',name)))
+  `(progn
+     (cl:setf (cl:get ',name ':coalton-operator) ':expression
+              (cl:get ',name ':coalton-operator-lambda-list) ',lambda-list)
+     (defmacro ,name ,lambda-list
+       ,docstring
+       (declare (ignore ,@(remove-if (lambda (sym) (char= #\& (char (symbol-name sym) 0)))
+                                     lambda-list)))
+       (error-coalton-only ',name))))
 
 
 ;;; Top-Level Forms
@@ -90,6 +96,10 @@
 (defmacro coalton:fn (vars &body form)
   "A lambda abstraction callable within coalton."
   (rt:construct-function-entry `(lambda ,vars ,@form) (length vars)))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (setf (get 'coalton:fn ':coalton-operator) ':expression
+        (get 'coalton:fn ':coalton-operator-lambda-list) '(vars &body form)))
 
 (define-coalton-editor-macro coalton:throw (exception)
     "Throw an exception.")


### PR DESCRIPTION
## Summary
- Add a new `coalton-operator` class to the docs generator model, so Coalton special forms (`define`, `fn`, `match`, `loop`, etc.) appear in generated documentation
- Tag faux macros with `:coalton-operator` property at macro-expansion time
- Add "Operators" sections to both markdown and HTML backends
- Add `find-umbrella-packages` to prefer user-facing umbrella packages (`COALTON-PRELUDE`, `COALTON/MATH`) over implementation sub-packages when generating package listings

### Files changed
- `src/doc/model.lisp` — `coalton-operator` class, `find-operators`, `find-umbrella-packages`, `symbols-covered-by-p`
- `src/doc/markdown.lisp` — operators section in markdown output
- `src/doc/html.lisp` — operators section in HTML output
- `src/faux-macros.lisp` — `:coalton-operator` property tagging in the editor macro wrappers + explicit `fn` tagging

Ref #1592, ref #886

## AI Disclaimer
AI was used to help implement these features. All code has been manually reviewed.

## Test plan
- [ ] Verify the project builds cleanly (`make`)
- [ ] Run `(coalton-doc:write-stdlib-documentation-to-file #p"/tmp/test.md")` and verify operators appear
- [ ] Check that `COALTON-PRELUDE` appears instead of individual sub-packages in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)