### PR TITLE
Rework do-control semantics

### DIFF
--- a/library/experimental/do-control-core.ct
+++ b/library/experimental/do-control-core.ct
@@ -49,25 +49,25 @@
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
 (coalton-toplevel
-  (define-class (Terminator :a)
-    "Represents a value that terminates a control flow."
-    (ended? (:a -> Boolean)))
+  (define-class (Truthlike :a)
+    "Represents a value that can be true/false for control flow."
+    (true? (:a -> Boolean)))
 
-  (define-instance (Terminator Boolean)
+  (define-instance (Truthlike Boolean)
     (inline)
-    (define ended? id))
+    (define true? id))
 
-  (define-instance (Terminator (Optional :a))
+  (define-instance (Truthlike (Optional :a))
     (inline)
-    (define ended? opt:none?))
+    (define true? opt:none?))
 
-  (define-instance (Terminator (Result :e :a))
+  (define-instance (Truthlike (Result :e :a))
     (inline)
-    (define ended? rst:err?))
+    (define true? rst:err?))
 
-  (define-instance (Terminator (List :a))
+  (define-instance (Truthlike (List :a))
     (inline)
-    (define ended? l:null?))
+    (define true? l:null?))
 
   (define-class (Traversable :y => Yielder :y)
     "A data type that can terminate or yield a value into control flow."
@@ -112,21 +112,20 @@
   ;;
 
   (inline)
-  (declare when_ ((Monad :m) (Terminator :t) => :t * :m :z -> :m Unit))
-  (define (when_ term? m)
-    "Run the monadic operation M when the terminator TERM? indicates completion,
-or do nothing."
-    (if (ended? term?)
+  (declare when_ ((Monad :m) (Truthlike :t) => :t * :m :z -> :m Unit))
+  (define (when_ val m)
+    "Run the monadic operation M when the value VAL is true-like. Otherwise do nothing."
+    (if (true? val)
         (do m (pure Unit))
         (pure Unit)))
 
   (inline)
-  (declare whenM ((Monad :m) (Terminator :t) => :m :t * :m :z -> :m Unit))
-  (define (whenM mterm? mop)
-    "Evaluate MTERM?, and if it indicates completion, run MOP, or do nothing."
+  (declare whenM ((Monad :m) (Truthlike :t) => :m :t * :m :z -> :m Unit))
+  (define (whenM mval mop)
+    "Evaluate MVAL, and if returns a true-like value, run MOP. Otherwise do nothing."
     (do
-     (term? <- mterm?)
-     (when_ term? mop)))
+     (val <- mval)
+     (when_ val mop)))
 
   (inline)
   (declare when-val ((Monad :m) (Yielder :y) => :y :a * (:a -> :m :z) -> :m Unit))
@@ -149,11 +148,11 @@ or do nothing."
      (when-val val? f->m)))
 
   (inline)
-  (declare if* ((Monad :m) (Terminator :t) => :t * :m :b * :m :b -> :m :b))
+  (declare if* ((Monad :m) (Truthlike :t) => :t * :m :b * :m :b -> :m :b))
   (define (if* val? m-true m-false)
-    "Choose between M-TRUE and M-FALSE based on VAL?. If (ended? VAL?) is true, run M-TRUE,
-else run M-FALSE."
-    (if (ended? val?)
+    "Choose between M-TRUE and M-FALSE based on VAL?. If VAL? is true-like, run M-TRUE,
+otherwise run M-FALSE."
+    (if (true? val?)
         m-true
         m-false))
 
@@ -214,7 +213,7 @@ over the value."
      (flatmap-success val? f->mval?b))))
 
 (cl:defmacro do-when (b cl:&body body)
-  "Run BODY (as a 'do' block) only when B indicates completion per Terminator semantics."
+  "Run BODY (as a 'do' block) only when B indicates completion per Truthlike semantics."
   `(when_ ,b
     (do
      ,@body)))

--- a/library/experimental/do-control-loops-adv.ct
+++ b/library/experimental/do-control-loops-adv.ct
@@ -6,6 +6,11 @@
   (:local-nicknames
    (:l #:coalton/list)
    (:ct #:coalton/experimental/do-control-core))
+  (:import-from #:coalton/experimental/do-control-core
+   #:Truthlike
+   #:true?
+   #:Yielder
+   #:yield)
   (:import-from #:coalton/monad/environment
    #:MonadEnvironment
    #:ask
@@ -187,32 +192,32 @@ break, or produced a value."
        ((Break%) (pure Unit))
        (_ (loop_ body)))))
 
-  (declare loop-while ((Monad :m) (ct::Terminator :t) => LoopT :m :t -> :m Unit))
+  (declare loop-while ((Monad :m) (Truthlike :t) => LoopT :m :t -> :m Unit))
   (define (loop-while body)
-    "Run BODY repeatedly until it returns a terminated value. Returns Unit."
+    "Run BODY. If it returns a true-like value, repeat. Otherwise stop."
     (do
      (r <- (unwrap-loop body))
      (match r
        ((Break%) (pure Unit))
        ((Continue%) (loop-while body))
        ((Value% t)
-        (if (ct::ended? t)
-            (pure Unit)
-            (loop-while body))))))
+        (if (true? t)
+            (loop-while body)
+            (pure Unit))))))
 
-  (declare loop-do-while ((Monad :m) (ct::Terminator :t) => :m :t * LoopT :m :a -> :m Unit))
+  (declare loop-do-while ((Monad :m) (Truthlike :t) => :m :t * LoopT :m :a -> :m Unit))
   (define (loop-do-while m-term? body)
-    "Before each iteration, evaluate M-TERM?. If it indicates completion, stop; otherwise run BODY.
-Respects break and continue within BODY. Returns Unit."
+    "Before each iteration, evaluate M-TERM?. If it returns a true-like value, run BODY.
+Otherwise, stop."
     (do
      (term? <- m-term?)
-     (if (ct::ended? term?)
-         (pure Unit)
+     (if (true? term?)
          (do
           (r <- (unwrap-loop body))
           (match r
             ((Break%) (pure Unit))
-            (_ (loop-do-while m-term? body)))))))
+            (_ (loop-do-while m-term? body))))
+         (pure Unit))))
 
   (declare loop-times (Monad :m => UFix * (UFix -> LoopT :m :a) -> :m Unit))
   (define (loop-times n body)
@@ -241,7 +246,7 @@ Stops when BODY breaks. Continues skip the rest of the iteration. Returns the co
          ((Value% val)
           (% (Cons val result)))))))
 
-  (declare collect-val ((Monad :m) (ct::Yielder :y) => LoopT :m (:y :a) -> :m (List :a)))
+  (declare collect-val ((Monad :m) (Yielder :y) => LoopT :m (:y :a) -> :m (List :a)))
   (define (collect-val body)
     "Run BODY in a loop, adding each available value it yields to a list.
 Stops when BODY yields no value or breaks. Continue skips the rest of the iteration.
@@ -253,7 +258,7 @@ Returns the collected list."
          ((Break%) (pure (l:reverse result)))
          ((Continue%) (% result))
          ((Value% val?)
-          (match (ct::yield val?)
+          (match (yield val?)
             ((Some x)
              (% (Cons x result)))
             ((None)

--- a/library/experimental/do-control-loops.ct
+++ b/library/experimental/do-control-loops.ct
@@ -6,8 +6,8 @@
    (:l #:coalton/list)
    (:it #:coalton/iterator))
   (:import-from #:coalton/experimental/do-control-core
-   #:Terminator
-   #:ended?
+   #:Truthlike
+   #:true?
    #:Yielder
    #:yield)
   (:export
@@ -33,14 +33,14 @@
 (cl:declaim #.coalton-impl/settings:*coalton-optimize-library*)
 
 (coalton-toplevel
-  (declare loop-while ((Monad :m) (Terminator :t) => :m :t -> :m Unit))
+  (declare loop-while ((Monad :m) (Truthlike :t) => :m :t -> :m Unit))
   (define (loop-while m-operation)
-    "Repeat M-OPERATION until it returns a terminated value. Returns Unit."
+    "Run M-OPERATION. If it returns a true-like value, repeat. Otherwise stop."
     (do
      (res <- m-operation)
-     (if (ended? res)
-         (pure Unit)
-         (loop-while m-operation))))
+     (if (true? res)
+         (loop-while m-operation)
+         (pure Unit))))
 
   (declare loop-while-valM ((Monad :m) (Yielder :y) => :m (:y :a) * (:a -> :m :b) -> :m Unit))
   (define (loop-while-valM m-operation f)
@@ -56,17 +56,17 @@ Returns Unit."
        ((None)
         (pure Unit)))))
 
-  (declare loop-do-while ((Monad :m) (Terminator :t) => :m :t * :m :a -> :m Unit))
+  (declare loop-do-while ((Monad :m) (Truthlike :t) => :m :t * :m :a -> :m Unit))
   (define (loop-do-while m-term? body)
-    "Before each iteration, evaluate M-TERM?. If it indicates completion, stop; otherwise run BODY.
-Returns Unit."
+    "Before each iteration, evaluate M-TERM?. If it returns a true-like value, run BODY.
+Otherwise, stop."
     (do
      (term? <- m-term?)
-     (if (ended? term?)
-         (pure Unit)
+     (if (true? term?)
          (do
           body
-          (loop-do-while m-term? body)))))
+          (loop-do-while m-term? body))
+         (pure Unit))))
 
   (declare loop-times (Monad :m => UFix * (UFix -> :m :a) -> :m Unit))
   (define (loop-times n m-operation)


### PR DESCRIPTION
Addresses #1742

The old `Terminator` class was over-indexed on my initial use case for the loops module, which was looping through lists inside `do` blocks. The scope has expanded a lot beyond that, so I've replaced `Terminator` with a much more natural `Truthlike` abstraction instead. The intuition is the same: Booleans are true if they're true, collections are true if they're non-empty, and types like Option/Result are true if they represent a successful value.

Here's a little example file (excuse the boilerplate free monad stuff. I have some ideas planned for streamlining that a bit):

```lisp
  (declare less? (Integer -> App Boolean))
  (define (less? target)
    (do
     (x <- get)
     (pure (< x target))))

  (declare prompt-add (App Unit))
  (define prompt-add
    (do
     (write-line "Enter a number to add:")
     (input <- read-line)
     (match (parse-int input)
       ((Some x)
        (modify (fn (state) (+ state x))))
       ((None)
        (write-line "Invalid number.")))))

  (declare print-app (App Unit))
  (define print-app
    (do
     (x <- get)
     (write-line (show-as-string x))))
     
 (run-app!
  (l:do-loop-do-while (less? 100)
   prompt-add
   (write "Current value: ")
   print-app)))
