### PR TITLE
Fix bug in read-sequence-completely that hung EOF

### DIFF
--- a/library/file.ct
+++ b/library/file.ct
@@ -514,9 +514,12 @@ Automatically returns the lisp condition if one is thrown."
 (cl:defun %read-sequence-completely (v s n)
   "Read N elements of the stream S into the sequence V."
   (cl:loop
-    :with begin := 0
-    :while (cl:< begin n)
-    :do (cl:incf begin (cl:read-sequence v s :start begin))
+    :with pos := 0
+    :while (cl:< pos n)
+    :do (cl:let ((new-pos (cl:read-sequence v s :start pos :end n)))
+          (cl:when (cl:= new-pos pos)
+            (cl:error 'cl:end-of-file :stream s))
+          (cl:setf pos new-pos))
     :finally (cl:return v)))
 
 (coalton-toplevel


### PR DESCRIPTION
**Ok, I ran the test script again and this did fix it for me. I just accidentally checked out main instead when I was testing. But please double check me.**

cl:read-sequence returns the new position in the sequence. This caused it to loop forever if it tried to read in an empty sequence.

Here's an example file demonstrating. On `main`, this hangs forever:

```lisp
(cl:in-package :cl-user)
(defpackage :io-file-test
  (:use
   #:coalton
   #:coalton-prelude)
  (:local-nicknames
   (:f #:coalton-library/file)))
(in-package :io-file-test)

(named-readtables:in-readtable coalton:coalton)

(coalton-toplevel
  (declare test-load-file (Void -> Unit))
  (define (test-load-file)
    (trace "Starting")
    (f:with-temp-file
      (fn (fs)
        (f:write fs (the U8 65))
        (f:set-file-position fs 0)
        (f:read-vector fs 1)
        (f:read-vector fs 1)))
    (trace "Done")
    Unit))

(coalton (test-load-file))
```