### PR TITLE
Add or-def utility function

### DIFF
--- a/library/optional.ct
+++ b/library/optional.ct
@@ -6,7 +6,8 @@
   (:export
    #:from-some
    #:some?
-   #:none?))
+   #:none?
+   #:or-def))
 
 (in-package #:coalton/optional)
 
@@ -18,6 +19,7 @@
   ;; Optional
   ;;
 
+  (inline)
   (declare from-some (String * (Optional :a) -> :a))
   (define (from-some str opt)
     "Get the value of OPT, erroring with the provided string if it is None."
@@ -40,6 +42,14 @@
     (match x
       ((None) True)
       ((Some _) False)))
+
+  (inline)
+  (declare or-def (:a * Optional :a -> :a))
+  (define (or-def def val?)
+    "Get the value of OPT if it is Some, or use DEF as the default."
+    (match val?
+      ((Some val) val)
+      ((None) def)))
 
   ;;
   ;; Instances

--- a/library/optional.ct
+++ b/library/optional.ct
@@ -7,7 +7,7 @@
    #:from-some
    #:some?
    #:none?
-   #:or-def))
+   #:from-some-or))
 
 (in-package #:coalton/optional)
 
@@ -44,8 +44,8 @@
       ((Some _) False)))
 
   (inline)
-  (declare or-def (:a * Optional :a -> :a))
-  (define (or-def def val?)
+  (declare from-some-or (:a * Optional :a -> :a))
+  (define (from-some-or def val?)
     "Get the value of OPT if it is Some, or use DEF as the default."
     (match val?
       ((Some val) val)


### PR DESCRIPTION
Adds a small utility function. Mirrors `ok-or-def` from Result, but with a shorter name.