### PR TITLE
Fix rec accessor inference and simplify rec annotations

### DIFF
--- a/docs/internals/internals.md
+++ b/docs/internals/internals.md
@@ -61,8 +61,6 @@ The IR of this phase is an AST. Each node is a sub-structure of `node`.
 
 Parsing of expressions also occurs in this file.
 
-Some constructions are de-sugared directly in parsing. For example, there is no `node-rec`; it is desugared into a `node-let` immediately.
-
 ### Intermediate representation for types
 
 File: `src/parser/types.lisp`

--- a/docs/manual/site/operators/declare.md
+++ b/docs/manual/site/operators/declare.md
@@ -16,8 +16,8 @@ weight: 30
 ## Semantics
 
 - Top-level `declare` is commonly paired with `define`.
-- Local `declare` also works inside binding lists of `let`, `let*`, `for`, and
-  `for*`.
+- Local `declare` also works inside binding lists of `let`, `let*`, `rec`,
+  `for`, and `for*`.
 - Coalton infers types, but `declare` is the main way to make intent explicit.
 - Using `forall` makes the type variables scoped to the variable's definition.
 

--- a/docs/manual/site/operators/rec.md
+++ b/docs/manual/site/operators/rec.md
@@ -10,27 +10,37 @@ weight: 180
 ## Syntax
 
 ```lisp
-(rec ⟨name-spec⟩ ((⟨var⟩ ⟨init⟩) ...)
-  ⟨body⟩)
+(rec ⟨name⟩ (⟨binding⟩...)
+  ⟨body⟩...)
 
-;; ⟨name-spec⟩ := ⟨name⟩
-;;              | (⟨name⟩ ⟨type⟩)
+;; ⟨binding⟩ := ⟨declare-form⟩
+;;            | (⟨var⟩ ⟨init⟩)
 ```
 
 ## Semantics
 
-- `rec` is useful for iteration. `⟨name⟩` should name a
-  function to be called tail recursively.
-- The recursive name can optionally carry an explicit type.
-- The names `go` or `%` are often used.
+- `rec` introduces a local recursive function `⟨name⟩` and immediately calls it
+  with the initial values from the binding list.
+- `rec` is useful for iteration. The names `go` and `%` are common.
+- Init bindings may be declared with `declare`, like in `let`, `let*`, `for`,
+  and `for*`.
+- Local `declare` forms in the binding list apply to init variables, which in
+  turn constrain the recursive function's parameters.
+- If you want to constrain the result type of a `rec` expression, wrap the
+  whole form in `the`.
 - Tail recursion is not enforced.
 - `⟨body⟩` has an implicit `progn`.
 
 ## Example
 
 ```lisp
-(rec % ((i n) (acc 0))
-  (if (== i 0)
-      acc
-      (% (1- i) (+ acc i))))
+(the Integer
+  (rec %
+       ((declare i Integer)
+        (declare acc Integer)
+        (i n)
+        (acc 0))
+    (if (== i 0)
+        acc
+        (% (1- i) (+ acc i)))))
 ```

--- a/docs/manual/site/topics/whirlwind-tour.md
+++ b/docs/manual/site/topics/whirlwind-tour.md
@@ -625,19 +625,22 @@ This function can be run for arbitrarily large `limit` without affecting the sta
 COMMON-LISP:T
 ```
 
-Coalton has a special built-in operator `rec` for doing "named-let"-style iteration. It's general syntax is:
+Coalton has a special built-in operator `rec` for doing "named-let"-style iteration. Its general syntax is:
 
 ```lisp
 (rec <name> (<binding>*)
-  <body>)
+  <body>...)
 
-;; <name> := <symbol>
-;;         | (<symbol> <type>)
-;;
-;; <binding> := (<symbol> <value>)
+;; <binding> := <declare-form>
+;;            | (<symbol> <value>)
 ```
 
-The `<name>` is in essence a local (tail-recursive) function in the `<body>`. Optionally, the type of this function can be declared, which is useful to avoid unwanted polymorphism. The `rec` operator does not require the invocation to be in tail position.
+The `<name>` is in essence a local recursive function in the `<body>`, and the
+binding list supplies the arguments for its initial call. Local `declare` forms
+inside the binding list apply to the initial bindings, which in turn constrain
+the recursive function's parameters. If you want to constrain the result type of
+the whole `rec` expression, wrap it in `the`. The `rec` operator does not
+require the invocation to be in tail position.
 
 It is idiomatic in Coalton to choose the name `%` when there is no other reasonable name.
 
@@ -671,18 +674,23 @@ The type is `∀ A B. (NUM B) (NUM A) ⇒ (A → B)` and thus can be used for wh
 55.0
 ```
 
