### PR TITLE
separate result packs from value variables

### DIFF
--- a/examples/small-coalton-programs/src/brainfold.ct
+++ b/examples/small-coalton-programs/src/brainfold.ct
@@ -172,9 +172,9 @@
     "Takes and stores a character as an ascii code at the pointer."
     (do
      (bfs <- state:get)
-     (pure (vec:set! (cell:read (.pointer bfs))
-                     (into (char:char-code (prompt-char)))
-                     (.memory bfs)))
+     (let _ = (vec:set! (cell:read (.pointer bfs))
+                        (into (char:char-code (prompt-char)))
+                        (.memory bfs)))
       (state:put bfs))))
 
 ;;;

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -123,7 +123,7 @@
     (multiple-value-bind (ty preds accessors node subs)
         (tc:infer-expression-type (tc:resolve-control-flow
                                    (parser:rename-variables node))
-                                  (tc:make-variable)
+                                  (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                                   nil
                                   (tc:make-tc-env :env env))
 

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -539,10 +539,13 @@
   (cond
     ((eq node *direct-values-node*)
      (values t *direct-values-output-types*))
-    ((zero-result-type-p expected-type)
-     (values t nil))
     (t
-     (values nil nil))))
+     ;; Preserve the surrounding expression's full output context when
+     ;; resolving an unknown callee type.  This allows local recursive
+     ;; functions and other tyvar-valued operators to retain Void and
+     ;; multi-value returns instead of collapsing back to an ordinary
+     ;; single-value placeholder.
+     (values t (tc:multiple-value-output-types expected-type)))))
 
 (defun function-keyword-entry (type keyword)
   (declare (type tc:function-ty type)
@@ -738,6 +741,7 @@ function type matching the call site shape and unify it with the operator."
            (values tc:function-ty tc:substitution-list &optional))
   (multiple-value-bind (has-output-context-p output-types)
       (direct-call-output-context node (tc:apply-substitution subs expected-type))
+    (declare (ignore has-output-context-p))
     (let* ((new-froms (loop :repeat (length positional-rands)
                             :collect (tc:make-variable)))
            (new-keywords (loop :for arg :in keyword-rands
@@ -752,15 +756,11 @@ function type matching the call site shape and unify it with the operator."
            ;; function-value coercion can accept callee values carrying
            ;; additional optional keywords without requiring exact match.
            (keyword-open-p (consp keyword-rands))
-           (new-to (and (not has-output-context-p)
-                        (tc:make-variable)))
            (new-ty (tc:make-function-ty
                     :positional-input-types new-froms
                     :keyword-input-types (normalize-keyword-entries new-keywords)
                     :keyword-open-p keyword-open-p
-                    :output-types (if has-output-context-p
-                                      output-types
-                                      (list new-to)))))
+                    :output-types output-types)))
       (setf subs (tc:unify subs fun-ty new-ty))
       (values (tc:apply-substitution subs new-ty) subs))))
 
