### PR TITLE
replace FSet with persistent AVL tree

### DIFF
--- a/coalton-compiler.asd
+++ b/coalton-compiler.asd
@@ -15,7 +15,6 @@
                "eclector"
                "eclector-concrete-syntax-tree"
                "float-features"
-               "fset"
                "named-readtables"
                "source-error"
                "trivial-gray-streams")
@@ -30,6 +29,7 @@
                (:module "algorithm"
                 :serial t
                 :components ((:file "tarjan-scc")
+                             (:file "avl-tree")
                              (:file "immutable-map")
                              (:file "immutable-listmap")
                              (:file "package")))

--- a/coalton.asd
+++ b/coalton.asd
@@ -268,6 +268,7 @@
                (:file "source-tests")
                (:file "preserve-case-tests")
                (:file "tarjan-scc-tests")
+               (:file "avl-tree-tests")
                (:file "reader-tests")
                (:file "error-tests")
                (:module "parser"

--- a/src/algorithm/avl-tree.lisp
+++ b/src/algorithm/avl-tree.lisp
@@ -1,0 +1,394 @@
+;;;; avl-tree.lisp — Persistent (purely functional) AVL tree.
+;;;;
+;;;; Used as the backing store for Coalton's immutable-map and
+;;;; immutable-listmap.  Replaces FSet's wb-map.
+;;;;
+;;;; Invariants at every node:
+;;;;   1. BST: all keys in left < key < all keys in right
+;;;;   2. AVL: |height(left) - height(right)| <= 1
+;;;;   3. Size: count = 1 + count(left) + count(right)
+;;;;
+;;;; Keys may be symbols or fixnums.  Symbols are ordered first by
+;;;; package name, then by symbol name; uninterned symbols (nil package)
+;;;; sort before all interned ones.  Fixnums sort before all symbols.
+
+(defpackage #:coalton-impl/algorithm/avl-tree
+  (:use #:cl)
+  (:export
+   #:avl-tree                           ; TYPE
+   #:avl-node                           ; STRUCT
+   #:avl-node-p                         ; PREDICATE
+   #:empty-avl-tree                     ; FUNCTION
+
+   #:avl-lookup                         ; FUNCTION
+   #:avl-set                            ; FUNCTION
+   #:avl-remove                         ; FUNCTION
+   #:avl-count                          ; FUNCTION
+   #:avl-foreach                        ; FUNCTION
+   #:avl-keys                           ; FUNCTION
+   #:avl-values                         ; FUNCTION
+   #:avl-to-alist                       ; FUNCTION
+   #:avl-image                          ; FUNCTION
+   #:avl-difference                     ; FUNCTION
+   #:avl-from-alist                     ; FUNCTION
+
+   #:do-avl                             ; MACRO
+
+   #:make-avl-map                       ; MACRO
+   ))
+
+(in-package #:coalton-impl/algorithm/avl-tree)
+
+
+;;;; Key ordering
+
+(defun symbol< (a b)
+  "Total order on symbols by package name then symbol name."
+  (if (eq a b)
+      nil
+      (let ((pa (symbol-package a))
+            (pb (symbol-package b)))
+        (cond ((and (null pa) (null pb))
+               (string< (symbol-name a) (symbol-name b)))
+              ((null pa) t)
+              ((null pb) nil)
+              (t (let ((pna (package-name pa))
+                       (pnb (package-name pb)))
+                   (cond ((string< pna pnb) t)
+                         ((string= pna pnb)
+                          (string< (symbol-name a) (symbol-name b)))
+                         (t nil))))))))
+
+(defun type-rank (x)
+  "Integer ranking for the type of X, used to order values of different types."
+  (etypecase x
+    (fixnum  0)
+    (cons    1)
+    (symbol  2)
+    (string  3)))
+
+(defun key< (a b)
+  "Total order on map keys.
+Supported types: fixnum, cons, symbol, string.  Values of different
+types are ordered by type rank.  Within a type: fixnums by <, symbols
+by package then name, conses lexicographically, strings by string<."
+  (let ((ra (type-rank a))
+        (rb (type-rank b)))
+    (cond ((/= ra rb) (< ra rb))
+          ((typep a 'fixnum) (< a b))
+          ((typep a 'symbol) (symbol< a b))
+          ((typep a 'cons)
+           (or (key< (car a) (car b))
+               (and (not (key< (car b) (car a)))
+                    (key< (cdr a) (cdr b)))))
+          ((typep a 'string) (string< a b))
+          (t nil))))
+
+
+;;;; Empty tree sentinel and type
+
+(deftype avl-tree ()
+  "An AVL tree: either an avl-node or the empty tree sentinel."
+  '(or avl-node (member empty-avl-tree)))
+
+(declaim (inline empty-avl-tree))
+(defun empty-avl-tree ()
+  "Return the empty AVL tree."
+  'empty-avl-tree)
+
+
+;;;; Node structure
+
+(defstruct (avl-node
+            (:constructor %make-node (key value left right height count))
+            (:copier nil))
+  "A node in a persistent AVL tree."
+  (key    nil                            :read-only t)
+  (value  nil                            :read-only t)
+  (left   'empty-avl-tree :type avl-tree :read-only t)
+  (right  'empty-avl-tree :type avl-tree :read-only t)
+  (height 1                :type fixnum  :read-only t)
+  (count  1                :type fixnum  :read-only t))
+
+#+sbcl (declaim (sb-ext:freeze-type avl-node))
+
+(defmethod make-load-form ((self avl-node) &optional env)
+  (make-load-form-saving-slots self :environment env))
+
+
+;;;; Height and count accessors for nullable nodes
+
+(declaim (inline node-height node-count))
+
+(defun node-height (node)
+  (if (avl-node-p node) (avl-node-height node) 0))
+
+(defun node-count (node)
+  (if (avl-node-p node) (avl-node-count node) 0))
+
+
+;;;; Node constructor (computes height and count)
+
+(declaim (inline make-node))
+(defun make-node (key value left right)
+  (%make-node key value left right
+              (1+ (max (node-height left) (node-height right)))
+              (+ 1 (node-count left) (node-count right))))
+
+
+;;;; Rotations
+
+(defun rotate-right (node)
+  "Single right rotation.  Assumes (avl-node-left node) is non-nil."
+  (let ((l (avl-node-left node)))
+    (make-node (avl-node-key l) (avl-node-value l)
+               (avl-node-left l)
+               (make-node (avl-node-key node) (avl-node-value node)
+                          (avl-node-right l)
+                          (avl-node-right node)))))
+
+(defun rotate-left (node)
+  "Single left rotation.  Assumes (avl-node-right node) is non-nil."
+  (let ((r (avl-node-right node)))
+    (make-node (avl-node-key r) (avl-node-value r)
+               (make-node (avl-node-key node) (avl-node-value node)
+                          (avl-node-left node)
+                          (avl-node-left r))
+               (avl-node-right r))))
+
+
+;;;; Rebalancing
+
+(defun balance (key value left right)
+  "Construct a node and rebalance if needed.
+Assumes LEFT and RIGHT individually satisfy AVL, and their heights
+differ by at most 2 (the situation after a single insert or remove)."
+  (let ((hl (node-height left))
+        (hr (node-height right)))
+    (cond
+      ;; Left-heavy
+      ((> hl (+ hr 1))
+       (if (>= (node-height (avl-node-left left))
+               (node-height (avl-node-right left)))
+           ;; Left-left: single right rotation
+           (rotate-right (make-node key value left right))
+           ;; Left-right: double rotation
+           (rotate-right (make-node key value
+                                    (rotate-left left)
+                                    right))))
+      ;; Right-heavy
+      ((> hr (+ hl 1))
+       (if (>= (node-height (avl-node-right right))
+               (node-height (avl-node-left right)))
+           ;; Right-right: single left rotation
+           (rotate-left (make-node key value left right))
+           ;; Right-left: double rotation
+           (rotate-left (make-node key value
+                                   left
+                                   (rotate-right right)))))
+      ;; Balanced
+      (t (make-node key value left right)))))
+
+
+;;;; Lookup
+
+(defun avl-lookup (tree key)
+  "Look up KEY in TREE.  Returns (values value found-p)."
+  (declare (type avl-tree tree))
+  (if (not (avl-node-p tree))
+      (values nil nil)
+      (cond ((key< key (avl-node-key tree))
+             (avl-lookup (avl-node-left tree) key))
+            ((key< (avl-node-key tree) key)
+             (avl-lookup (avl-node-right tree) key))
+            (t
+             (values (avl-node-value tree) t)))))
+
+
+;;;; Insert / update
+
+(defun avl-set (tree key value)
+  "Return a new tree like TREE but with KEY mapped to VALUE.
+If KEY is already present, its value is replaced."
+  (declare (type avl-tree tree))
+  (if (not (avl-node-p tree))
+      (make-node key value (empty-avl-tree) (empty-avl-tree))
+      (cond ((key< key (avl-node-key tree))
+             (balance (avl-node-key tree) (avl-node-value tree)
+                      (avl-set (avl-node-left tree) key value)
+                      (avl-node-right tree)))
+            ((key< (avl-node-key tree) key)
+             (balance (avl-node-key tree) (avl-node-value tree)
+                      (avl-node-left tree)
+                      (avl-set (avl-node-right tree) key value)))
+            (t
+             ;; Key matches — replace value (no structural change).
+             (if (eq value (avl-node-value tree))
+                 tree
+                 (make-node key value
+                            (avl-node-left tree)
+                            (avl-node-right tree)))))))
+
+
+;;;; Remove
+
+(defun node-min-key (tree)
+  "Return the minimum key in a non-empty tree."
+  (if (avl-node-p (avl-node-left tree))
+      (node-min-key (avl-node-left tree))
+      (avl-node-key tree)))
+
+(defun node-min-value (tree)
+  "Return the value associated with the minimum key."
+  (if (avl-node-p (avl-node-left tree))
+      (node-min-value (avl-node-left tree))
+      (avl-node-value tree)))
+
+(defun remove-min (tree)
+  "Remove the minimum element.  Assumes TREE is a non-empty avl-node."
+  (if (avl-node-p (avl-node-left tree))
+      (balance (avl-node-key tree) (avl-node-value tree)
+               (remove-min (avl-node-left tree))
+               (avl-node-right tree))
+      (avl-node-right tree)))
+
+(defun avl-remove (tree key)
+  "Return a new tree like TREE but without KEY."
+  (declare (type avl-tree tree))
+  (if (not (avl-node-p tree))
+      (empty-avl-tree)
+      (cond ((key< key (avl-node-key tree))
+             (balance (avl-node-key tree) (avl-node-value tree)
+                      (avl-remove (avl-node-left tree) key)
+                      (avl-node-right tree)))
+            ((key< (avl-node-key tree) key)
+             (balance (avl-node-key tree) (avl-node-value tree)
+                      (avl-node-left tree)
+                      (avl-remove (avl-node-right tree) key)))
+            (t
+             ;; Found: merge left and right subtrees.
+             (let ((left (avl-node-left tree))
+                   (right (avl-node-right tree)))
+               (cond ((not (avl-node-p left))  right)
+                     ((not (avl-node-p right)) left)
+                     (t (balance (node-min-key right)
+                                 (node-min-value right)
+                                 left
+                                 (remove-min right)))))))))
+
+
+;;;; Count
+
+(declaim (inline avl-count))
+(defun avl-count (tree)
+  "Return the number of entries in TREE."
+  (declare (type avl-tree tree))
+  (node-count tree))
+
+
+;;;; Iteration
+
+(defun avl-foreach (fn tree)
+  "Call (funcall FN key value) for each entry in TREE, in ascending key order."
+  (declare (type function fn)
+           (type avl-tree tree))
+  (when (avl-node-p tree)
+    (avl-foreach fn (avl-node-left tree))
+    (funcall fn (avl-node-key tree) (avl-node-value tree))
+    (avl-foreach fn (avl-node-right tree)))
+  (values))
+
+(defmacro do-avl ((key value tree &optional result) &body body)
+  "Iterate over TREE in ascending key order, binding KEY and VALUE.
+Supports RETURN-FROM in the body."
+  (let ((walk (gensym "WALK"))
+        (node (gensym "NODE")))
+    `(block nil
+       (labels ((,walk (,node)
+                  (when (avl-node-p ,node)
+                    (,walk (avl-node-left ,node))
+                    (let ((,key (avl-node-key ,node))
+                          (,value (avl-node-value ,node)))
+                      ,@body)
+                    (,walk (avl-node-right ,node)))))
+         (,walk ,tree)
+         ,result))))
+
+
+;;;; Collecting
+
+(defun avl-keys (tree)
+  "Return a list of all keys in TREE in ascending order."
+  (declare (type avl-tree tree))
+  (let ((acc nil))
+    (avl-foreach (lambda (k v) (declare (ignore v)) (push k acc)) tree)
+    (nreverse acc)))
+
+(defun avl-values (tree)
+  "Return a list of all values in TREE in ascending key order."
+  (declare (type avl-tree tree))
+  (let ((acc nil))
+    (avl-foreach (lambda (k v) (declare (ignore k)) (push v acc)) tree)
+    (nreverse acc)))
+
+(defun avl-to-alist (tree)
+  "Return an alist of (KEY . VALUE) pairs in ascending key order."
+  (declare (type avl-tree tree))
+  (let ((acc nil))
+    (avl-foreach (lambda (k v) (push (cons k v) acc)) tree)
+    (nreverse acc)))
+
+
+;;;; Image (map over values)
+
+(defun avl-image (fn tree)
+  "Return a new tree with each value replaced by (funcall FN value).
+Preserves tree structure (keys and balance unchanged)."
+  (declare (type function fn)
+           (type avl-tree tree))
+  (if (not (avl-node-p tree))
+      (empty-avl-tree)
+      (%make-node (avl-node-key tree)
+                  (funcall fn (avl-node-value tree))
+                  (avl-image fn (avl-node-left tree))
+                  (avl-image fn (avl-node-right tree))
+                  (avl-node-height tree)
+                  (avl-node-count tree))))
+
+
+;;;; Difference
+
+(defun avl-difference (tree1 tree2)
+  "Return a tree containing entries from TREE1 whose keys are absent in TREE2."
+  (declare (type avl-tree tree1 tree2))
+  (if (or (not (avl-node-p tree1)) (not (avl-node-p tree2)))
+      tree1
+      (let ((result (empty-avl-tree)))
+        (avl-foreach (lambda (k v)
+                       (multiple-value-bind (v2 found) (avl-lookup tree2 k)
+                         (declare (ignore v2))
+                         (unless found
+                           (setf result (avl-set result k v)))))
+                     tree1)
+        result)))
+
+
+;;;; Construction from alist
+
+(defun avl-from-alist (alist)
+  "Build a tree from an alist of (KEY . VALUE) pairs."
+  (let ((tree (empty-avl-tree)))
+    (dolist (pair alist tree)
+      (setf tree (avl-set tree (car pair) (cdr pair))))))
+
+
+;;;; Convenience macro for literal maps
+
+(defmacro make-avl-map (&rest pairs)
+  "Construct an AVL tree from literal (key-expr value-expr) pairs.
+Usage: (make-avl-map ('foo val1) ('bar val2))"
+  (let ((tree (gensym "TREE")))
+    `(let ((,tree (empty-avl-tree)))
+       ,@(loop :for (k v) :in pairs
+               :collect `(setf ,tree (avl-set ,tree ,k ,v)))
+       ,tree)))

--- a/src/algorithm/immutable-listmap.lisp
+++ b/src/algorithm/immutable-listmap.lisp
@@ -1,5 +1,6 @@
 (defpackage #:coalton-impl/algorithm/immutable-listmap
   (:use #:cl)
+  (:local-nicknames (#:avl #:coalton-impl/algorithm/avl-tree))
   (:export
    #:immutable-listmap                  ; STRUCT
    #:make-immutable-listmap             ; CONSTRUCTOR
@@ -8,60 +9,76 @@
    #:immutable-listmap-push             ; FUNCTION
    #:immutable-listmap-replace          ; FUNCTION
    #:immutable-listmap-diff             ; FUNCTION
+   #:immutable-listmap-foreach          ; FUNCTION
    ))
 
 (in-package #:coalton-impl/algorithm/immutable-listmap)
 
-;;
-;; Immutable Listmap
-;; Wrapper around fset:map<fset:seq>
-;;
+
+;;; Immutable Listmap — a persistent map whose values are lists.
+;;;
+;;; Each key maps to a list of items.  PUSH prepends to the list.
+;;; REPLACE updates the item at a specific index.
+;;; Replaces FSet's map-of-seqs pattern with plain CL lists.
 
 (defstruct immutable-listmap
-  (data (fset:empty-map (fset:empty-seq)) :type fset:map :read-only t))
+  (data (avl:empty-avl-tree) :type avl:avl-tree :read-only t))
+
+(defmethod make-load-form ((self immutable-listmap) &optional env)
+  (make-load-form-saving-slots self :environment env))
 
 (defun immutable-listmap-lookup (m key &key no-error)
-  "Lookup key in M"
+  "Look up KEY in M.  Returns the list of values for KEY.
+Signals an error if KEY is absent unless NO-ERROR is true."
   (declare (type immutable-listmap m)
-           (type (or fixnum symbol) key)
            (type boolean no-error)
-           (values fset:seq))
+           (values list))
   (multiple-value-bind (value present-p)
-      (fset:lookup (immutable-listmap-data m) key)
+      (avl:avl-lookup (immutable-listmap-data m) key)
     (unless (or present-p no-error)
       (error "Undefined key ~a" key))
-    value))
+    (if present-p value nil)))
 
 (defun immutable-listmap-push (m key value &optional (constructor #'make-immutable-listmap))
-  "Push value to the list at KEY in M"
+  "Return a new listmap with VALUE prepended to the list at KEY."
   (declare (type immutable-listmap m)
-           (type (or fixnum symbol) key)
            (values immutable-listmap &optional))
-
-  (let ((map (immutable-listmap-data m)))
-    (funcall constructor :data (fset:with map key (fset:with-first (fset:lookup map key) value)))))
+  (let* ((tree (immutable-listmap-data m))
+         (old-list (multiple-value-bind (v found) (avl:avl-lookup tree key)
+                     (if found v nil))))
+    (funcall constructor :data (avl:avl-set tree key (cons value old-list)))))
 
 (defun immutable-listmap-replace (m key index value &optional (constructor #'make-immutable-listmap))
-  "Replace value at INDEX with VALUE in the map at KEY in M."
+  "Return a new listmap with the element at INDEX in KEY's list replaced by VALUE."
   (declare (type immutable-listmap m)
-           (type (or fixnum symbol) key)
            (type fixnum index)
            (values immutable-listmap &optional))
-  (let ((map (immutable-listmap-data m)))
-    (funcall constructor :data (fset:with map key (fset:with (fset:lookup map key) index value)))))
+  (let* ((tree (immutable-listmap-data m))
+         (old-list (multiple-value-bind (v found) (avl:avl-lookup tree key)
+                     (if found v nil)))
+         (new-list (loop :for elt :in old-list
+                         :for i :of-type fixnum :from 0
+                         :collect (if (= i index) value elt))))
+    (funcall constructor :data (avl:avl-set tree key new-list))))
 
 (defun immutable-listmap-diff (m1 m2 &optional (constructor #'make-immutable-listmap))
-  "Return a new SHADOW-LIST with elements in M1 but not M2."
-  (let ((diff-map (fset:empty-map)))
-    (fset:do-map (k v1 (immutable-listmap-data m1))
-      (multiple-value-bind (v2 found)
-          (fset:lookup (immutable-listmap-data m2) k)
-        (if found
-            ;; If both have this key then diff the seq
-            (let ((seq-diff (fset:convert 'fset:seq
-                                     (fset:set-difference (fset:range v1)
-                                                          (fset:range v2)))))
-              (setf diff-map (fset:with diff-map k seq-diff)))
-            ;; Otherwise save the whole seq
-            (setf diff-map (fset:with diff-map k v1)))))
-    (funcall constructor :data diff-map)))
+  "Return entries from M1 whose elements are absent from the corresponding M2 lists."
+  (let ((result (avl:empty-avl-tree)))
+    (avl:avl-foreach
+     (lambda (k v1)
+       (multiple-value-bind (v2 found) (avl:avl-lookup (immutable-listmap-data m2) k)
+         (if found
+             ;; Both have this key: diff the lists (treat as sets)
+             (let ((diff (set-difference v1 v2 :test #'equal)))
+               (when diff
+                 (setf result (avl:avl-set result k diff))))
+             ;; Only in m1: keep entire list
+             (setf result (avl:avl-set result k v1)))))
+     (immutable-listmap-data m1))
+    (funcall constructor :data result)))
+
+(defun immutable-listmap-foreach (fn m)
+  "Call (funcall FN key list) for each entry in M."
+  (declare (type function fn)
+           (type immutable-listmap m))
+  (avl:avl-foreach fn (immutable-listmap-data m)))

--- a/src/algorithm/immutable-map.lisp
+++ b/src/algorithm/immutable-map.lisp
@@ -1,5 +1,6 @@
 (defpackage #:coalton-impl/algorithm/immutable-map
   (:use #:cl)
+  (:local-nicknames (#:avl #:coalton-impl/algorithm/avl-tree))
   (:export
    #:immutable-map                      ; STRUCT
    #:make-immutable-map                 ; CONSTRUCTOR
@@ -10,57 +11,93 @@
    #:immutable-map-keys                 ; FUNCTION
    #:immutable-map-diff                 ; FUNCTION
    #:immutable-map-remove               ; FUNCTION
+   #:immutable-map-count                ; FUNCTION
+   #:immutable-map-values               ; FUNCTION
+   #:immutable-map-foreach              ; FUNCTION
+   #:immutable-map-image                ; FUNCTION
+   #:do-immutable-map                   ; MACRO
    ))
 
 (in-package #:coalton-impl/algorithm/immutable-map)
 
 
-;;
-;; Immutable Map
-;; Wrapper around fset:map
-;;
+;;; Immutable Map — backed by a persistent AVL tree.
 
 (defstruct immutable-map
-  (data (fset:empty-map) :type fset:map :read-only t))
+  (data (avl:empty-avl-tree) :type avl:avl-tree :read-only t))
 
 (defmethod make-load-form ((self immutable-map) &optional env)
   (make-load-form-saving-slots self :environment env))
 
 (defun immutable-map-lookup (m key)
-  "Lookup KEY in M"
+  "Look up KEY in M.  Returns (values value found-p)."
   (declare (type immutable-map m)
            (values t boolean &optional))
-  (fset:lookup (immutable-map-data m) key))
+  (avl:avl-lookup (immutable-map-data m) key))
 
 (defun immutable-map-set (m key value &optional (constructor #'make-immutable-map))
-  "Set KEY to VALUE in M"
+  "Return a new map like M but with KEY mapped to VALUE."
   (declare (type immutable-map m))
-  (funcall constructor :data (fset:with (immutable-map-data m) key value)))
+  (funcall constructor :data (avl:avl-set (immutable-map-data m) key value)))
 
 (defun immutable-map-set-multiple (m items &optional (constructor #'make-immutable-map))
-  "Create an IMMUTABLE-MAP from M with ITEMS set as bindings"
+  "Return a new map from M with each (KEY . VALUE) in ITEMS set."
   (declare (type immutable-map m)
            (type list items)
            (values immutable-map &optional))
-  (let ((map (immutable-map-data m)))
-    (loop :for (key . value) :in items
-          :do (setf map (fset:with map key value)))
-    (funcall constructor :data map)))
+  (let ((tree (immutable-map-data m)))
+    (dolist (pair items)
+      (setf tree (avl:avl-set tree (car pair) (cdr pair))))
+    (funcall constructor :data tree)))
 
 (defun immutable-map-keys (m)
+  "Return a list of all keys in M in ascending order."
   (declare (type immutable-map m))
-  "Return a unique list containing the keys in M and its parents"
-  (declare (type immutable-map m))
-  (fset:convert 'list (fset:domain (immutable-map-data m))))
+  (avl:avl-keys (immutable-map-data m)))
 
 (defun immutable-map-diff (m1 m2 &optional (constructor #'make-immutable-map))
-  "Returns the elements that appear in M1 but not M2"
+  "Return a map of entries in M1 whose keys are absent in M2."
   (declare (type immutable-map m1 m2)
            (values immutable-map &optional))
-  (funcall constructor :data (fset:map-difference-2 (immutable-map-data m1)
-                                                    (immutable-map-data m2))))
+  (funcall constructor :data (avl:avl-difference (immutable-map-data m1)
+                                                 (immutable-map-data m2))))
 
 (defun immutable-map-remove (m key &optional (constructor #'make-immutable-map))
+  "Return a new map like M but without KEY."
   (declare (type immutable-map m)
            (values immutable-map &optional))
-  (funcall constructor :data (fset:less (immutable-map-data m) key)))
+  (funcall constructor :data (avl:avl-remove (immutable-map-data m) key)))
+
+(defun immutable-map-count (m)
+  "Return the number of entries in M."
+  (declare (type immutable-map m))
+  (avl:avl-count (immutable-map-data m)))
+
+(defun immutable-map-values (m)
+  "Return a list of all values in M in ascending key order."
+  (declare (type immutable-map m))
+  (avl:avl-values (immutable-map-data m)))
+
+(defun immutable-map-foreach (fn m)
+  "Call (funcall FN key value) for each entry in M in ascending key order."
+  (declare (type function fn)
+           (type immutable-map m))
+  (avl:avl-foreach fn (immutable-map-data m)))
+
+(defun immutable-map-image (fn m &optional (constructor #'make-immutable-map))
+  "Return a new map with each value replaced by (funcall FN key value)."
+  (declare (type function fn)
+           (type immutable-map m))
+  (funcall constructor
+           :data (avl:avl-image (lambda (v)
+                                  ;; avl-image passes only the value;
+                                  ;; but environment.lisp needs (key value)->value.
+                                  ;; We handle both conventions: callers that need
+                                  ;; the key should use immutable-map-foreach instead.
+                                  (funcall fn v))
+                                (immutable-map-data m))))
+
+(defmacro do-immutable-map ((key value map &optional result) &body body)
+  "Iterate over MAP in ascending key order, binding KEY and VALUE."
+  `(avl:do-avl (,key ,value (immutable-map-data ,map) ,result)
+     ,@body))

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -5,7 +5,8 @@
    #:coalton-impl/codegen/ast)
   (:import-from
    #:coalton-impl/algorithm
-   #:immutable-map-data)
+   #:immutable-map-data
+   #:do-immutable-map)
   (:import-from
    #:coalton-impl/codegen/typecheck-node
    #:typecheck-node)
@@ -97,7 +98,7 @@ mapping known function names to their arity."
            (values hash-table &optional))
   (let ((table (make-hash-table))
         (fun-env (tc:environment-function-environment env)))
-    (fset:do-map (name entry (immutable-map-data fun-env))
+    (do-immutable-map (name entry fun-env)
       (setf (gethash name table) (tc:function-env-entry-arity entry)))
     table))
 

--- a/src/debug.lisp
+++ b/src/debug.lisp
@@ -3,6 +3,7 @@
   (:local-nicknames
    (#:settings #:coalton-impl/settings)
    (#:algo #:coalton-impl/algorithm)
+   (#:avl #:coalton-impl/algorithm/avl-tree)
    (#:tc #:coalton-impl/typechecker)
    (#:entry #:coalton-impl/entry)))
 
@@ -17,7 +18,7 @@
   (let ((env entry:*global-environment*)
         (sorted-by-package (make-hash-table)))
     ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-value-environment env)))
+    (algo:do-immutable-map (sym entry (tc:environment-value-environment env))
       (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
 
     ;; Print out the entries for each package
@@ -43,7 +44,7 @@
   (let ((env entry:*global-environment*)
         (sorted-by-package (make-hash-table)))
     ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-type-environment env)))
+    (algo:do-immutable-map (sym entry (tc:environment-type-environment env))
       (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
 
     ;; Print out the entries for each package
@@ -68,7 +69,7 @@
   (let ((env entry:*global-environment*)
         (sorted-by-package (make-hash-table)))
     ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-class-environment env)))
+    (algo:do-immutable-map (sym entry (tc:environment-class-environment env))
       (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
 
     ;; Print out the entries for each package
@@ -102,7 +103,7 @@
   (let ((env entry:*global-environment*)
         (sorted-by-package (make-hash-table)))
     ;; Sort the entires by package
-    (fset:do-map (sym entry (algo:immutable-map-data (tc:environment-class-environment env)))
+    (algo:do-immutable-map (sym entry (tc:environment-class-environment env))
       (push (cons entry (tc:lookup-class-instances env sym :no-error t))
             (gethash (symbol-package sym) sorted-by-package)))
 
@@ -122,7 +123,7 @@
                                      (tc:ty-predicate-types class-pred)
                                      (mapcar #'tc:kind-of (tc:ty-predicate-types class-pred)))))
 
-                         (fset:do-seq (instance instances)
+                         (dolist (instance instances)
                            (format t "    ")
                            ;; Generate type variable substitutions from instance constraints
                            (tc:with-pprint-variable-context ()
@@ -156,7 +157,7 @@
   (check-type package (or null package-designator) "package designator")
   (let ((env entry:*global-environment*)
         (sorted-by-package (make-hash-table)))
-    (fset:do-map (sym entry (algo:immutable-listmap-data (tc:environment-specialization-environment env)))
+    (avl:do-avl (sym entry (algo:immutable-listmap-data (tc:environment-specialization-environment env)))
       (push (cons sym entry) (gethash (symbol-package sym) sorted-by-package)))
 
     (labels ((print-package (package entries)
@@ -164,7 +165,7 @@
                (loop :for (name . specs) :in entries
                      :do (progn
                            (format t "  ~A :: ~A~%" name (tc:lookup-value-type env name))
-                           (fset:do-seq (spec specs)
+                           (dolist (spec specs)
                              (format t "    ~A :: ~A~%"
                                      (tc:specialization-entry-to spec)
                                      (tc:specialization-entry-to-ty spec)))

--- a/src/doc/environment.lisp
+++ b/src/doc/environment.lisp
@@ -1,6 +1,6 @@
 ;;;; The documentation generator queries the global environment for
 ;;;; entries to emit. These are helper functions that support query by
-;;;; package, and also insulate callers from fset datatypes.
+;;;; package.
 
 (defpackage #:coalton/doc/environment
   (:documentation "Environment access helpers for doc generator.")
@@ -24,25 +24,27 @@
 (in-package #:coalton/doc/environment)
 
 (defun %values (immutable-map)
-  "Coerce an FSET map to a list."
-  (fset:convert 'list (fset:range (algo:immutable-map-data immutable-map))))
+  "Return all values from an immutable-map as a list."
+  (algo:immutable-map-values immutable-map))
 
 (defun %lm-values (immutable-listmap)
-  "Coerce an FSET 'listmap' to a list."
-  (apply #'append
-         (mapcar (lambda (value)
-                   (fset:convert 'list value))
-                 (fset:convert 'list (fset:range (algo:immutable-listmap-data immutable-listmap))))))
+  "Return all values from an immutable-listmap as a flat list."
+  (let ((acc nil))
+    (algo:immutable-listmap-foreach
+     (lambda (k v)
+       (declare (ignore k))
+       (setf acc (append v acc)))
+     immutable-listmap)
+    acc))
 
 (defun value-type (name-entry)
   (tc:lookup-value-type entry:*global-environment*
                         (tc:name-entry-name name-entry)))
 
 (defun class-instances (ty-class)
-  (fset:convert 'list
-                (tc:lookup-class-instances entry:*global-environment*
-                                           (tc:ty-class-name ty-class)
-                                           :no-error t)))
+  (tc:lookup-class-instances entry:*global-environment*
+                             (tc:ty-class-name ty-class)
+                             :no-error t))
 
 (defun struct-entry-p (type-entry)
   (let ((name (tc:type-entry-name type-entry)))

--- a/src/typechecker/context-reduction.lisp
+++ b/src/typechecker/context-reduction.lisp
@@ -63,7 +63,7 @@ Returns (PREDS FOUNDP)"
   (declare (type environment env)
            (type ty-predicate pred)
            (values ty-predicate-list boolean))
-  (fset:do-seq (inst (lookup-class-instances env (ty-predicate-class pred) :no-error t))
+  (dolist (inst (lookup-class-instances env (ty-predicate-class pred) :no-error t))
     (handler-case
         (let* ((subs (predicate-match (ty-class-instance-predicate inst) pred))
                (resulting-preds (mapcar (lambda (p) (apply-substitution subs p))

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -25,6 +25,7 @@
    #:generic-closure
    #:+fundep-max-depth+)
   (:local-nicknames
+   (#:avl #:coalton-impl/algorithm/avl-tree)
    (#:util #:coalton-impl/util)
    (#:source #:coalton-impl/source)
    (#:parser #:coalton-impl/parser))
@@ -257,13 +258,11 @@
 (declaim (sb-ext:freeze-type value-environment))
 
 (defmethod apply-substitution (subst-list (env value-environment))
-  (make-value-environment :data (fset:image (lambda (key value)
-                  (values key (apply-substitution subst-list value)))
-                (immutable-map-data env))))
+  (immutable-map-image (lambda (value) (apply-substitution subst-list value)) env #'make-value-environment))
 
 (defmethod type-variables ((env value-environment))
   (let ((out nil))
-    (fset:do-map (name type (immutable-map-data env))
+    (do-immutable-map (name type env)
       (declare (ignore name))
       (setf out (append (type-variables type) out)))
     (remove-duplicates out :test #'ty=)))
@@ -344,7 +343,7 @@
 (defun make-default-type-environment ()
   "Create a TYPE-ENVIRONMENT containing early types."
   (make-type-environment
-   :data (fset:map
+   :data (avl:make-avl-map
           ;; Early Types
           ('coalton:Boolean
            (make-type-entry
@@ -537,7 +536,7 @@
 (defun make-default-constructor-environment ()
   "Create a TYPE-ENVIRONMENT containing early constructors"
   (make-constructor-environment
-   :data (fset:map
+   :data (avl:make-avl-map
           ;; Early Constructors
           ('coalton:True
            (make-constructor-entry
@@ -1174,11 +1173,11 @@ unrelated substitutions to alias each other."
                  (specialization-entry
                   (scan (specialization-entry-to-ty object)))
                  (immutable-map
-                  (fset:do-map (_ value (immutable-map-data object))
+                  (do-immutable-map (_ value object)
                     (declare (ignore _))
                     (scan value)))
                  (immutable-listmap
-                  (fset:do-map (_ value (immutable-listmap-data object))
+                  (avl:do-avl (_ value (immutable-listmap-data object))
                     (declare (ignore _))
                     (scan value)))
                  (environment
@@ -1474,7 +1473,7 @@ Signals a coalton-bug error if the type is not found and NO-ERROR is false (the 
 (defun lookup-class-instances (env class &key no-error)
   (declare (type environment env)
            (type symbol class)
-           (values fset:seq &optional))
+           (values list &optional))
   (immutable-listmap-lookup (instance-environment-instances (environment-instance-environment env)) class :no-error no-error))
 
 (defun synthesized-class-instance-constraints (pred)
@@ -1506,7 +1505,7 @@ Returns two values:
   (declare (type environment env))
   (let* ((pred-class (ty-predicate-class pred))
          (instances (lookup-class-instances env pred-class :no-error no-error)))
-    (fset:do-seq (instance instances)
+    (dolist (instance instances)
       (handler-case
           (let ((subs (predicate-match (ty-class-instance-predicate instance) pred)))
             (return-from lookup-class-instance (values instance subs)))
@@ -1563,7 +1562,9 @@ Returns two values:
   (unless (lookup-class env class)
     (error "Class ~S does not exist." class))
 
-  (fset:do-seq (inst (lookup-class-instances env class :no-error t) :index index)
+  (loop :for inst :in (lookup-class-instances env class :no-error t)
+        :for index :from 0
+        :do
     (when (handler-case (or (predicate-mgu (ty-class-instance-predicate value)
                                            (ty-class-instance-predicate inst))
                             t)
@@ -1664,7 +1665,9 @@ Returns two values:
          (to-scheme (quantify (type-variables to-ty)
                               (qualify nil to-ty))))
 
-    (fset:do-seq (elem (immutable-listmap-lookup (environment-specialization-environment env) from :no-error t) :index index)
+    (loop :for elem :in (immutable-listmap-lookup (environment-specialization-environment env) from :no-error t)
+          :for index :from 0
+          :do
       (let* ((type (specialization-entry-to-ty elem))
              (scheme (quantify (type-variables type)
                                (qualify nil type))))
@@ -1702,7 +1705,7 @@ Returns two values:
            (type symbol from)
            (type symbol to)
            (values (or null specialization-entry) &optional))
-  (fset:do-seq (elem (immutable-listmap-lookup (environment-specialization-environment env) from :no-error no-error))
+  (dolist (elem (immutable-listmap-lookup (environment-specialization-environment env) from :no-error no-error))
     (when (eq to (specialization-entry-to elem))
       (return-from lookup-specialization elem)))
 
@@ -1714,7 +1717,7 @@ Returns two values:
            (type symbol from)
            (type ty ty)
            (values (or null specialization-entry) &optional))
-  (fset:do-seq (elem (immutable-listmap-lookup (environment-specialization-environment env) from :no-error no-error))
+  (dolist (elem (immutable-listmap-lookup (environment-specialization-environment env) from :no-error no-error))
     (handler-case
         (progn
           (match (specialization-entry-to-ty elem) ty)
@@ -1875,7 +1878,7 @@ This function will return the single functional dependency
                           pred-tys)
           :do (block update-block
                 ;; Try to find a matching relation for the current fundep
-                (fset:do-seq (s state)
+                (dolist (s state)
                   ;; If the left side matches checking either direction
                   (when (or (handler-case
                                 (progn
@@ -1942,7 +1945,7 @@ This function will return the single functional dependency
 
          (new-pred (make-ty-predicate :class class-name :types vars :location (source:location pred))))
 
-    (fset:do-seq (inst (lookup-class-instances env class-name))
+    (dolist (inst (lookup-class-instances env class-name))
       (handler-case
           (progn
             (predicate-mgu new-pred (ty-class-instance-predicate inst))
@@ -2137,7 +2140,7 @@ predicates with all substitutions applied and the new substitutions."
 
 (defun generate-fundep-subs-for-pred% (pred state class-variables fundep subs)
   (declare (type ty-predicate pred)
-           (type fset:seq state)
+           (type list state)
            (type util:symbol-list class-variables)
            (type fundep fundep)
            (type substitution-list subs)
@@ -2152,7 +2155,7 @@ predicates with all substitutions applied and the new substitutions."
                     class-variables
                     (ty-predicate-types pred))))
 
-    (fset:do-seq (entry state)
+    (dolist (entry state)
       (handler-case
           (let* ((fresh-entry (fresh-fundep-entry entry))
                  (left-subs (match-list from-tys (fundep-entry-from fresh-entry)))

--- a/tests/avl-tree-tests.lisp
+++ b/tests/avl-tree-tests.lisp
@@ -1,0 +1,484 @@
+;;;; avl-tree-tests.lisp — Comprehensive tests for the persistent AVL tree.
+
+(in-package #:coalton-tests)
+
+;;;; Helpers
+
+(defun avl-empty ()
+  "Shorthand for the empty AVL tree in tests."
+  (coalton-impl/algorithm/avl-tree:empty-avl-tree))
+
+(defun avl-empty-p (tree)
+  "Return T if TREE is the empty AVL tree."
+  (not (coalton-impl/algorithm/avl-tree:avl-node-p tree)))
+
+(defun avl-height (tree)
+  "Return the height of TREE (0 for empty)."
+  (if (coalton-impl/algorithm/avl-tree:avl-node-p tree)
+      (coalton-impl/algorithm/avl-tree::avl-node-height tree)
+      0))
+
+(defun avl-balanced-p (tree)
+  "Return T if TREE satisfies the AVL balance invariant at every node."
+  (or (avl-empty-p tree)
+      (let* ((l (coalton-impl/algorithm/avl-tree::avl-node-left tree))
+             (r (coalton-impl/algorithm/avl-tree::avl-node-right tree))
+             (bf (- (avl-height l) (avl-height r))))
+        (and (<= -1 bf 1)
+             (avl-balanced-p l)
+             (avl-balanced-p r)))))
+
+(defun avl-bst-p (tree &optional lo hi)
+  "Return T if TREE satisfies the BST ordering invariant.
+LO and HI are exclusive bounds (nil means unbounded)."
+  (or (avl-empty-p tree)
+      (let ((k (coalton-impl/algorithm/avl-tree::avl-node-key tree)))
+        (and (or (null lo) (coalton-impl/algorithm/avl-tree::key< lo k))
+             (or (null hi) (coalton-impl/algorithm/avl-tree::key< k hi))
+             (avl-bst-p (coalton-impl/algorithm/avl-tree::avl-node-left tree) lo k)
+             (avl-bst-p (coalton-impl/algorithm/avl-tree::avl-node-right tree) k hi)))))
+
+(defun avl-count-correct-p (tree)
+  "Return T if every node's count field equals 1 + count(left) + count(right)."
+  (or (avl-empty-p tree)
+      (let ((l (coalton-impl/algorithm/avl-tree::avl-node-left tree))
+            (r (coalton-impl/algorithm/avl-tree::avl-node-right tree)))
+        (and (= (coalton-impl/algorithm/avl-tree::avl-node-count tree)
+                (+ 1
+                   (coalton-impl/algorithm/avl-tree::node-count l)
+                   (coalton-impl/algorithm/avl-tree::node-count r)))
+             (avl-count-correct-p l)
+             (avl-count-correct-p r)))))
+
+(defun avl-height-correct-p (tree)
+  "Return T if every node's height field equals 1 + max(height(left), height(right))."
+  (or (avl-empty-p tree)
+      (let ((l (coalton-impl/algorithm/avl-tree::avl-node-left tree))
+            (r (coalton-impl/algorithm/avl-tree::avl-node-right tree)))
+        (and (= (coalton-impl/algorithm/avl-tree::avl-node-height tree)
+                (1+ (max (avl-height l) (avl-height r))))
+             (avl-height-correct-p l)
+             (avl-height-correct-p r)))))
+
+(defun check-invariants (tree)
+  "Assert all AVL tree invariants hold."
+  (is (avl-balanced-p tree))
+  (is (avl-bst-p tree))
+  (is (avl-count-correct-p tree))
+  (is (avl-height-correct-p tree)))
+
+(defun build-tree (pairs)
+  "Build an AVL tree from a list of (key . value) pairs."
+  (let ((tree (avl-empty)))
+    (dolist (p pairs tree)
+      (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree (car p) (cdr p))))))
+
+
+;;;; Tests
+
+(deftest test-avl-empty ()
+  ;; Empty tree
+  (let ((empty (avl-empty)))
+    (is (avl-empty-p empty))
+    (is (= 0 (coalton-impl/algorithm/avl-tree:avl-count empty)))
+    (multiple-value-bind (val found)
+        (coalton-impl/algorithm/avl-tree:avl-lookup empty 'x)
+      (is (null val))
+      (is (null found)))
+    (is (null (coalton-impl/algorithm/avl-tree:avl-keys empty)))
+    (is (null (coalton-impl/algorithm/avl-tree:avl-values empty)))
+    (is (null (coalton-impl/algorithm/avl-tree:avl-to-alist empty)))
+    ;; Remove from empty returns empty
+    (is (avl-empty-p (coalton-impl/algorithm/avl-tree:avl-remove empty 'x)))))
+
+
+(deftest test-avl-single-insert ()
+  (let ((tree (coalton-impl/algorithm/avl-tree:avl-set (avl-empty) 'a 1)))
+    (check-invariants tree)
+    (is (= 1 (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    (multiple-value-bind (val found)
+        (coalton-impl/algorithm/avl-tree:avl-lookup tree 'a)
+      (is (= 1 val))
+      (is found))
+    ;; Key not present
+    (multiple-value-bind (val found)
+        (coalton-impl/algorithm/avl-tree:avl-lookup tree 'b)
+      (is (null val))
+      (is (null found)))))
+
+
+(deftest test-avl-insert-multiple ()
+  ;; Insert several keys and verify all are found
+  (let* ((keys '(d b f a c e g))
+         (tree (avl-empty)))
+    (loop :for k :in keys
+          :for i :from 1
+          :do (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree k i)))
+    (check-invariants tree)
+    (is (= 7 (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    (loop :for k :in keys
+          :for i :from 1
+          :do (multiple-value-bind (val found)
+                  (coalton-impl/algorithm/avl-tree:avl-lookup tree k)
+                (is found)
+                (is (= i val))))))
+
+
+(deftest test-avl-replace-value ()
+  ;; Inserting the same key replaces the value
+  (let* ((tree (coalton-impl/algorithm/avl-tree:avl-set (avl-empty) 'a 1))
+         (tree2 (coalton-impl/algorithm/avl-tree:avl-set tree 'a 2)))
+    (check-invariants tree2)
+    (is (= 1 (coalton-impl/algorithm/avl-tree:avl-count tree2)))
+    (multiple-value-bind (val found)
+        (coalton-impl/algorithm/avl-tree:avl-lookup tree2 'a)
+      (is (= 2 val))
+      (is found))
+    ;; Original tree is unchanged (persistence)
+    (multiple-value-bind (val found)
+        (coalton-impl/algorithm/avl-tree:avl-lookup tree 'a)
+      (is (= 1 val))
+      (is found))))
+
+
+(deftest test-avl-eq-value-no-copy ()
+  ;; When replacing with EQ-identical value, returns same tree node
+  (let* ((val (list 1 2 3))
+         (tree (coalton-impl/algorithm/avl-tree:avl-set (avl-empty) 'a val))
+         (tree2 (coalton-impl/algorithm/avl-tree:avl-set tree 'a val)))
+    (is (eq tree tree2))))
+
+
+(deftest test-avl-remove-leaf ()
+  (let* ((tree (build-tree '((a . 1) (b . 2) (c . 3))))
+         (tree2 (coalton-impl/algorithm/avl-tree:avl-remove tree 'a)))
+    (check-invariants tree2)
+    (is (= 2 (coalton-impl/algorithm/avl-tree:avl-count tree2)))
+    (multiple-value-bind (val found)
+        (coalton-impl/algorithm/avl-tree:avl-lookup tree2 'a)
+      (declare (ignore val))
+      (is (null found)))
+    ;; Other keys still present
+    (is (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup tree2 'b)))
+    (is (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup tree2 'c)))
+    ;; Original unchanged
+    (is (= 3 (coalton-impl/algorithm/avl-tree:avl-count tree)))))
+
+
+(deftest test-avl-remove-root ()
+  (let* ((tree (build-tree '((a . 1) (b . 2) (c . 3))))
+         (tree2 (coalton-impl/algorithm/avl-tree:avl-remove tree 'b)))
+    (check-invariants tree2)
+    (is (= 2 (coalton-impl/algorithm/avl-tree:avl-count tree2)))
+    (is (null (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup tree2 'b))))
+    (is (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup tree2 'a)))
+    (is (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup tree2 'c)))))
+
+
+(deftest test-avl-remove-absent ()
+  ;; Removing a nonexistent key returns unchanged tree
+  (let* ((tree (build-tree '((a . 1) (b . 2))))
+         (tree2 (coalton-impl/algorithm/avl-tree:avl-remove tree 'z)))
+    (check-invariants tree2)
+    (is (= 2 (coalton-impl/algorithm/avl-tree:avl-count tree2)))))
+
+
+(deftest test-avl-remove-all ()
+  ;; Insert and remove every key, tree should be empty
+  (let ((keys '(d b f a c e g))
+        (tree (avl-empty)))
+    (loop :for k :in keys
+          :for i :from 1
+          :do (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree k i)))
+    (dolist (k keys)
+      (setf tree (coalton-impl/algorithm/avl-tree:avl-remove tree k))
+      (check-invariants tree))
+    (is (avl-empty-p tree))))
+
+
+(deftest test-avl-ascending-insert ()
+  ;; Worst case for naive BST — ascending insertion.
+  ;; AVL must remain balanced.
+  (let ((tree (avl-empty)))
+    (loop :for i :from 0 :below 100
+          :do (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree i i)))
+    (check-invariants tree)
+    (is (= 100 (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    ;; Height should be O(log n) — for 100 nodes, at most 9
+    (is (<= (avl-height tree) 9))
+    ;; Verify all values
+    (loop :for i :from 0 :below 100
+          :do (is (= i (nth-value 0 (coalton-impl/algorithm/avl-tree:avl-lookup tree i)))))))
+
+
+(deftest test-avl-descending-insert ()
+  ;; Other worst case — descending insertion
+  (let ((tree (avl-empty)))
+    (loop :for i :from 99 :downto 0
+          :do (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree i i)))
+    (check-invariants tree)
+    (is (= 100 (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    (is (<= (avl-height tree) 9))))
+
+
+(deftest test-avl-keys-sorted ()
+  ;; Keys should come out in ascending order regardless of insertion order
+  (let* ((tree (build-tree '((c . 3) (a . 1) (e . 5) (b . 2) (d . 4))))
+         (keys (coalton-impl/algorithm/avl-tree:avl-keys tree)))
+    (is (equal '(a b c d e) keys))))
+
+
+(deftest test-avl-values-in-key-order ()
+  (let* ((tree (build-tree '((c . 3) (a . 1) (e . 5) (b . 2) (d . 4))))
+         (vals (coalton-impl/algorithm/avl-tree:avl-values tree)))
+    (is (equal '(1 2 3 4 5) vals))))
+
+
+(deftest test-avl-to-alist ()
+  (let* ((tree (build-tree '((c . 3) (a . 1) (b . 2))))
+         (alist (coalton-impl/algorithm/avl-tree:avl-to-alist tree)))
+    (is (equal '((a . 1) (b . 2) (c . 3)) alist))))
+
+
+(deftest test-avl-from-alist ()
+  (let* ((alist '((c . 3) (a . 1) (b . 2)))
+         (tree (coalton-impl/algorithm/avl-tree:avl-from-alist alist)))
+    (check-invariants tree)
+    (is (= 3 (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    (is (equal '((a . 1) (b . 2) (c . 3))
+               (coalton-impl/algorithm/avl-tree:avl-to-alist tree)))))
+
+
+(deftest test-avl-from-alist-duplicate-keys ()
+  ;; Later pairs overwrite earlier ones
+  (let* ((tree (coalton-impl/algorithm/avl-tree:avl-from-alist
+                '((a . 1) (b . 2) (a . 99)))))
+    (check-invariants tree)
+    (is (= 2 (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    (is (= 99 (nth-value 0 (coalton-impl/algorithm/avl-tree:avl-lookup tree 'a))))))
+
+
+(deftest test-avl-foreach ()
+  (let* ((tree (build-tree '((c . 3) (a . 1) (b . 2))))
+         (acc nil))
+    (coalton-impl/algorithm/avl-tree:avl-foreach
+     (lambda (k v) (push (cons k v) acc))
+     tree)
+    ;; foreach visits in ascending order, so reversed acc matches
+    (is (equal '((a . 1) (b . 2) (c . 3)) (nreverse acc)))))
+
+
+(deftest test-avl-do-avl ()
+  ;; do-avl macro iterates in order and supports early return
+  (let* ((tree (build-tree '((a . 1) (b . 2) (c . 3) (d . 4))))
+         (acc nil))
+    (coalton-impl/algorithm/avl-tree:do-avl (k v tree)
+      (declare (ignore v))
+      (push k acc))
+    (is (equal '(d c b a) acc)))
+  ;; Test result form
+  (let ((tree (build-tree '((a . 1) (b . 2)))))
+    (is (= 42
+           (coalton-impl/algorithm/avl-tree:do-avl (k v tree 42)
+             (declare (ignore k v))))))
+  ;; Test early return
+  (let ((tree (build-tree '((a . 1) (b . 2) (c . 3)))))
+    (is (= 2
+           (coalton-impl/algorithm/avl-tree:do-avl (k v tree)
+             (declare (ignore k))
+             (when (= v 2) (return v)))))))
+
+
+(deftest test-avl-image ()
+  ;; Transform all values
+  (let* ((tree (build-tree '((a . 1) (b . 2) (c . 3))))
+         (tree2 (coalton-impl/algorithm/avl-tree:avl-image #'1+ tree)))
+    (check-invariants tree2)
+    (is (equal '((a . 2) (b . 3) (c . 4))
+               (coalton-impl/algorithm/avl-tree:avl-to-alist tree2)))
+    ;; Original unchanged
+    (is (equal '((a . 1) (b . 2) (c . 3))
+               (coalton-impl/algorithm/avl-tree:avl-to-alist tree)))))
+
+
+(deftest test-avl-image-empty ()
+  (let ((result (coalton-impl/algorithm/avl-tree:avl-image #'1+ (avl-empty))))
+    (is (avl-empty-p result))))
+
+
+(deftest test-avl-difference ()
+  (let* ((t1 (build-tree '((a . 1) (b . 2) (c . 3) (d . 4))))
+         (t2 (build-tree '((b . 99) (d . 99))))
+         (diff (coalton-impl/algorithm/avl-tree:avl-difference t1 t2)))
+    (check-invariants diff)
+    (is (equal '((a . 1) (c . 3))
+               (coalton-impl/algorithm/avl-tree:avl-to-alist diff)))))
+
+
+(deftest test-avl-difference-disjoint ()
+  ;; No overlap: difference = tree1
+  (let* ((t1 (build-tree '((a . 1) (b . 2))))
+         (t2 (build-tree '((c . 3) (d . 4))))
+         (diff (coalton-impl/algorithm/avl-tree:avl-difference t1 t2)))
+    (check-invariants diff)
+    (is (equal '((a . 1) (b . 2))
+               (coalton-impl/algorithm/avl-tree:avl-to-alist diff)))))
+
+
+(deftest test-avl-difference-empty ()
+  (let ((tree (build-tree '((a . 1))))
+        (empty (avl-empty)))
+    ;; diff(tree, empty) = tree
+    (is (eq tree (coalton-impl/algorithm/avl-tree:avl-difference tree empty)))
+    ;; diff(empty, tree) = empty
+    (is (avl-empty-p (coalton-impl/algorithm/avl-tree:avl-difference empty tree)))))
+
+
+(deftest test-avl-make-avl-map ()
+  (let ((tree (coalton-impl/algorithm/avl-tree:make-avl-map ('a 1) ('b 2) ('c 3))))
+    (check-invariants tree)
+    (is (= 3 (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    (is (= 1 (nth-value 0 (coalton-impl/algorithm/avl-tree:avl-lookup tree 'a))))
+    (is (= 2 (nth-value 0 (coalton-impl/algorithm/avl-tree:avl-lookup tree 'b))))
+    (is (= 3 (nth-value 0 (coalton-impl/algorithm/avl-tree:avl-lookup tree 'c))))))
+
+
+;;; Key ordering tests
+
+(deftest test-avl-fixnum-keys ()
+  ;; Fixnum keys sort numerically
+  (let ((tree (build-tree '((3 . c) (1 . a) (2 . b)))))
+    (check-invariants tree)
+    (is (equal '(1 2 3) (coalton-impl/algorithm/avl-tree:avl-keys tree)))))
+
+
+(deftest test-avl-string-keys ()
+  (let ((tree (build-tree '(("cherry" . 3) ("apple" . 1) ("banana" . 2)))))
+    (check-invariants tree)
+    (is (equal '("apple" "banana" "cherry")
+               (coalton-impl/algorithm/avl-tree:avl-keys tree)))))
+
+
+(deftest test-avl-cons-keys ()
+  ;; Cons keys sort lexicographically
+  (let ((tree (build-tree '(((b . 2) . :b2) ((a . 2) . :a2) ((a . 1) . :a1)))))
+    (check-invariants tree)
+    (is (equal '((a . 1) (a . 2) (b . 2))
+               (coalton-impl/algorithm/avl-tree:avl-keys tree)))))
+
+
+(deftest test-avl-mixed-type-keys ()
+  ;; Keys of different types: fixnum < cons < symbol < string
+  (let ((tree (build-tree '((foo . :sym) (42 . :num) ("bar" . :str) ((a . b) . :cons)))))
+    (check-invariants tree)
+    (is (equal '(42 (a . b) foo "bar")
+               (coalton-impl/algorithm/avl-tree:avl-keys tree)))))
+
+
+(deftest test-avl-symbol-ordering ()
+  ;; Symbols ordered by package then name
+  (let ((tree (avl-empty)))
+    ;; Use keywords and CL symbols to test cross-package ordering
+    (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree :z 1))
+    (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree :a 2))
+    (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree 'cl:list 3))
+    (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree 'cl:car 4))
+    (check-invariants tree)
+    (let ((keys (coalton-impl/algorithm/avl-tree:avl-keys tree)))
+      ;; All CL symbols before KEYWORD symbols (alphabetically by package name)
+      (is (eq 'cl:car (first keys)))
+      (is (eq 'cl:list (second keys)))
+      (is (eq :a (third keys)))
+      (is (eq :z (fourth keys))))))
+
+
+(deftest test-avl-uninterned-symbol-keys ()
+  ;; Uninterned symbols (nil package) sort before interned ones
+  (let* ((u1 (make-symbol "ZZZ"))
+         (u2 (make-symbol "AAA"))
+         (tree (build-tree (list (cons u1 1) (cons 'cl:car 2) (cons u2 3)))))
+    (check-invariants tree)
+    (let ((keys (coalton-impl/algorithm/avl-tree:avl-keys tree)))
+      ;; Uninterned first (sorted by name), then interned
+      (is (eq u2 (first keys)))
+      (is (eq u1 (second keys)))
+      (is (eq 'cl:car (third keys))))))
+
+
+;;; Persistence tests
+
+(deftest test-avl-persistence ()
+  ;; Modifications produce new trees; originals are unchanged
+  (let* ((t0 (avl-empty))
+         (t1 (coalton-impl/algorithm/avl-tree:avl-set t0 'a 1))
+         (t2 (coalton-impl/algorithm/avl-tree:avl-set t1 'b 2))
+         (t3 (coalton-impl/algorithm/avl-tree:avl-remove t2 'a)))
+    (is (= 0 (coalton-impl/algorithm/avl-tree:avl-count t0)))
+    (is (= 1 (coalton-impl/algorithm/avl-tree:avl-count t1)))
+    (is (= 2 (coalton-impl/algorithm/avl-tree:avl-count t2)))
+    (is (= 1 (coalton-impl/algorithm/avl-tree:avl-count t3)))
+    ;; t1 still has 'a
+    (is (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup t1 'a)))
+    ;; t3 does not
+    (is (null (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup t3 'a))))
+    ;; t3 still has 'b
+    (is (nth-value 1 (coalton-impl/algorithm/avl-tree:avl-lookup t3 'b)))))
+
+
+;;; Stress test
+
+(deftest test-avl-stress-insert-remove ()
+  ;; Insert 1000 keys, verify all present, remove half, verify invariants
+  (let ((tree (avl-empty))
+        (n 1000))
+    ;; Insert 0..999
+    (loop :for i :from 0 :below n
+          :do (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree i (* i i))))
+    (check-invariants tree)
+    (is (= n (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    ;; Verify all
+    (loop :for i :from 0 :below n
+          :do (multiple-value-bind (val found)
+                  (coalton-impl/algorithm/avl-tree:avl-lookup tree i)
+                (is found)
+                (is (= (* i i) val))))
+    ;; Remove even keys
+    (loop :for i :from 0 :below n :by 2
+          :do (setf tree (coalton-impl/algorithm/avl-tree:avl-remove tree i)))
+    (check-invariants tree)
+    (is (= (/ n 2) (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    ;; Even keys gone, odd keys remain
+    (loop :for i :from 0 :below n
+          :do (multiple-value-bind (val found)
+                  (coalton-impl/algorithm/avl-tree:avl-lookup tree i)
+                (if (evenp i)
+                    (is (null found))
+                    (progn
+                      (is found)
+                      (is (= (* i i) val))))))))
+
+
+(deftest test-avl-stress-overwrite ()
+  ;; Repeated overwrites of same keys — tests that replacement is stable
+  (let ((tree (avl-empty))
+        (n 200))
+    (dotimes (round 5)
+      (loop :for i :from 0 :below n
+            :do (setf tree (coalton-impl/algorithm/avl-tree:avl-set tree i (+ i round)))))
+    (check-invariants tree)
+    (is (= n (coalton-impl/algorithm/avl-tree:avl-count tree)))
+    ;; Final values should be from round 4
+    (loop :for i :from 0 :below n
+          :do (is (= (+ i 4)
+                     (nth-value 0 (coalton-impl/algorithm/avl-tree:avl-lookup tree i)))))))
+
+
+;;; make-load-form test (FASL serialization)
+
+(deftest test-avl-make-load-form ()
+  ;; avl-node supports make-load-form (required for FASL)
+  (let ((tree (build-tree '((a . 1) (b . 2)))))
+    (multiple-value-bind (creation init)
+        (make-load-form tree)
+      (declare (ignore init))
+      (is (not (null creation))))))


### PR DESCRIPTION
Remove the FSet dependency entirely and replace it with a ~280-line portable Common Lisp persistent AVL tree. The AVL tree backs immutable-map and immutable-listmap with simple, correct value replacement, avoiding FSet's WB-tree corruption under Coalton's compile-time + FASL-load-time double-update pattern.