-We can make a monomorphic variant for `Integer` by declaring the type of the recursion.
+We can make a monomorphic variant for `Integer` by declaring the init bindings
+and wrapping the whole `rec` in `the`.
 
 ```lisp
 (define (fib-monomorphic n)
-  (rec (% (Integer * Integer * Integer -> Integer))
-       ((i n)
-        (a 0)
-        (b 1))
-    (cond
-      ((== 0 i) a)
-      ((== 1 i) b)
-      (True (% (- i 1) b (+ a b))))))
+  (the Integer
+    (rec %
+         ((declare i Integer)
+          (declare a Integer)
+          (declare b Integer)
+          (i n)
+          (a 0)
+          (b 1))
+      (cond
+        ((== 0 i) a)
+        ((== 1 i) b)
+        (True (% (- i 1) b (+ a b)))))))
 ```
 
 Now it works without any type declarations on use:

--- a/library/hashmap.ct
+++ b/library/hashmap.ct
@@ -838,8 +838,9 @@ but not in both."
   (declare dump (HashMap :k :v -> Void))
   (define (dump hm)
     "For debugging"
-    (rec (dump-node ((HmNode :k :v) * Integer -> Void))
-         ((node (root hm))
+    (rec dump-node
+         ((declare indent Integer)
+          (node (root hm))
           (indent 0))
       (match node
         ((Leaf entry)

--- a/src/parser/collect.lisp
+++ b/src/parser/collect.lisp
@@ -221,6 +221,13 @@ in expressions. May not include all bound variables."
      (mapcan #'collect-variables-generic% (node-let-bindings node))
      (collect-variables-generic% (node-let-body node))))
 
+  (:method ((node node-rec))
+    (declare (values node-variable-list))
+    (nconc
+     (mapcan #'collect-variables-generic% (node-rec-bindings node))
+     (mapcan #'collect-variables-generic% (node-rec-call-args node))
+     (collect-variables-generic% (node-rec-body node))))
+
   (:method ((node node-dynamic-let))
     (declare (values node-variable-list))
     (nconc

--- a/src/parser/expression.lisp
+++ b/src/parser/expression.lisp
@@ -84,6 +84,14 @@
    #:node-let-declares                  ; ACCESSOR
    #:node-let-body                      ; ACCESSOR
    #:node-let-sequential-p              ; ACCESSOR
+   #:node-rec                           ; STRUCT
+   #:make-node-rec                      ; CONSTRUCTOR
+   #:node-rec-name                      ; ACCESSOR
+   #:node-rec-bindings                  ; ACCESSOR
+   #:node-rec-declares                  ; ACCESSOR
+   #:node-rec-params                    ; ACCESSOR
+   #:node-rec-call-args                 ; ACCESSOR
+   #:node-rec-body                      ; ACCESSOR
    #:node-dynamic-let                   ; STRUCT
    #:make-node-dynamic-let              ; CONSTRUCTOR
    #:node-dynamic-let-bindings          ; ACCESSOR
@@ -341,7 +349,7 @@ Rebound to NIL parsing an anonymous FN.")
 ;;;;
 ;;;; node-let := "(" ("let" | "let*") "(" (node-let-binding | node-let-declare)+ ")" body ")"
 ;;;;
-;;;; node-rec := "(" "rec" (identifier | "(" identifier [qualified-ty] ")" ) "(" (node-let-binding | node-let-declare)+ ")" body ")"
+;;;; node-rec := "(" "rec" identifier "(" (node-let-binding | node-let-declare)+ ")" body ")"
 ;;;;
 ;;;; node-lisp := "(" "lisp" type "(" lisp-variable* ")" lisp-form+ ")"
 ;;;;
@@ -582,6 +590,22 @@ Rebound to NIL parsing an anonymous FN.")
   (body         (util:required 'body)     :type node-body             :read-only t)
   ;; T when parsed from LET*, so later bindings can see earlier ones.
   (sequential-p nil                       :type boolean               :read-only t))
+
+(defstruct (node-rec
+            (:include node)
+            (:copier nil))
+  ;; Name of the recursive function introduced by `rec`.
+  (name      (util:required 'name)      :type node-variable         :read-only t)
+  ;; Non-self init bindings that seed the immediate recursive call.
+  (bindings  (util:required 'bindings)  :type node-let-binding-list :read-only t)
+  ;; Declarations for the init bindings.
+  (declares  (util:required 'declares)  :type node-let-declare-list :read-only t)
+  ;; Parameters of the recursive function, in source order.
+  (params    (util:required 'params)    :type pattern-list          :read-only t)
+  ;; Arguments passed in the implicit immediate call, in source order.
+  (call-args (util:required 'call-args) :type node-variable-list    :read-only t)
+  ;; Body of the recursive function itself.
+  (body      (util:required 'body)      :type node-body             :read-only t))
 
 (defstruct (node-dynamic-let
             (:include node)
@@ -1498,7 +1522,7 @@ Rebound to NIL parsing an anonymous FN.")
     ((and (cst:atom (cst:first form))
           (eq 'coalton:rec (cst:raw (cst:first form))))
 
-     (multiple-value-bind (name type rec-bindings body)
+     (multiple-value-bind (name rec-bindings body)
          (cond
            ;; (rec)
            ((not (cst:consp (cst:rest form)))
@@ -1515,37 +1539,21 @@ Rebound to NIL parsing an anonymous FN.")
             (parse-error "Malformed rec"
                          (note-end source (cst:third form)
                                    "expected rec body")))
+           ;; (rec () ...)
            ((cst:null (cst:second form))
             (parse-error "Malformed rec"
                          (note source (cst:second form)
-                               "unexpected empty list")))
+                               "expected function name")))
+           ;; (rec <non-symbol> ...)
+           ((not (cst:atom (cst:second form)))
+            (parse-error "Malformed rec"
+                         (note source (cst:second form)
+                               "expected function name")))
            ;; (rec name bindings ...)
-           ((cst:atom (cst:second form))
-            (values (cst:second form)
-                    nil
-                    (cst:third form)
-                    (cst:nthrest 3 form)))
-           ;; (rec (name qual-ty) bindings ...)
            (t
-            (cond
-              ((cst:null (cst:rest (cst:second form)))
-               (values (cst:first (cst:second form))
-                       nil
-                       (cst:third form)
-                       (cst:nthrest 3 form)))
-              ((cst:consp (cst:rest (cst:second form)))
-               (when (cst:consp (cst:nthrest 2 (cst:second form)))
-                 (parse-error "Malformed rec"
-                              (note-end source (cst:second (cst:second form))
-                                        "unexpected trailing form(s)")))
-               (values (cst:first (cst:second form))
-                       (cst:second (cst:second form))
-                       (cst:third form)
-                       (cst:nthrest 3 form)))
-              (t
-               (parse-error "Malformed rec"
-                            (note source (cst:rest (cst:second form))
-                                  "unexpected dotted list"))))))
+            (values (cst:second form)
+                    (cst:third form)
+                    (cst:nthrest 3 form))))
 
        (unless (cst:proper-list-p rec-bindings)
          (parse-error "Malformed rec"
@@ -1568,49 +1576,24 @@ Rebound to NIL parsing an anonymous FN.")
                  :finally
                     (return (values declares binding-list vars)))
 
-         (make-node-let
+         (make-node-rec
+          :name (parse-variable name source)
           :declares declares
           :bindings
-          ;; Remove recursive bindings
+          ;; Remove trivial self-bindings from the synthetic outer let; their
+          ;; argument comes from the surrounding scope.
           (remove-if
            (lambda (binding)
              (and (typep (node-let-binding-value binding)
                          'node-variable)
-
                   (eq (node-variable-name (node-let-binding-name binding))
                       (node-variable-name (node-let-binding-value binding)))))
            bindings)
-          :body
-          (make-node-body
-           :nodes nil
-           :last-node
-           (make-node-let
-            :declares (if type
-                          (list
-                           (make-node-let-declare
-                            :name (parse-variable name source)
-                            :type (parse-qualified-type type source)
-                            :location (form-location source type)))
-                          nil)
-            :bindings (list (make-node-let-binding
-                             :name (parse-variable name source)
-                             :value
-                             (make-node-abstraction
-                              :params (mapcar (lambda (var)
-                                                (parse-pattern var source))
-                                              vars)
-                              :body (parse-body body form source)
-                              :location (form-location source form))
-                             :location (form-location source form)))
-            :body
-            (make-node-body
-             :nodes nil
-             :last-node
-             (make-node-application
-              :rator (parse-expression name source)
-              :rands (mapcar #'node-let-binding-name bindings)
-              :location (form-location source form)))
-            :location (form-location source form)))
+          :params (mapcar (lambda (var)
+                            (parse-pattern var source))
+                          vars)
+          :call-args (mapcar #'node-let-binding-name bindings)
+          :body (parse-body body form source)
           :location (form-location source form)))))
 
     ((and (cst:atom (cst:first form))

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -273,6 +273,42 @@
            :location (source:location node))
           ctx)))))
 
+  (:method ((node node-rec) ctx)
+    (declare (type algo:immutable-map ctx)
+             (values node algo:immutable-map))
+
+    (let* ((outer-bindings
+             (make-local-vars
+              (mapcar (alexandria:compose #'node-variable-name
+                                          #'node-let-binding-name)
+                      (node-rec-bindings node))))
+           (outer-ctx
+             (algo:immutable-map-set-multiple ctx outer-bindings))
+           (rec-name
+             (make-local-var (node-variable-name (node-rec-name node))))
+           (param-bindings
+             (make-local-vars
+              (mapcar #'pattern-var-name
+                      (pattern-variables (node-rec-params node)))))
+           (body-ctx
+             (algo:immutable-map-set-multiple
+              (algo:immutable-map-set ctx
+                                      (node-variable-name (node-rec-name node))
+                                      rec-name)
+              param-bindings)))
+      (values
+       (make-node-rec
+        :name (make-node-variable
+               :name rec-name
+               :location (source:location (node-rec-name node)))
+        :bindings (rename-variables-generic% (node-rec-bindings node) outer-ctx)
+        :declares (rename-variables-generic% (node-rec-declares node) outer-ctx)
+        :params (rename-variables-generic% (node-rec-params node) body-ctx)
+        :call-args (rename-variables-generic% (node-rec-call-args node) outer-ctx)
+        :body (rename-variables-generic% (node-rec-body node) body-ctx)
+        :location (source:location node))
+       ctx)))
+
   (:method ((node node-dynamic-let) ctx)
     (declare (type algo:immutable-map ctx)
              (values node algo:immutable-map))

--- a/src/redef-detection/dependencies.lisp
+++ b/src/redef-detection/dependencies.lisp
@@ -96,6 +96,30 @@
                         (setf (gethash name new-locals) t)))
                     (traverse (parser:node-let-body node) new-locals)))
 
+                 ;; REC lowers to an outer let for init bindings, plus a local
+                 ;; recursive function and immediate application.
+                 (parser:node-rec
+                  (dolist (binding (parser:node-rec-bindings node))
+                    (traverse (parser:node-let-binding-value binding)
+                              local-bindings))
+                  (let ((outer-locals (alexandria:copy-hash-table local-bindings)))
+                    (dolist (binding (parser:node-rec-bindings node))
+                      (setf (gethash (parser:node-variable-name
+                                      (parser:node-let-binding-name binding))
+                                     outer-locals)
+                            t))
+                    (let ((body-locals (alexandria:copy-hash-table outer-locals)))
+                      (setf (gethash (parser:node-variable-name
+                                      (parser:node-rec-name node))
+                                     body-locals)
+                            t)
+                      (dolist (pvar (parser:pattern-variables
+                                     (parser:node-rec-params node)))
+                        (setf (gethash (parser:pattern-var-name pvar) body-locals) t))
+                      (traverse (parser:node-rec-body node) body-locals))
+                    (dolist (arg (parser:node-rec-call-args node))
+                      (traverse arg outer-locals))))
+
                  ;; Dynamic binding - initializers and body both see the same
                  ;; lexical scope because dynamic bindings do not introduce
                  ;; lexical variables.

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -1049,6 +1049,321 @@ Returns four values:
             (tc:quantify (tc:type-variables qual-ty) qual-ty))
            subs))))))
 
+(defun rec-node-bindings-independent-p (node)
+  "Return true when REC's synthetic outer init bindings do not depend on each
+other, so they can be inferred monomorphically before the recursive body."
+  (declare (type parser:node-rec node)
+           (values boolean &optional))
+  (let ((names (mapcar (alexandria:compose #'parser:node-variable-name
+                                           #'parser:node-let-binding-name)
+                       (parser:node-rec-bindings node))))
+    (every (lambda (binding)
+             (null
+              (intersection
+               names
+               (mapcar #'parser:node-variable-name
+                       (parser:collect-variables
+                        (parser:node-let-binding-value binding)))
+               :test #'eq)))
+           (parser:node-rec-bindings node))))
+
+(defun rec-node-inner-binding (node)
+  "Build the parser let-binding for REC's local recursive function."
+  (declare (type parser:node-rec node)
+           (values parser:node-let-binding &optional))
+  (parser:make-node-let-binding
+   :name (parser:node-rec-name node)
+   :value (parser:make-node-abstraction
+           :params (parser:node-rec-params node)
+           :keyword-params nil
+           :body (parser:node-rec-body node)
+           :location (source:location node))
+   :location (source:location node)))
+
+(defun rec-node-declare-table (node)
+  "Validate REC's init bindings and declarations, then return a declare table."
+  (declare (type parser:node-rec node)
+           (values hash-table &optional))
+  (let ((def-table (make-hash-table :test #'eq))
+        (dec-table (make-hash-table :test #'eq)))
+    (loop :for binding :in (parser:node-rec-bindings node)
+          :for name := (parser:node-variable-name (parser:node-let-binding-name binding))
+          :if (gethash name def-table)
+            :do (tc-error "Duplicate binding in rec"
+                          (tc-note (parser:node-let-binding-name binding)
+                                   "second definition here")
+                          (tc-note (parser:node-let-binding-name
+                                    (gethash name def-table))
+                                   "first definition here"))
+          :else
+            :do (setf (gethash name def-table) binding))
+
+    (loop :for declare :in (parser:node-rec-declares node)
+          :for name := (parser:node-variable-name (parser:node-let-declare-name declare))
+          :if (gethash name dec-table)
+            :do (tc-error "Duplicate declaration in rec"
+                          (tc-note (parser:node-let-declare-name declare)
+                                   "second declaration here")
+                          (tc-note (parser:node-let-declare-name
+                                    (gethash name dec-table))
+                                   "first declaration here"))
+          :else
+            :do (setf (gethash name dec-table) declare))
+
+    (loop :for declare :in (parser:node-rec-declares node)
+          :for name := (parser:node-variable-name (parser:node-let-declare-name declare))
+          :unless (gethash name def-table)
+            :do (tc-error "Orphan declare in rec"
+                          (tc-note (parser:node-let-declare-name declare)
+                                   "declaration does not have an associated definition")))
+
+    (loop :with table := (make-hash-table :test #'eq)
+          :for declare :in (parser:node-rec-declares node)
+          :for name := (parser:node-variable-name (parser:node-let-declare-name declare))
+          :do (setf (gethash name table) (parser:node-let-declare-type declare))
+          :finally (return table))))
+
+(defun infer-rec-init-binding-type (binding declared-type subs env)
+  "Infer one REC init binding, preserving init-binding declarations."
+  (declare (type parser:node-let-binding binding)
+           (type (or null parser:qualified-ty) declared-type)
+           (type tc:substitution-list subs)
+           (type tc-env env)
+           (values tc:ty-predicate-list node-let-binding tc:qualified-ty tc:ty-scheme tc:substitution-list))
+  (if declared-type
+      (let ((declared-scheme (parse-ty-scheme declared-type (tc-env-parser-env env))))
+        (multiple-value-bind (binding-preds typed-binding subs_)
+            (infer-expl-binding-type binding
+                                     declared-scheme
+                                     (source:location (parser:node-let-binding-name binding))
+                                     subs
+                                     env)
+          (setf binding-preds (tc:apply-substitution subs_ binding-preds))
+          (setf typed-binding (tc:apply-substitution subs_ typed-binding))
+          (let ((binding-qual-ty (node-type (node-let-binding-name typed-binding))))
+            (values binding-preds
+                    typed-binding
+                    binding-qual-ty
+                    (tc:apply-substitution subs_ declared-scheme)
+                    subs_))))
+
+      (multiple-value-bind (binding-preds binding-accessors typed-binding subs_)
+          (infer-binding-type binding (tc:make-variable) subs env)
+        (setf subs subs_)
+        (setf binding-preds (tc:apply-substitution subs binding-preds))
+        (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) binding-preds subs)))
+        (setf binding-accessors (tc:apply-substitution subs binding-accessors))
+
+        (multiple-value-bind (binding-accessors subs__)
+            (solve-accessors binding-accessors (tc-env-env env))
+          (setf subs (tc:compose-substitution-lists subs subs__))
+
+          (when binding-accessors
+            (tc-error "Ambiguous accessor"
+                      (tc-note (first binding-accessors)
+                               "accessor is ambiguous")))
+
+          (setf binding-preds (tc:apply-substitution subs binding-preds))
+          (setf typed-binding (tc:apply-substitution subs typed-binding))
+          (let* ((binding-name (node-let-binding-name typed-binding))
+                 (binding-type (tc:qualified-ty-type (node-type binding-name)))
+                 (binding-qual-ty (tc:qualify binding-preds binding-type)))
+            (values binding-preds
+                    typed-binding
+                    binding-qual-ty
+                    (tc:to-scheme binding-qual-ty)
+                    subs))))))
+
+(defun lower-rec-node-to-let (node)
+  "Lower REC to the parser nested-let form used before the refactor."
+  (declare (type parser:node-rec node)
+           (values parser:node-let &optional))
+  (let* ((location (source:location node))
+         (inner-binding (rec-node-inner-binding node)))
+    (parser:make-node-let
+     :bindings (parser:node-rec-bindings node)
+     :declares (parser:node-rec-declares node)
+     :body (make-parser-body
+            (parser:make-node-let
+             :bindings (list inner-binding)
+             :declares nil
+             :body (make-parser-body
+                    (parser:make-node-application
+                     :rator (parser:node-rec-name node)
+                     :rands (parser:node-rec-call-args node)
+                     :location location))
+             :location location))
+     :location location)))
+
+(defun infer-rec-node-type (node expected-type subs env)
+  "Infer the type of a parser REC node.
+
+Simple REC forms are handled directly so init binding types can seed the
+recursive parameter types before local accessor solving. More complex forms are
+lowered back to the ordinary nested-let representation and inferred there."
+  (declare (type parser:node-rec node)
+           (type tc:ty expected-type)
+           (type tc:substitution-list subs)
+           (type tc-env env)
+           (values tc:ty tc:ty-predicate-list accessor-list node-let tc:substitution-list))
+
+  (when (not (rec-node-bindings-independent-p node))
+    (return-from infer-rec-node-type
+      (infer-expression-type (lower-rec-node-to-let node)
+                             expected-type
+                             subs
+                             env)))
+
+  (check-duplicates
+   (mapcan #'parser:pattern-variables (parser:node-rec-params node))
+   #'parser:pattern-var-name
+   (lambda (first second)
+     (tc-error "Duplicate definition in rec"
+               (tc-note first "first definition here")
+               (tc-note second "second definition here"))))
+
+  (let ((preds nil)
+        (accessors nil)
+        (init-binding-info nil)
+        (call-env env)
+        (declare-table (rec-node-declare-table node)))
+    ;; `rec` init bindings are only used to seed the immediate recursive call,
+    ;; so keep them monomorphic here instead of routing through ordinary `let`
+    ;; generalization/defaulting.
+    (dolist (binding (parser:node-rec-bindings node))
+      (let ((declared-type
+              (gethash (parser:node-variable-name (parser:node-let-binding-name binding))
+                       declare-table)))
+        (multiple-value-bind (binding-preds typed-binding binding-qual-ty binding-scheme subs_)
+            (infer-rec-init-binding-type binding declared-type subs env)
+          (setf subs subs_)
+          (setf call-env
+                (tc-env-shadow-definition call-env
+                                          (node-variable-name (node-let-binding-name typed-binding))
+                                          binding-scheme))
+          (setf preds (append preds binding-preds))
+          (push (cons typed-binding binding-qual-ty) init-binding-info))))
+
+    (setf init-binding-info (nreverse init-binding-info))
+    (tc:apply-substitution subs call-env)
+
+    (let* ((arg-info
+             (loop :for arg :in (parser:node-rec-call-args node)
+                   :collect
+                     (multiple-value-bind (arg-ty arg-preds)
+                         (tc-env-lookup-value call-env arg)
+                       (setf preds (append preds arg-preds))
+                       (list arg arg-ty arg-preds))))
+           (param-types
+             (loop :for (_arg arg-ty _preds) :in arg-info
+                   :collect (tc:apply-substitution subs arg-ty)))
+           (result-type
+             (tc:make-variable))
+           (rec-function-type
+             (tc:make-function-type* param-types result-type))
+           (rec-name
+             (parser:node-variable-name (parser:node-rec-name node)))
+           (inner-binding
+             (rec-node-inner-binding node))
+           (binding-env
+             (tc-env-shadow-definition call-env rec-name (tc:to-scheme rec-function-type))))
+
+      (multiple-value-bind (binding-preds binding-accessors typed-binding subs)
+          (infer-binding-type inner-binding rec-function-type subs binding-env)
+
+        (tc:apply-substitution subs binding-env)
+
+        ;; The init bindings above determine the recursive parameter types, but
+        ;; class fundeps may still need to fire before accessors are concrete.
+        (setf binding-preds (tc:apply-substitution subs binding-preds))
+        (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) binding-preds subs)))
+        (setf binding-accessors (tc:apply-substitution subs binding-accessors))
+
+        (multiple-value-bind (binding-accessors subs_)
+            (solve-accessors binding-accessors (tc-env-env env))
+          (setf subs (tc:compose-substitution-lists subs subs_))
+
+          (when binding-accessors
+            (tc-error "Ambiguous accessor"
+                      (tc-note (first binding-accessors)
+                               "accessor is ambiguous")))
+
+          (setf binding-preds (tc:apply-substitution subs binding-preds))
+          (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) binding-preds subs)))
+          (tc:apply-substitution subs call-env)
+
+          (handler-case
+              (setf subs (tc:unify subs (tc:apply-substitution subs result-type) expected-type))
+            (tc:coalton-internal-type-error ()
+              (standard-expression-type-mismatch-error node subs expected-type result-type)))
+
+          (setf binding-preds (tc:apply-substitution subs binding-preds))
+          (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) binding-preds subs)))
+
+          (let* ((ty
+                   (tc:apply-substitution subs result-type))
+                 (rec-qual-ty
+                   (tc:qualify binding-preds
+                               (tc:apply-substitution subs rec-function-type)))
+                 (rewrite-table
+                   (let ((table (make-hash-table :test #'eq)))
+                     (setf (gethash rec-name table) rec-qual-ty)
+                     table))
+                 (typed-inner-binding
+                   (rewrite-recursive-calls
+                    (attach-explicit-binding-type
+                     (tc:apply-substitution subs typed-binding)
+                     rec-qual-ty)
+                    rewrite-table))
+                 (typed-rator
+                   (make-node-variable
+                    :type rec-qual-ty
+                    :location (source:location (parser:node-rec-name node))
+                    :name rec-name))
+                 (typed-rands
+                   (loop :for (arg arg-ty arg-preds) :in arg-info
+                         :collect
+                           (make-node-variable
+                            :type (tc:qualify (tc:apply-substitution subs arg-preds)
+                                              (tc:apply-substitution subs arg-ty))
+                            :location (source:location arg)
+                            :name (parser:node-variable-name arg))))
+                 (typed-application
+                   (make-node-application
+                    :type (tc:qualify nil ty)
+                    :location (source:location node)
+                    :rator typed-rator
+                    :rands typed-rands
+                    :keyword-rands nil))
+                 (typed-inner-let
+                   (make-node-let
+                    :type (tc:qualify nil ty)
+                    :location (source:location node)
+                    :bindings (list typed-inner-binding)
+                    :body (make-node-body
+                           :nodes nil
+                           :last-node typed-application)))
+                 (typed-init-bindings
+                   (loop :for (binding . qual-ty) :in init-binding-info
+                         :collect
+                           (attach-explicit-binding-type
+                            (tc:apply-substitution subs binding)
+                            (tc:apply-substitution subs qual-ty)))))
+            (setf preds (tc:apply-substitution subs preds))
+            (setf preds (append preds binding-preds))
+            (values
+             ty
+             preds
+             accessors
+             (make-node-let
+              :type (tc:qualify nil ty)
+              :location (source:location node)
+              :bindings typed-init-bindings
+              :body (make-node-body
+                     :nodes nil
+                     :last-node typed-inner-let))
+             subs)))))))
+
 (defgeneric infer-expression-type (node expected-type subs env)
   (:documentation "Infer the type of NODE and then unify against EXPECTED-TYPE
 
@@ -1578,6 +1893,14 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                        subs))))
                 (tc:coalton-internal-type-error ()
                   (standard-expression-type-mismatch-error node subs effective-expected-type ty)))))))))
+
+  (:method ((node parser:node-rec) expected-type subs env)
+    (declare (type tc:ty expected-type)
+             (type tc:substitution-list subs)
+             (type tc-env env)
+             (values tc:ty tc:ty-predicate-list accessor-list node-let tc:substitution-list))
+
+    (infer-rec-node-type node expected-type subs env))
 
   (:method ((node parser:node-let) expected-type subs env)
     (declare (type tc:ty expected-type)
@@ -3581,6 +3904,13 @@ as a recursive function rather than a recursive value."
       (tc:apply-substitution subs body-env)
 
       (setf accessors (tc:apply-substitution subs accessors))
+      ;; Accessor disambiguation needs any substitutions implied by
+      ;; functional dependencies before the accessor source type is concrete.
+      (setf fresh-preds (tc:apply-substitution subs fresh-preds))
+      (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) fresh-preds subs)))
+      (setf preds (tc:apply-substitution subs preds))
+      (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) preds subs)))
+      (setf accessors (tc:apply-substitution subs accessors))
 
       (multiple-value-bind (accessors subs_)
           (solve-accessors accessors (tc-env-env env))
@@ -3797,6 +4127,11 @@ value-restriction and variance logic used for implicit bindings."
         (setf subs subs_)
         (tc:apply-substitution subs env)
 
+        (setf accessors (tc:apply-substitution subs accessors))
+        ;; Solve functional dependencies before accessors so field lookups can
+        ;; see types fixed by class fundeps.
+        (setf preds (tc:apply-substitution subs preds))
+        (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) preds subs)))
         (setf accessors (tc:apply-substitution subs accessors))
 
         (multiple-value-bind (accessors subs_)
@@ -4161,6 +4496,11 @@ as a recursive function rather than a recursive value."
 
         (tc:apply-substitution subs env)
 
+        (setf accessors (tc:apply-substitution subs accessors))
+        ;; Solve functional dependencies before accessors so field lookups can
+        ;; see types fixed by class fundeps.
+        (setf preds (tc:apply-substitution subs preds))
+        (setf subs (nth-value 1 (tc:solve-fundeps (tc-env-env env) preds subs)))
         (setf accessors (tc:apply-substitution subs accessors))
 
         (multiple-value-bind (accessors subs_)

--- a/tests/test-files/parse-rec.txt
+++ b/tests/test-files/parse-rec.txt
@@ -39,45 +39,48 @@
               (even? (coalton-prelude:1- m)))))))
 
 ================================================================================