@@ -1072,7 +1072,7 @@ Returns four values:
            (values tc:ty-scheme tc:substitution-list &optional))
   (multiple-value-bind (ty preds accessors _ subs)
       (infer-expression-type node
-                             (tc:make-variable)
+                             (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                              subs
                              env)
     (declare (ignore _))
@@ -1595,7 +1595,7 @@ lowered back to the ordinary nested-let representation and inferred there."
              (loop :for (_arg arg-ty _preds) :in arg-info
                    :collect (tc:apply-substitution subs arg-ty)))
            (result-type
-             (tc:make-variable))
+             (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
            (rec-function-type
              (tc:make-function-type* param-types result-type))
            (rec-name
@@ -1992,7 +1992,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-bind-expr node)
-                               (tc:make-variable)
+                               (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                                subs
                                env)
 
@@ -2096,7 +2096,10 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
            (body-nodes
              (loop :for node_ :in (parser:node-body-nodes node)
                    :collect (multiple-value-bind (node_ty_ preds_ accessors_ node_ subs_)
-                                (infer-expression-type node_ (tc:make-variable) subs env)
+                                (infer-expression-type node_
+                                                       (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
+                                                       subs
+                                                       env)
                               (declare (ignore node_ty_))
                               (setf subs subs_)
                               (setf preds (append preds preds_))
@@ -2141,7 +2144,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
       (let* ((body-return-block
                (body-return-block-node (parser:node-abstraction-body node)))
-             (body-result-ty (tc:make-variable))
+             (body-result-ty (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
              (*return-blocks*
                (if body-return-block
                    (acons (parser:node-block-name body-return-block)
@@ -2333,9 +2336,17 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
     (let ((declared-ty
             (tc:output-types-result-type
-             (mapcar (lambda (output-type)
-                       (parse-type output-type (tc-env-parser-env env)))
-                     (parser:node-lisp-output-types node)))))
+             (let ((output-types (parser:node-lisp-output-types node)))
+               (cond
+                 ((null output-types)
+                  nil)
+                 ((null (cdr output-types))
+                  (list (parse-output-slot-type (first output-types)
+                                                (tc-env-parser-env env))))
+                 (t
+                  (mapcar (lambda (output-type)
+                            (parse-type output-type (tc-env-parser-env env)))
+                          output-types)))))))
 
       (handler-case
           (progn
@@ -2388,7 +2399,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                 (setf subs subs_)
                                 pat-node)))
 
-             (ret-ty (tc:make-variable))
+             (ret-ty (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
 
              ;; Infer the type of each branch, unifying against ret-ty
              (branch-body-nodes
@@ -2633,7 +2644,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              (type tc-env env)
              (values tc:ty tc:ty-predicate-list accessor-list node-block tc:substitution-list))
 
-    (let* ((block-type (tc:make-variable))
+    (let* ((block-type (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
            (block-info (make-return-block-info :type block-type)))
       (multiple-value-bind (body-ty preds accessors body-node subs)
           (let ((*return-blocks*
@@ -2691,7 +2702,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
         (multiple-value-bind (expr-ty preds accessors expr-node subs)
             (infer-expression-type (parser:node-the-expr node)
-                                   (tc:make-variable)
+                                   (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                                    subs
                                    expr-env)
 
@@ -2796,7 +2807,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
     (let ((block-info (return-block-info (parser:node-return-from-name node))))
       (multiple-value-bind (expr-ty preds accessors expr-node subs)
           (infer-expression-type (parser:node-return-from-expr node)
-                                 (tc:make-variable)
+                                 (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                                  subs
                                  env)
         (let ((first-return (return-block-info-first-return block-info)))
@@ -3026,7 +3037,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
       (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
           (infer-expression-type (parser:node-when-body node)
-                                 (tc:make-variable)
+                                 (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                                  subs
                                  env)
         (declare (ignore body-ty))
@@ -3065,7 +3076,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
       (multiple-value-bind (body-ty preds_ accessors_ body-node subs)
           (infer-expression-type (parser:node-unless-body node)
-                                 (tc:make-variable)
+                                 (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                                  subs
                                  env)
         (declare (ignore body-ty))
@@ -3210,7 +3221,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
               (multiple-value-bind (result-ty preds_ accessors_ returns-node subs)
                   (if (parser:node-for-returns node)
                       (infer-expression-type (parser:node-for-returns node)
-                                             (tc:make-variable)
+                                             (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
                                              subs
                                              loop-env)
                       (values (zero-result-type) nil nil nil subs))
@@ -3362,7 +3373,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
     (let* ((preds nil)
            (accessors nil)
 
-           (ret-ty (tc:make-variable))
+           (ret-ty (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
 
            (clause-nodes
              (loop :for clause :in (parser:node-cond-clauses node)
@@ -3437,7 +3448,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              (values tc:ty tc:ty-predicate-list accessor-list node-do tc:substitution-list))
 
     (let* (;; m-type is the type of the monad and has kind "* -> *"
-           (m-type (tc:make-variable (tc:make-kfun :from tc:+kstar+ :to tc:+kstar+)))
+           (m-type (tc:make-variable :kind (tc:make-kfun :from tc:+kstar+ :to tc:+kstar+)))
 
            (monad-symbol (util:find-symbol "MONAD" "COALTON/CLASSES"))
 
@@ -4856,7 +4867,10 @@ as a recursive function rather than a recursive value."
                                             :type (tc:qualify nil annotated-ty)))
                     annotated-ty)
                    (t
-                    (tc-env-add-variable env name))))))
+                    (tc-env-add-variable env
+                                         name
+                                         :allow-result-p
+                                         (typep binding 'parser:toplevel-define)))))))
 
       (let* (;; track variables bound before typechecking
              (bound-variables (tc-env-bound-variables env))

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -21,6 +21,7 @@
   (:export
    #:apply-type-alias-substitutions     ; FUNCTION
    #:parse-type                         ; FUNCTION
+   #:parse-output-slot-type             ; FUNCTION
    #:parse-qualified-type               ; FUNCTION
    #:parse-qualified-type-info          ; FUNCTION
    #:parse-ty-scheme                    ; FUNCTION
@@ -46,35 +47,110 @@
 ;;; Entrypoints
 ;;;
 
+(defun compute-result-capable-type-variables (type &optional (root-output-slot-p nil))
+  "Return the set of type variables that denote whole function-output slots.
+
+These binders may unify with result packs (Void or multiple values).
+Any occurrence in an ordinary value position cancels that privilege."
+  (declare (type (or parser:ty parser:qualified-ty) type)
+           (type boolean root-output-slot-p)
+           (values hash-table &optional))
+  (let ((result-capable (make-hash-table :test #'eq))
+        (ordinary (make-hash-table :test #'eq)))
+    (labels ((mark (table name)
+               (setf (gethash name table) t))
+             (walk (type output-slot-p)
+               (typecase type
+                 (parser:tyvar
+                  (if output-slot-p
+                      (mark result-capable (parser:tyvar-name type))
+                      (mark ordinary (parser:tyvar-name type))))
+                 (parser:tycon
+                  nil)
+                 (parser:tapp
+                  (walk (parser:tapp-from type) nil)
+                  (walk (parser:tapp-to type) nil))
+                 (parser:keyword-ty-entry
+                  (walk (parser:keyword-ty-entry-type type) nil))
+                 (parser:function-ty
+                  (map nil (lambda (input)
+                             (walk input nil))
+                       (parser:function-ty-positional-input-types type))
+                  (map nil (lambda (entry)
+                             (walk entry nil))
+                       (parser:function-ty-keyword-input-types type))
+                  (let ((outputs (parser:function-ty-output-types type)))
+                    (cond
+                      ((null outputs)
+                       nil)
+                      ;; A single output slot may itself be result-polymorphic.
+                      ;; Components of an explicit output pack are ordinary
+                      ;; value types, not result-pack binders.
+                      ((and (null (cdr outputs))
+                            (not (typep (first outputs) 'parser:result-ty)))
+                       (walk (first outputs) t))
+                      (t
+                       (map nil (lambda (output)
+                                  (walk output nil))
+                            outputs)))))
+                 (parser:result-ty
+                  (map nil (lambda (output)
+                             (walk output nil))
+                       (parser:result-ty-output-types type)))
+                 (parser:qualified-ty
+                  (map nil (lambda (pred)
+                             (walk pred nil))
+                       (parser:qualified-ty-predicates type))
+                  (walk (parser:qualified-ty-type type) nil))
+                 (parser:ty-predicate
+                  (map nil (lambda (pred-type)
+                             (walk pred-type nil))
+                       (parser:ty-predicate-types type)))
+                 (list
+                  (map nil (lambda (elt)
+                             (walk elt nil))
+                       type)))))
+      (walk type root-output-slot-p)
+      (maphash (lambda (name _value)
+                 (declare (ignore _value))
+                 (when (gethash name ordinary)
+                   (remhash name result-capable)))
+               result-capable)
+      result-capable)))
+
 (defun seed-qualified-type-variables (unparsed-ty partial-env)
   (declare (type parser:qualified-ty unparsed-ty)
            (type partial-type-env partial-env)
            (values tc:tyvar-list boolean &optional))
-  (cond
-    ((parser:qualified-ty-explicit-p unparsed-ty)
-     (let ((explicit-vars (parser:qualified-ty-explicit-variables unparsed-ty)))
-       (check-duplicates
-        explicit-vars
-        #'parser:keyword-src-name
-        (lambda (first second)
-          (tc-error "Duplicate quantified type variable"
-                    (tc-note first "first binding here")
-                    (tc-note second "second binding here"))))
-       (values
-        (loop :for tvar :in explicit-vars
-              :collect (partial-type-env-add-var partial-env
-                                                 (parser:keyword-src-name tvar)
-                                                 (or (parser:keyword-src-source-name tvar)
-                                                     (parser:keyword-src-name tvar))))
-        t)))
-    (t
-     (loop :for tvar :in (parser:collect-type-variables unparsed-ty)
-           :for tvar-name := (parser:tyvar-name tvar)
-           :do (partial-type-env-ensure-var partial-env
-                                            tvar-name
-                                            (or (parser:tyvar-source-name tvar)
-                                                tvar-name)))
-     (values nil nil))))
+  (let ((result-capable-vars (compute-result-capable-type-variables unparsed-ty)))
+    (cond
+      ((parser:qualified-ty-explicit-p unparsed-ty)
+       (let ((explicit-vars (parser:qualified-ty-explicit-variables unparsed-ty)))
+         (check-duplicates
+          explicit-vars
+          #'parser:keyword-src-name
+          (lambda (first second)
+            (tc-error "Duplicate quantified type variable"
+                      (tc-note first "first binding here")
+                      (tc-note second "second binding here"))))
+         (values
+          (loop :for tvar :in explicit-vars
+                :for name := (parser:keyword-src-name tvar)
+                :collect (partial-type-env-add-var partial-env
+                                                   name
+                                                   (or (parser:keyword-src-source-name tvar)
+                                                       name)
+                                                   (gethash name result-capable-vars)))
+          t)))
+      (t
+       (loop :for tvar :in (parser:collect-type-variables unparsed-ty)
+             :for tvar-name := (parser:tyvar-name tvar)
+             :do (partial-type-env-ensure-var partial-env
+                                              tvar-name
+                                              (or (parser:tyvar-source-name tvar)
+                                                  tvar-name)
+                                              (gethash tvar-name result-capable-vars)))
+       (values nil nil)))))
 
 (defun parse-qualified-type-internal (unparsed-ty env)
   (declare (type parser:qualified-ty unparsed-ty)
@@ -267,14 +343,51 @@
 
   (let ((partial-env (if (typep env 'tc:environment)
                          (make-partial-type-env :env env)
-                         env)))
+                         env))
+        (result-capable-vars (compute-result-capable-type-variables parser-ty)))
 
     (loop :for tvar :in (parser:collect-type-variables parser-ty)
           :for tvar-name := (parser:tyvar-name tvar)
           :do (partial-type-env-ensure-var partial-env
                                            tvar-name
                                            (or (parser:tyvar-source-name tvar)
-                                               tvar-name)))
+                                               tvar-name)
+                                           (gethash tvar-name result-capable-vars)))
+
+    (multiple-value-bind (ty ksubs)
+        (infer-type-kinds parser-ty
+                          kind
+                          ksubs
+                          partial-env)
+
+      (setf ty (tc:apply-ksubstitution ksubs ty))
+      (setf ksubs (tc:kind-monomorphize-subs (tc:kind-variables ty) ksubs))
+      (setf ty (tc:apply-ksubstitution ksubs ty))
+      (setf ty (apply-type-alias-substitutions ty parser-ty partial-env))
+      (values ty ksubs))))
+
+(defun parse-output-slot-type (parser-ty env &optional ksubs (kind tc:+kstar+))
+  "Parse PARSER-TY as a whole function/lisp output slot.
+
+Unlike PARSE-TYPE, a bare type variable here may denote a result pack
+(for example `(lisp (-> :a) ...)` in a Void context)."
+  (declare (type parser:ty parser-ty)
+           (type (or tc:environment partial-type-env) env)
+           (type tc:ksubstitution-list ksubs)
+           (type tc:kind kind)
+           (values tc:ty tc:ksubstitution-list &optional))
+  (let ((partial-env (if (typep env 'tc:environment)
+                         (make-partial-type-env :env env)
+                         env))
+        (result-capable-vars (compute-result-capable-type-variables parser-ty t)))
+
+    (loop :for tvar :in (parser:collect-type-variables parser-ty)
+          :for tvar-name := (parser:tyvar-name tvar)
+          :do (partial-type-env-ensure-var partial-env
+                                           tvar-name
+                                           (or (parser:tyvar-source-name tvar)
+                                               tvar-name)
+                                           (gethash tvar-name result-capable-vars)))
 
     (multiple-value-bind (ty ksubs)
         (infer-type-kinds parser-ty
@@ -525,6 +638,16 @@ the substitution :b +-> T can be inferred.
 
         (multiple-value-bind (arg-ty ksubs)
             (infer-type-kinds (parser:tapp-to type) arg-kind ksubs env)
+
+          (when (typep fun-ty 'tc:result-ty)
+            (tc-error "Malformed type"
+                      (tc-note (parser:tapp-from type)
+                               "Void and multi-value types cannot be applied as ordinary types")))
+
+          (when (typep arg-ty 'tc:result-ty)
+            (tc-error "Malformed type"
+                      (tc-note (parser:tapp-to type)
+                               "Void and multi-value types cannot be used as type arguments")))
 
           (handler-case
               (progn

--- a/src/typechecker/partial-type-env.lisp
+++ b/src/typechecker/partial-type-env.lisp
@@ -35,7 +35,7 @@
   (ty-table    (make-hash-table :test #'eq) :type hash-table     :read-only t)
   (class-table (make-hash-table :test #'eq) :type hash-table     :read-only t))
 
-(defun partial-type-env-add-var (env var &optional (source-name var))
+(defun partial-type-env-add-var (env var &optional (source-name var) (allow-result-p nil))
   "Add a fresh type variable binding for VAR to ENV.
 
 SOURCE-NAME preserves the programmer-written binder name for later
@@ -45,9 +45,11 @@ type variable and overwrites any existing binding for VAR."
            (type symbol var)
            (values tc:tyvar))
   (setf (gethash var (partial-type-env-ty-table env))
-        (tc:make-variable (tc:make-kvariable) source-name)))
+        (tc:make-variable :kind (tc:make-kvariable)
+                          :source-name source-name
+                          :allow-result-p allow-result-p)))
 
-(defun partial-type-env-ensure-var (env var &optional (source-name var))
+(defun partial-type-env-ensure-var (env var &optional (source-name var) (allow-result-p nil))
   "Return the existing type variable for VAR in ENV, or create one.
 
 SOURCE-NAME is only used when a new variable must be created. This is
@@ -57,7 +59,7 @@ binder share a single type variable."
            (type symbol var)
            (values tc:tyvar))
   (or (gethash var (partial-type-env-ty-table env))
-      (partial-type-env-add-var env var source-name)))
+      (partial-type-env-add-var env var source-name allow-result-p)))
 
 (defun partial-type-env-lookup-var (env var source)
   (declare (type partial-type-env env)

--- a/src/typechecker/scheme.lisp
+++ b/src/typechecker/scheme.lisp
@@ -218,6 +218,7 @@ programmer-written binders."
                       :collect (make-substitution
                                 :from var
                                 :to (make-tgen :id id
+                                               :allow-result-p (tyvar-allow-result-p var)
                                                :source-name (tyvar-source-name var))))))
     (make-ty-scheme
      :explicit-p nil
@@ -233,6 +234,8 @@ and pretty printing can recover the programmer-written binders."
            (values tyvar-list &optional))
   (let* ((source-names (make-array (length (ty-scheme-kinds ty-scheme))
                                    :initial-element nil))
+         (allow-result-flags (make-array (length (ty-scheme-kinds ty-scheme))
+                                         :initial-element nil))
          (scheme-type (ty-scheme-type ty-scheme)))
     (labels ((collect-instantiation-metadata (object)
                (typecase object
@@ -240,7 +243,10 @@ and pretty printing can recover the programmer-written binders."
                   (when (< (tgen-id object) (length source-names))
                     (setf (aref source-names (tgen-id object))
                           (or (aref source-names (tgen-id object))
-                              (tgen-source-name object)))))
+                              (tgen-source-name object)))
+                    (setf (aref allow-result-flags (tgen-id object))
+                          (or (aref allow-result-flags (tgen-id object))
+                              (tgen-allow-result-p object)))))
                  (tapp
                   (collect-instantiation-metadata (tapp-from object))
                   (collect-instantiation-metadata (tapp-to object)))
@@ -262,8 +268,9 @@ and pretty printing can recover the programmer-written binders."
       (collect-instantiation-metadata scheme-type)
       (loop :for kind :in (ty-scheme-kinds ty-scheme)
             :for i :from 0
-            :collect (make-variable kind
-                                    (aref source-names i))))))
+            :collect (make-variable :kind kind
+                                    :source-name (aref source-names i)
+                                    :allow-result-p (aref allow-result-flags i))))))
 
 (defgeneric to-scheme (ty)
   (:method ((ty qualified-ty))
@@ -320,6 +327,7 @@ become lexically scoped."
                       :collect (make-substitution
                                 :from var
                                 :to (make-tgen :id id
+                                               :allow-result-p (tyvar-allow-result-p var)
                                                :source-name (tyvar-source-name var))))))
     (make-ty-scheme
      :explicit-p explicit-p

--- a/src/typechecker/tc-env.lisp
+++ b/src/typechecker/tc-env.lisp
@@ -91,7 +91,7 @@ type variables instead of re-instantiating the declared scheme."
                  :ty-table ty-table
                  :typevar-table (tc-env-typevar-table env))))
 
-(defun tc-env-add-variable (env name)
+(defun tc-env-add-variable (env name &key (allow-result-p nil))
   "Add a variable named NAME to ENV and return the scheme."
   (declare (type tc-env env)
            (type symbol name)
@@ -100,7 +100,11 @@ type variables instead of re-instantiating the declared scheme."
   (when (gethash name (tc-env-ty-table env))
     (util:coalton-bug "Attempt to add already defined variable with name ~S." name))
 
-  (tc:qualified-ty-type (tc:fresh-inst (setf (gethash name (tc-env-ty-table env)) (tc:to-scheme (tc:make-variable))))))
+  (tc:qualified-ty-type
+   (tc:fresh-inst
+    (setf (gethash name (tc-env-ty-table env))
+          (tc:to-scheme (tc:make-variable :kind tc:+kstar+
+                                          :allow-result-p allow-result-p))))))
 
 (defun tc-env-suggest-value (env name)
   "If value lookup failed, generate suggestions for what to do, if anything."

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -15,6 +15,7 @@
    #:tyvar-id                           ; ACCESSOR
    #:tyvar-kind                         ; ACCESSOR
    #:tyvar-source-name                  ; ACCESSOR
+   #:tyvar-allow-result-p               ; ACCESSOR
    #:tyvar-p                            ; FUNCTION
    #:tyvar-list                         ; TYPE
    #:tycon                              ; STRUCT
@@ -45,6 +46,7 @@
    #:make-tgen                          ; CONSTRUCTOR
    #:tgen-id                            ; ACCESSOR
    #:tgen-source-name                   ; ACCESSOR
+   #:tgen-allow-result-p                ; ACCESSOR
    #:tgen-p                             ; FUNCTION
    #:make-variable                      ; FUNCTION
    #:ensure-next-variable-id-at-least   ; FUNCTION
@@ -165,6 +167,9 @@
 (defstruct (tyvar (:include ty))
   (id          (util:required 'id)      :type fixnum             :read-only t)
   (kind        (util:required 'kind)    :type kind               :read-only t)
+  ;; True when this variable may unify with a result pack (Void or
+  ;; multiple values). Ordinary value variables leave this false.
+  (allow-result-p nil                   :type boolean            :read-only t)
   ;; The original programmer-written name, if this type variable originated
   ;; from source rather than anonymous inference state.
   (source-name nil                      :type (or null symbol)   :read-only t))
@@ -209,6 +214,9 @@
 
 (defstruct (tgen (:include ty))
   (id          (util:required 'id)      :type fixnum             :read-only t)
+  ;; Preserve whether this quantified variable may unify with result
+  ;; packs when re-instantiated later.
+  (allow-result-p nil                   :type boolean            :read-only t)
   ;; Preserve source binder names across quantification so fresh
   ;; instantiation and printing can recover them later.
   (source-name nil                      :type (or null symbol)   :read-only t))
@@ -225,10 +233,15 @@
 #+sbcl
 (declaim (sb-ext:always-bound *next-variable-id*))
 
-(declaim (ftype (function (&optional kind (or null symbol)) tyvar) make-variable))
+(declaim (ftype (function (&key
+                           (:kind kind)
+                           (:source-name (or null symbol))
+                           (:allow-result-p boolean))
+                          tyvar)
+                make-variable))
 (declaim (inline make-variable))
-(defun make-variable (&optional (kind +kstar+) source-name)
-  "Create a fresh type variable with KIND and optional source metadata.
+(defun make-variable (&key (kind +kstar+) source-name (allow-result-p nil))
+  "Create a fresh type variable with optional KIND and source metadata.
 
 SOURCE-NAME preserves the programmer-written binder for later pretty
 printing and documentation.
@@ -237,6 +250,7 @@ Each call returns a variable with a globally unique inference ID, even
 when KIND and SOURCE-NAME are the same."
   (prog1 (make-tyvar :id *next-variable-id*
                      :kind kind
+                     :allow-result-p allow-result-p
                      :source-name source-name)
     (incf *next-variable-id*)))
 
@@ -267,8 +281,9 @@ Example usage in scheme instantiation:
 The function preserves the kind of the original variable, so if TYVAR has kind
 * -> *, the returned variable will also have kind * -> *. It also preserves
 TYVAR's SOURCE-NAME metadata."
-  (make-variable (kind-of tyvar)
-                 (tyvar-source-name tyvar)))
+  (make-variable :kind (kind-of tyvar)
+                 :source-name (tyvar-source-name tyvar)
+                 :allow-result-p (tyvar-allow-result-p tyvar)))
 
 ;;;
 ;;; Methods
@@ -362,6 +377,7 @@ Throws an error if applied to a malformed type application.")
    :alias (mapcar (lambda (alias) (apply-ksubstitution subs alias)) (ty-alias type))
    :id (tyvar-id type)
    :kind (apply-ksubstitution subs (tyvar-kind type))
+   :allow-result-p (tyvar-allow-result-p type)
    :source-name (tyvar-source-name type)))
 
 (defmethod apply-ksubstitution (subs (type tycon))
@@ -471,6 +487,8 @@ Examples:
   (:method ((type1 tyvar) (type2 tyvar))
     (and (equalp (tyvar-id type1)
                  (tyvar-id type2))
+         (eq (tyvar-allow-result-p type1)
+             (tyvar-allow-result-p type2))
          (equalp (tyvar-kind type1)
                  (tyvar-kind type2))))
 
@@ -519,8 +537,10 @@ Examples:
                 (result-ty-output-types type2))))
 
   (:method ((type1 tgen) (type2 tgen))
-    (equalp (tgen-id type1)
-            (tgen-id type2)))
+    (and (equalp (tgen-id type1)
+                 (tgen-id type2))
+         (eq (tgen-allow-result-p type1)
+             (tgen-allow-result-p type2))))
 
   (:method (type1 type2)
     (declare (ignore type1 type2))

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -237,6 +237,27 @@ to the zero-result type."
     ((and (tyvar-p type)
           (ty= type tyvar))
      nil)
+    ((and (typep type 'result-ty)
+          (not (tyvar-allow-result-p tyvar)))
+     (error 'unification-error :type1 tyvar :type2 type))
+    ((tyvar-p type)
+     (when (not (equalp (kind-of tyvar)
+                        (kind-of type)))
+       (error 'kind-mismatch-error
+              :type tyvar
+              :kind (kind-of type)))
+     ;; Preserve the stricter representative when only one side may
+     ;; unify with result packs, so ordinary value variables never
+     ;; widen into result-pack variables through indirection.
+     (cond
+       ((and (not (tyvar-allow-result-p tyvar))
+             (tyvar-allow-result-p type))
+        (list (make-substitution :from type :to tyvar)))
+       ((and (tyvar-allow-result-p tyvar)
+             (not (tyvar-allow-result-p type)))
+        (list (make-substitution :from tyvar :to type)))
+       (t
+        (list (make-substitution :from tyvar :to type)))))
     ((find tyvar (type-variables type))
      (error 'infinite-type-unification-error :type type))
     ((not (equalp (kind-of tyvar)
@@ -271,9 +292,18 @@ apply s type1 == type2")
     (ensure-compatible-result-types type1 type2 'unification-error)
     (match-result-types type1 type2))
   (:method ((type1 tyvar) (type2 ty))
-    (if (equalp (kind-of type1) (kind-of type2))
-        (list (make-substitution :from type1 :to type2))
-        (error 'type-kind-mismatch-error :type1 type1 :type2 type2)))
+    (cond
+      ((not (equalp (kind-of type1) (kind-of type2)))
+       (error 'type-kind-mismatch-error :type1 type1 :type2 type2))
+      ((and (not (tyvar-allow-result-p type1))
+            (typep type2 'result-ty))
+       (error 'unification-error :type1 type1 :type2 type2))
+      ((and (not (tyvar-allow-result-p type1))
+            (tyvar-p type2)
+            (tyvar-allow-result-p type2))
+       (error 'unification-error :type1 type1 :type2 type2))
+      (t
+       (list (make-substitution :from type1 :to type2)))))
   (:method ((type1 tycon) (type2 tycon))
     (if (ty= type1 type2)
         nil

--- a/tests/test-files/struct.txt
+++ b/tests/test-files/struct.txt
@@ -203,7 +203,7 @@ error: Ambiguous accessor
 111 accessor-sees-monadenvironment-fundeps
 ================================================================================
 
-(package coalton-unit-tests/struct
+(package coalton-unit-tests/struct-env
   (import (coalton/monad/environment as env)))
 
 (define-struct Book

--- a/tests/test-files/type-inference.txt
+++ b/tests/test-files/type-inference.txt
@@ -402,6 +402,73 @@ error: Unexpected return
    |            ^^^^^^^^^^^^^^^^ returns must be inside a lambda
 
 ================================================================================
+Return branches must agree on type
+================================================================================
+
+(package coalton-unit-tests/inference)
+
+(define (f a)
+  (if a
+      (return "hello")
+      (return 5))
+  Unit)
+
+--------------------------------------------------------------------------------
+
+error: Return type mismatch
+  --> test:5:6
+   |
+ 5 |        (return "hello")
+   |        ^^^^^^^^^^^^^^^^ First return is of type 'String'
+ 6 |        (return 5))
+ 7 |    Unit)
+   |    ^^^^ Second return is of type 'Unit'
+
+================================================================================
+Return branches must agree on value arity
+================================================================================
+
+(package coalton-unit-tests/inference)
+
+(define (f a)
+  (if a
+      (return 1)
+      (return (values 1 2)))
+  Unit)
+
+--------------------------------------------------------------------------------
+
+error: Return type mismatch
+  --> test:5:6
+   |
+ 5 |        (return 1)
+   |        ^^^^^^^^^^ First return is of type ':A'
+ 6 |        (return (values 1 2)))
+   |        ^^^^^^^^^^^^^^^^^^^^^ Second return is of type ':A * :B'
+
+================================================================================
+Bare return must agree with valued return arity
+================================================================================
+
+(package coalton-unit-tests/inference)
+
+(define (f a)
+  (if a
+      (return)
+      (return 1))
+  Unit)
+
+--------------------------------------------------------------------------------
+
+error: Return type mismatch
+  --> test:5:6
+   |
+ 5 |        (return)
+   |        ^^^^^^^^ First return is of type 'Void'
+ 6 |        (return 1))
+   |        ^^^^^^^^^^ Second return is of type ':A'
+
+================================================================================
 Check that the monomorphism restriction still applies to defaulted bindings
 ================================================================================
 

--- a/tests/test-files/void-bind.txt
+++ b/tests/test-files/void-bind.txt
@@ -43,7 +43,7 @@
 100 Cannot bind Void to a variable
 ================================================================================
 
-(package coalton-unit-tests/void-bind)
+(package coalton-unit-tests/void-bind-plain)
 
 (define (f)
   (let b = (values))
@@ -61,7 +61,7 @@ error: Cannot bind to variable
 101 Cannot bind result of Void function to a variable
 ================================================================================
 
-(package coalton-unit-tests/void-bind)
+(package coalton-unit-tests/void-bind-plain)
 
 (declare void-fn (Void -> Void))
 (define (void-fn)
@@ -121,7 +121,7 @@ error: Cannot bind to variable
 104 Cannot bind inline multiple values to a variable
 ================================================================================
 
-(package coalton-unit-tests/void-bind)
+(package coalton-unit-tests/void-bind-plain)
 
 (define (f)
   (let b = (values 1 2))
@@ -162,7 +162,7 @@ error: Cannot bind to variable
 200 Cannot declare a binding as Void
 ================================================================================
 
-(package coalton-unit-tests/void-bind)
+(package coalton-unit-tests/void-bind-plain)
 
 (declare f Void)
 (define f (values))
@@ -179,7 +179,7 @@ error: Malformed declaration
 201 Cannot declare a binding as a multi-value type
 ================================================================================
 
-(package coalton-unit-tests/void-bind)
+(package coalton-unit-tests/void-bind-plain)
 
 (declare f (Integer * Integer))
 (define f (values 1 2))
@@ -196,7 +196,7 @@ error: Malformed declaration
 202 Void cannot appear as a component of a multi-value type
 ================================================================================
 
-(package coalton-unit-tests/void-bind)
+(package coalton-unit-tests/void-bind-plain)
 
 (declare f (Void -> Void * Integer))
 (define (f)
@@ -209,3 +209,81 @@ error: Malformed type
    |
  3 |  (declare f (Void -> Void * Integer))
    |                      ^^^^ Void and multi-value types cannot appear as components of a multi-value type
+
+================================================================================
+203 Void cannot be used as a type argument
+================================================================================
+
+(package coalton-unit-tests/void-bind-identity
+  (import coalton-prelude
+          (coalton/monad/identity as m-id)))
+
+(declare void-identity (Void -> m-id:Identity Void))
+(define (void-identity)
+  (pure (values)))
+
+--------------------------------------------------------------------------------
+
+error: Malformed type
+  --> test:5:46
+   |
+ 5 |  (declare void-identity (Void -> m-id:Identity Void))
+   |                                                ^^^^ Void and multi-value types cannot be used as type arguments
+
+================================================================================
+204 Multi-value type cannot be used as a type argument
+================================================================================
+
+(package coalton-unit-tests/void-bind
+  (import coalton-prelude))
+
+(declare f (List (Integer * Integer)))
+(define f (make-list (values 1 2)))
+
+--------------------------------------------------------------------------------
+
+error: Malformed type
+  --> test:4:17
+   |
+ 4 |  (declare f (List (Integer * Integer)))
+   |                   ^^^^^^^^^^^^^^^^^^^ Void and multi-value types cannot be used as type arguments
+
+================================================================================
+205 Void value cannot be passed as an ordinary argument
+================================================================================
+
+(package coalton-unit-tests/void-bind
+  (import coalton-prelude))
+
+(define (f x) 1)
+
+(define (g)
+  (f (values)))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:7:5
+   |
+ 7 |    (f (values)))
+   |       ^^^^^^^^ Expected type ':A' but got 'Void'
+
+================================================================================
+206 Void value cannot be lifted into a monad as a first-class value
+================================================================================
+
+(package coalton-unit-tests/void-bind
+  (import coalton-prelude))
+
+(define bad
+  (do
+    (pure (values))
+    (pure 1)))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:6:10
+   |
+ 6 |      (pure (values))
+   |            ^^^^^^^^ Expected type ':A' but got 'Void'

--- a/tests/type-inference-tests.lisp
+++ b/tests/type-inference-tests.lisp
@@ -1071,45 +1071,6 @@
 
    '("f" . "(String -> String)")))
 
-(deftest test-multiple-returns-reject-different-types ()
-  (let ((error
-          (collect-compiler-error
-           "(package coalton-unit-tests/inference)
-
-(define (f a)
-  (if a
-      (return \"hello\")
-      (return 5))
-  Unit)")))
-    (is error)
-    (is (search "Return type mismatch" error) error)))
-
-(deftest test-multiple-returns-reject-different-value-arities ()
-  (let ((error
-          (collect-compiler-error
-           "(package coalton-unit-tests/inference)
-
-(define (f a)
-  (if a
-      (return 1)
-      (return (values 1 2)))
-  Unit)")))
-    (is error)
-    (is (search "Return type mismatch" error) error)))
-
-(deftest test-multiple-returns-reject-bare-return-arity-mismatch ()
-  (let ((error
-          (collect-compiler-error
-           "(package coalton-unit-tests/inference)
-
-(define (f a)
-  (if a
-      (return)
-      (return 1))
-  Unit)")))
-    (is error)
-    (is (search "Return type mismatch" error) error)))
-
 (deftest test-defaulting ()
   ;; See gh #505
   (check-coalton-types
@@ -1142,7 +1103,6 @@
    "(define x (even? 2))"
 
    '("x" . "Boolean")))
-
 
 (deftest test-nameless-overapplication ()
   ;; See gh #1208


### PR DESCRIPTION
Track whether a type variable may unify with result packs and preserve that across parsing, quantification, and instantiation.

Reject Void and multi-value packs in ordinary value positions, and move the regression coverage into file-based compiler tests.

fix #1866