### PR TITLE
Fix Functor Arrow instance matching

### DIFF
--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -33,6 +33,20 @@
            (values (or null keyword-ty-entry) &optional))
   (find keyword entries :key #'keyword-ty-entry-keyword :test #'eq))
 
+(defun unary-function-type-as-arrow-type (type)
+  "Return TYPE as a fully applied `Arrow` type when that encoding exists."
+  (declare (type function-ty type)
+           (values (or null tapp) &optional))
+  (when (and (= 1 (length (function-ty-positional-input-types type)))
+             (= 1 (length (function-ty-output-types type)))
+             (null (function-ty-keyword-input-types type))
+             (not (function-ty-keyword-open-p type)))
+    (make-tapp
+     :from (make-tapp
+            :from *arrow-type*
+            :to (first (function-ty-positional-input-types type)))
+     :to (output-types-result-type (function-ty-output-types type)))))
+
 (defun ensure-compatible-function-types (type1 type2 condition)
   "Verify that two function types have compatible structure for unification.
 
@@ -191,6 +205,16 @@ to the zero-result type."
            (s2 (mgu (apply-substitution s1 (tapp-to type1))
                     (apply-substitution s1 (tapp-to type2)))))
       (compose-substitution-lists s2 s1)))
+  (:method ((type1 tapp) (type2 function-ty))
+    (let ((arrow-type2 (unary-function-type-as-arrow-type type2)))
+      (if arrow-type2
+          (mgu type1 arrow-type2)
+          (error 'unification-error :type1 type1 :type2 type2))))
+  (:method ((type1 function-ty) (type2 tapp))
+    (let ((arrow-type1 (unary-function-type-as-arrow-type type1)))
+      (if arrow-type1
+          (mgu arrow-type1 type2)
+          (error 'unification-error :type1 type1 :type2 type2))))
   (:method ((type1 function-ty) (type2 function-ty))
     (ensure-compatible-function-types type1 type2 'unification-error)
     (mgu-keyword-function-types type1 type2))
@@ -230,6 +254,16 @@ apply s type1 == type2")
     (let ((s1 (match (tapp-from type1) (tapp-from type2)))
           (s2 (match (tapp-to type1) (tapp-to type2))))
       (merge-substitution-lists s1 s2)))
+  (:method ((type1 tapp) (type2 function-ty))
+    (let ((arrow-type2 (unary-function-type-as-arrow-type type2)))
+      (if arrow-type2
+          (match type1 arrow-type2)
+          (error 'unification-error :type1 type1 :type2 type2))))
+  (:method ((type1 function-ty) (type2 tapp))
+    (let ((arrow-type1 (unary-function-type-as-arrow-type type1)))
+      (if arrow-type1
+          (match arrow-type1 type2)
+          (error 'unification-error :type1 type1 :type2 type2))))
   (:method ((type1 function-ty) (type2 function-ty))
     (ensure-compatible-function-types type1 type2 'unification-error)
     (match-keyword-function-types type1 type2))

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -698,6 +698,14 @@
     (declare test-bare-testtype (TestType -> TestType))
     (define test-bare-testtype test-bare)")
 
+  (check-coalton-types
+   "(declare lifted (Integer -> Integer))
+    (define lifted
+      (map (fn (x) (+ x 1))
+           (fn (x) x)))"
+
+   '("lifted" . "(Integer -> Integer)"))
+
   ;; Check that it works with functional dependencies
   (check-coalton-types
    "(define-type (Box :a)

--- a/tests/typechecker/lisp-type-tests.lisp
+++ b/tests/typechecker/lisp-type-tests.lisp
@@ -229,6 +229,92 @@
     (is (coalton-impl/typechecker:ty= left right))
     (is (= 1 (length (coalton-impl/typechecker:ty-scheme-kinds scheme))))))
 
+(deftest test-unary-function-types-match-arrow-applications ()
+  (let* ((functor-var (coalton-impl/typechecker:make-tyvar
+                       :id 1000
+                       :kind (coalton-impl/typechecker:make-kfun
+                              :from coalton-impl/typechecker:+kstar+
+                              :to coalton-impl/typechecker:+kstar+)
+                       :source-name :f))
+         (result-var (coalton-impl/typechecker:make-tyvar
+                      :id 1001
+                      :kind coalton-impl/typechecker:+kstar+
+                      :source-name :result))
+         (expected
+           (nth-value 0
+             (coalton-impl/typechecker:apply-type-argument functor-var result-var)))
+         (actual
+           (coalton-impl/typechecker:make-function-type
+            coalton-impl/typechecker:*integer-type*
+            coalton-impl/typechecker:*boolean-type*))
+         (subs (coalton-impl/typechecker:match expected actual))
+         (arrow-partial
+           (nth-value 0
+             (coalton-impl/typechecker:apply-type-argument
+              coalton-impl/typechecker:*arrow-type*
+              coalton-impl/typechecker:*integer-type*))))
+    (is (coalton-impl/typechecker:ty=
+         (coalton-impl/typechecker:apply-substitution subs functor-var)
+         arrow-partial))
+    (is (coalton-impl/typechecker:ty=
+         (coalton-impl/typechecker:apply-substitution subs result-var)
+         coalton-impl/typechecker:*boolean-type*))))
+
+(deftest test-arrow-matching-rejects-zero-output-functions ()
+  (let* ((functor-var (coalton-impl/typechecker:make-tyvar
+                       :id 1002
+                       :kind (coalton-impl/typechecker:make-kfun
+                              :from coalton-impl/typechecker:+kstar+
+                              :to coalton-impl/typechecker:+kstar+)
+                       :source-name :f))
+         (result-var (coalton-impl/typechecker:make-tyvar
+                      :id 1003
+                      :kind coalton-impl/typechecker:+kstar+
+                      :source-name :result))
+         (expected
+           (nth-value 0
+             (coalton-impl/typechecker:apply-type-argument functor-var result-var)))
+         (actual
+           (coalton-impl/typechecker:make-function-ty
+            :positional-input-types (list coalton-impl/typechecker:*integer-type*)
+            :keyword-input-types nil
+            :keyword-open-p nil
+            :output-types nil)))
+    (handler-case
+        (progn
+          (coalton-impl/typechecker:match expected actual)
+          (is nil))
+      (coalton-impl/typechecker/type-errors:unification-error ()
+        (is t)))))
+
+(deftest test-arrow-matching-rejects-multi-output-functions ()
+  (let* ((functor-var (coalton-impl/typechecker:make-tyvar
+                       :id 1004
+                       :kind (coalton-impl/typechecker:make-kfun
+                              :from coalton-impl/typechecker:+kstar+
+                              :to coalton-impl/typechecker:+kstar+)
+                       :source-name :f))
+         (result-var (coalton-impl/typechecker:make-tyvar
+                      :id 1005
+                      :kind coalton-impl/typechecker:+kstar+
+                      :source-name :result))
+         (expected
+           (nth-value 0
+             (coalton-impl/typechecker:apply-type-argument functor-var result-var)))
+         (actual
+           (coalton-impl/typechecker:make-function-ty
+            :positional-input-types (list coalton-impl/typechecker:*integer-type*)
+            :keyword-input-types nil
+            :keyword-open-p nil
+            :output-types (list coalton-impl/typechecker:*boolean-type*
+                                coalton-impl/typechecker:*string-type*))))
+    (handler-case
+        (progn
+          (coalton-impl/typechecker:match expected actual)
+          (is nil))
+      (coalton-impl/typechecker/type-errors:unification-error ()
+        (is t)))))
+
 (deftest test-scoped-forall-dictionary-resolution ()
   (is (coalton:lookup-code 'coalton-native-tests::explicit-rec-eq-integer))
   (is (coalton:lookup-code 'coalton-native-tests::scoped-dict-method-integer)))


### PR DESCRIPTION
Recent fixed-arity function work introduced a separate `function-ty` representation for functions, but class and instance matching still saw partially applied constructors like `(:f :a)` as `tapp` forms. That broke the bridge to `Arrow` for unary functions, so uses of `Functor (Arrow :a)` started failing at type inference.

Teach unification and matching to treat unary, keyword-free `function-ty` values as fully applied `Arrow` types when needed.

fix #1855 