-4 Parse rec with type declaration
+4 Parse rec with result type annotation
 ================================================================================
 
 (package coalton-unit-tests)
 
 (define x
-  (rec (f (UFix -> UFix)) ((n 5))
-    (if (coalton-prelude:== n 1)
-        1
-        (coalton-prelude:* n (f (coalton-prelude:1- n))))))
+  (the UFix
+    (rec f ((n 5))
+      (if (coalton-prelude:== n 1)
+          1
+          (coalton-prelude:* n (f (coalton-prelude:1- n)))))))
 
 ================================================================================
-5 Parse rec with type alias declaration
-================================================================================
-
-(package coalton-unit-tests)
-
-(define-type-alias UnaryUfixFunction (UFix -> UFix))
-
-(define x
-  (rec (f UnaryUfixFunction) ((n 5))
-    (if (coalton-prelude:== n 1)
-        1
-        (coalton-prelude:* n (f (coalton-prelude:1- n))))))
-
-================================================================================
-6 Parse rec without type declaration
+5 Parse rec with result type alias annotation
 ================================================================================
 
 (package coalton-unit-tests)
 
+(define-type-alias UFixAlias UFix)
+
 (define x
-  (rec (f) ((n 5))
+  (the UFixAlias
+    (rec f ((n 5))
+      (if (coalton-prelude:== n 1)
+          1
+          (coalton-prelude:* n (f (coalton-prelude:1- n)))))))
+
+================================================================================
+6 Parse rec with declared init bindings
+================================================================================
+
+(package coalton-unit-tests)
+
+(define x
+  (rec f ((declare n UFix)
+          (n 5))
     (if (coalton-prelude:== n 1)
         1
         (coalton-prelude:* n (f (coalton-prelude:1- n))))))
 
 ================================================================================
-7 Parse rec with unexpected empty list
+7 Parse rec with list name
 ================================================================================
 
 (package coalton-unit-tests)
@@ -91,51 +94,44 @@ error: Malformed rec
   --> test:4:7
    |
  4 |    (rec () ((n 5)) n))
