### PR TITLE
mine: reduce idle CPU usage

### DIFF
--- a/mine/src/app/mine.ct
+++ b/mine/src/app/mine.ct
@@ -4782,14 +4782,60 @@ Render-app is NOT called here; the main loop handles rendering."
 
 ;;; Main loop (single-threaded, consumes queued terminal input)
 
+  (declare %min-redraw-delay ((Optional UFix) * (Optional UFix) -> (Optional UFix)))
+  (define (%min-redraw-delay a b)
+    "Return the earlier of two optional redraw delays."
+    (match a
+      ((None) b)
+      ((Some av)
+       (match b
+         ((None) a)
+         ((Some bv) (Some (min av bv)))))))
+
+  (declare %quick-result-redraw-delay-ms (MineState -> (Optional UFix)))
+  (define (%quick-result-redraw-delay-ms st)
+    "Return the delay until the visible Quick Result popup should expire."
+    (lisp (-> (Optional UFix)) (st)
+      (cl:let* ((box (mine/app/state:get-quick-result-state st))
+                (state (mine/app/state::%native-box-value box))
+                (expiry (cl:and state (cl:getf state :expiry))))
+        (cl:if expiry
+               (cl:let ((now (cl:get-internal-real-time)))
+                 (Some
+                  (cl:if (cl:<= expiry now)
+                         0
+                         (cl:ceiling (cl:* 1000 (cl:- expiry now))
+                                     cl:internal-time-units-per-second))))
+               None))))
+
+  (declare %timed-redraw-delay-ms (MineState -> (Optional UFix)))
+  (define (%timed-redraw-delay-ms st)
+    "Return the next intentional redraw delay, or None when the UI can block."
+    (let busy-delay =
+      (if (and (cell:read (.ms-repl-busy st))
+               (not (cell:read (.ms-io-request-active st)))
+               (not (cell:read (.ms-debugger-active st))))
+          (Some 100)
+          None))
+    (%min-redraw-delay
+     busy-delay
+     (%min-redraw-delay
+      (status:statusbar-redraw-delay-ms (.ms-status st))
+      (%quick-result-redraw-delay-ms st))))
+
   (declare main-loop (MineState * term:Terminal * (ev:Event -> Void) -> Void))
   (define (main-loop st term handler)
-    "Poll terminal for input, dispatch events, process async protocol messages, render."
+    "Wait for input/protocol activity, dispatch events, process async protocol messages, render."
     (cond
       ((cell:read (.ms-quit st)) (values))
       (True
-       ;; Read input events (50ms timeout)
-       (let events = (term:terminal-read-input term))
+       ;; Redraw on the next visible UI deadline (spinner tick, elapsed time,
+       ;; transient message expiry), otherwise block until input or wakeup.
+       (let events = (match (%timed-redraw-delay-ms st)
+                      ((Some delay-ms)
+                       (term:terminal-read-input-timeout term delay-ms))
+                      ((None)
+                       (term:terminal-read-input term))))
        ;; Dispatch key/mouse/resize events
        (dispatch-input-events handler events)
        ;; Process any pending protocol messages (async responses, debugger, etc.)
@@ -5185,7 +5231,8 @@ Handles #:foo, :foo, 'foo, \"foo\", and bare symbols."
   (cl:let ((box (mine/app/state:get-update-check-state st)))
     (mine/app/check-update:start-update-check-thread
      (cl:lambda (state)
-       (cl:setf (mine/app/state::%native-box-value box) state))))
+       (cl:setf (mine/app/state::%native-box-value box) state)
+       (mine/term/terminal:terminal-post-wakeup))))
   (cl:values))
 
 (cl:defun update-check-message-cl (st)
@@ -5217,12 +5264,15 @@ Handles #:foo, :foo, 'foo, \"foo\", and bare symbols."
                           (cl:let ((msg (mine/protocol/server::read-message stream)))
                             (cl:cond
                               (msg
-                               (sb-concurrency:send-message mailbox msg))
+                               (sb-concurrency:send-message mailbox msg)
+                               (mine/term/terminal:terminal-post-wakeup))
                               (cl:t
                                (sb-concurrency:send-message mailbox lost-message)
+                               (mine/term/terminal:terminal-post-wakeup)
                                (cl:return))))
                         (cl:error ()
                           (sb-concurrency:send-message mailbox lost-message)
+                          (mine/term/terminal:terminal-post-wakeup)
                           (cl:return)))))))
         cl:t))))
 

