### PR TITLE
fix Coalton reader syntax in fallback lists

### DIFF
--- a/src/parser/reader.lisp
+++ b/src/parser/reader.lisp
@@ -20,6 +20,7 @@
    #:builder-when-marker
    #:desugar-bracket-builder
    #:with-reader-context
+   #:with-coalton-reader-context
    #:maybe-read-form))
 
 (in-package #:coalton-impl/parser/reader)
@@ -618,6 +619,14 @@
       nil
       'eof
       nil)))
+
+(defmacro with-coalton-reader-context (stream &body body)
+  "Run BODY in a toplevel reader context with Coalton reader syntax installed."
+  `(let ((eclector.readtable:*readtable*
+           (eclector.readtable:copy-readtable eclector.readtable:*readtable*)))
+     (install-coalton-reader-syntax eclector.readtable:*readtable*)
+     (with-reader-context ,stream
+       ,@body)))
 
 (defun maybe-read-form (stream source &optional (eclector-client eclector.base:*client*))
   "Read the next form or return if there is no next form.

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -91,46 +91,54 @@ This symbol may be bound to a string source in the case of direct evaluation in 
           (setf dotted-context t)
           (eclector.reader:recover c))))))
 
+(defmacro with-coalton-parser-readtable (&body body)
+  "Run BODY with Coalton's Eclector reader syntax installed."
+  `(let ((eclector.readtable:*readtable*
+           (eclector.readtable:copy-readtable eclector.readtable:*readtable*)))
+     (preader:install-coalton-reader-syntax eclector.readtable:*readtable*)
+     ,@body))
+
 (defun maybe-read-coalton (stream source)
   "If the first form on STREAM indicates that Coalton code is present, read a program, and perform the indicated operation (compile, codegen, etc.).
 SOURCE provides metadata for the stream argument, for error messages."
-  (parser:with-reader-context stream
-    (let ((first-form
-            (multiple-value-bind (form presentp)
-                (parser:maybe-read-form stream source)
-              (unless presentp
-                (return-from maybe-read-coalton nil))
-              form)))
+  (with-coalton-parser-readtable
+    (parser:with-reader-context stream
+      (let ((first-form
+              (multiple-value-bind (form presentp)
+                  (parser:maybe-read-form stream source)
+                (unless presentp
+                  (return-from maybe-read-coalton nil))
+                form)))
 
-      (case (cst:raw first-form)
-        (coalton:coalton-toplevel
-          (entry:compile-coalton-toplevel (parser:read-program stream source ':macro)))
+        (case (cst:raw first-form)
+          (coalton:coalton-toplevel
+            (entry:compile-coalton-toplevel (parser:read-program stream source ':macro)))
 
-        (coalton:coalton-codegen
-          (let ((settings:*emit-type-annotations* nil))
-            `',(entry:entry-point (parser:read-program stream source ':macro))))
+          (coalton:coalton-codegen
+            (let ((settings:*emit-type-annotations* nil))
+              `',(entry:entry-point (parser:read-program stream source ':macro))))
 
-        (coalton:coalton-codegen-types
-          (let ((settings:*emit-type-annotations* t))
-            `',(entry:entry-point (parser:read-program stream source ':macro))))
+          (coalton:coalton-codegen-types
+            (let ((settings:*emit-type-annotations* t))
+              `',(entry:entry-point (parser:read-program stream source ':macro))))
 
-        (coalton:coalton-codegen-ast
-          (let* ((settings:*emit-type-annotations* nil)
-                 (ast nil)
-                 (codegen:*codegen-hook* (lambda (op &rest args)
-                                           (when (eql op ':AST)
-                                             (push args ast)))))
-            (entry:entry-point (parser:read-program stream source ':macro))
-            (loop :for (name type value) :in (nreverse ast)
-                  :do (format t "~A :: ~A~%~A~%~%~%" name type value)))
-          nil)
+          (coalton:coalton-codegen-ast
+            (let* ((settings:*emit-type-annotations* nil)
+                   (ast nil)
+                   (codegen:*codegen-hook* (lambda (op &rest args)
+                                             (when (eql op ':AST)
+                                               (push args ast)))))
+              (entry:entry-point (parser:read-program stream source ':macro))
+              (loop :for (name type value) :in (nreverse ast)
+                    :do (format t "~A :: ~A~%~A~%~%~%" name type value)))
+            nil)
 
-        (coalton:coalton
-         (entry:expression-entry-point (parser:read-expressions stream source)))
+          (coalton:coalton
+           (entry:expression-entry-point (parser:read-expressions stream source)))
 
-        ;; Fall back to reading the list manually
-        (t
-         (read-lisp stream source first-form))))))
+          ;; Fall back to reading the list manually.
+          (t
+           (read-lisp stream source first-form)))))))
 
 (defun utf-8-char-width (char)
   "Return the number of UTF-8 octets required to encode CHAR."
@@ -199,32 +207,33 @@ SOURCE provides metadata for the stream argument, for error messages."
   "Read a Coalton toplevel form from STREAM and defer compilation to macroexpansion.
 SOURCE provides metadata for the stream argument, and START is the offset of
 the opening parenthesis that began the current form."
-  (parser:with-reader-context stream
-    (let ((first-form
-            (multiple-value-bind (form presentp)
-                (parser:maybe-read-form stream source)
-              (unless presentp
-                (return-from maybe-read-coalton-deferred nil))
-              form)))
-      (let ((mode (cst:raw first-form)))
-        (case mode
-          ((coalton:coalton-toplevel
-            coalton:coalton-codegen
-            coalton:coalton-codegen-types
-            coalton:coalton-codegen-ast
-            coalton:coalton)
-           ;; Consume the original source form now, but compile it later from
-           ;; the exact source span so repeated compiler passes do not
-           ;; monomorphize or inline the same form more than once.
-           (read-lisp stream source first-form)
-           (make-deferred-coalton-form mode
-                                       source
-                                       (normalized-source-span source
-                                                               mode
-                                                               start
-                                                               (file-position stream))))
-          (t
-           (read-lisp stream source first-form)))))))
+  (with-coalton-parser-readtable
+    (parser:with-reader-context stream
+      (let ((first-form
+              (multiple-value-bind (form presentp)
+                  (parser:maybe-read-form stream source)
+                (unless presentp
+                  (return-from maybe-read-coalton-deferred nil))
+                form)))
+        (let ((mode (cst:raw first-form)))
+          (case mode
+            ((coalton:coalton-toplevel
+              coalton:coalton-codegen
+              coalton:coalton-codegen-types
+              coalton:coalton-codegen-ast
+              coalton:coalton)
+             ;; Consume the original source form now, but compile it later from
+             ;; the exact source span so repeated compiler passes do not
+             ;; monomorphize or inline the same form more than once.
+             (read-lisp stream source first-form)
+             (make-deferred-coalton-form mode
+                                         source
+                                         (normalized-source-span source
+                                                                 mode
+                                                                 start
+                                                                 (file-position stream))))
+            (t
+             (read-lisp stream source first-form))))))))
 
 (defun expand-source-coalton-form-1 (mode source span)
   "Compile the Coalton form identified by MODE from SOURCE at SPAN.
@@ -323,11 +332,63 @@ Eclector bracket reader in parser/reader.lisp."
   (declare (ignore stream char))
   (error "Unmatched close bracket `]`"))
 
+(defun read-cl-short-lambda-char-string (char)
+  (let ((string (string char)))
+    (ecase (readtable-case *readtable*)
+      (:upcase
+       (string-upcase string))
+      (:downcase
+       (string-downcase string))
+      (:preserve
+       string)
+      (:invert
+       (cond
+         ((upper-case-p char)
+          (string-downcase string))
+         ((lower-case-p char)
+          (string-upcase string))
+         (t
+          string))))))
+
+(defun read-cl-short-lambda-char-symbol (char)
+  (intern (read-cl-short-lambda-char-string char) *package*))
+
+(defun read-cl-short-lambda-form (stream char)
+  "Reader macro for `ƒx.body` syntax on the CL readtable."
+  (declare (ignore char))
+  (let ((params nil)
+        (seen-names (make-hash-table :test #'eq)))
+    (loop :for param-char := (read-char stream nil nil)
+          :do
+             (cond
+               ((null param-char)
+                (error "Malformed short lambda: missing `.`"))
+               ((char= #\. param-char)
+                (unless (peek-char t stream nil nil)
+                  (error "Malformed short lambda: missing body expression"))
+                (return (list 'coalton:fn
+                              (nreverse params)
+                              (read stream t nil t))))
+               ((char= #\_ param-char)
+                (push (read-cl-short-lambda-char-symbol param-char) params))
+               ((alpha-char-p param-char)
+                (let ((name (read-cl-short-lambda-char-symbol param-char)))
+                  (when (gethash name seen-names)
+                    (error "Malformed short lambda: duplicate parameter `~A`"
+                           param-char))
+                  (setf (gethash name seen-names) t)
+                  (push name params)))
+               (t
+                (error
+                 "Malformed short lambda: expected alphabetic parameter, `_`, or `.`, got `~A`"
+                 param-char))))))
+
 (named-readtables:defreadtable coalton:coalton
   (:merge :standard)
   (:macro-char #\( 'read-coalton-toplevel-open-paren)
   (:macro-char #\[ 'read-cl-bracket-form)
   (:macro-char #\] 'read-cl-close-bracket)
+  (:macro-char #\ƒ 'read-cl-short-lambda-form)
   (:macro-char #\` (lambda (s c)
                      (let ((*coalton-reader-allowed* nil))
                        (funcall (get-macro-character #\` (named-readtables:ensure-readtable :standard)) s c))))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -91,54 +91,46 @@ This symbol may be bound to a string source in the case of direct evaluation in 
           (setf dotted-context t)
           (eclector.reader:recover c))))))
 
-(defmacro with-coalton-parser-readtable (&body body)
-  "Run BODY with Coalton's Eclector reader syntax installed."
-  `(let ((eclector.readtable:*readtable*
-           (eclector.readtable:copy-readtable eclector.readtable:*readtable*)))
-     (preader:install-coalton-reader-syntax eclector.readtable:*readtable*)
-     ,@body))
-
 (defun maybe-read-coalton (stream source)
   "If the first form on STREAM indicates that Coalton code is present, read a program, and perform the indicated operation (compile, codegen, etc.).
 SOURCE provides metadata for the stream argument, for error messages."
-  (with-coalton-parser-readtable
-    (parser:with-reader-context stream
-      (let ((first-form
-              (multiple-value-bind (form presentp)
-                  (parser:maybe-read-form stream source)
-                (unless presentp
-                  (return-from maybe-read-coalton nil))
-                form)))
+  (parser:with-coalton-reader-context stream
+    (let ((first-form
+            (multiple-value-bind (form presentp)
+                (parser:maybe-read-form stream source)
+              (unless presentp
+                (return-from maybe-read-coalton nil))
+              form)))
 
-        (case (cst:raw first-form)
-          (coalton:coalton-toplevel
-            (entry:compile-coalton-toplevel (parser:read-program stream source ':macro)))
+      (case (cst:raw first-form)
+        (coalton:coalton-toplevel
+          (entry:compile-coalton-toplevel (parser:read-program stream source ':macro)))
 
-          (coalton:coalton-codegen
-            (let ((settings:*emit-type-annotations* nil))
-              `',(entry:entry-point (parser:read-program stream source ':macro))))
+        (coalton:coalton-codegen
+          (let ((settings:*emit-type-annotations* nil))
+            `',(entry:entry-point (parser:read-program stream source ':macro))))
 
-          (coalton:coalton-codegen-types
-            (let ((settings:*emit-type-annotations* t))
-              `',(entry:entry-point (parser:read-program stream source ':macro))))
+        (coalton:coalton-codegen-types
+          (let ((settings:*emit-type-annotations* t))
+            `',(entry:entry-point (parser:read-program stream source ':macro))))
 
-          (coalton:coalton-codegen-ast
-            (let* ((settings:*emit-type-annotations* nil)
-                   (ast nil)
-                   (codegen:*codegen-hook* (lambda (op &rest args)
-                                             (when (eql op ':AST)
-                                               (push args ast)))))
-              (entry:entry-point (parser:read-program stream source ':macro))
-              (loop :for (name type value) :in (nreverse ast)
-                    :do (format t "~A :: ~A~%~A~%~%~%" name type value)))
-            nil)
+        (coalton:coalton-codegen-ast
+          (let* ((settings:*emit-type-annotations* nil)
+                 (ast nil)
+                 (codegen:*codegen-hook* (lambda (op &rest args)
+                                           (when (eql op ':AST)
+                                             (push args ast)))))
+            (entry:entry-point (parser:read-program stream source ':macro))
+            (loop :for (name type value) :in (nreverse ast)
+                  :do (format t "~A :: ~A~%~A~%~%~%" name type value)))
+          nil)
 
-          (coalton:coalton
-           (entry:expression-entry-point (parser:read-expressions stream source)))
+        (coalton:coalton
+         (entry:expression-entry-point (parser:read-expressions stream source)))
 
-          ;; Fall back to reading the list manually.
-          (t
-           (read-lisp stream source first-form)))))))
+        ;; Fall back to reading the list manually.
+        (t
+         (read-lisp stream source first-form))))))
 
 (defun utf-8-char-width (char)
   "Return the number of UTF-8 octets required to encode CHAR."
@@ -207,33 +199,32 @@ SOURCE provides metadata for the stream argument, for error messages."
   "Read a Coalton toplevel form from STREAM and defer compilation to macroexpansion.
 SOURCE provides metadata for the stream argument, and START is the offset of
 the opening parenthesis that began the current form."
-  (with-coalton-parser-readtable
-    (parser:with-reader-context stream
-      (let ((first-form
-              (multiple-value-bind (form presentp)
-                  (parser:maybe-read-form stream source)
-                (unless presentp
-                  (return-from maybe-read-coalton-deferred nil))
-                form)))
-        (let ((mode (cst:raw first-form)))
-          (case mode
-            ((coalton:coalton-toplevel
-              coalton:coalton-codegen
-              coalton:coalton-codegen-types
-              coalton:coalton-codegen-ast
-              coalton:coalton)
-             ;; Consume the original source form now, but compile it later from
-             ;; the exact source span so repeated compiler passes do not
-             ;; monomorphize or inline the same form more than once.
-             (read-lisp stream source first-form)
-             (make-deferred-coalton-form mode
-                                         source
-                                         (normalized-source-span source
-                                                                 mode
-                                                                 start
-                                                                 (file-position stream))))
-            (t
-             (read-lisp stream source first-form))))))))
+  (parser:with-coalton-reader-context stream
+    (let ((first-form
+            (multiple-value-bind (form presentp)
+                (parser:maybe-read-form stream source)
+              (unless presentp
+                (return-from maybe-read-coalton-deferred nil))
+              form)))
+      (let ((mode (cst:raw first-form)))
+        (case mode
+          ((coalton:coalton-toplevel
+            coalton:coalton-codegen
+            coalton:coalton-codegen-types
+            coalton:coalton-codegen-ast
+            coalton:coalton)
+           ;; Consume the original source form now, but compile it later from
+           ;; the exact source span so repeated compiler passes do not
+           ;; monomorphize or inline the same form more than once.
+           (read-lisp stream source first-form)
+           (make-deferred-coalton-form mode
+                                       source
+                                       (normalized-source-span source
+                                                               mode
+                                                               start
+                                                               (file-position stream))))
+          (t
+           (read-lisp stream source first-form)))))))
 
 (defun expand-source-coalton-form-1 (mode source span)
   "Compile the Coalton form identified by MODE from SOURCE at SPAN.

--- a/tests/reader-tests.lisp
+++ b/tests/reader-tests.lisp
@@ -152,6 +152,30 @@
                          (parser:builder-for-marker))))))
       (delete-package *package*))))
 
+(deftest coalton-readtable-syntax-in-lisp-fallback ()
+  (let ((*package* (make-package "COALTON-SYNTAX-FALLBACK-PACKAGE" :use nil)))
+    (unwind-protect
+         (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
+               (list-symbol (intern "LIST" *package*))
+               (f-symbol (intern "F" *package*))
+               (x-symbol (intern "X" *package*)))
+           (is (equal (list list-symbol
+                            (list (parser:collection-builder-marker) x-symbol))
+                      (read-from-string "(list [x])"))
+               "bracket syntax should survive Lisp fallback after the first symbol")
+           (is (equal (list (list (parser:collection-builder-marker) f-symbol)
+                            x-symbol)
+                      (read-from-string "([f] x)"))
+               "bracket syntax should survive Lisp fallback in operator position")
+           (is (equal (list list-symbol
+                            (list 'coalton:fn (list x-symbol) x-symbol))
+                      (read-from-string "(list ƒx.x)"))
+               "short lambda syntax should survive Lisp fallback")
+           (is (equal (list 'coalton:fn (list x-symbol) x-symbol)
+                      (read-from-string "ƒx.x"))
+               "short lambda syntax should be active on the Coalton readtable"))
+      (delete-package *package*))))
+
 (deftest reader-defers-coalton-compilation ()
   (uiop:with-temporary-file (:stream stream
                              :pathname input-file

--- a/tests/reader-tests.lisp
+++ b/tests/reader-tests.lisp
@@ -3,12 +3,9 @@
 (defun read-form-with-source (string)
   (let ((source (source:make-source-string string :name "test")))
     (with-open-stream (stream (source:source-stream source))
-      (let ((eclector.readtable:*readtable*
-             (eclector.readtable:copy-readtable eclector.readtable:*readtable*)))
-        (parser:install-coalton-reader-syntax eclector.readtable:*readtable*)
-        (parser:with-reader-context stream
-          (values (parser:maybe-read-form stream source parser::*coalton-eclector-client*)
-                  source))))))
+      (parser:with-coalton-reader-context stream
+        (values (parser:maybe-read-form stream source parser::*coalton-eclector-client*)
+                source)))))
 
 (defun cst-symbol-spans (form name)
   (labels ((walk (node spans)


### PR DESCRIPTION
The coalton:coalton readtable handled [ at the CL readtable level, but the special ( reader path delegated list contents to Eclector while detecting Coalton forms and falling back to Lisp. That Eclector context did not have Coalton reader syntax installed, so syntax inside non-Coalton lists could be tokenized as ordinary symbols instead of reader expansions.

Install the full Coalton Eclector reader syntax around the root detection/fallback path so bracket builders and short lambda forms are read consistently anywhere the Coalton readtable is active. Also add a CL readtable implementation for short lambda syntax so direct reads through coalton:coalton do not parse ƒ forms as symbols.