-   |         ^^ unexpected empty list
+   |         ^^ expected function name
 
 ================================================================================
-8 Parse rec with dotted list
-================================================================================
-
-(package coalton-unit-tests)
-
-(define-type-alias UnaryUfixFunction (UFix -> UFix))
-
-(define x
-  (rec (f . UnaryUfixFunction) ((n 5)) n))
-
---------------------------------------------------------------------------------
-
-error: Malformed rec
-  --> test:6:12
-   |
- 6 |    (rec (f . UnaryUfixFunction) ((n 5)) n))
-   |              ^^^^^^^^^^^^^^^^^ unexpected dotted list
-
-================================================================================
-9 Parse rec with extra arguments after type declaration
+8 Parse rec with typed name
 ================================================================================
 
 (package coalton-unit-tests)
 
-(define-type-alias UnaryUfixFunction (UFix -> UFix))
-
 (define x
-  (rec (f (UFix -> UFix) g) ((n 5))
-    (if (coalton-prelude:== n 1)
-        1
-        (coalton-prelude:* n (f (coalton-prelude:1- n))))))
+  (rec (f (UFix -> UFix)) ((n 5)) n))
 
 --------------------------------------------------------------------------------
 
 error: Malformed rec
-  --> test:6:24
+  --> test:4:7
    |
