### PR TITLE
fix specialization through superclass predicates

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -283,7 +283,8 @@
                (:ct-file "runtime-tests")
                (:module "typechecker"
                 :serial t
-                :components ((:file "lisp-type-tests")))
+                :components ((:file "lisp-type-tests")
+                             (:file "dictionary-resolution-tests")))
                (:file "environment-persist-tests")
                (:file "coalton-tests")
                (:file "shortcut-tailcall-tests")

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -288,33 +288,52 @@ values."
            (values node &optional))
   (translate-body-elements-into body-nodes (zero-values-node) ctx env))
 
-(defun specialize-qual-type-to-context (qual-ty ctx)
+(defun reachable-context-predicates (pred env)
+  "Return PRED plus any predicates reachable from it through superclasses."
+  (declare (type tc:ty-predicate pred)
+           (type tc:environment env)
+           (values tc:ty-predicate-list &optional))
+  (labels ((walk (pred)
+             (let* ((class (tc:lookup-class env (tc:ty-predicate-class pred)))
+                    (subs (tc:predicate-match (tc:ty-class-predicate class) pred))
+                    (supers (tc:apply-substitution subs (tc:ty-class-superclasses class))))
+               (cons pred
+                     (mapcan #'walk supers)))))
+    (walk pred)))
+
+(defun specialize-qual-type-to-context (qual-ty ctx env)
   "Specialize QUAL-TY to any uniquely matching predicates in CTX.
 
 This matters for overloaded values that are captured without an
 application site, such as variables passed into `lisp` forms."
   (declare (type tc:qualified-ty qual-ty)
            (type pred-context ctx)
+           (type tc:environment env)
            (values tc:qualified-ty &optional))
   (let ((subs nil))
     (dolist (pred (tc:qualified-ty-predicates qual-ty))
       (let ((matches
-              (loop :for (ctx-pred . nil) :in ctx
-                    :for match
-                      := (and (eq (tc:ty-predicate-class pred)
-                                  (tc:ty-predicate-class ctx-pred))
-                              (handler-case
-                                  (tc:predicate-match pred ctx-pred subs)
-                                (tc:predicate-unification-error ()
-                                  nil)
-                                (tc:coalton-internal-type-error ()
-                                  nil)))
-                    :when match
-                      :collect match)))
+              (remove-duplicates
+               (loop :for (ctx-pred . nil) :in ctx
+                     :append (loop :for reachable-pred :in (reachable-context-predicates ctx-pred env)
+                                   :for match
+                                     := (and (eq (tc:ty-predicate-class pred)
+                                                 (tc:ty-predicate-class reachable-pred))
+                                             (handler-case
+                                                 (tc:predicate-match pred reachable-pred subs)
+                                               (tc:predicate-unification-error ()
+                                                 nil)
+                                               (tc:coalton-internal-type-error ()
+                                                 nil)))
+                                   :when match
+                                     :collect (cons (tc:apply-substitution match pred)
+                                                    match)))
+               :test #'tc:type-predicate=
+               :key #'car)))
         (when (= 1 (length matches))
           (setf subs
                 (tc:compose-substitution-lists
-                 (first matches)
+                 (cdar matches)
                  subs)))))
     (if subs
         (tc:apply-substitution subs qual-ty)
@@ -374,7 +393,7 @@ needs to synthesize those trailing parameters explicitly."
             (or eta-rands eta-keyword-rands))
        (make-qualified-variable-application
         binding-value
-        (specialize-qual-type-to-context (tc:node-type binding-value) ctx)
+        (specialize-qual-type-to-context (tc:node-type binding-value) ctx env)
         (tc:function-return-type (tc:qualified-ty-type qual-ty))
         eta-rands
         eta-keyword-rands
@@ -524,7 +543,8 @@ direct-call shape needed by later tail-call and direct-application passes."
            (values node &optional))
   (let* ((qual-ty (specialize-qual-type-to-context
                    (tc:node-type expr)
-                   ctx))
+                   ctx
+                   env))
          (translated-rands
            (mapcar
             (lambda (rand)
@@ -1452,7 +1472,7 @@ dictionaries applied."
            (type pred-context ctx)
            (type tc:environment env)
            (values node))
-  (let* ((qual-ty (specialize-qual-type-to-context (tc:node-type expr) ctx))
+  (let* ((qual-ty (specialize-qual-type-to-context (tc:node-type expr) ctx env))
 
          (dicts (mapcar
                  (lambda (pred)

--- a/tests/typechecker/dictionary-resolution-tests.lisp
+++ b/tests/typechecker/dictionary-resolution-tests.lisp
@@ -1,0 +1,91 @@
+(in-package #:coalton-native-tests)
+
+(coalton-toplevel
+  (declare explicit-rec-eq
+    (forall (:item)
+      (coalton/classes:Eq :item => :item -> Boolean)))
+  (define (explicit-rec-eq x)
+    (if (== x x)
+        True
+        (explicit-rec-eq x)))
+
+  (declare explicit-rec-eq-integer (Integer -> Boolean))
+  (define (explicit-rec-eq-integer x)
+    (explicit-rec-eq x))
+
+  (repr :transparent)
+  (define-type (ScopedDictBox :a)
+    (ScopedDictBox :a))
+
+  (define-class (ScopedDictClass :wrapper)
+    (scoped-dict-method
+      (forall (:item)
+        (coalton/classes:Eq :item => (:wrapper :item) * (coalton/types:Proxy :item) -> Boolean))))
+
+  (define-instance (ScopedDictClass ScopedDictBox)
+    (define (scoped-dict-method wrapped proxy)
+      (match wrapped
+        ((ScopedDictBox inner)
+         (let ((declare rebuild
+                       (forall (:ignored)
+                         (coalton/classes:Eq :item => (coalton/types:Proxy :ignored) * :item -> Boolean)))
+               (rebuild (fn (_other value)
+                          (== value inner))))
+           (rebuild proxy inner))))))
+
+  (declare scoped-dict-method-integer (Integer -> Boolean))
+  (define (scoped-dict-method-integer x)
+    (scoped-dict-method (ScopedDictBox x) (coalton/types:proxy-of x)))
+
+  (define-type (SuperclassMapBox :a)
+    (SuperclassMapBox :a))
+
+  (define-type (SuperclassMapWrap :a)
+    (SuperclassMapWrap :a))
+
+  (define-instance (Functor SuperclassMapBox)
+    (define (map f x)
+      (match x
+        ((SuperclassMapBox y) (SuperclassMapBox (f y))))))
+
+  (define-instance (Functor SuperclassMapWrap)
+    (define (map f x)
+      (match x
+        ((SuperclassMapWrap y) (SuperclassMapWrap (f y))))))
+
+  (define-instance (Applicative SuperclassMapWrap)
+    (define (pure x)
+      (SuperclassMapWrap x))
+    (define (lifta2 f x y)
+      (match x
+        ((SuperclassMapWrap xv)
+         (match y
+           ((SuperclassMapWrap yv)
+            (SuperclassMapWrap (f xv yv))))))))
+
+  (define-instance (Monad SuperclassMapWrap)
+    (define (>>= x f)
+      (match x
+        ((SuperclassMapWrap y) (f y)))))
+
+  (declare superclass-map-regression
+    ((Functor :f) (Monad :m) => :f Unit * :m Integer -> :m Integer))
+  (define (superclass-map-regression _dummy m)
+    (map 1+ m))
+
+  (declare superclass-map-regression-run
+    (SuperclassMapBox Unit * SuperclassMapWrap Integer -> SuperclassMapWrap Integer))
+  (define (superclass-map-regression-run dummy m)
+    (superclass-map-regression dummy m)))
+
+(define-test superclass-map-regression-runtime ()
+  (matches (SuperclassMapWrap 2)
+           (superclass-map-regression-run
+            (SuperclassMapBox Unit)
+            (SuperclassMapWrap 1))))
+
+(in-package #:coalton-tests)
+
+(deftest test-scoped-forall-dictionary-resolution ()
+  (is (coalton:lookup-code 'coalton-native-tests::explicit-rec-eq-integer))
+  (is (coalton:lookup-code 'coalton-native-tests::scoped-dict-method-integer)))

--- a/tests/typechecker/lisp-type-tests.lisp
+++ b/tests/typechecker/lisp-type-tests.lisp
@@ -55,42 +55,6 @@
   (declare pretty-keyword-fn (Integer &key (:timeout Integer) (:extra Integer) -> Integer))
   (define (pretty-keyword-fn x &key (timeout 0) (extra 10))
     (+ x (+ timeout extra)))
-
-  (declare explicit-rec-eq
-    (forall (:item)
-      (coalton/classes:Eq :item => :item -> Boolean)))
-  (define (explicit-rec-eq x)
-    (if (== x x)
-        True
-        (explicit-rec-eq x)))
-
-  (declare explicit-rec-eq-integer (Integer -> Boolean))
-  (define (explicit-rec-eq-integer x)
-    (explicit-rec-eq x))
-
-  (repr :transparent)
-  (define-type (ScopedDictBox :a)
-    (ScopedDictBox :a))
-
-  (define-class (ScopedDictClass :wrapper)
-    (scoped-dict-method
-      (forall (:item)
-        (coalton/classes:Eq :item => (:wrapper :item) * (coalton/types:Proxy :item) -> Boolean))))
-
-  (define-instance (ScopedDictClass ScopedDictBox)
-    (define (scoped-dict-method wrapped proxy)
-      (match wrapped
-        ((ScopedDictBox inner)
-         (let ((declare rebuild
-                       (forall (:ignored)
-                         (coalton/classes:Eq :item => (coalton/types:Proxy :ignored) * :item -> Boolean)))
-               (rebuild (fn (_other value)
-                          (== value inner))))
-           (rebuild proxy inner))))))
-
-  (declare scoped-dict-method-integer (Integer -> Boolean))
-  (define (scoped-dict-method-integer x)
-    (scoped-dict-method (ScopedDictBox x) (coalton/types:proxy-of x)))
   )
 
 (in-package #:coalton-tests)
@@ -314,7 +278,3 @@
           (is nil))
       (coalton-impl/typechecker/type-errors:unification-error ()
         (is t)))))
-
-(deftest test-scoped-forall-dictionary-resolution ()
-  (is (coalton:lookup-code 'coalton-native-tests::explicit-rec-eq-integer))
-  (is (coalton:lookup-code 'coalton-native-tests::scoped-dict-method-integer)))


### PR DESCRIPTION
Fix incorrect dictionary specialization for overloaded values when the needed constraint is only available through a superclass chain.

Root cause: `specialize-qual-type-to-context` only looked for direct predicate matches in the local context. In a context like `(Functor :f)` plus `(Monad :m)`, a use of `map` on `:m` could incorrectly specialize to the direct `Functor :f` dictionary instead of deriving `Functor :m` through the superclass path `Monad => Applicative => Functor`.

fix #1869 