### PR TITLE
Add a link to awesome-coalton to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Coalton is currently used in production to build defense and [quantum computing 
 
 **Learn**: Start with [*Whirlwind Tour of Coalton*](docs/manual/site/topics/whirlwind-tour.md), the [language manual](https://coalton-lang.github.io/manual/), and the [standard library reference](https://coalton-lang.github.io/reference/), and then take a peek at the [examples directory](examples/). It may also be helpful to check out the [introductory blog post](https://coalton-lang.github.io/20211010-introducing-coalton/).
 
+**Open Source Community**: [Awesome Coalton](https://github.com/Jason94/awesome-coalton) has a list of community-built libraries, applications, and examples, that you can use in your own projects or as examples to learn from.
+
 ## What's Here?
 
 This repository contains the source code to the [Coalton compiler](src/), and the [standard library](library/).


### PR DESCRIPTION
Does what it says on the tin. I'm open to the readme not being the right place for this - maybe the website?