- 6 |    (rec (f (UFix -> UFix) g) ((n 5))
-   |                          ^ unexpected trailing form(s)
+ 4 |    (rec (f (UFix -> UFix)) ((n 5)) n))
+   |         ^^^^^^^^^^^^^^^^^^ expected function name
 
 ================================================================================
-10 Parse rec with type declaration
+9 Parse rec with parenthesized bare name
+================================================================================
+
+(package coalton-unit-tests)
+
+(define x
+  (rec (f) ((n 5)) n))
+
+--------------------------------------------------------------------------------
+
+error: Malformed rec
+  --> test:4:7
+   |
+ 4 |    (rec (f) ((n 5)) n))
+   |         ^^^ expected function name
+
+================================================================================
+10 Parse rec with declared init bindings
 ================================================================================
 
 (package coalton-unit-tests)
@@ -187,18 +183,16 @@ error: Malformed rec
 
 (package coalton-unit-tests)
 
-(define-type-alias UnaryUfixFunction (UFix -> UFix))
-
 (define x
-  (rec (f UnaryUfixFunction) hi 0))
+  (rec f hi 0))
 
 --------------------------------------------------------------------------------
 
 error: Malformed rec
-  --> test:6:29
+  --> test:4:9
    |
- 6 |    (rec (f UnaryUfixFunction) hi 0))
-   |                               ^^ expected binding list
+ 4 |    (rec f hi 0))
+   |           ^^ expected binding list
 
 ================================================================================
 14 Parse rec wrong number of arguments