--- a/mine/src/app/setup.ct
+++ b/mine/src/app/setup.ct
@@ -124,7 +124,7 @@
 
   (declare %read-event (term:Terminal -> input:InputEvent))
   (define (%read-event terminal)
-    "Read a single input event with resize detection via polling."
+    "Read a single input event, ignoring internal wakeups."
     (let events = (term:terminal-read-input terminal))
     (match events
       ((Cons ev _) ev)

--- a/mine/src/bindings/platform-unix.lisp
+++ b/mine/src/bindings/platform-unix.lisp
@@ -107,11 +107,13 @@ Falls back to 24x80 if the ioctl fails."
 
 (defun platform-read-bytes (timeout-ms)
   "Read available bytes from stdin with TIMEOUT-MS millisecond wait.
+If TIMEOUT-MS is NIL, wait indefinitely.
 Returns (VALUES byte-vector count) on success, or (VALUES NIL 0) on
 timeout or error."
-  (let ((timeout-secs (if (plusp timeout-ms)
-                          (/ timeout-ms 1000.0d0)
-                          0.0d0)))
+  (let ((timeout-secs (when timeout-ms
+                        (if (plusp timeout-ms)
+                            (/ timeout-ms 1000.0d0)
+                            0.0d0))))
     (cond
       ((sb-sys:wait-until-fd-usable 0 :input timeout-secs)
        ;; Data available — read as many bytes as we can

--- a/mine/src/bindings/platform-win32.lisp
+++ b/mine/src/bindings/platform-win32.lisp
@@ -25,6 +25,7 @@
 ;; WaitForSingleObject return values
 (defconstant +wait-object-0+ 0)
 (defconstant +wait-timeout+  #x102)
+(defconstant +wait-infinite+ #xFFFFFFFF)
 
 ;;; ---- Foreign function bindings (kernel32.dll) ----
 
@@ -242,6 +243,7 @@ Returns (VALUES byte-vector count) or (VALUES NIL 0)."
 
 (defun platform-read-bytes (timeout-ms)
   "Read available bytes from stdin with TIMEOUT-MS wait.
+If TIMEOUT-MS is NIL, wait indefinitely.
 Returns (VALUES byte-vector count) on success, or (VALUES NIL 0)
 on timeout or error."
   (ensure-read-buf)
@@ -249,20 +251,27 @@ on timeout or error."
     ;; Pipe mode: poll with PeekNamedPipe (WaitForSingleObject does not
     ;; respect timeouts on synchronous pipe handles).
     (*stdin-is-pipe*
-     (let ((deadline (+ (get-internal-real-time)
-                        (* timeout-ms
-                           (/ internal-time-units-per-second 1000)))))
-       (loop
-         (when (%pipe-data-available-p)
-           (return (%read-available-bytes)))
-         (when (>= (get-internal-real-time) deadline)
-           (return (values nil 0)))
-         (sleep 0.005))))
+     (cond
+       ((null timeout-ms)
+        (%read-available-bytes))
+       (t
+        (let ((deadline (+ (get-internal-real-time)
+                           (* timeout-ms
+                              (/ internal-time-units-per-second 1000)))))
+          (loop
+            (when (%pipe-data-available-p)
+              (return (%read-available-bytes)))
+            (when (>= (get-internal-real-time) deadline)
+              (return (values nil 0)))
+            (sleep 0.005))))))
     ;; Console mode: use WaitForSingleObject
     (t
      (let ((wait-result (%wait-for-single-object
                          *stdin-handle*
-                         (if (plusp timeout-ms) timeout-ms 0))))
+                         (cond
+                           ((null timeout-ms) +wait-infinite+)
+                           ((plusp timeout-ms) timeout-ms)
+                           (t 0)))))
        (cond
          ((= wait-result +wait-object-0+)
           (%read-available-bytes))

--- a/mine/src/pane/status.ct
+++ b/mine/src/pane/status.ct
@@ -13,7 +13,8 @@
    #:statusbar-new
    #:statusbar-render
    #:statusbar-update!
-   #:statusbar-set-message!))
+   #:statusbar-set-message!
+   #:statusbar-redraw-delay-ms))
 
 (in-package #:mine/pane/status)
 
@@ -72,6 +73,23 @@
                           (cl:* 3 cl:internal-time-units-per-second))))
     (cell:write! (.message-expiry sb) expiry)
     (values))
+
+  (declare %delay-ms-until (UFix -> UFix))
+  (define (%delay-ms-until deadline)
+    "Return milliseconds until DEADLINE, or 0 if it has already passed."
+    (lisp (-> UFix) (deadline)
+      (cl:let ((now (cl:get-internal-real-time)))
+        (cl:if (cl:<= deadline now)
+               0
+               (cl:ceiling (cl:* 1000 (cl:- deadline now))
+                           cl:internal-time-units-per-second)))))
+
+  (declare statusbar-redraw-delay-ms (StatusBar -> (Optional UFix)))
+  (define (statusbar-redraw-delay-ms sb)
+    "Return the delay until the temporary status message should expire."
+    (match (cell:read (.message sb))
+      ((Some _) (Some (%delay-ms-until (cell:read (.message-expiry sb)))))
+      ((None) None)))
 
   ;;; Rendering
 

--- a/mine/src/term/input.ct
+++ b/mine/src/term/input.ct
@@ -1,5 +1,7 @@
 (cl:defpackage #:mine/term/input
   (:use #:coalton #:coalton-prelude)
+  (:local-nicknames
+   (#:vec #:coalton/vector))
   (:export
    #:Key
    #:KeyChar #:KeyCtrl #:KeyEnter #:KeyTab #:KeyBackspace
@@ -89,38 +91,6 @@
     (IEvResize UFix UFix)
     IEvNone)
 
-  ;;; Vector helpers (via lisp escape since no local nickname)
-
-  (declare vec-length ((Vector UFix) -> UFix))
-  (define (vec-length v)
-    (lisp (-> UFix) (v)
-      (cl:length v)))
-
-  (declare vec-ref ((Vector UFix) * UFix -> UFix))
-  (define (vec-ref v i)
-    (lisp (-> UFix) (v i)
-      (cl:aref v i)))
-
-  (declare vec-new (Void -> (Vector UFix)))
-  (define (vec-new)
-    (lisp (-> (Vector UFix)) ()
-      (cl:make-array 0 :fill-pointer 0 :adjustable cl:t
-                       :element-type cl:t)))
-
-  (declare vec-from-offset ((Vector UFix) * UFix -> (Vector UFix)))
-  (define (vec-from-offset v start)
-    "Create a new vector containing elements from START to the end."
-    (lisp (-> (Vector UFix)) (v start)
-      (cl:let* ((len (cl:length v))
-                (new-len (cl:max 0 (cl:- len start)))
-                (result (cl:make-array new-len :fill-pointer new-len
-                                               :adjustable cl:t
-                                               :element-type cl:t)))
-        (cl:dotimes (i new-len)
-          (cl:setf (cl:aref result i)
-                   (cl:aref v (cl:+ start i))))
-        result)))
-
   ;;; Byte-to-char conversion
 
   (declare ufix-to-char (UFix -> Char))
@@ -169,7 +139,7 @@
   (define (parse-csi-params buf start)
     "Parse CSI numeric parameters from BUF starting at START.
 Returns (params final-byte next-pos)."
-    (let len = (vec-length buf))
+    (let len = (vec:length buf))
     (lisp (-> (Tuple3 (List UFix) UFix UFix)) (buf start len)
       (cl:let ((params (cl:list 0))
                (pos start))
@@ -239,8 +209,8 @@ Returns (params final-byte next-pos)."
   (declare decode-utf8 ((Vector UFix) * UFix -> (Tuple Char UFix)))
   (define (decode-utf8 buf pos)
     "Decode a UTF-8 character from BUF at POS. Returns (char next-pos)."
-    (let b0 = (vec-ref buf pos))
-    (let len = (vec-length buf))
+    (let b0 = (vec:index-unsafe pos buf))
+    (let len = (vec:length buf))
     (cond
       ;; ASCII
       ((< b0 128)
@@ -249,7 +219,7 @@ Returns (params final-byte next-pos)."
       ((and (>= b0 192) (< b0 224))
        (cond
          ((< (+ pos 1) len)
-          (let b1 = (vec-ref buf (+ pos 1)))
+          (let b1 = (vec:index-unsafe (+ pos 1) buf))
           (let cp = (+ (* (- b0 192) 64) (- b1 128)))
           (Tuple (ufix-to-char cp) (+ pos 2)))
          (True (Tuple #\? (+ pos 1)))))
@@ -257,8 +227,8 @@ Returns (params final-byte next-pos)."
       ((and (>= b0 224) (< b0 240))
        (cond
          ((< (+ pos 2) len)
-          (let b1 = (vec-ref buf (+ pos 1)))
-          (let b2 = (vec-ref buf (+ pos 2)))
+          (let b1 = (vec:index-unsafe (+ pos 1) buf))
+          (let b2 = (vec:index-unsafe (+ pos 2) buf))
           (let cp = (+ (* (- b0 224) 4096)
                        (+ (* (- b1 128) 64) (- b2 128))))
           (Tuple (ufix-to-char cp) (+ pos 3)))
@@ -267,9 +237,9 @@ Returns (params final-byte next-pos)."
       ((and (>= b0 240) (< b0 248))
        (cond
          ((< (+ pos 3) len)
-          (let b1 = (vec-ref buf (+ pos 1)))
-          (let b2 = (vec-ref buf (+ pos 2)))
-          (let b3 = (vec-ref buf (+ pos 3)))
+          (let b1 = (vec:index-unsafe (+ pos 1) buf))
+          (let b2 = (vec:index-unsafe (+ pos 2) buf))
+          (let b3 = (vec:index-unsafe (+ pos 3) buf))
           (let cp = (+ (* (- b0 240) 262144)
                        (+ (* (- b1 128) 4096)
                           (+ (* (- b2 128) 64)
@@ -286,9 +256,9 @@ Returns (params final-byte next-pos)."
   (define (dispatch-csi buf start)
     "Parse a CSI sequence from BUF starting after the '['.
 Returns (event next-pos)."
-    (let len = (vec-length buf))
+    (let len = (vec:length buf))
     ;; Check for SGR mouse: CSI < ...
-    (if (and (< start len) (== (vec-ref buf start) 60))
+    (if (and (< start len) (== (vec:index-unsafe start buf) 60))
         ;; SGR mouse sequence
         (match (parse-csi-params buf start)
           ((Tuple3 params final-byte next)
@@ -377,7 +347,7 @@ Returns (event next-pos)."
             (lisp (-> Void) (rows cols)
               (mine/bindings/terminal:terminal-set-pipe-size rows cols)
               (cl:values))
-            IEvNone))
+            (IEvResize cols rows)))
          (_ (IEvKey (KeyUnknown 116) ModNone))))
       ;; CSI u (progressive keyboard enhancement)
       ;; Kitty protocol sends base (unshifted) codepoints with shift in
@@ -476,8 +446,8 @@ Returns (event next-pos)."
   (define (parse-one buf pos)
     "Parse a single input event from BUF starting at POS.
 Returns (event next-pos)."
-    (let len = (vec-length buf))
-    (let b = (vec-ref buf pos))
+    (let len = (vec:length buf))
+    (let b = (vec:index-unsafe pos buf))
     (cond
       ;; ESC (byte 27) — CSI/SS3 lead-in, or Alt prefix in best-effort mode
       ((== b 27)
@@ -486,7 +456,7 @@ Returns (event next-pos)."
           ;; Bare ESC at end of buffer -- incomplete, return IEvNone
           (Tuple IEvNone pos))
          (True
-          (let next-byte = (vec-ref buf (+ pos 1)))
+          (let next-byte = (vec:index-unsafe (+ pos 1) buf))
           (cond
             ;; ESC [ -> CSI
             ((== next-byte 91)
@@ -499,7 +469,7 @@ Returns (event next-pos)."
                ((>= (+ pos 2) len)
                 (Tuple IEvNone pos))
                (True
-                (let fb = (vec-ref buf (+ pos 2)))
+                (let fb = (vec:index-unsafe (+ pos 2) buf))
                 (Tuple (dispatch-ss3 fb) (+ pos 3)))))
             ;; ESC ESC -> Alt prefix (Option-as-Meta sends ESC before sequences)
             ((== next-byte 27)
@@ -507,19 +477,19 @@ Returns (event next-pos)."
                ((>= (+ pos 2) len)
                 (Tuple IEvNone pos))
                ;; ESC ESC [ -> Alt + CSI sequence
-               ((== (vec-ref buf (+ pos 2)) 91)
+               ((== (vec:index-unsafe (+ pos 2) buf) 91)
                 (if (>= (+ pos 3) len)
                     (Tuple IEvNone pos)
                     (match (dispatch-csi buf (+ pos 3))
                       ((Tuple ev next)
                        (Tuple (%apply-alt ev) next)))))
                ;; ESC ESC O -> Alt + SS3 sequence
-               ((== (vec-ref buf (+ pos 2)) 79)
+               ((== (vec:index-unsafe (+ pos 2) buf) 79)
                 (cond
                   ((>= (+ pos 3) len)
                    (Tuple IEvNone pos))
                   (True
-                   (let fb = (vec-ref buf (+ pos 3)))
+                   (let fb = (vec:index-unsafe (+ pos 3) buf))
                    (Tuple (%apply-alt (dispatch-ss3 fb)) (+ pos 4)))))
                ;; ESC ESC + other -> just ESC
                (True
@@ -575,9 +545,9 @@ Returns (event next-pos)."
   (define (parse-input buf)
     "Parse all available input events from a byte buffer.
 Returns a tuple of (parsed-events remaining-bytes)."
-    (let len = (vec-length buf))
+    (let len = (vec:length buf))
     (if (== len 0)
-        (Tuple Nil (vec-new))
+        (Tuple Nil (vec:new))
         (parse-loop buf 0 len Nil)))
 
   (declare parse-loop
@@ -585,17 +555,13 @@ Returns a tuple of (parsed-events remaining-bytes)."
      -> (Tuple (List InputEvent) (Vector UFix))))
   (define (parse-loop buf pos len acc)
     (if (>= pos len)
-        (Tuple (reverse acc) (vec-new))
+        (Tuple (reverse acc) (vec:new))
         (match (parse-one buf pos)
           ((Tuple (IEvNone) next-pos)
-           ;; TODO: Add parser regression tests for:
-           ;; - ESC[8;40;120t is fully consumed with no remainder.
-           ;; - ESC[8;40;120t followed by `a` still yields the `a` key event.
-           ;; - A partial resize sequence remains in the remainder until completed.
            (if (> next-pos pos)
-               ;; Fully consumed internal control sequence (for example, resize).
+               ;; Fully consumed internal control sequence with no public event.
                (parse-loop buf next-pos len acc)
                ;; Incomplete sequence -- return what we have plus remaining bytes.
-               (Tuple (reverse acc) (vec-from-offset buf pos))))
+               (Tuple (reverse acc) (vec:subseq buf pos len))))
           ((Tuple ev next-pos)
            (parse-loop buf next-pos len (Cons ev acc)))))))

--- a/mine/src/term/terminal.ct
+++ b/mine/src/term/terminal.ct
@@ -17,10 +17,12 @@
    #:terminal-flush
    #:terminal-clear-screen
    #:terminal-read-input
+   #:terminal-read-input-timeout
    #:terminal-wait-for-key
    #:terminal-pause-input!
    #:terminal-resume-input!
-   #:terminal-poll-bytes!))
+   #:terminal-poll-bytes!
+   #:terminal-post-wakeup))
 
 (in-package #:mine/term/terminal)
 
@@ -32,57 +34,114 @@
   (thread    cl:nil :type cl:t)
   (running-p cl:t :type cl:boolean))
 
-(cl:defun %terminal-input-runtime-start (runtime term initial-cols initial-rows)
+(cl:defvar *terminal-input-mailbox* cl:nil
+  "Mailbox for waking the main UI loop from non-terminal threads.")
+
+(cl:defvar *terminal-wakeup-message* (cl:gensym "TERMINAL-WAKEUP-")
+  "Internal sentinel used to wake the main UI loop without a terminal event.")
+
+(cl:define-condition %terminal-input-stop () ())
+
+(cl:defun %terminal-post-wakeup ()
+  "Wake the main UI loop without adding a user-visible input event."
+  (cl:let ((mailbox *terminal-input-mailbox*))
+    (cl:when mailbox
+      (sb-concurrency:send-message mailbox *terminal-wakeup-message*))))
+
+(cl:defun %terminal-post-resize (cl:&optional (mailbox *terminal-input-mailbox*))
+  "Post a resize event using the current terminal dimensions."
+  (cl:when mailbox
+    (cl:multiple-value-bind (rows cols)
+        (mine/bindings/terminal:terminal-get-size)
+      (sb-concurrency:send-message
+       mailbox
+       (mine/term/input:IEvResize cols rows)))))
+
+(cl:defun %terminal-install-resize-handler ()
+  #-win32
+  (sb-sys:enable-interrupt
+   sb-posix:sigwinch
+   (cl:lambda (cl:&rest _)
+     (cl:declare (cl:ignore _))
+     (%terminal-post-resize)))
+  #+win32
+  cl:nil)
+
+(cl:defun %terminal-input-events (messages)
+  (cl:let ((events cl:nil))
+    (cl:dolist (message messages (cl:nreverse events))
+      (cl:unless (cl:eq message *terminal-wakeup-message*)
+        (cl:push message events)))))
+
+(cl:defun %terminal-input-runtime-start (runtime term)
   (cl:let ((thread (%terminal-input-runtime-thread runtime)))
     (cl:when (cl:or (cl:null thread)
                     (cl:not (sb-thread:thread-alive-p thread)))
       (cl:setf (%terminal-input-runtime-running-p runtime) cl:t)
+      (cl:setf *terminal-input-mailbox*
+               (%terminal-input-runtime-mailbox runtime))
       (cl:setf (%terminal-input-runtime-thread runtime)
                (mine/bindings/thread:make-thread
                 "mine-input"
                 (cl:lambda ()
-                  (cl:let ((mailbox (%terminal-input-runtime-mailbox runtime))
-                           (last-cols initial-cols)
-                           (last-rows initial-rows))
-                    (cl:loop
-                      :while (%terminal-input-runtime-running-p runtime)
-                      :do
-                      (cl:let ((events (mine/term/terminal::%poll-raw-input! term)))
-                        (cl:multiple-value-bind (rows cols)
-                            (mine/bindings/terminal:terminal-get-size)
-                          (cl:when (cl:or (cl:/= last-cols cols)
-                                          (cl:/= last-rows rows))
-                            (cl:setf last-cols cols
-                                     last-rows rows)
-                            (sb-concurrency:send-message
-                             mailbox
-                             (mine/term/input:IEvResize cols rows)))
-                          (cl:dolist (event events)
-                            (sb-concurrency:send-message mailbox event)))))))))))
+                  (cl:handler-case
+                      (cl:let ((mailbox (%terminal-input-runtime-mailbox runtime)))
+                        (%terminal-install-resize-handler)
+                        (cl:loop
+                          :while (%terminal-input-runtime-running-p runtime)
+                          :do
+                          (cl:let ((events (mine/term/terminal::%poll-raw-input! term)))
+                            (cl:dolist (event events)
+                              (sb-concurrency:send-message mailbox event)))))
+                    (%terminal-input-stop () cl:nil)))))))
   (cl:values))
 
 (cl:defun %terminal-input-runtime-stop (runtime)
   (cl:setf (%terminal-input-runtime-running-p runtime) cl:nil)
   (cl:let ((thread (%terminal-input-runtime-thread runtime)))
     (cl:when thread
+      (cl:when (sb-thread:thread-alive-p thread)
+        (cl:ignore-errors
+          (sb-thread:interrupt-thread
+           thread
+           (cl:lambda ()
+             (cl:error '%terminal-input-stop)))))
       (cl:ignore-errors
         (sb-thread:join-thread thread :timeout 0.25d0 :default cl:nil))
       (cl:unless (sb-thread:thread-alive-p thread)
         (cl:setf (%terminal-input-runtime-thread runtime) cl:nil))))
+  (cl:when (cl:eq *terminal-input-mailbox*
+                  (%terminal-input-runtime-mailbox runtime))
+    (cl:setf *terminal-input-mailbox* cl:nil))
   (cl:values))
 
 (cl:defun %terminal-input-runtime-read-batch (runtime)
   (cl:let ((mailbox (%terminal-input-runtime-mailbox runtime)))
     (cl:multiple-value-bind (first ok)
-        (sb-concurrency:receive-message mailbox :timeout 0.05d0)
+        (sb-concurrency:receive-message mailbox)
       (cl:if ok
-             (cl:cons first (sb-concurrency:receive-pending-messages mailbox))
+             (%terminal-input-events
+              (cl:cons first (sb-concurrency:receive-pending-messages mailbox)))
+             Nil))))
+
+(cl:defun %terminal-input-runtime-read-batch-timeout (runtime timeout-ms)
+  (cl:let ((mailbox (%terminal-input-runtime-mailbox runtime)))
+    (cl:multiple-value-bind (first ok)
+        (sb-concurrency:receive-message
+         mailbox
+         :timeout (cl:/ timeout-ms 1000.0d0))
+      (cl:if ok
+             (%terminal-input-events
+              (cl:cons first (sb-concurrency:receive-pending-messages mailbox)))
              Nil))))
 
 (cl:defun %terminal-input-runtime-read-one (runtime)
-  (cl:nth-value 0
-                (sb-concurrency:receive-message
-                 (%terminal-input-runtime-mailbox runtime))))
+  (cl:let ((mailbox (%terminal-input-runtime-mailbox runtime)))
+    (cl:loop
+      (cl:multiple-value-bind (message ok)
+          (sb-concurrency:receive-message mailbox)
+        (cl:when (cl:and ok (cl:not (cl:eq message *terminal-wakeup-message*)))
+          (cl:return message))))))
 
 (cl:defun %read-terminal-bytes (timeout-ms)
   "Read available bytes from stdin via the platform layer.
@@ -250,6 +309,21 @@ Rejects kitty < 0.21.0 which has broken F1-F4 encoding."
     (lisp (-> TerminalInputRuntime) ()
       (make-%terminal-input-runtime)))
 
+  (declare terminal-post-wakeup (Void -> Void))
+  (define (terminal-post-wakeup)
+    "Wake the main UI loop without adding a user-visible input event."
+    (lisp (-> Void) ()
+      (%terminal-post-wakeup)
+      (cl:values)))
+
+  (declare %terminal-current-size (Void -> (Tuple UFix UFix)))
+  (define (%terminal-current-size)
+    "Return the current terminal size as (cols, rows)."
+    (lisp (-> (Tuple UFix UFix)) ()
+      (cl:multiple-value-bind (rows cols)
+          (mine/bindings/terminal:terminal-get-size)
+        (Tuple cols rows))))
+
   ;;; Terminal
 
   (define-struct Terminal
@@ -292,23 +366,17 @@ queries the terminal size, and returns a new Terminal with a fresh Screen."
       (mine/bindings/terminal:terminal-flush)
       (cl:values))
     ;; Get terminal size and create screen
-    (let cols = (lisp (-> UFix) ()
-                  (cl:multiple-value-bind (r c)
-                      (mine/bindings/terminal:terminal-get-size)
-                    (cl:declare (cl:ignore r)) c)))
-    (let rows = (lisp (-> UFix) ()
-                  (cl:multiple-value-bind (r c)
-                      (mine/bindings/terminal:terminal-get-size)
-                    (cl:declare (cl:ignore c)) r)))
-    (let runtime = (%terminal-input-runtime-new))
-    (let term = (Terminal (screen:screen-new cols rows)
-                          (cell:new True)
-                          runtime
-                          (cell:new (%make-input-buf))
-                          (cell:new cols)
-                          (cell:new rows)))
-    (%start-input-thread! term cols rows)
-    term)
+    (match (%terminal-current-size)
+      ((Tuple cols rows)
+       (let runtime = (%terminal-input-runtime-new))
+       (let term = (Terminal (screen:screen-new cols rows)
+                             (cell:new True)
+                             runtime
+                             (cell:new (%make-input-buf))
+                             (cell:new cols)
+                             (cell:new rows)))
+       (%start-input-thread! term)
+       term)))
 
   ;;; Shutdown
 
@@ -349,14 +417,11 @@ cursor, and disables raw mode."
   (declare terminal-update-size! (Terminal -> Void))
   (define (terminal-update-size! term)
     "Re-query the terminal size and update cached values."
-    (let cols-cell = (.terminal-cols-cell term))
-    (let rows-cell = (.terminal-rows-cell term))
-    (lisp (-> Void) (cols-cell rows-cell)
-      (cl:multiple-value-bind (r c)
-          (mine/bindings/terminal:terminal-get-size)
-        (coalton/cell:write! cols-cell c)
-        (coalton/cell:write! rows-cell r)
-        (cl:values))))
+    (match (%terminal-current-size)
+      ((Tuple cols rows)
+       (cell:write! (.terminal-cols-cell term) cols)
+       (cell:write! (.terminal-rows-cell term) rows)
+       (values))))
 
   ;;; Flush
 
@@ -380,16 +445,14 @@ cursor, and disables raw mode."
   (declare %make-input-buf (Void -> (Vector UFix)))
   (define (%make-input-buf)
     "Create a fresh input buffer."
-    (lisp (-> (Vector UFix)) ()
-      (cl:make-array 0 :fill-pointer 0 :adjustable cl:t
-                       :element-type cl:t)))
+    (vec:new))
 
-  (declare %start-input-thread! (Terminal * UFix * UFix -> Void))
-  (define (%start-input-thread! term cols rows)
+  (declare %start-input-thread! (Terminal -> Void))
+  (define (%start-input-thread! term)
     "Start the terminal-owned input reader thread."
     (let runtime = (.terminal-input-runtime term))
-    (lisp (-> Void) (runtime term cols rows)
-      (%terminal-input-runtime-start runtime term cols rows)
+    (lisp (-> Void) (runtime term)
+      (%terminal-input-runtime-start runtime term)
       (cl:values)))
 
   (declare %poll-raw-input! (Terminal -> (List input:InputEvent)))
@@ -397,7 +460,7 @@ cursor, and disables raw mode."
     "Read raw bytes, update the internal remainder buffer, and return parsed input events."
     (let prev-buf = (cell:read (.terminal-input-buf term)))
     (let new-bytes = (lisp (-> (Vector UFix)) ()
-                      (%read-terminal-bytes 50)))
+                      (%read-terminal-bytes cl:nil)))
     (let full-buf = (%concat-bufs prev-buf new-bytes))
     (match (input:parse-input full-buf)
       ((Tuple events remainder)
@@ -407,25 +470,22 @@ cursor, and disables raw mode."
   (declare terminal-read-input (Terminal -> (List input:InputEvent)))
   (define (terminal-read-input term)
     "Read available input from the terminal mailbox.
-Wait up to 50ms for the first event, then drain any immediately pending events."
+Block until the first event or internal wakeup, then drain any immediately pending events."
     (let runtime = (.terminal-input-runtime term))
     (lisp (-> (List input:InputEvent)) (runtime)
       (%terminal-input-runtime-read-batch runtime)))
 
+  (declare terminal-read-input-timeout (Terminal * UFix -> (List input:InputEvent)))
+  (define (terminal-read-input-timeout term timeout-ms)
+    "Read terminal input, waiting up to TIMEOUT-MS for the first event."
+    (let runtime = (.terminal-input-runtime term))
+    (lisp (-> (List input:InputEvent)) (runtime timeout-ms)
+      (%terminal-input-runtime-read-batch-timeout runtime timeout-ms)))
+
   (declare %concat-bufs ((Vector UFix) * (Vector UFix) -> (Vector UFix)))
   (define (%concat-bufs a b)
     "Concatenate two byte vectors."
-    (lisp (-> (Vector UFix)) (a b)
-      (cl:let* ((alen (cl:length a))
-                (blen (cl:length b))
-                (total (cl:+ alen blen))
-                (result (cl:make-array total :fill-pointer total
-                                             :adjustable cl:t
-                                             :element-type cl:t)))
-        (cl:dotimes (i alen) (cl:setf (cl:aref result i) (cl:aref a i)))
-        (cl:dotimes (i blen) (cl:setf (cl:aref result (cl:+ alen i))
-                                       (cl:aref b i)))
-        result)))
+    (vec:append a b))
 
   ;;; Blocking key read (for modal dialogs)
 
@@ -451,12 +511,7 @@ directly via TERMINAL-POLL-BYTES!. Pair with TERMINAL-RESUME-INPUT!."
   (declare terminal-resume-input! (Terminal -> Void))
   (define (terminal-resume-input! term)
     "Restart the background input-reader thread after a TERMINAL-PAUSE-INPUT!."
-    (let runtime = (.terminal-input-runtime term))
-    (let cols = (cell:read (.terminal-cols-cell term)))
-    (let rows = (cell:read (.terminal-rows-cell term)))
-    (lisp (-> Void) (runtime term cols rows)
-      (%terminal-input-runtime-start runtime term cols rows)
-      (cl:values)))
+    (%start-input-thread! term))
 
   (declare terminal-poll-bytes! (Terminal * UFix -> (Vector UFix)))
   (define (terminal-poll-bytes! term timeout-ms)

--- a/mine/tests/package.lisp
+++ b/mine/tests/package.lisp
@@ -67,6 +67,9 @@
                   check-symbol-input-fn-alias
                   check-short-lambda-introducer-highlights-as-fn
                   check-chained-short-lambda-introducers-each-highlight
+                  check-resize-sequence-emits-resize
+                  check-resize-sequence-consumes-before-next-key
+                  check-partial-resize-sequence-is-preserved
                   check-indent-hunchentoot-style-handler-body
                   check-indent-multiple-value-bind-special-form
                   check-indent-lambda-list-keyword-alignment

--- a/mine/tests/syntax-tests.lisp
+++ b/mine/tests/syntax-tests.lisp
@@ -4,12 +4,19 @@
   (:use #:coalton #:coalton-prelude)
   (:local-nicknames
    (#:lexer #:mine/syntax/lexer)
+   (#:input #:mine/term/input)
+   (#:vec #:coalton/vector)
    (#:tok #:mine/syntax/token))
   (:export
    #:short-lambda-introducer-highlights-as-fn?
-   #:chained-short-lambda-introducers-each-highlight?))
+   #:chained-short-lambda-introducers-each-highlight?
+   #:resize-sequence-emits-resize?
+   #:resize-sequence-consumes-before-next-key?
+   #:partial-resize-sequence-is-preserved?))
 
 (in-package #:mine-tests/syntax)
+
+(named-readtables:in-readtable coalton:coalton)
 
 (coalton-toplevel
   (declare token-kinds ((coalton:List tok:Token) -> (coalton:List tok:TokenKind)))
@@ -20,18 +27,49 @@
   (define (short-lambda-introducer-highlights-as-fn?)
     (let toks = (lexer:lex-line (lexer:lexer-state-new 0) "ƒx.x" 0))
     (== (token-kinds toks)
-        (make-list tok:TokCoaltonKeyword
-                   tok:TokSymbol)))
+        [ tok:TokCoaltonKeyword
+          tok:TokSymbol ]))
 
   (declare chained-short-lambda-introducers-each-highlight? (Void -> Boolean))
   (define (chained-short-lambda-introducers-each-highlight?)
     (let toks = (lexer:lex-line (lexer:lexer-state-new 0) "ƒx.ƒy.(+ x y)" 0))
     (== (token-kinds toks)
-        (make-list tok:TokCoaltonKeyword tok:TokSymbol
-                   tok:TokCoaltonKeyword tok:TokSymbol
-                   tok:TokOpenParen tok:TokOperator tok:TokWhitespace
-                   tok:TokSymbol tok:TokWhitespace tok:TokSymbol
-                   tok:TokCloseParen))))
+        [ tok:TokCoaltonKeyword tok:TokSymbol
+          tok:TokCoaltonKeyword tok:TokSymbol
+          tok:TokOpenParen tok:TokOperator tok:TokWhitespace
+          tok:TokSymbol tok:TokWhitespace tok:TokSymbol
+          tok:TokCloseParen ]))
+
+  (declare resize-sequence-emits-resize? (Void -> Boolean))
+  (define (resize-sequence-emits-resize?)
+    (match (input:parse-input [27 91 56 59 52 48 59 49 50 48 116])
+      ((Tuple events remainder)
+       (and (== (vec:length remainder) 0)
+            (match events
+              ((Cons (input:IEvResize cols rows) (Nil))
+               (and (== cols 120) (== rows 40)))
+              (_ False))))))
+
+  (declare resize-sequence-consumes-before-next-key? (Void -> Boolean))
+  (define (resize-sequence-consumes-before-next-key?)
+    (match (input:parse-input [27 91 56 59 52 48 59 49 50 48 116 97])
+      ((Tuple events remainder)
+       (and (== (vec:length remainder) 0)
+            (match events
+              ((Cons (input:IEvResize cols rows)
+                     (Cons (input:IEvKey (input:KeyChar ch) (input:ModNone))
+                           (Nil)))
+               (and (== cols 120) (and (== rows 40) (== ch #\a))))
+              (_ False))))))
+
+  (declare partial-resize-sequence-is-preserved? (Void -> Boolean))
+  (define (partial-resize-sequence-is-preserved?)
+    (match (input:parse-input [27 91 56 59 52])
+      ((Tuple events remainder)
+       (and (== (vec:length remainder) 5)
+            (match events
+              ((Nil) True)
+              (_ False)))))))
 
 (in-package #:mine-tests)
 
@@ -49,3 +87,15 @@
 (defun check-chained-short-lambda-introducers-each-highlight ()
   (%check (mine-tests/syntax:chained-short-lambda-introducers-each-highlight?)
           "Expected each ƒ in `ƒx.ƒy.(+ x y)` to lex as a TokCoaltonKeyword"))
+
+(defun check-resize-sequence-emits-resize ()
+  (%check (mine-tests/syntax:resize-sequence-emits-resize?)
+          "Expected CSI 8;rows;cols t to emit an IEvResize event"))
+
+(defun check-resize-sequence-consumes-before-next-key ()
+  (%check (mine-tests/syntax:resize-sequence-consumes-before-next-key?)
+          "Expected a resize sequence followed by a key to emit resize then key events"))
+
+(defun check-partial-resize-sequence-is-preserved ()
+  (%check (mine-tests/syntax:partial-resize-sequence-is-preserved?)
+          "Expected an incomplete resize sequence to remain buffered"))


### PR DESCRIPTION
Replace the fixed input polling loop with an event-driven terminal mailbox so the UI can block while idle and wake immediately for terminal input, protocol-reader activity, and resize notifications.

Preserve expected actively-updating UI behavior by adding deadline-driven redraw scheduling. The main loop now keeps the existing busy REPL spinner cadence, wakes exactly when temporary status messages expire, and redraws completed Quick Result popups at their expiry deadline instead of depending on incidental input.

Clean up platform timeout handling for Unix and Win32, add explicit terminal wakeup support, parse terminal resize escape sequences, and move more helper/test logic into Coalton syntax where practical.

Validated by observing idle CPU sample showing 0.0% CPU after roughly one minute.