### PR TITLE
Add #T tuple shorthand (for both types and values)

### DIFF
--- a/src/codegen/codegen-type-definition.lisp
+++ b/src/codegen/codegen-type-definition.lisp
@@ -15,6 +15,7 @@
    (#:source #:coalton-impl/source)
    (#:global-lexical #:coalton-impl/global-lexical)
    (#:tc #:coalton-impl/typechecker)
+   (#:types #:coalton-impl/typechecker/types)
    (#:rt #:coalton-impl/runtime))
   (:export
    #:codegen-type-definition
@@ -82,6 +83,7 @@
             :for classname := (tc:constructor-entry-classname constructor)
             :for superclass := (tc:type-definition-name def)
             :for constructor-name :=  (tc:constructor-entry-name constructor)
+            :for tuple-arity := (types:tuple-constructor-arity constructor-name)
             :for fields
               := (loop :for field :in (tc:constructor-arguments constructor-name env)
                        :for runtime-type := (tc:lisp-type field env)
@@ -116,6 +118,41 @@
                                     (type ,classname self)
                                     (values ,classname))
                            (format stream "#.~s" ',(tc:constructor-entry-name constructor))
+                           self))
+                       ((and tuple-arity
+                             (= tuple-arity (tc:constructor-entry-arity constructor)))
+                        `(defmethod print-object ((self ,classname) stream)
+                           (declare (type stream stream)
+                                    (type ,classname self)
+                                    (values ,classname))
+                           (cond
+                             (*print-readably*
+                              (format stream "#.(~s" ',(tc:constructor-entry-name constructor))
+                              ,@(loop :for slot :in field-names
+                                      :collect `(cond
+                                                  ((and *print-readably* (not *read-eval*))
+                                                   (error 'print-not-readable :object self))
+
+                                                  ((and *print-readably*
+                                                        (or (listp (slot-value self ',slot))
+                                                            (symbolp (slot-value self ',slot))))
+
+                                                   (write-string " '" stream)
+                                                   (prin1 (slot-value self ',slot) stream))
+
+                                                  (t
+                                                   (write-string " " stream)
+                                                   (prin1 (slot-value self ',slot) stream))))
+                              (write-string ")" stream))
+                             (t
+                              (write-string "#T(" stream)
+                              ,@(loop :for slot :in field-names
+                                      :for first := t :then nil
+                                      :collect `(progn
+                                                  ,@(unless first
+                                                      '((write-string " " stream)))
+                                                  (prin1 (slot-value self ',slot) stream)))
+                              (write-string ")" stream)))
                            self))
                        (t
                         `(defmethod print-object ((self ,classname) stream)

--- a/src/parser/reader.lisp
+++ b/src/parser/reader.lisp
@@ -18,6 +18,51 @@
 
 (defvar *coalton-eclector-client* (make-instance 'coalton-eclector-client))
 
+(defun resolve-symbol-from-package (package-name symbol-name)
+  "Resolve SYMBOL-NAME from PACKAGE-NAME without interning."
+  (declare (type string package-name symbol-name)
+           (values symbol &optional))
+  (let ((package (find-package package-name)))
+    (unless package
+      (error "Unable to find package ~A while expanding #T shorthand" package-name))
+    (multiple-value-bind (symbol status)
+        (find-symbol symbol-name package)
+      (unless (and symbol (eq status :external))
+        (error "Unable to resolve symbol ~A in package ~A while expanding #T shorthand"
+               symbol-name package-name))
+      symbol)))
+
+(defun tuple-shorthand-symbol (arity)
+  "Return the tuple constructor/type symbol for ARITY."
+  (declare (type (integer 0) arity)
+           (values symbol &optional))
+  (cond
+    ((= arity 2)
+     (resolve-symbol-from-package "COALTON/CLASSES" "TUPLE"))
+    ((<= 3 arity 5)
+     (resolve-symbol-from-package "COALTON/TUPLE"
+                                  (format nil "TUPLE~D" arity)))
+    (t
+     (error "#T tuple shorthand only supports arities 2 through 5"))))
+
+(defun tuple-shorthand (stream sub-char parameter)
+  "Reader dispatch function for #T(...), expanding into Tuple constructor application."
+  (declare (ignore sub-char))
+  (when parameter
+    (error "#T tuple shorthand does not accept a numeric parameter"))
+  (let ((elements (eclector.reader:read stream t nil t)))
+    (unless (alexandria:proper-list-p elements)
+      (error "#T tuple shorthand expects a proper list, e.g. #T(x y)"))
+    (cons (tuple-shorthand-symbol (length elements))
+          elements)))
+
+(defun configure-coalton-readtable (&optional (readtable eclector.readtable:*readtable*))
+  "Install Coalton-specific reader dispatch macros into READTABLE."
+  (declare (values t))
+  (eclector.readtable:set-dispatch-macro-character
+   readtable #\# #\T #'tuple-shorthand)
+  t)
+
 ;;;; Check which version of eclector is installed
 (eval-when (:compile-toplevel)
   (if (uiop:version< (asdf:component-version (asdf:find-system :eclector)) "0.10.0")
@@ -40,14 +85,17 @@
 
 (defmacro with-reader-context (stream &rest body)
   "Run the body in the toplevel reader context."
-  `(eclector.reader:call-as-top-level-read
-    *coalton-eclector-client*
-    (lambda ()
-      ,@body)
-    ,stream
-    nil
-    'eof
-    nil))
+  `(let ((eclector.readtable:*readtable*
+           (eclector.readtable:copy-readtable eclector.readtable:*readtable*)))
+     (configure-coalton-readtable eclector.readtable:*readtable*)
+     (eclector.reader:call-as-top-level-read
+      *coalton-eclector-client*
+      (lambda ()
+        ,@body)
+      ,stream
+      nil
+      'eof
+      nil)))
 
 (defun maybe-read-form (stream source &optional (eclector-client eclector.base:*client*))
   "Read the next form or return if there is no next form.

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -52,6 +52,7 @@
    #:push-type-alias                    ; FUNCTION
    #:flatten-type                       ; FUNCTION
    #:tuple-symbol                       ; FUNCTION
+   #:tuple-constructor-arity            ; FUNCTION
    #:tuple-type-p                       ; FUNCTION
    #:tuple-component-types              ; FUNCTION
    #:apply-type-argument                ; FUNCTION
@@ -425,6 +426,24 @@ the list (T1 T2 T3 T4 ...). Otherwise, return (LIST TYPE)."
                         "TUPLE" pkg))
     sym))
 
+(defun tuple-constructor-arity (constructor-name)
+  "Return tuple arity for supported tuple constructors, otherwise NIL."
+  (declare (type symbol constructor-name)
+           (values (or null fixnum) &optional))
+  (let ((pkg (symbol-package constructor-name)))
+    (when pkg
+      (let ((package-name (package-name pkg))
+            (symbol-name (symbol-name constructor-name)))
+        (cond
+          ((and (string= package-name "COALTON/CLASSES")
+                (string= symbol-name "TUPLE"))
+           2)
+          ((and (string= package-name "COALTON/TUPLE")
+                (member symbol-name '("TUPLE3" "TUPLE4" "TUPLE5") :test #'string=))
+           (nth-value 0 (parse-integer (subseq symbol-name (length "TUPLE")))))
+          (t
+           nil))))))
+
 (defun tuple-type-p (type)
   "Return true when TYPE is a two-element Tuple type."
   (declare (type ty type)
@@ -638,12 +657,23 @@ the list (T1 T2 T3 T4 ...). Otherwise, return (LIST TYPE)."
                      (t (pprint-ty stream to)))))
           (print-subfunction (tapp-to ty)))
         (write-string ")" stream))
-       (t ;; Print type constructors
+      (t ;; Print type constructors
         (let* ((tcon ty)
                (tcon-args (loop :while (tapp-p tcon)
                                 :collect (tapp-to tcon)
-                                :do (setf tcon (tapp-from tcon)))))
+                                :do (setf tcon (tapp-from tcon))))
+               (tuple-arity (and (tycon-p tcon)
+                                 (tuple-constructor-arity (tycon-name tcon)))))
           (cond
+            ((and tuple-arity
+                  (= tuple-arity (length tcon-args)))
+             (write-string "#T(" stream)
+             (loop :for arg :in (reverse tcon-args)
+                   :for first := t :then nil
+                   :do (unless first
+                         (write-string " " stream))
+                       (pprint-ty stream arg))
+             (write-string ")" stream))
             ((and (tycon-p tcon)
                   (simple-kind-p (tycon-kind tcon))
                   (<= (length tcon-args)

--- a/tests/reader-tests.lisp
+++ b/tests/reader-tests.lisp
@@ -37,3 +37,30 @@
         (is (string= "Type mismatch"
                      (source:message c))
             "condition message is correct")))))
+
+(deftest tuple-printing-uses-shorthand ()
+  (let ((*package* (find-package "COALTON-USER")))
+    (is (string= "#T(1 2)"
+                 (princ-to-string
+                  (eval (read-from-string "(coalton (Tuple 1 2))")))))
+    (is (string= "#T(1 2 3)"
+                 (princ-to-string
+                  (eval (read-from-string "(coalton (Tuple3 1 2 3))")))))))
+
+(deftest tuple-type-printing-uses-shorthand ()
+  (let ((*package* (find-package "COALTON-USER"))
+        (coalton-impl/settings:*coalton-print-unicode* nil))
+    (eval (read-from-string
+           "(coalton-toplevel
+              (declare tuple-printing-id ((Tuple Integer Integer) -> (Tuple Integer Integer)))
+              (define (tuple-printing-id x) x))"))
+    (eval (read-from-string
+           "(coalton-toplevel
+              (declare tuple-printing-id3 ((Tuple3 Integer Integer Integer) -> (Tuple3 Integer Integer Integer)))
+              (define (tuple-printing-id3 x) x))"))
+    (is (string= "(#T(INTEGER INTEGER) -> #T(INTEGER INTEGER))"
+                 (format nil "~A"
+                         (coalton:type-of (find-symbol "TUPLE-PRINTING-ID" "COALTON-USER")))))
+    (is (string= "(#T(INTEGER INTEGER INTEGER) -> #T(INTEGER INTEGER INTEGER))"
+                 (format nil "~A"
+                         (coalton:type-of (find-symbol "TUPLE-PRINTING-ID3" "COALTON-USER")))))))

--- a/tests/test-files/parse-expression.txt
+++ b/tests/test-files/parse-expression.txt
@@ -299,3 +299,22 @@ warn: non-exhaustive match
            (cl:truncate x 2))
     ((Tuple q r)
      (+ q r))))
+
+================================================================================
+106 Parse expression
+================================================================================
+
+(package coalton-unit-tests/prelude
+  (import coalton-prelude))
+
+(declare pair-swap-parse106 (#T(Integer Integer) -> #T(Integer Integer)))
+(define (pair-swap-parse106 p)
+  (match p
+    (#T(a b)
+     #T(b a))))
+
+(declare rotate-parse106 (#T(Integer Integer Integer) -> #T(Integer Integer Integer)))
+(define (rotate-parse106 p)
+  (match p
+    (#T(a b c)
+     #T(c a b))))


### PR DESCRIPTION
I didn't overhaul the standard library, and I also didn't add any notes to the README. That may cause some inadvertent confusion, but I want this feature to be exercised before going whole-hog on refactoring.

Syntax is only supported in the Coalton readtable.