### PR TITLE
Update existing guides: numeric casting, Lisp interop, typeclass constraints

### DIFF
--- a/docs/coalton-documentation-guide.md
+++ b/docs/coalton-documentation-guide.md
@@ -10,8 +10,9 @@ Coalton's `define` form allows for docstrings to go after the variable or functi
 ```
 (coalton-toplevel
 
-  (define *pi* (the Double-Float math:pi)
-    "This is a constant of `pi`, that will always be a `Double-Float`.")
+  (define *pi*
+    "This is a constant of `pi`, that will always be a `Double-Float`."
+    (the Double-Float math:pi))
 
   (define (get-pi)
     "This is a function that returns the `Double-Float` constant `*pi*`."

--- a/docs/coalton-lisp-interop.md
+++ b/docs/coalton-lisp-interop.md
@@ -176,6 +176,55 @@ Here, we used `lisp` to actually construct, type, and return our `RandomState` o
 
 See [`Vector`](https://github.com/coalton-lang/coalton/blob/main/library/vector.lisp) for a more extensive example.
 
+## Promises of `define-struct`
+
+The `define-struct` form creates a single-constructor type with named fields. Its behavior varies by interaction mode:
+
+### Development Mode
+
+In development mode, structs are compiled as CLOS classes. This allows re-definition and interactive development.
+
+```
+(define-struct Point
+  (x Integer)
+  (y Integer))
+```
+
+Generates a CLOS class named `POINT` with:
+- A constructor function `POINT` that takes positional arguments: `(POINT 3 4)`
+- Field accessor functions named `CLASSNAME-FIELDNAME`, e.g., `POINT-X` and `POINT-Y`
+
+### Release Mode
+
+In release mode, structs are compiled as `defstruct` (frozen CL structs) for performance. The generated interface (constructor and accessor names) is the same, but the underlying representation uses CL's `defstruct` with `:read-only t` slots.
+
+### Accessor Naming
+
+**PROMISE**: For a struct defined as `(define-struct Foo (bar T1) (baz T2))`, the following Lisp functions will exist:
+- `FOO`: a constructor function taking positional arguments `(FOO bar-val baz-val)`
+- `FOO-BAR`: a reader function for the `bar` field
+- `FOO-BAZ`: a reader function for the `baz` field
+
+**WARNING**: Struct fields are read-only from Lisp. Coalton does not generate writer functions.
+
+### Using Structs from Lisp
+
+```lisp
+;; After defining a struct in Coalton:
+;;   (define-struct Point (x Integer) (y Integer))
+
+;; Constructing from Lisp:
+(point 3 4)               ; => #<POINT ...>
+
+;; Accessing fields from Lisp:
+(point-x (point 3 4))     ; => 3
+(point-y (point 3 4))     ; => 4
+```
+
+### Parametric Structs
+
+Parametric structs like `(define-struct (Pair :a) (first :a) (second :a))` follow the same accessor naming convention. The constructor and accessors are polymorphic at the Lisp level (they accept any type), so it is the caller's responsibility to ensure type correctness.
+
 ## Promises of `define`
 
 Consider the following definitions:
@@ -259,6 +308,34 @@ Each `<captured-variable>` refers to a lexical variable in the surrounding Coalt
 ```
 
 Here, the values of the parameters `a` and `b` are captured for use inside of the `lisp` form.
+
+## Accessing Lisp Variables from Coalton
+
+Coalton expressions cannot directly reference Lisp variables. To access a Lisp variable's value from within a `coalton` or `coalton-toplevel` form, you must use the `lisp` escape form and capture the variable explicitly:
+
+```lisp
+;; This does NOT work — x is a Lisp variable, not a Coalton binding:
+;; (let ((x 42))
+;;   (coalton (+ x 1)))  ; ERROR
+
+;; Instead, use the lisp form to bring the value into Coalton:
+(let ((x 42))
+  (coalton
+    (+ (lisp Integer () x) 1)))  ; => 43
+```
+
+The `lisp` form's capture list (the second argument) is for capturing *Coalton* lexical variables. When accessing a *Lisp* variable, leave the capture list empty and reference the variable directly in the Lisp body, since the `lisp` form's body is ordinary Lisp code with access to the surrounding Lisp lexical environment.
+
+For Lisp special (dynamic) variables, the same pattern works:
+
+```lisp
+(defvar *my-config* 100)
+
+(coalton-toplevel
+  (define (get-config)
+    (lisp Integer ()
+      *my-config*)))
+```
 
 ## Soundness of Coalton-Lisp Interop
 