```

Full file with boilerplate:

```lisp
(cl:in-package :cl-user)
(defpackage :test
  (:use
   #:coalton
   #:coalton-prelude
   #:coalton/experimental/do-control-core
   #:coalton/monad/statet
   )
  (:import-from #:coalton/string
    #:parse-int)
  (:local-nicknames
   (:f #:coalton/monad/free)
   (:ft #:coalton-library/monad/freet)
   (:l #:coalton/experimental/do-control-loops)
   ))

(in-package :test)

(coalton-toplevel
  (define-class (Monad :m => MonadIoTerm :m)
    (write (Into :a String => :a -> :m Unit))
    (write-line (Into :a String => :a -> :m Unit))
    (read-line (:m String))
    ))

(cl:defmacro derive-monad-io-term (monadT-form)
  "Automatically derive an instance of MonadIoTerm for a monad transformer.

Example:
  (derive-monad-io-term (st:StateT :s :m))"
  `(define-instance (MonadIoTerm :m => MonadIoTerm ,monadT-form)
     (define write (compose lift write))
     (define write-line (compose lift write-line))
     (define read-line (lift read-line))
     ))

(coalton-toplevel
  (derive-monad-io-term (StateT :s :m)))

;;
;; IO Implementation
;;

(coalton-toplevel
  (define-type (IOF :t)
    (WriteF String :t)
    (WriteLineF String :t)
    (ReadLineF (String -> :t))
    )

  (define-instance (Functor IOF)
    (define (map f io)
      (match io
        ((WriteF s next) (WriteF s (f next)))
        ((WriteLineF s next) (WriteLineF s (f next)))
        ((ReadLineF cont) (ReadLineF (fn (x)
                                       (f (cont x)))))
        )))

  (define-type-alias IO (f:Free IOF))

  (define-instance (MonadIoTerm IO)
    (inline)
    (define (write s)
      (f:liftf (WriteF (into s) Unit)))
    (inline)
    (define (write-line s)
      (f:liftf (WriteLineF (into s) Unit)))
    (inline)
    (define read-line
      (f:liftf (ReadLineF id)))
    ))

(coalton-toplevel
  (declare run! (IO :t -> :t))
  (define (run! op)
    (f:run-free
     (fn (iof)
       (match iof
         ((WriteF s next)
          (lisp (-> :a) (s)
            (cl:format cl:t "~a" s))
          next)
         ((WriteLineF s next)
          (lisp (-> :a) (s)
            (cl:format cl:t "~a~%" s))
          next)
         ((ReadLineF cont)
          (let input = (lisp (-> String) ()
                         (cl:read-line)))
          (cont input))))
     op)))

(coalton-toplevel

  (define-type-alias App (StateT Integer IO))

  (define (run-app! app)
    (run! (run-stateT_ app 0)))

  (declare less? (Integer -> App Boolean))
  (define (less? target)
    (do
     (x <- get)
     (pure (< x target))))

  (declare prompt-add (App Unit))
  (define prompt-add
    (do
     (write-line "Enter a number to add:")
     (input <- read-line)
     (match (parse-int input)
       ((Some x)
        (modify (fn (state) (+ state x))))
       ((None)
        (write-line "Invalid number.")))))

  (declare print-app (App Unit))
  (define print-app
    (do
     (x <- get)
     (write-line (show-as-string x))))
     
  )

(coalton
 (run-app!
  (l:do-loop-do-while (less? 100)
   prompt-add
   (write "Current value: ")
   print-app)))
```