### PR TITLE
allow scoped type variables with THE

### DIFF
--- a/docs/manual/site/operators/the.md
+++ b/docs/manual/site/operators/the.md
@@ -19,6 +19,8 @@ weight: 100
 - It is especially useful around numeric literals, collection builders,
   sequence builders, and conversions.
 - Unlike `declare`, `the` works directly at expression sites.
+- `the` accepts explicit `forall` binders; when present, those type variables
+  are scoped over the enclosed expression.
 
 ## Example
 

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -356,7 +356,7 @@ Rebound to NIL parsing an anonymous FN.")
 ;;;; node-type-of := "(" "type-of" expression ")"
 ;;;; node-unsafe := "(" "unsafe" body ")"
 ;;;;
-;;;; node-the := "(" "the" type expression ")"
+;;;; node-the := "(" "the" qualified-ty expression ")"
 ;;;;
 ;;;; node-return := "(" "return" expression? ")"
 ;;;;
@@ -636,8 +636,8 @@ Rebound to NIL parsing an anonymous FN.")
 (defstruct (node-the
             (:include node)
             (:copier nil))
-  (type (util:required 'type) :type ty   :read-only t)
-  (expr (util:required 'expr) :type node :read-only t))
+  (type (util:required 'type) :type qualified-ty :read-only t)
+  (expr (util:required 'expr) :type node         :read-only t))
 
 (defstruct (node-collection-builder
             (:include node)
@@ -1716,7 +1716,7 @@ Rebound to NIL parsing an anonymous FN.")
                           "unexpected trailing form")))
 
      (make-node-the
-      :type (parse-type (cst:second form) source)
+      :type (parse-qualified-type (cst:second form) source)
       :expr (parse-expression (cst:third form) source)
       :location (form-location source form)))
 

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -81,6 +81,18 @@
     (t
      env)))
 
+(defun parse-the-type-annotation (annotation env)
+  (declare (type parser:qualified-ty annotation)
+           (type tc-env env)
+           (values tc:qualified-ty tc:tyvar-list boolean &optional))
+  (multiple-value-bind (qual-ty explicit-tvars explicit-p)
+      (parse-qualified-type-info annotation (tc-env-parser-env env))
+    (when (tc:qualified-ty-predicates qual-ty)
+      (tc-error "Invalid type annotation"
+                (tc-note annotation
+                         "`the` annotations cannot include predicate contexts")))
+    (values qual-ty explicit-tvars explicit-p)))
+
 (defmacro with-type-string-environment ((env) &body body)
   `(let ((*type-string-environment*
            (or *type-string-environment*
@@ -1981,52 +1993,58 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              (type tc-env env)
              (values tc:ty tc:ty-predicate-list accessor-list node tc:substitution-list &optional))
 
-    (let ((declared-ty (parse-type (parser:node-the-type node)
-                                   (tc-env-parser-env env))))
+    (multiple-value-bind (declared-qual-ty explicit-tvars explicit-p)
+        (parse-the-type-annotation (parser:node-the-type node) env)
+      (let* ((declared-ty (tc:qualified-ty-type declared-qual-ty))
+             (expr-env (if explicit-p
+                           (tc-env-extend-type-variable-scope
+                            env
+                            (remove-duplicates explicit-tvars :test #'tc:ty=))
+                           env)))
 
-      (multiple-value-bind (expr-ty preds accessors expr-node subs)
-          (infer-expression-type (parser:node-the-expr node)
-                                 (tc:make-variable)
-                                 subs
-                                 env)
+        (multiple-value-bind (expr-ty preds accessors expr-node subs)
+            (infer-expression-type (parser:node-the-expr node)
+                                   (tc:make-variable)
+                                   subs
+                                   expr-env)
 
-        ;; Ensure subs are applied
-        (setf expr-ty (tc:apply-substitution subs expr-ty))
+          ;; Ensure subs are applied
+          (setf expr-ty (tc:apply-substitution subs expr-ty))
 
-        ;; Check that declared-ty and expr-ty unify
-        (handler-case
-            (setf subs (tc:unify subs declared-ty expr-ty))
-          (tc:coalton-internal-type-error ()
-            (tc-error "Type mismatch"
-                      (tc-note node "Declared type '~A' does not match inferred type '~A'"
-                               (type-object-string (tc:apply-substitution subs declared-ty))
-                               (type-object-string (tc:apply-substitution subs expr-ty))))))
+          ;; Check that declared-ty and expr-ty unify
+          (handler-case
+              (setf subs (tc:unify subs declared-ty expr-ty))
+            (tc:coalton-internal-type-error ()
+              (tc-error "Type mismatch"
+                        (tc-note node "Declared type '~A' does not match inferred type '~A'"
+                                 (type-object-string (tc:apply-substitution subs declared-ty))
+                                 (type-object-string (tc:apply-substitution subs expr-ty))))))
 
-        ;; Check that declared-ty is not more specific than expr-ty
-        (handler-case
-            (tc:match expr-ty declared-ty)
-          (tc:coalton-internal-type-error ()
-            (tc-error "Declared type too general"
-                      (tc-note node "Declared type '~A' is more general than inferred type '~A'"
-                               (type-object-string (tc:apply-substitution subs declared-ty))
-                               (type-object-string (tc:apply-substitution subs expr-ty))))))
+          ;; Check that declared-ty is not more specific than expr-ty
+          (handler-case
+              (tc:match expr-ty declared-ty)
+            (tc:coalton-internal-type-error ()
+              (tc-error "Declared type too general"
+                        (tc-note node "Declared type '~A' is more general than inferred type '~A'"
+                                 (type-object-string (tc:apply-substitution subs declared-ty))
+                                 (type-object-string (tc:apply-substitution subs expr-ty))))))
 
-        ;; SAFETY: If declared-ty and expr-ty unify, and expr-ty is
-        ;; more general than declared-ty then matching should be
-        ;; infallible
-        (setf subs (tc:compose-substitution-lists subs (tc:match expr-ty declared-ty)))
+          ;; SAFETY: If declared-ty and expr-ty unify, and expr-ty is
+          ;; more general than declared-ty then matching should be
+          ;; infallible
+          (setf subs (tc:compose-substitution-lists subs (tc:match expr-ty declared-ty)))
 
-        (handler-case
-            (progn
-              (setf subs (tc:unify subs expr-ty expected-type))
-              (values
-               (tc:apply-substitution subs expr-ty)
-               preds
-               accessors
-               expr-node
-               subs))
-          (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node subs expected-type expr-ty))))))
+          (handler-case
+              (progn
+                (setf subs (tc:unify subs expr-ty expected-type))
+                (values
+                 (tc:apply-substitution subs expr-ty)
+                 preds
+                 accessors
+                 expr-node
+                 subs))
+            (tc:coalton-internal-type-error ()
+              (standard-expression-type-mismatch-error node subs expected-type expr-ty)))))))
 
   (:method ((node parser:node-collection-builder) expected-type subs env)
     (declare (type tc:ty expected-type)
@@ -4112,10 +4130,9 @@ as a recursive function rather than a recursive value."
                         (values (or null tc:ty) &optional))
                (let ((value (parser:binding-value binding)))
                  (when (typep value 'parser:node-the)
-                   ;; `parse-type` also returns kind substitutions; only keep the parsed type.
-                   (nth-value 0
-                              (parse-type (parser:node-the-type value)
-                                          (tc-env-env env))))))
+                   (tc:qualified-ty-type
+                    (parse-the-type-annotation (parser:node-the-type value)
+                                               env)))))
              (add-implicit-binding-type (name binding)
                (declare (type symbol name)
                         (type (or parser:toplevel-define parser:node-let-binding) binding)

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -411,6 +411,14 @@
    '("scoped-local-explicit" . "(forall (:outer) (:outer -> :outer))"))
 
   (check-coalton-types
+   "(define the-scoped-forall
+      (the (forall (:item) (:item -> :item))
+        (fn (x)
+          (the :item x))))"
+
+   '("the-scoped-forall" . "(forall (:item) (:item -> :item))"))
+
+  (check-coalton-types
    "(declare scoped-proxy-roundtrip (forall (:item) :item -> :item))
     (define (scoped-proxy-roundtrip x)
       (let ((declare reify (coalton/types:Proxy :item -> :item))


### PR DESCRIPTION
Allows `forall` to exist in `the` and provide scope over the enclosed expression.