@@ -223,18 +217,16 @@ error: Malformed rec
 
 (package coalton-unit-tests)
 
-(define-type-alias UnaryUfixFunction (UFix -> UFix))
-
 (define x
-  (rec (f UnaryUfixFunction) ((x 0))))
+  (rec f ((x 0))))
 
 --------------------------------------------------------------------------------
 
 error: Malformed rec
-  --> test:6:36
+  --> test:4:16
    |
- 6 |    (rec (f UnaryUfixFunction) ((x 0))))
-   |                                      ^ expected rec body
+ 4 |    (rec f ((x 0))))
+   |                  ^ expected rec body
 
 ================================================================================
 16 Parse rec reusing a symbol

--- a/tests/test-files/struct.txt
+++ b/tests/test-files/struct.txt
@@ -181,3 +181,55 @@ error: Ambiguous accessor
    |
  8 |    (let ((g (fn (p) (.x p))))
    |                      ^^ accessor is ambiguous
+
+================================================================================
+110 rec-accessors-use-init-binding-types
+================================================================================
+
+(package coalton-unit-tests/struct)
+
+(define-struct Point
+  (x Integer)
+  (y Integer))
+
+(declare f (Point -> Integer))
+(define (f p)
+  (rec % ((x p))
+    (.x x)))
+
+--------------------------------------------------------------------------------
+
+================================================================================
+111 accessor-sees-monadenvironment-fundeps
+================================================================================
+
+(package coalton-unit-tests/struct
+  (import (coalton/monad/environment as env)))
+
+(define-struct Book
+  (title String)
+  (pages Integer))
+
+(declare book-title (env:Env Book String))
+(define book-title
+  (env:asks (fn (book) (.title book))))
+
+--------------------------------------------------------------------------------
+
+================================================================================
+112 rec-accessors-see-init-binding-declares
+================================================================================
+
+(package coalton-unit-tests/struct)
+
+(define-struct Point
+  (x Integer)
+  (y Integer))
+
+(declare f (Point -> Integer))
+(define (f p)
+  (rec % ((declare x Point)
+          (x p))
+    (.x x)))
+
+--------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes ambiguous accessor failures that occurred when accessor disambiguation ran before enough type information was available.

The underlying issue was the same in both reports:

- `rec` accessors could be checked before init-binding types had been propagated to the recursive parameters.
- Accessors in fundep-driven contexts could be checked before functional dependencies had improved the relevant types.

The fix delays accessor disambiguation until the relevant source types are actually known.

For `rec`, the typechecker now preserves the structure of the construct long enough to infer init bindings first, then type the recursive function with those parameter types in place.

For fundep-driven cases, substitutions implied by functional dependencies are applied before accessor solving, so field lookup sees the concrete type it needs.

Fix #1476

Fix #1656