--- a/docs/internals/design-docs/typeclasses.md
+++ b/docs/internals/design-docs/typeclasses.md
@@ -44,21 +44,23 @@ Higher kinded types are outside of scope of the initial typeclass implementation
 
 ### Constraints in Class Declarations
 
-_This section is no longer accurate._
-
 Referred to as Decision 9 in Jones 1997.
 
-```lisp
-;; Is not allowed
-(define-class (Test :a)
-  (test (fn (Eq :a) => :a -> :a -> Bool)))
+**Update**: Coalton now allows constraints on class variables in class method signatures. This was previously disallowed to simplify the implementation, but the restriction has since been lifted.
 
-;; Is allowed
+```lisp
+;; Now allowed: constraints on class variable :a in a method signature
+(define-class (Foo :a)
+  (bar (Num :a => :a -> :a)))
+
+;; Also allowed: constraints on non-class variables (always was)
 (define-class (Test :a)
-  (test (fn (Eq :b) => :b -> :b -> Bool)))
+  (test (Eq :b => :b -> :b -> Boolean)))
 ```
 
-Constraints of class variables in class methods are not allowed since this complicates code and will result in the constraint being propogated up to the class, which is already supported by the class definition syntax.
+When a method has a constraint on the class variable, the constraint is effectively propagated to the class context. For example, any call to `bar` above will require both a `Foo` instance and a `Num` instance for the type in question.
+
+This change allows more expressive type class definitions where individual methods may require additional capabilities beyond what the class itself demands.
 
 ### Self Referential Class Definitions
 

--- a/docs/intro-to-coalton.md
+++ b/docs/intro-to-coalton.md
@@ -757,6 +757,26 @@ Lastly, there's a ratio type called `Fraction`, which is a ratio of two `Integer
 
 Numbers implement the `Num` type class, which has methods `+`, `-`, `*`, and `fromInt`.
 
+### Implicit Numeric Casting with `fromInt`
+
+Integer literals in Coalton are polymorphic. When you write `5` in a context that expects a type with a `Num` instance (such as `Double-Float`, `I32`, or `Fraction`), Coalton implicitly applies `fromInt` to convert the `Integer` into the expected type. This means you can write numeric code without explicit conversions in many cases:
+
+```lisp
+(coalton-toplevel
+  ;; No explicit conversion needed: 5 and 7 are converted to Double-Float
+  ;; via (fromInt 5) and (fromInt 7) implicitly
+  (declare f Double-Float)
+  (define f (+ 5 7)))         ;; f is 12.0d0
+```
+
+If the target type is ambiguous, Coalton will report a type error asking you to clarify. You can always call `fromInt` explicitly if needed:
+
+```lisp
+(coalton-toplevel
+  (declare g (F32 -> F32))
+  (define (g x) (+ x (fromInt 3))))
+```
+
 ### Division, in short
 
 Division is complicated; see the next section. But here are some quick tips.


### PR DESCRIPTION
## Summary
Update four existing documentation files with corrections and new content:

- **`docs/intro-to-coalton.md`**: Add section on implicit `fromInt` numeric casting behavior
- **`docs/coalton-lisp-interop.md`**: Add `define-struct` promises section and accessing Lisp variables from Coalton
- **`docs/internals/design-docs/typeclasses.md`**: Update to reflect that constrained methods are now allowed (previously documented as unsupported)
- **`docs/coalton-documentation-guide.md`**: Fix docstring ordering example

Fixes #1244, fixes #1520, fixes #1457, fixes #961, fixes #629

## AI Disclaimer
AI was used to help draft these updates. All changes have been manually reviewed against the current codebase behavior.

## Test plan
- [ ] Review each section for technical accuracy
- [ ] Verify code examples compile and run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)