### PR TITLE
Replace bespoke HashMap show function with Show typeclass instance

### DIFF
--- a/library/hashmap.lisp
+++ b/library/hashmap.lisp
@@ -13,6 +13,7 @@
    (#:bits #:coalton/bits)
    (#:cell #:coalton/cell)
    (#:iter #:coalton/iterator)
+   (#:show #:coalton/show)
    (#:list #:coalton/list)
    (#:math #:coalton/math)
    (#:util #:coalton-impl/runtime)
@@ -37,8 +38,7 @@
    #:union
    #:intersection
    #:difference
-   #:xor
-   #:show))
+   #:xor))
 
 (in-package #:coalton/hashmap)
 
@@ -783,21 +783,25 @@ but not in both."
   (define-instance (Hash :k => Monoid (HashMap :k :v))
     (define mempty Empty))
 
-  (declare show ((Hash :k) (Into :k String) (Into :v String) => HashMap :k :v -> String))
-  (define (show hm)
-    "Return a human-readable representation of HM."
-    (let the-entries = (entries hm))
-    (match (iter:next! the-entries)
-      ((None) "()")
-      ((Some (Tuple k1 v1))
-       (<> "("
-           (<>
-            (iter:fold!
-             (fn (accum (Tuple k v))
-                 (<> accum (<> ", " (<> (into k) (<> " -> " (into v))))))
-             (<> (into k1) (<> " -> " (into v1)))
-             the-entries)
-            ")")))))
+  (define-instance ((show:Show :k) (show:Show :v) (Hash :k) => show:Show (HashMap :k :v))
+    (define (show:show-to f hm)
+      (let the-entries = (entries hm))
+      (match (iter:next! the-entries)
+        ((None) (f "()"))
+        ((Some (Tuple k1 v1))
+         (f "(")
+         (show:show-to f k1)
+         (f " -> ")
+         (show:show-to f v1)
+         (rec %show-rest ()
+           (match (iter:next! the-entries)
+             ((None) (f ")"))
+             ((Some (Tuple k v))
+              (f ", ")
+              (show:show-to f k)
+              (f " -> ")
+              (show:show-to f v)
+              (%show-rest))))))))
   )
 
 ;;

--- a/tests/hashmap-tests.lisp
+++ b/tests/hashmap-tests.lisp
@@ -473,4 +473,4 @@
                   (make-list (Tuple 0 0)
                              (Tuple 1 10)))))
   (is (== "(0 -> 0, 1 -> 10)"
-          (hashmap:show hm))))
+          (show:show-as-string hm))))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -35,6 +35,7 @@
    (#:slice #:coalton/slice)
    (#:hashtable #:coalton/hashtable)
    (#:hashmap #:coalton/hashmap)
+   (#:show #:coalton/show)
    (#:cell #:coalton/cell)
    (#:iter #:coalton/iterator)
    (#:list #:coalton/list)


### PR DESCRIPTION
## Problem

`HashMap` defines a standalone `show` function using `Into :k String` / `Into :v String` constraints instead of participating in the `Show` typeclass. This is inconsistent with how other types (e.g., `LispArray`, `Complex`) handle display.

Fixes #1816

## Fix Scope

**library/hashmap.lisp:**
- Removed the standalone `show` function and its `#:show` export
- Added a `Show` typeclass instance for `HashMap` using the `show-to` callback pattern
- Uses `(Show :k) (Show :v) (Hash :k)` constraints instead of `(Into :k String) (Into :v String)`

**tests/hashmap-tests.lisp:**
- Updated `hashmap-show` test to use `show:show-as-string` instead of `hashmap:show`

**tests/package.lisp:**
- Added `(#:show #:coalton/show)` local nickname for the test package

## Output Format

The output format is preserved: empty maps produce `()`, non-empty maps produce `(k1 -> v1, k2 -> v2)`.

## Known Limitations

- This PR only addresses `HashMap` as the most prominent example mentioned in the issue. Other types (e.g., `Hashtable`, `Vector`, `Queue`) could also benefit from `Show` instances in follow-up PRs.
- Could not run `make test` locally (no SBCL available in current environment). Code was reviewed twice via external code review tool.