### PR TITLE
fix nullary method wrappers

### DIFF
--- a/src/codegen/codegen-class.lisp
+++ b/src/codegen/codegen-class.lisp
@@ -46,16 +46,13 @@
                              nil
                              ,(getf spec :supplied-p-var)))))))
 
-(defun method-wrapper-call (method-accessor positional-params keyword-specs)
+(defun method-wrapper-call (method-accessor visible-type positional-params keyword-specs)
   (declare (type symbol method-accessor)
+           (type tc:ty visible-type)
            (type list positional-params keyword-specs)
            (values t &optional))
   (cond
-    ((null keyword-specs)
-     (if (null positional-params)
-         `(,method-accessor dict)
-         `(rt:exact-call (,method-accessor dict) ,@positional-params)))
-    (t
+    ((not (null keyword-specs))
      `(apply #'rt:call-coalton-function
              (,method-accessor dict)
              (append
@@ -63,7 +60,13 @@
               ,@(loop :for spec :in keyword-specs
                       :collect `(if ,(getf spec :supplied-p-var)
                                     (list ,(getf spec :keyword) ,(getf spec :var))
-                                    '())))))))
+                                    '())))))
+    ((not (null positional-params))
+     `(rt:exact-call (,method-accessor dict) ,@positional-params))
+    ((tc:function-type-p visible-type)
+     `(rt:exact-call (,method-accessor dict)))
+    (t
+     `(,method-accessor dict))))
 
 (defun codegen-class-definitions (classes env)
   (declare (type tc:ty-class-list classes)
@@ -130,7 +133,7 @@
                             ,@(loop :for spec :in keyword-specs
                                     :append (list (getf spec :var)
                                                   (getf spec :supplied-p-var)))))
-        ,(method-wrapper-call method-accessor params keyword-specs))
+        ,(method-wrapper-call method-accessor visible-type params keyword-specs))
       ;; Generate the wrapper functions
       (global-lexical:define-global-lexical ,method-name rt:function-entry)
       (setf ,method-name

--- a/tests/runtime-tests.ct
+++ b/tests/runtime-tests.ct
@@ -50,7 +50,29 @@
 
   (define-instance (KeywordMethodRuntime Integer)
     (define (keyword-method-runtime x &key (offset 1))
-      (+ x offset))))
+      (+ x offset)))
+
+  (define-class (Monad :m => RuntimeHasStore :m)
+    (runtime-get-store
+     (Void -> m-env:EnvT Unit :m Unit)))
+
+  (define-instance (Monad :m => RuntimeHasStore :m)
+    (define (runtime-get-store)
+      (pure Unit)))
+
+  (declare runtime-use-store
+    (RuntimeHasStore :m => Void -> m-env:EnvT Unit :m Unit))
+  (define (runtime-use-store)
+    (do
+     (s <- (noinline (runtime-get-store)))
+     (pure s)))
+
+  (declare runtime-run-store (Void -> Unit))
+  (define (runtime-run-store)
+    (m-id:run-identity
+     (m-env:run-envT
+      (runtime-use-store)
+      Unit))))
 
 (coalton-toplevel
   (declare type-of-literal-string String)
@@ -111,6 +133,9 @@
 (define-test test-keyword-instance-method-runtime ()
   (is (== (keyword-method-runtime 10) 11))
   (is (== (keyword-method-runtime 10 :offset 5) 15)))
+
+(define-test test-nullary-typeclass-method-runtime ()
+  (is (== Unit (runtime-run-store))))
 
 (define-test test-type-of-shows-constrained-polymorphic-types ()
   (is (== type-of-literal-string


### PR DESCRIPTION
Generic nullary typeclass wrappers returned function entries instead of calling them.  Call function-typed nullary methods with exact-call and add a regression test.

fix #1888