### PR TITLE
ensure doc links are unique by package

### DIFF
--- a/src/doc/html.lisp
+++ b/src/doc/html.lisp
@@ -315,7 +315,7 @@ summary{cursor:pointer;font-weight:600;padding:6px 0}
   (string (object-name pkg)))
 
 (defun package-id (pkg)
-  (format nil "~a-package" (string-downcase (package-name-string pkg))))
+  (object-aname pkg))
 
 (defun sidebar-html (packages)
   (with-html-string

--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -35,13 +35,13 @@
 ;;;;
 ;;;; The following format is used for links to objects in documentation:
 ;;;;
-;;;; Package: `${name}-package`
+;;;; Package: `${sanitized-package-name}-package`
 ;;;; File: `${package}-${name}-file`
 ;;;;   where `name` is the filepath relative to the provided asdf system
 ;;;;   with all non-alphanumeric characters replaced with `-`.
-;;;; Type: `${name}-type`
-;;;; Class: `${name}-class`
-;;;; Value: `${name}-value`
+;;;; Type: `${sanitized-package-name}-${name}-type`
+;;;; Class: `${sanitized-package-name}-${name}-class`
+;;;; Value: `${sanitized-package-name}-${name}-value`
 
 (defpackage #:coalton/doc/markdown
   (:use
@@ -308,8 +308,12 @@
                  (to-markdown new-type)))))))
 
 (defmethod to-markdown ((object tc:ty-predicate))
-  (let ((class-source-name (lookup-class-source-name (tc:ty-predicate-class object))))
-    (format nil "<a href=\"#~(~A-class~)\">~:*~A</a>~{ ~A~}"
+  (let* ((class-name (tc:ty-predicate-class object))
+         (class-source-name (lookup-class-source-name class-name)))
+    (format nil "<a href=\"#~A\">~A</a>~{ ~A~}"
+            (package-qualified-anchor (symbol-package class-name)
+                                      class-source-name
+                                      "class")
             (html-entities:encode-entities class-source-name)
             (mapcar #'to-markdown (tc:ty-predicate-types object)))))
 

--- a/src/doc/model.lisp
+++ b/src/doc/model.lisp
@@ -31,6 +31,8 @@
    ;; object classes and properties
    #:coalton-object
    #:object-aname
+   #:package-qualified-anchor
+   #:sanitize-anchor-component
    #:source
    #:source-span
    #:object-docstring
@@ -111,6 +113,25 @@
 (defgeneric object-aname (self)
   (:documentation "The link target of a thing: <name>-class, e.g."))
 
+(defun sanitize-anchor-component (string)
+  "Convert STRING into a lowercase anchor component using `-` for non-alphanumerics."
+  (string-downcase
+   (map 'string
+        (lambda (char)
+          (if (alphanumericp char)
+              char
+              #\-))
+        string)))
+
+(defun package-qualified-anchor (package name suffix)
+  "Return an anchor name with PACKAGE's sanitized name prefixed to NAME."
+  (let ((package-prefix (and package
+                             (sanitize-anchor-component (package-name package)))))
+    (format nil "~@[~A-~]~(~A-~A~)"
+            package-prefix
+            name
+            suffix)))
+
 (defun ensure-suffix (char string)
   "If STRING doesn't end with CHAR, append it."
   (if (char= (aref string (1- (length string))) char)
@@ -180,7 +201,12 @@
   "TYPE")
 
 (defmethod object-aname ((object coalton-type))
-  (format nil "~(~A-type~)" (object-name object)))
+  (let ((entry (type-entry object)))
+    (package-qualified-anchor
+     (symbol-package (tc:type-entry-name entry))
+     (or (tc:type-entry-source-name entry)
+         (symbol-name (tc:type-entry-name entry)))
+     "type")))
 
 (defclass coalton-struct (coalton-object)
   ((type-entry :initarg :type-entry
@@ -218,8 +244,12 @@
   "STRUCT")
 
 (defmethod object-aname ((self coalton-struct))
-  (format nil "~(~A-type~)"
-          (symbol-name (tc:type-entry-name (type-entry self)))))
+  (let ((entry (type-entry self)))
+    (package-qualified-anchor
+     (symbol-package (tc:type-entry-name entry))
+     (or (tc:type-entry-source-name entry)
+         (symbol-name (tc:type-entry-name entry)))
+     "type")))
 
 (defclass coalton-class (coalton-object)
   ((class-entry :initarg :class
@@ -268,7 +298,12 @@
   "CLASS")
 
 (defmethod object-aname ((self coalton-class))
-  (format nil "~(~A-class~)" (object-name self)))
+  (let ((entry (class-entry self)))
+    (package-qualified-anchor
+     (symbol-package (tc:ty-class-name entry))
+     (or (tc:ty-class-source-name entry)
+         (symbol-name (tc:ty-class-name entry)))
+     "class")))
 
 ;;; class coalton-value
 
@@ -306,7 +341,11 @@
       "VALUE"))
 
 (defmethod object-aname ((object coalton-value))
-  (format nil "~(~A-value~)" (symbol-name (tc:name-entry-name (name-entry object)))))
+  (let ((name (tc:name-entry-name (name-entry object))))
+    (package-qualified-anchor
+     (symbol-package name)
+     (symbol-name name)
+     "value")))
 
 ;;; class coalton-package
 
@@ -328,7 +367,8 @@
   (string-upcase (package-name (lisp-package self))))
 
 (defmethod object-aname ((self coalton-package))
-  (format nil "~A-package" (string-downcase (package-name (lisp-package self)))))
+  (format nil "~A-package"
+          (sanitize-anchor-component (package-name (lisp-package self)))))
 
 (defun package-objects (coalton-package)
   (let ((package (lisp-package coalton-package)))
@@ -431,11 +471,18 @@
   (documentation (coalton-macro-name x) 'function))
 
 (defmethod object-aname ((x coalton-macro))
-  (substitute
-   #\- #\/
-   (format nil "~(~A-~A-macro~)"
-           (package-name (symbol-package (coalton-macro-name x)))
-           (symbol-name (coalton-macro-name x)))))
+  (let ((name (coalton-macro-name x)))
+    (package-qualified-anchor
+     (symbol-package name)
+     (symbol-name name)
+     "macro")))
+
+(defmethod object-aname ((ty tc:tycon))
+  (let ((tcon-name (tc:tycon-name ty)))
+    (package-qualified-anchor
+     (symbol-package tcon-name)
+     (lookup-type-source-name tcon-name)
+     "type")))
 
 ;;; Public API
 

--- a/src/doc/string.lisp
+++ b/src/doc/string.lisp
@@ -28,9 +28,6 @@
           (format stream "~S" tcon-name)
           (format stream "~A" (lookup-type-source-name tcon-name))))))
 
-(defmethod object-aname ((ty tc:tycon))
-  (format nil "~(~A-type~)" (html-entities:encode-entities (object-name ty))))
-
 (defun write-function-types (ty)
   (with-output-to-string (stream)
     (write-string "(" stream)

--- a/tests/typechecker/lisp-type-tests.lisp
+++ b/tests/typechecker/lisp-type-tests.lisp
@@ -124,6 +124,31 @@
                      (render-type (coalton-type-of 'coalton-native-tests::explicit-method)))
       )))
 
+(deftest test-documentation-anchors-include-package-name ()
+  (let* ((env coalton-impl/entry:*global-environment*)
+         (hashmap-count
+           (coalton/doc/model::make-coalton-value
+            (coalton-impl/typechecker/environment:lookup-name env 'coalton/hashmap:count)))
+         (hashtable-count
+           (coalton/doc/model::make-coalton-value
+            (coalton-impl/typechecker/environment:lookup-name env 'coalton/hashtable:count)))
+         (explicit-method-markdown
+           (coalton/doc/markdown::to-markdown
+            (coalton-impl/typechecker/environment:lookup-value-type
+             env
+             'coalton-native-tests::explicit-method))))
+    (check-string= "hashmap count anchor"
+                   "coalton-hashmap-count-value"
+                   (coalton/doc/model:object-aname hashmap-count))
+    (check-string= "hashtable count anchor"
+                   "coalton-hashtable-count-value"
+                   (coalton/doc/model:object-aname hashtable-count))
+    (is (not (string= (coalton/doc/model:object-aname hashmap-count)
+                      (coalton/doc/model:object-aname hashtable-count))))
+    (is (search "href=\"#coalton-types-proxy-type\"" explicit-method-markdown))
+    (is (search "href=\"#coalton-native-tests-explicitmethodclass-class\""
+                explicit-method-markdown))))
+
 (deftest test-tyvar-source-names-do-not-affect-quantification ()
   (let* ((left (coalton-impl/typechecker:make-tyvar
                 :id 0


### PR DESCRIPTION
Doc links were based on symbol name only, which led to ambiguity.