### PR TITLE
Fix kind error spans for repeated type constructors

### DIFF
--- a/src/parser/reader.lisp
+++ b/src/parser/reader.lisp
@@ -1,7 +1,6 @@
 (defpackage #:coalton-impl/parser/reader
   (:use #:cl)
   (:local-nicknames
-   (#:cst #:concrete-syntax-tree)
    (#:source #:coalton-impl/source))
   (:shadowing-import-from
    #:coalton-impl/parser/base
@@ -13,30 +12,10 @@
 
 (in-package #:coalton-impl/parser/reader)
 
-(defclass coalton-eclector-client (eclector.parse-result:parse-result-client)
+(defclass coalton-eclector-client (eclector.concrete-syntax-tree:cst-client)
   ())
 
 (defvar *coalton-eclector-client* (make-instance 'coalton-eclector-client))
-
-;;;; Check which version of eclector is installed
-(eval-when (:compile-toplevel)
-  (if (uiop:version< (asdf:component-version (asdf:find-system :eclector)) "0.10.0")
-      (pushnew :eclector-pre-0-10-0 *features*)
-      (pushnew :eclector-post-0-10-0 *features*)))
-
-(defmethod eclector.parse-result:make-expression-result
-    ((client coalton-eclector-client) expression children source)
-
-  ;; All of our nodes need access to source into so we will tag all
-  ;; children with source info.
-
-  ;; Hack to handle breaking change in eclector
-  ;; See https://github.com/s-expressionists/Concrete-Syntax-Tree/pull/36
-  ;; See https://github.com/coalton-lang/coalton/issues/887
-  #+eclector-pre-0-10-0
-  (cst:reconstruct expression children client :default-source source)
-  #+eclector-post-0-10-0
-  (cst:reconstruct client expression children :default-source source))
 
 (defmacro with-reader-context (stream &rest body)
   "Run the body in the toplevel reader context."

--- a/tests/error-tests.lisp
+++ b/tests/error-tests.lisp
@@ -67,3 +67,18 @@ help: message 5
  16 |               (*==* a2 b2)))
     |                ----
 "))))
+
+(deftest repeated-type-constructors-report-the-correct-span ()
+  (check-string=
+   "issue 916"
+   (collect-compiler-error
+    "(package issue916
+  (import coalton-prelude))
+
+(define-class (C :a)
+  (cf (:a -> Tuple Integer Integer -> List Tuple Integer Integer)))")
+   "error: Kind mismatch
+  --> test:5:43
+   |
+ 5 |    (cf (:a -> Tuple Integer Integer -> List Tuple Integer Integer)))
+   |                                             ^^^^^ Expected kind '*' but got kind '* → (* → *)'"))

--- a/tests/reader-tests.lisp
+++ b/tests/reader-tests.lisp
@@ -1,5 +1,28 @@
 (in-package #:coalton-tests)
 
+(defun read-form-with-source (string)
+  (let ((source (source:make-source-string string :name "test")))
+    (with-open-stream (stream (source:source-stream source))
+      (parser:with-reader-context stream
+        (values (parser:maybe-read-form stream source parser::*coalton-eclector-client*)
+                source)))))
+
+(defun cst-symbol-spans (form name)
+  (labels ((walk (node spans)
+             (cond
+               ((concrete-syntax-tree:consp node)
+                (walk (concrete-syntax-tree:rest node)
+                      (walk (concrete-syntax-tree:first node) spans)))
+               ((concrete-syntax-tree:atom node)
+                (let ((raw (concrete-syntax-tree:raw node)))
+                  (if (and (symbolp raw)
+                           (string= (symbol-name raw) name))
+                      (cons (concrete-syntax-tree:source node) spans)
+                      spans)))
+               (t
+                spans))))
+    (nreverse (walk form nil))))
+
 (defmacro coalton-example-with-gensym ()
   (let ((x (gensym)))
     `(coalton:coalton
@@ -37,3 +60,15 @@
         (is (string= "Type mismatch"
                      (source:message c))
             "condition message is correct")))))
+
+(deftest repeated-symbols-retain-distinct-source-spans ()
+  (let ((form-string "(:a -> Tuple Integer Integer -> List Tuple Integer Integer)"))
+    (multiple-value-bind (form source)
+        (read-form-with-source form-string)
+      (declare (ignore source))
+      (let* ((first (search "Tuple" form-string))
+             (second (search "Tuple" form-string :start2 (1+ first)))
+             (expected (list (cons first (+ first (length "Tuple")))
+                             (cons second (+ second (length "Tuple"))))))
+        (is (equal expected
+                   (cst-symbol-spans form "TUPLE")))))))

--- a/tests/test-files/parse-attribute.txt
+++ b/tests/test-files/parse-attribute.txt
@@ -111,10 +111,10 @@ error: Malformed repr :native attribute
 --------------------------------------------------------------------------------
 
 error: Malformed repr :native attribute
-  --> test:3:6
+  --> test:3:22
    |
  3 |  (repr :native :native :native)
-   |        ^^^^^^^ unexpected form
+   |                        ^^^^^^^ unexpected form
 
 ================================================================================
 107 Unknown repr attribute


### PR DESCRIPTION
Repeated type constructors could reuse the first occurrences source span, so kind mismatch errors highlighted the wrong `Tuple` in malformed return types. Switch the Coalton reader to Eclectors CST client so repeated atoms keep distinct spans, and add reader-level and end-to-end regression tests.

fix #916 