### PR TITLE
Add module preambles to compiler internal files

### DIFF
--- a/src/analysis/analysis.lisp
+++ b/src/analysis/analysis.lisp
@@ -1,3 +1,11 @@
+;;;; analysis.lisp
+;;;;
+;;;; The top-level analysis driver. After type checking, the analysis pass
+;;;; runs static checks on the typed AST: pattern exhaustiveness (are all
+;;;; match cases covered?), unused variables (are any bindings dead?), and
+;;;; underapplied values (are partially-applied constructors used as values
+;;;; where a full application was likely intended?).
+
 (defpackage #:coalton-impl/analysis/analysis
   (:use
    #:cl

--- a/src/analysis/unused-variables.lisp
+++ b/src/analysis/unused-variables.lisp
@@ -1,3 +1,11 @@
+;;;; unused-variables.lisp
+;;;;
+;;;; Detects unused variable bindings in typed definitions. Walks the
+;;;; typed AST to collect variable references, then checks each parameter
+;;;; and let-binding against the set of used variables, emitting warnings
+;;;; for any that are unreferenced (excluding variables whose names start
+;;;; with underscore, which are conventionally unused).
+
 (defpackage #:coalton-impl/analysis/unused-variables
   (:use
    #:cl)

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -1,3 +1,18 @@
+;;;; ast.lisp
+;;;;
+;;;; The codegen AST (abstract syntax tree): a lower-level intermediate
+;;;; representation used during code generation. Unlike the typechecker's
+;;;; AST which mirrors the source language, the codegen AST is closer to
+;;;; Common Lisp and includes nodes for:
+;;;;
+;;;; - Direct function application (bypassing FUNCALL)
+;;;; - Explicit type class dictionary passing
+;;;; - Struct field access and mutation
+;;;; - Loop constructs (while, for, break, continue)
+;;;; - Lisp escape nodes for FFI
+;;;;
+;;;; Each node carries its inferred type for use during optimization.
+
 (defpackage #:coalton-impl/codegen/ast
   (:use
    #:cl

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -1,3 +1,12 @@
+;;;; codegen-expression.lisp
+;;;;
+;;;; The final code generation stage: transforms the optimized codegen AST
+;;;; into Common Lisp forms that can be compiled by the host CL compiler.
+;;;; Handles translation of Coalton constructs into their CL equivalents:
+;;;; pattern matching into TYPECASE/IF chains, closures into LAMBDA forms,
+;;;; type class dispatch into structure slot access, and loop constructs
+;;;; into TAGBODY/GO forms.
+
 (defpackage #:coalton-impl/codegen/codegen-expression
   (:use
    #:cl

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -1,3 +1,19 @@
+;;;; optimizer.lisp
+;;;;
+;;;; The codegen optimizer transforms the codegen AST to improve the
+;;;; quality of generated Common Lisp code. Optimizations include:
+;;;;
+;;;; - Direct application: eliminates FUNCALL overhead by recognizing
+;;;;   known-function calls and emitting direct CL function calls.
+;;;; - Inlining: replaces calls to inline-declared functions with their
+;;;;   bodies, specializing for the call site.
+;;;; - Monomorphization: generates type-specialized copies of polymorphic
+;;;;   functions, eliminating dictionary-passing overhead.
+;;;; - Constant folding and dead code elimination.
+;;;; - Match compilation: optimizes nested pattern matches.
+;;;;
+;;;; The optimizer runs after translation and before final CL codegen.
+
 (defpackage #:coalton-impl/codegen/optimizer
   (:use
    #:cl

--- a/src/codegen/program.lisp
+++ b/src/codegen/program.lisp
@@ -1,3 +1,17 @@
+;;;; program.lisp
+;;;;
+;;;; The top-level code generation driver. Orchestrates the full pipeline
+;;;; from a typed translation unit to compiled Common Lisp forms:
+;;;;
+;;;; 1. Translate type definitions into CL struct/class definitions
+;;;; 2. Translate type class definitions into CL class hierarchies
+;;;; 3. Translate value definitions through the codegen pipeline
+;;;; 4. Optimize the codegen AST (inline, monomorphize, etc.)
+;;;; 5. Generate final CL forms and update the global environment
+;;;;
+;;;; The *codegen-hook* variable allows external tools (e.g., the docs
+;;;; generator) to observe the generated CL forms.
+
 (defpackage #:coalton-impl/codegen/program
   (:use
    #:cl

--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -1,3 +1,17 @@
+;;;; context-reduction.lisp
+;;;;
+;;;; Type class context reduction: simplifies the set of type class
+;;;; constraints that a definition requires. After type inference, a
+;;;; function may accumulate many redundant or entailed constraints
+;;;; (e.g., both Eq :a and Ord :a, where Ord implies Eq). Context
+;;;; reduction removes redundant constraints and splits them into
+;;;; "deferred" (still polymorphic) and "retained" (can be resolved
+;;;; now) sets.
+;;;;
+;;;; Also implements defaulting: when a type variable appears only in
+;;;; Num constraints and has no other constraints, it can be defaulted
+;;;; to Integer, similar to Haskell's defaulting rules.
+
 (defpackage #:coalton-impl/typechecker/context-reduction
   (:use
    #:cl

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -1,3 +1,19 @@
+;;;; environment.lisp
+;;;;
+;;;; The global type environment: the central database that stores all type
+;;;; information accumulated during compilation. This includes:
+;;;;
+;;;; - Type definitions (algebraic types, structs, type aliases)
+;;;; - Type class definitions and their instances
+;;;; - Value bindings and their inferred type schemes
+;;;; - Constructor entries mapping data constructors to their parent types
+;;;; - Specialization entries for optimized type class dispatch
+;;;; - Source names for preserving user-written names through compilation
+;;;;
+;;;; The environment is an immutable data structure backed by FSET maps.
+;;;; Each compilation unit produces a new environment by extending the
+;;;; previous one, enabling incremental compilation.
+
 (defpackage #:coalton-impl/typechecker/environment
   (:use
    #:cl

--- a/src/typechecker/kinds.lisp
+++ b/src/typechecker/kinds.lisp
@@ -1,3 +1,17 @@
+;;;; kinds.lisp
+;;;;
+;;;; The kind system classifies types by their arity. Just as types
+;;;; classify values, kinds classify type constructors:
+;;;;
+;;;;   * (KSTAR) — the kind of concrete types (Integer, Boolean, etc.)
+;;;;   * -> * (KFUN) — the kind of type constructors taking one argument
+;;;;                    (List, Optional, etc.)
+;;;;   (* -> *) -> * — higher-kinded types (like Functor's argument)
+;;;;
+;;;; Kind checking ensures that type constructors are applied to the
+;;;; correct number of arguments (e.g., List needs one argument,
+;;;; Hashtable needs two).
+
 (defpackage #:coalton-impl/typechecker/kinds
   (:use
    #:cl

--- a/src/typechecker/predicate.lisp
+++ b/src/typechecker/predicate.lisp
@@ -1,3 +1,16 @@
+;;;; predicate.lisp
+;;;;
+;;;; Type class predicates and related structures. A predicate like
+;;;; (Eq :a) constrains a type variable to belong to a type class.
+;;;; This module defines:
+;;;;
+;;;; - TY-PREDICATE: a class name applied to type arguments
+;;;; - TY-CLASS: a type class definition (superclasses, methods, fundeps)
+;;;; - TY-CLASS-INSTANCE: a concrete implementation of a class for a type
+;;;; - QUALIFIED-TY: a type with class constraints (e.g., Eq :a => :a -> :a -> Boolean)
+;;;;
+;;;; These form the constraint language that drives type class resolution.
+
 (defpackage #:coalton-impl/typechecker/predicate
   (:use
    #:cl

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -1,3 +1,13 @@
+;;;; scheme.lisp
+;;;;
+;;;; Type schemes (universally quantified types). A type scheme like
+;;;; ∀ :a. Eq :a => :a -> :a -> Boolean represents a polymorphic type
+;;;; that can be instantiated with fresh type variables at each use site.
+;;;;
+;;;; Quantification (QUANTIFY) closes over free type variables in a type,
+;;;; producing a scheme. Instantiation (INSTANTIATE) replaces the bound
+;;;; variables with fresh ones for each use, enabling let-polymorphism.
+
 (defpackage #:coalton-impl/typechecker/scheme
   (:use
    #:cl

--- a/src/typechecker/substitutions.lisp
+++ b/src/typechecker/substitutions.lisp
@@ -1,3 +1,15 @@
+;;;; substitutions.lisp
+;;;;
+;;;; Type substitutions: mappings from type variables to types. During type
+;;;; inference, constraints between types are solved by building up a
+;;;; substitution that, when applied to all types in scope, makes them
+;;;; consistent.
+;;;;
+;;;; A substitution list is composed and applied left-to-right. The key
+;;;; operations are COMPOSE-SUBSTITUTION-LISTS (combine two substitutions)
+;;;; and APPLY-SUBSTITUTION (replace type variables in a type according to
+;;;; the substitution).
+
 (defpackage #:coalton-impl/typechecker/substitutions
   (:use
    #:cl

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -1,3 +1,19 @@
+;;;; types.lisp
+;;;;
+;;;; The core type representation. Types in Coalton are represented as a
+;;;; tree of structs:
+;;;;
+;;;;   TY (abstract base)
+;;;;   ├── TYVAR   — type variable (e.g., :a), identified by a unique integer ID
+;;;;   ├── TYCON   — type constructor (e.g., Integer, List), named by a symbol
+;;;;   └── TAPP    — type application (e.g., (List Integer)), combining FROM and TO
+;;;;
+;;;; Function types like (:a -> :b) are represented as TAPP chains using
+;;;; the built-in Arrow type constructor.
+;;;;
+;;;; This module also provides the pretty-printer for types, which maps
+;;;; internal type variable IDs to human-readable names (:A, :B, ...).
+
 (defpackage #:coalton-impl/typechecker/types
   (:use
    #:cl

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -1,3 +1,14 @@
+;;;; unify.lisp
+;;;;
+;;;; Type unification: the core algorithm that determines whether two types
+;;;; can be made equal by finding a substitution (mapping of type variables
+;;;; to types). Unification is the engine of type inference—each use of a
+;;;; variable or function generates constraints that are solved by unification.
+;;;;
+;;;; UNIFY finds the most general unifier (MGU) of two types, while MATCH
+;;;; finds a one-way substitution (type1 can be specialized to type2).
+;;;; Both operate on types and on type class predicates.
+
 (defpackage #:coalton-impl/typechecker/unify
   (:use
    #:cl


### PR DESCRIPTION
## Summary
- Add descriptive comment blocks at the top of 14 compiler source files in `analysis/`, `codegen/`, and `typechecker/`
- Each preamble summarizes the module's purpose, key abstractions, and relationships to other modules

### Files
- `src/analysis/analysis.lisp`, `src/analysis/unused-variables.lisp`
- `src/codegen/ast.lisp`, `src/codegen/codegen-expression.lisp`, `src/codegen/optimizer.lisp`, `src/codegen/program.lisp`
- `src/typechecker/context-reduction.lisp`, `src/typechecker/environment.lisp`, `src/typechecker/kinds.lisp`, `src/typechecker/predicate.lisp`, `src/typechecker/scheme.lisp`, `src/typechecker/substitutions.lisp`, `src/typechecker/types.lisp`, `src/typechecker/unify.lisp`

Ref #1502

## AI Disclaimer
AI was used to help draft these preambles. All descriptions have been manually reviewed against the source code.

## Test plan
- [ ] Verify the project builds cleanly (`make`)
- [ ] Spot-check that preamble descriptions match the module contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)