### PR TITLE
Add GADTs to Coalton

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -289,6 +289,7 @@
                 :serial t
                 :components ((:file "lisp-type-tests")
                              (:file "dictionary-resolution-tests")))
+               (:ct-file "gadt-tests")
                (:file "environment-persist-tests")
                (:file "coalton-tests")
                (:file "shortcut-tailcall-tests")

--- a/src/analysis/analysis.lisp
+++ b/src/analysis/analysis.lisp
@@ -21,12 +21,14 @@
 (defun check-pattern-exhaustiveness (pattern env)
   (declare (type tc:pattern pattern)
            (type tc:environment env))
-  (let ((missing
-          (find-non-matching-value
-           ;; binding patterns can be collapsed in exhaustiveness check
-           (list (list (collapse-binding-patterns pattern)))
-           1
-           env)))
+  (let* ((pattern (collapse-binding-patterns pattern))
+         (pattern-type (tc:qualified-ty-type (tc:pattern-type pattern)))
+         (missing
+           (find-non-matching-value
+            ;; binding patterns can be collapsed in exhaustiveness check
+            (list (list (collapse-binding-patterns pattern)))
+            (list pattern-type)
+            env)))
     (unless (eq t missing)
       (tc-error "Non-exhaustive match"
                 (source:secondary-note pattern "missing case ~w"
@@ -37,10 +39,12 @@
   (declare (type tc:translation-unit translation-unit)
            (type tc:environment env))
   (flet ((analysis-match-traversal (node)
-           (let ((patterns
+           (let ((scrutinee-type (tc:qualified-ty-type (tc:node-type
+                                                        (tc:node-match-expr node))))
+                 (patterns
                    ;; for exhaustiveness checking, we can collapse
                    ;; binding patterns, (@ VAR PAT) is part of an
-                   ;; exhaustive match expression iff PAT is. 
+                   ;; exhaustive match expression iff PAT is.
                    (loop :for branch :in (tc:node-match-branches node)
                          :for pat := (tc:node-match-branch-pattern branch)
                          :collect (collapse-binding-patterns pat))))
@@ -48,7 +52,9 @@
                    :do (check-for-var-matching-constructor pattern env))
 
              (let ((exhaustive-or-missing
-                     (find-non-matching-value (mapcar #'list patterns) 1 env)))
+                     (find-non-matching-value (mapcar #'list patterns)
+                                              (list scrutinee-type)
+                                              env)))
                (unless (eq t exhaustive-or-missing)
                  (let ((head-note (source:note node "non-exhaustive match"))
                        (tail-notes (if (first exhaustive-or-missing)
@@ -59,7 +65,7 @@
                                        nil)))
                    (apply #'source:warn "non-exhaustive match" (list* head-note tail-notes))))
                (loop :for pattern :in patterns
-                     :unless (useful-pattern-p patterns pattern env) :do
+                     :unless (useful-pattern-p patterns pattern env scrutinee-type) :do
                        (source:warn "Useless match case"
                                     (source:note pattern "useless match case")
                                     (source:note node "in this match")))))

--- a/src/analysis/pattern-exhaustiveness.lisp
+++ b/src/analysis/pattern-exhaustiveness.lisp
@@ -6,7 +6,6 @@
    (#:util #:coalton-impl/util))
   (:export
    #:non-exhaustive-match-warning
-   #:useless-pattern-warning
    #:exhaustive-patterns-p
    #:useful-pattern-p
    #:find-non-matching-value
@@ -76,22 +75,46 @@
 ;;;
 ;;;
 
-(defun exhaustive-patterns-p (patterns env)
-  "Are PATTERNS exhaustive?"
+(defun make-wildcard-for-type (type)
+  (declare (type tc:ty type)
+           (values tc:pattern-wildcard &optional))
+  (tc:make-pattern-wildcard
+   :type (tc:qualify nil type)))
+
+(defun pattern-bare-type (pattern)
+  (declare (type tc:pattern pattern)
+           (values tc:ty))
+  (tc:qualified-ty-type (tc:pattern-type pattern)))
+
+(defun exhaustive-patterns-p (patterns env column-type)
+  "Are PATTERNS exhaustive for COLUMN-TYPE? In practice, column type only matters
+for GADTs, because ADTs have the same return type for every constructor."
+  (declare (type tc:pattern-list patterns)
+           (type tc:environment env)
+           (type tc:ty column-type)
+           (values boolean))
   (not
    (useful-pattern-clause-p
     (mapcar #'list patterns)
     (list (tc:make-pattern-wildcard
            :type (tc:qualify nil (tc:make-variable))))
+    (list column-type)
     env)))
 
-(defun useful-pattern-p (patterns pattern env)
-  "Is PATTERN useful within list PATTERNS? PATTERN must EQ one element of PATTERNS."
+(defun useful-pattern-p (patterns pattern env column-type)
+  "Is PATTERN useful within list PATTERNS for COLUMN-TYPE? PATTERN must EQ one element
+of PATTERNS."
+  (declare (type tc:pattern-list patterns)
+           (type tc:pattern pattern)
+           (type tc:environment env)
+           (type tc:ty column-type)
+           (values boolean))
   (useful-pattern-clause-p
    (loop :for p :in patterns
          :while (not (eq p pattern))
          :collect (list p))
    (list pattern)
+   (list column-type)
    env))
 
 (defun pattern-matrix-p (x)
@@ -106,17 +129,176 @@
 (deftype pattern-matrix ()
   '(satisfies pattern-matrix-p))
 
-(defun useful-pattern-clause-p (pattern-matrix clause env)
+(defun type-entry-for-column-type (type env)
+  "Return the TYPE-ENTRY for the head type constructor of TYPE, if any."
+  (declare (type tc:ty type)
+           (type tc:environment env)
+           (values (or null tc:type-entry)))
+  (let ((head (first (tc:flatten-type type))))
+    (when (tc:tycon-p head)
+      (tc:lookup-type env (tc:tycon-name head) :no-error t))))
+
+(defun possible-constructor-pattern (constructor-name column-type env)
+  "If CONSTRUCTOR-NAME can construct COLUMN-TYPE, return a synthetic
+PATTERN-CONSTRUCTOR whose subpatterns are typed wildcards. Otherwise return NIL."
+  (declare (type symbol constructor-name)
+           (type tc:ty column-type)
+           (type tc:environment env)
+           (values (or null tc:pattern-constructor)))
+  (let ((scheme (tc:lookup-value-type env constructor-name :no-error t)))
+    (when scheme
+      (let* ((fresh-qual-ty (tc:fresh-inst scheme))
+             (constructor-ty (tc:qualified-ty-type fresh-qual-ty))
+             (return-ty (tc:function-return-type constructor-ty)))
+        (handler-case
+            (let* (;; Unify, don't match. COLUMN-TYPE may itself contain
+                   ;; type variables, and a GADT constructor may unify them.
+                   (subs (tc:unify nil return-ty column-type))
+                   (constructor-ty (tc:apply-substitution subs constructor-ty))
+                   (return-ty (tc:apply-substitution subs return-ty))
+                   (argument-tys (tc:function-type-arguments constructor-ty)))
+              (tc:make-pattern-constructor :type (tc:qualify nil return-ty)
+                                           :name constructor-name
+                                           :patterns (loop :for arg-ty :in argument-tys
+                                                           :collect (make-wildcard-for-type arg-ty))))
+          (tc:coalton-internal-type-error ()
+            nil))))))
+
+(defun type-entry-for-seen-constructor-patterns (patterns env)
+  "Return the TYPE-ENTRY implied by constructor patterns in PATTERNS, if any.
+
+This is needed when COLUMN-TYPE is still a tyvar. In that case the column
+type has no type-constructor head, but the constructors already present in
+the pattern matrix may sitll identify the full ADT signature."
+  (declare (type tc:pattern-list patterns)
+           (type tc:environment env)
+           (values (or null tc:type-entry)))
+  (loop :for pattern :in patterns
+        :when (tc:pattern-constructor-p pattern)
+          :do (let ((entry (type-entry-for-column-type
+                            (pattern-bare-type pattern)
+                            env)))
+                (when (and entry
+                           (member (tc:pattern-constructor-name pattern)
+                                   (tc:type-entry-constructors entry)
+                                   :test #'eq))
+                  (return entry)))))
+
+(defun possible-constructor-patterns (column-type env seen-patterns)
+  "Return synthetic constructor patterns for every constructor that can produce COLUMN-TYPE.
+
+If COLUMN-TYPE has no concrete type-constructor head, use SEEN-PATTERNS as a fallback to
+recover the constructor signature from the matrix itself."
+  (declare (type tc:ty column-type)
+           (type tc:environment env)
+           (type tc:pattern-list seen-patterns)
+           (values tc:pattern-list))
+  (let ((entry (or (type-entry-for-column-type column-type env)
+                   (and (tc:tyvar-p column-type)
+                        (type-entry-for-seen-constructor-patterns
+                         seen-patterns
+                         env)))))
+    (if entry
+        (loop :for constructor-name :in (tc:type-entry-constructors entry)
+              :for pattern := (possible-constructor-pattern constructor-name
+                                                            column-type
+                                                            env)
+              :when pattern
+                :collect pattern)
+        nil)))
+
+(defun first-column-patterns (pattern-matrix)
+  (declare (type pattern-matrix pattern-matrix)
+           (values tc:pattern-list))
+  (loop :for row :in pattern-matrix
+        :for elem := (first row)
+        :when (or (tc:pattern-literal-p elem)
+                  (tc:pattern-constructor-p elem))
+          :collect elem))
+
+(defun first-column-constructors (pattern-matrix)
+  (declare (type pattern-matrix pattern-matrix)
+           (values tc:pattern-list))
+  (loop :for row :in pattern-matrix
+        :for elem := (first row)
+        :when (tc:pattern-constructor-p elem)
+          :collect elem))
+
+(defun constructor-pattern-names (patterns)
+  (declare (type tc:pattern-list patterns)
+           (values util:symbol-list))
+  (loop :for pattern :in patterns
+        :when (tc:pattern-constructor-p pattern)
+          :collect (tc:pattern-constructor-name pattern)))
+
+(defun specialize-column-types (column-types pattern)
+  "Update COLUMN-TYPES after specializing the first column by PATTERN.
+
+For a constructor C with fields T1 ... Tn, the first column is replaced with
+T1 ... Tn. The unification substitution is also applied to the remaining
+columns, which preserves GADT equalities between nested fields."
+  (declare (type tc:ty-list column-types)
+           (type (or tc:pattern-literal tc:pattern-constructor) pattern)
+           (values tc:ty-list boolean))
+  (let ((current-column-type (first column-types)))
+    (handler-case
+        (let* ((subs (tc:unify nil (pattern-bare-type pattern) current-column-type))
+               (new-column-types (etypecase pattern
+                                   (tc:pattern-literal (rest column-types))
+                                   (tc:pattern-constructor
+                                    (append (mapcar #'pattern-bare-type
+                                                    (tc:pattern-constructor-patterns pattern))
+                                            (rest column-types))))))
+          (values (tc:apply-substitution subs new-column-types) t))
+      (tc:coalton-internal-type-error ()
+        (values nil nil)))))
+
+(defun default-column-types-for-constructor (column-types constructor-pattern)
+  "Drop the first column after choosing CONSTRUCTOR-PATTERN for a wildcard
+column. Unlike SPECIALIZE-COLUMN-TYPES, this does not add constructor argument
+types, because the wildcard does not inspect constructor fields.
+
+It only applies the GADT refinement induced by the constructor return type to
+the remaining columns."
+  (declare (type tc:ty-list column-types)
+           (type tc:pattern-constructor constructor-pattern)
+           (values tc:ty-list boolean))
+  (let ((current-column-type (first column-types)))
+    (handler-case
+        (let ((subs (tc:unify nil
+                              (pattern-bare-type constructor-pattern)
+                              current-column-type)))
+          (values (tc:apply-substitution subs (rest column-types)) t))
+      (tc:coalton-internal-type-error ()
+        (values nil nil)))))
+
+(defun missing-constructor-patterns (seen-patterns possible-ctors)
+  "Return possible constructors for COLUMN-TYPE that are not named in SEEN-PATTERNS."
+  (declare (type tc:pattern-list seen-patterns)
+           (type tc:pattern-list possible-ctors)
+           (values tc:pattern-list))
+  (let ((seen-names (constructor-pattern-names seen-patterns)))
+    (remove-if
+     (lambda (constructor-pattern)
+       (member (tc:pattern-constructor-name constructor-pattern)
+               seen-names
+               :test #'eq))
+     possible-ctors)))
+
+(defun useful-pattern-clause-p (pattern-matrix clause column-types env)
   "Is CLAUSE useful with respect to PATTERN-MATRIX?
 
 PATTERN-MATRIX is a list of lists representing a pattern matrix in row-major format.
-CLAUSE is a list representing a row-vector of patterns."
+CLAUSE is a list representing a row-vector of patterns. COLUMN-TYPES is the current
+type of each matrix column."
   (declare (type pattern-matrix pattern-matrix)
            (type tc:pattern-list clause)
+           (type tc:ty-list column-types)
            (type tc:environment env)
            (values boolean &optional))
 
-  ;; NOTE: It is assumed that all rows of PATTERN-MATRIX have the same number of columns.
+  ;; NOTE: It is assumed that all rows of PATTERN-MATRIX have the same number of columns,
+  ;; and that COLUMN-TYPES has the same length as CLAUSE.
   (cond
     ;;
     ;; Check our base cases
@@ -136,40 +318,81 @@ CLAUSE is a list representing a row-vector of patterns."
     ;; Sub-case 1: The first member of CLAUSE is a constructor (or literal).
     ((or (tc:pattern-literal-p (first clause))
          (tc:pattern-constructor-p (first clause)))
-     (useful-pattern-clause-p
-      (specialize-matrix pattern-matrix (first clause))
-      (first (specialize-matrix (list clause) (first clause)))
-      env))
+     (multiple-value-bind (specialized-column-types possible-p)
+         (specialize-column-types column-types (first clause))
+       (when possible-p
+         (let ((specialized-matrix (specialize-matrix pattern-matrix (first clause)))
+               (specialized-clause (specialize-matrix (list clause) (first clause))))
+           (and specialized-clause
+                (useful-pattern-clause-p specialized-matrix
+                                         (first specialized-clause)
+                                         specialized-column-types
+                                         env))))))
 
     ;; Sub-case 2: The first member of CLAUSE is a wildcard (or variable)
     ((or (tc:pattern-wildcard-p (first clause))
          (tc:pattern-var-p (first clause)))
 
-     (let ((first-column-constructors
-             (loop :for row :in pattern-matrix
-                   :for elem := (first row)
-                   :when (or (tc:pattern-literal-p elem)
-                             (tc:pattern-constructor-p elem))
-                     :collect elem)))
+     (let* ((current-column-type (first column-types))
+            (first-column-patterns (first-column-patterns pattern-matrix))
+            (possible-constructors (possible-constructor-patterns current-column-type
+                                                                  env
+                                                                  first-column-patterns)))
        (cond
-         ;; If the constructors form a complete signature then CLAUSE
-         ;; is only useful if it is useful when specialized over the
-         ;; constructor.
-         ((complete-signature-p first-column-constructors env)
-          (loop :for pattern :in first-column-constructors
-                :when (useful-pattern-clause-p
-                       (specialize-matrix pattern-matrix pattern)
-                       (first (specialize-matrix (list clause) pattern))
-                       env)
-                  :do (return t)
-                :finally (return nil)))
-         ;; Otherwise, create a defaulted matrix and recurse, removing
-         ;; the first member of CLAUSE.
-         (t
+         ;; If this column has no known algebraic constructor signature, fall back
+         ;; to the ordinary default matrix case.
+         ((null possible-constructors)
           (useful-pattern-clause-p
            (default-matrix pattern-matrix)
            (rest clause)
-           env)))))
+           (rest column-types)
+           env))
+
+         ;; If the matrix has a complete constructor signature for this colmun,
+         ;; specialize over every possible constructor. This is the normal
+         ;; Maranget rule.
+         ((complete-signature-p first-column-patterns possible-constructors)
+          (loop :for constructor-pattern :in possible-constructors
+                :thereis
+                (multiple-value-bind (specialized-column-types possible-p)
+                    (specialize-column-types column-types constructor-pattern)
+                  (when possible-p
+                    (let ((specialized-clause (specialize-matrix (list clause)
+                                                                 constructor-pattern)))
+                      (and specialized-clause
+                           (useful-pattern-clause-p
+                            (specialize-matrix pattern-matrix constructor-pattern)
+                            (first specialized-clause)
+                            specialized-column-types
+                            env)))))))
+
+         ;; If the signature is incomplete, the useful value can be chosen from
+         ;; one of the missing constructors. Explicit constructor rows cannot match
+         ;; that value, so only the default matrix matters.
+         ;;
+         ;; For GADTs, different missing constructors may refine the remaining
+         ;; columns differently, so try each missing constructor. But do NOT expand
+         ;; into the constructor's fields; the wildcard did not inspect them.
+         (t
+          (let ((defaulted-matrix
+                  (default-matrix pattern-matrix))
+                (defaulted-clause
+                  (rest clause))
+                (missing-constructors
+                  (missing-constructor-patterns
+                   first-column-patterns
+                   possible-constructors)))
+            (loop :for constructor-pattern :in missing-constructors
+                  :thereis
+                  (multiple-value-bind (defaulted-column-types possible-p)
+                      (default-column-types-for-constructor column-types constructor-pattern)
+                    (and possible-p
+                         (useful-pattern-clause-p
+                          defaulted-matrix
+                          defaulted-clause
+                          defaulted-column-types
+                          env)))))))))
+
     (t
      (util:coalton-bug "Not reachable."))))
 
@@ -221,10 +444,10 @@ CLAUSE is a list representing a row-vector of patterns."
                   (t
                    (util:coalton-bug "Not reachable.")))))
 
-(defun complete-signature-p (patterns env)
-  "Do the set of PATTERNS form a complete signature of the constructed type?"
+(defun complete-signature-p (patterns possible-ctors)
+  "Do PATTERNS mention every constructor that can produce COLUMN-TYPE?"
   (declare (type tc:pattern-list patterns)
-           (type tc:environment env)
+           (type tc:pattern-list possible-ctors)
            (values boolean))
   (cond
     ;; Zero constructors cannot form a complete signature.
@@ -238,10 +461,14 @@ CLAUSE is a list representing a row-vector of patterns."
 
     ;; Otherwise ensure that all constructors are accounted for in PATTERNS.
     (t
-     (let* ((constructor-names (mapcar #'tc:pattern-constructor-name patterns))
-            (constructed-type (tc:constructor-entry-constructs (tc:lookup-constructor env (first constructor-names))))
-            (type-constructors (tc:type-entry-constructors (tc:lookup-type env constructed-type))))
-       (null (set-difference type-constructors constructor-names :test #'eq))))))
+     (let ((constructor-names (constructor-pattern-names patterns))
+           (possible-constructor-names (mapcar #'tc:pattern-constructor-name
+                                               possible-ctors)))
+       (and possible-constructor-names
+            (null
+             (set-difference possible-constructor-names
+                             constructor-names
+                             :test #'eq)))))))
 
 (defun default-matrix (pattern-matrix)
   "Default the given PATTERN-MATRIX."
@@ -282,85 +509,95 @@ CLAUSE is a list representing a row-vector of patterns."
      (collapse-binding-patterns
       (tc:pattern-binding-pattern pat)))))
 
-(defun find-non-matching-value (pattern-matrix n env)
-  "Finds an example of a non-matching value for PATTERN-MATRIX or, if
-   PATTERN-MATRIX is exhaustive returns T."
-  (declare (type pattern-matrix pattern-matrix)
-           (type (integer 0) n)
-           (optimize (debug 3)))
-  (cond
-    ;; An empty pattern generates n wildcards.
-    ((and (zerop (length pattern-matrix)))
-     (loop :for i :below n
-           :collect (tc:make-pattern-wildcard
-                     :type (tc:qualify nil (tc:make-variable)))))
-    ;; Zero wildcards with a pattern matrix that has zero columns indicates the matrix is exhaustive.
-    ((and (zerop n)
-          (zerop (length (first pattern-matrix))))
-     t)
-    (t
-     (let ((first-column-constructors
-             (loop :for row :in pattern-matrix
-                   :for elem := (first row)
-                   :when (tc:pattern-constructor-p elem)
-                     :collect elem)))
-       (cond
-         ;; If the constructors in the PATTERN-MATRIX form a complete
-         ;; signature then specialize and return the first
-         ;; non-matching sub-value.
-         ((complete-signature-p first-column-constructors env)
-          (loop :for ctor :in first-column-constructors
-                :for ctor-arity := (length (tc:pattern-constructor-patterns ctor))
-                :for val := (find-non-matching-value
-                             (specialize-matrix pattern-matrix ctor)
-                             (+ ctor-arity n -1)
-                             env)
-                :unless (eq val t)
-                  :do (return (cons (tc:make-pattern-constructor
-                                     :type (tc:pattern-type ctor)
-                                     :name (tc:pattern-constructor-name ctor)
-                                     :patterns (subseq val 0 ctor-arity))
-                                    (subseq val ctor-arity (+ ctor-arity n -1))))
-                :finally (return t)))
-         ;; Otherwise, check the defaulted matrix.
-         (t
-          (let ((val (find-non-matching-value
-                      (default-matrix pattern-matrix)
-                      (1- n)
-                      env)))
-            (cond
-              ;; If this is exhaustive then PATTERN-MATRIX is exhaustive.
-              ((eq val t)
-               t)
-              ;; If there are no constructors then emit a wildcard.
-              ((null first-column-constructors)
-               (cons (tc:make-pattern-wildcard
-                      :type (tc:qualify nil (tc:make-variable)))
-                     val))
-              ;; Or emit a constructor which was not named in this pattern.
-              (t
-               (cons (find-unnamed-constructor first-column-constructors env)
-                     val))))))))))
-
-(defun find-unnamed-constructor (patterns env)
-  "Find and create a pattern constructor with the type of, but not named in PATTERNS."
+(defun find-unnamed-constructor (patterns possible-ctors)
+  "Find and create a pattern constructor for COLUMN-TYPE that is not named in PATTERNS."
   (declare (type tc:pattern-list patterns)
-           (type tc:environment env)
-           (values tc:pattern))
-  (let* ((constructor-names (mapcar #'tc:pattern-constructor-name patterns))
-         (constructed-type (tc:constructor-entry-constructs (tc:lookup-constructor env (first constructor-names))))
-         (type-constructors (tc:type-entry-constructors (tc:lookup-type env constructed-type)))
-         (unnamed-constructor (first (set-difference type-constructors constructor-names :test #'eq)))
-         (unnamed-constructor-entry (tc:lookup-constructor env unnamed-constructor)))
+           (type tc:pattern-list possible-ctors)
+           (values tc:pattern-constructor))
+  (let* ((constructor-names (constructor-pattern-names patterns))
+         (unnamed-constructor (find-if-not (lambda (constructor-pattern)
+                                             (member (tc:pattern-constructor-name constructor-pattern)
+                                                     constructor-names
+                                                     :test #'eq))
+                                           possible-ctors)))
     (unless unnamed-constructor
       (util:coalton-bug "Not reachable."))
 
     ;; NOTE: Here we _could_ reasonably return all missing
     ;; constructors, however that would require additional support in
     ;; the error generation. Instead we just select the first one.
-    (tc:make-pattern-constructor
-     :type (tc:pattern-type (first patterns))
-     :name unnamed-constructor
-     :patterns (loop :for i :below (tc:constructor-entry-arity unnamed-constructor-entry)
-                     :collect (tc:make-pattern-wildcard
-                               :type (tc:qualify nil (tc:make-variable)))))))
+    unnamed-constructor))
+
+(defun find-non-matching-value (pattern-matrix column-types env)
+  "Finds an example of a non-matching value for PATTERN-MATRIX or, if
+   PATTERN-MATRIX is exhaustive returns T.
+
+COLUMN-TYPES is the current type of each pattern-matrix column."
+  (declare (type pattern-matrix pattern-matrix)
+           (type tc:ty-list column-types)
+           (type tc:environment env))
+  (cond
+    ;; An empty pattern matrix misses one wildcard value for each current column.
+    ((zerop (length pattern-matrix))
+     (loop :for column-type :in column-types
+           :collect (make-wildcard-for-type column-type)))
+
+    ;; Zero columns with a non-empty matrix means the matrix is exhaustive.
+    ((and (null column-types)
+          (zerop (length (first pattern-matrix))))
+     t)
+
+    ((null column-types)
+     (util:coalton-bug "Pattern matrix has columns but no column types."))
+
+    (t
+     (let* ((current-column-type (first column-types))
+            (first-column-patterns (first-column-patterns pattern-matrix))
+            (first-column-constructors (first-column-constructors pattern-matrix))
+            (possible-constructors (possible-constructor-patterns current-column-type
+                                                                  env
+                                                                  first-column-patterns)))
+       (cond
+         ;; If the constructors in the PATTERN-MATRIX form a complete signature
+         ;; for the current column type, specialize and return the first
+         ;; non-maching sub value.
+         ((complete-signature-p first-column-patterns possible-constructors)
+          (loop :for constructor-pattern :in possible-constructors
+                :for constructor-arity := (length (tc:pattern-constructor-patterns constructor-pattern))
+                :for val := (multiple-value-bind (specialized-column-types possible-p)
+                                (specialize-column-types column-types constructor-pattern)
+                              (if possible-p
+                                  (find-non-matching-value
+                                   (specialize-matrix pattern-matrix constructor-pattern)
+                                   specialized-column-types
+                                   env)
+                                  t))
+                :unless (eq val t)
+                  :do (return
+                        (cons
+                         (tc:make-pattern-constructor :type (tc:pattern-type constructor-pattern)
+                                                      :name (tc:pattern-constructor-name constructor-pattern)
+                                                      :patterns (subseq val 0 constructor-arity))
+                         (subseq val constructor-arity)))
+                :finally (return t)))
+
+         ;; Otherwise, check the defaulted matrix.
+         (t
+          (let ((val (find-non-matching-value (default-matrix pattern-matrix)
+                                              (rest column-types)
+                                              env)))
+            (cond
+              ;; If this is exhaustive then PATTERN-MATRIX is exhaustive.
+              ((eq val t)
+               t)
+
+              ;; If there are no possible constructors, emit a wildcard.
+              ((null possible-constructors)
+               (cons (make-wildcard-for-type current-column-type)
+                     val))
+
+              ;; Otherwise emit a possible constructor that was not named.
+              (t
+               (cons (find-unnamed-constructor first-column-constructors
+                                               possible-constructors)
+                     val))))))))))

--- a/src/codegen/codegen-pattern.lisp
+++ b/src/codegen/codegen-pattern.lisp
@@ -124,7 +124,7 @@ EXPR-TYPE, returning (VALUES PREDICATE BINDINGS BINDING-TYPES).")
                                     (tc:fresh-inst
                                      (tc:lookup-value-type env ctor-name))))
                 (ctor-type (tc:apply-substitution
-                            (tc:match (tc:function-return-type generic-ctor-type) expr-type)
+                            (tc:unify nil (tc:function-return-type generic-ctor-type) expr-type)
                             generic-ctor-type))
                 (lisp-type-string (format nil "~A/~A" (tc:constructor-entry-constructs ctor) ctor-name)))
            (multiple-value-bind (preds bindings types)

--- a/src/codegen/inliner.lisp
+++ b/src/codegen/inliner.lisp
@@ -6,6 +6,7 @@
    (#:traverse #:coalton-impl/codegen/traverse)
    (#:transformations #:coalton-impl/codegen/transformations)
    (#:substitutions #:coalton-impl/codegen/ast-substitutions)
+   (#:pattern #:coalton-impl/codegen/pattern)
    (#:settings #:coalton-impl/settings)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker)
@@ -176,10 +177,152 @@ controlled by `settings:*print-inlining-occurences*' is enabled."
 
 ;;; Inlining
 
-(defun inline-code-from-application (application abstraction)
+(defun pattern-contains-gadt-constructor-p (pat env)
+  "Return T when PAT contains a GADT constructor."
+  (declare (type pattern:pattern pat)
+           (type tc:environment env)
+           (values boolean))
+  (etypecase pat
+    ((or pattern:pattern-var
+         pattern:pattern-wildcard
+         pattern:pattern-literal)
+     nil)
+
+    (pattern:pattern-binding
+     (pattern-contains-gadt-constructor-p
+      (pattern:pattern-binding-pattern pat)
+      env))
+
+    (pattern:pattern-constructor
+     (let ((ctor (tc:lookup-constructor env
+                                        (pattern:pattern-constructor-name pat)
+                                        :no-error t)))
+       (or (and ctor
+                (tc:constructor-entry-gadt-p ctor))
+           (some (lambda (subpat)
+                   (pattern-contains-gadt-constructor-p subpat env))
+                 (pattern:pattern-constructor-patterns pat)))))))
+
+(defun match-needs-gadt-pruning-p (node env)
+  "Returns T when NODE is a match containing a GADT constructor pattern
+that needs pruning.
+
+Inlining can make a previously valid GADT branch impossible by specializing
+the scrutinee."
+  (declare (type ast:node-match node)
+           (type tc:environment env)
+           (values boolean))
+  (some (lambda (branch)
+          (pattern-contains-gadt-constructor-p
+           (ast:match-branch-pattern branch)
+           env))
+        (ast:node-match-branches node)))
+
+(defun pattern-compatible-with-type-p (pat expr-type env)
+  "Return T if PAT can match an expression of EXPR-TYPE.
+
+This is a codegen-AST check. It is used after inlining has
+specialized a previously-valid GADT match."
+  (declare (type pattern:pattern pat)
+           (type tc:ty expr-type)
+           (type tc:environment env)
+           (values boolean))
+
+  (etypecase pat
+    ;; Variables, wildcards, and literals do not refine constructor shape.
+    ;; They are compatible exactly when their pattern type can be unified
+    ;; with the specialized scrutinee type.
+    ((or pattern:pattern-var
+         pattern:pattern-wildcard
+         pattern:pattern-literal)
+     (nth-value 1
+                (tc:try-unify nil
+                                 (pattern:pattern-type pat)
+                                 expr-type)))
+
+    ;; A binding pattern has its own outer pattern type, plus an inner
+    ;; pattern being bound. Both must remain compatible with the narrowed
+    ;; expression type.
+    (pattern:pattern-binding
+     (and
+      (nth-value 1
+                 (tc:try-unify nil
+                                  (pattern:pattern-type pat)
+                                  expr-type))
+      (pattern-compatible-with-type-p
+       (pattern:pattern-binding-pattern pat)
+       expr-type
+       env)))
+
+    ;; A constructor pattern is compatible only if the constructor's result
+    ;; type can unify with the narrowed scrutinee type. If it can, apply that
+    ;; substitution to the constructor argument types and recursively check
+    ;; each subpattern against its corresponding constructor argument.
+    (pattern:pattern-constructor
+     (let* ((ctor-name
+              (pattern:pattern-constructor-name pat))
+            (ctor-type
+              (tc:qualified-ty-type
+               (tc:fresh-inst
+                (tc:lookup-value-type env ctor-name )))))
+       (multiple-value-bind (subs unifies-p)
+           (tc:try-unify nil
+                            (tc:function-return-type ctor-type)
+                            expr-type)
+         (and unifies-p
+              (let* ((ctor-type
+                       (tc:apply-substitution subs ctor-type))
+                     (arg-types
+                       (tc:function-type-arguments ctor-type))
+                     (subpatterns
+                       (pattern:pattern-constructor-patterns pat)))
+                (and (= (length arg-types)
+                        (length subpatterns))
+                     (loop :for subpat :in subpatterns
+                           :for arg-type :in arg-types
+                           :always
+                           (pattern-compatible-with-type-p
+                            subpat
+                            arg-type
+                            env))))))))))
+
+(defun prune-impossible-match-branches (node env)
+  "Remove GADT match branches whose pattern cannot unify with the scrutinee type.
+
+This should only be used on copied/specialized code, such as after inlining.
+The source typechecker is still responsible for rejecting impossible branches
+in written code."
+  (declare (type ast:node node)
+           (type tc:environment env)
+           (values ast:node))
+  (traverse:traverse
+   node
+   (list
+    (traverse:action (:after ast:node-match node)
+      (if (not (match-needs-gadt-pruning-p node env))
+          node
+          (let* ((expr-type (ast:node-type (ast:node-match-expr node)))
+                 (branches (remove-if-not (lambda (branch)
+                                            (pattern-compatible-with-type-p
+                                             (ast:match-branch-pattern branch)
+                                             expr-type
+                                             env))
+                                          (ast:node-match-branches node))))
+
+            ;; If something has gone very wrong, do not turn the match
+            ;; into an empty match and mask the real compiler error.
+            (if branches
+                (ast:make-node-match
+                 :type (ast:node-type node)
+                 :expr (ast:node-match-expr node)
+                 :branches branches)
+                node)))))))
+
+(defun inline-code-from-application (application abstraction env)
   "Swap an application node with a let node where the body is the inlined function."
   (declare (type (or ast:node-application ast:node-direct-application) application)
            (type ast:node-abstraction abstraction)
+           (type tc:environment env)
            (values ast:node-let &optional))
 
   (let* ((fresh-abstraction
@@ -238,12 +381,16 @@ controlled by `settings:*print-inlining-occurences*' is enabled."
              (substitutions:apply-ast-substitution
               substitutions
               (ast:node-abstraction-subexpr fresh-abstraction)
-              t)))
+              t))
+           (specialized-subexpr
+             (tc:apply-substitution new-substitutions new-subexpr)))
       (ast:make-node-let
        :type     (ast:node-type application)
        :bindings (loop :for (name . expr) :in bindings
                        :collect (cons name (tc:apply-substitution new-substitutions expr)))
-       :subexpr  (tc:apply-substitution new-substitutions new-subexpr)))))
+       :subexpr  (prune-impossible-match-branches
+                  specialized-subexpr
+                  env)))))
 
 (defun try-inline-application (application env stack noinline-functions)
   "Try to inline an application node, checking internal traversal stack,
@@ -291,7 +438,8 @@ is appropriate."
        (inline-applications*
         (inline-code-from-application
          application
-         (lookup-global-application-body application env))
+         (lookup-global-application-body application env)
+         env)
         env
         stack
         noinline-functions))
@@ -310,7 +458,8 @@ is appropriate."
        (inline-applications*
         (inline-code-from-application
          application
-         (lookup-anonymous-application-body application))
+         (lookup-anonymous-application-body application)
+         env)
         env
         stack
         noinline-functions))

--- a/src/codegen/pattern.lisp
+++ b/src/codegen/pattern.lisp
@@ -207,9 +207,9 @@
   (declare (type pattern-list patterns)
            (type tc:ty type)
            (type tc:environment env)
-           (ignore type)
            (values boolean &optional))
   (pe:exhaustive-patterns-p
    (mapcar #'pe:collapse-binding-patterns
            (mapcar #'codegen-pattern->typechecker-pattern patterns))
-   env))
+   env
+   type))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -82,6 +82,7 @@
 
   ;; Primitive Syntax
   (:export
+   #:Type
    #:fn
    #:&key
    #:match

--- a/src/parser/renamer.lisp
+++ b/src/parser/renamer.lisp
@@ -1096,6 +1096,7 @@
              (values constructor))
     (make-constructor
      :name (constructor-name ctor)
+     :signature (rename-type-variables-generic% (constructor-signature ctor) ctx)
      :fields (rename-type-variables-generic% (constructor-fields ctor) ctx)
      :docstring (source:docstring ctor)
      :location (source:location ctor)))

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -30,8 +30,10 @@
    #:constructor                                 ; STRUCT
    #:make-constructor                            ; CONSTRUCTOR
    #:constructor-name                            ; ACCESSOR
+   #:constructor-signature                       ; ACCESSOR
    #:constructor-fields                          ; ACCESSOR
    #:constructor-list                            ; TYPE
+   #:constructor-gadt-p                          ; FUNCTION
    #:toplevel-define-type                        ; STRUCT
    #:make-toplevel-define-type                   ; CONSTRUCTOR
    #:toplevel-define-type-name                   ; ACCESSOR
@@ -42,6 +44,8 @@
    #:toplevel-define-type-head-location          ; ACCESSOR
    #:toplevel-define-type-exception-p            ; ACCESSOR
    #:toplevel-define-type-resumption-p           ; ACCESSOR
+   #:toplevel-define-type-p                      ; FUNCTION
+   #:toplevel-define-type-gadt-p                 ; FUNCTION
    #:toplevel-define-type-list                   ; TYPE
    #:toplevel-define-type-alias                  ; STRUCT
    #:make-toplevel-define-type-alias             ; CONSTRUCTOR
@@ -257,10 +261,17 @@
 
 (defstruct (constructor
             (:copier nil))
-  (name      (util:required 'name)      :type identifier-src   :read-only t)
-  (fields    (util:required 'fields)    :type ty-list          :read-only t)
-  (docstring (util:required 'docstring) :type (or null string) :read-only t)
-  (location  (util:required 'location)  :type source:location  :read-only t))
+  (name      (util:required 'name)      :type identifier-src         :read-only t)
+  (signature (util:required 'signature) :type (or null qualified-ty) :read-only t)
+  (fields    (util:required 'fields)    :type ty-list                :read-only t)
+  (docstring (util:required 'docstring) :type (or null string)       :read-only t)
+  (location  (util:required 'location)  :type source:location        :read-only t))
+
+(defun constructor-gadt-p (constr)
+  (declare (type constructor constr)
+           (values boolean))
+  (when (constructor-signature constr)
+    t))
 
 (defmethod source:location ((self constructor))
   (constructor-location self))
@@ -297,6 +308,13 @@
   (head-location (util:required 'head-location) :type source:location            :read-only t)
   (exception-p   (util:required 'exception-p)   :type boolean                    :read-only t)
   (resumption-p  (util:required 'resumption-p)  :type boolean                    :read-only t))
+
+(defun toplevel-define-type-gadt-p (type)
+  (declare (type toplevel-define-type type)
+           (values boolean))
+  (dolist (ctor (toplevel-define-type-ctors type))
+    (when (constructor-gadt-p ctor)
+      (return t))))
 
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (defun toplevel-define-type-list-p (x)
@@ -1292,35 +1310,43 @@ consume all attributes")))
      :vars (reverse variables)
      :docstring docstring
      :ctors
-     (loop
-       :for constructors_
-         := (cst:nthrest (if docstring 3 2) form)
-           :then (cst:rest constructors_)
-       :with ctors := nil
-       :while (cst:consp constructors_)
+     (let ((has-adt-ctor nil)
+           (has-gadt-ctor nil))
+       (loop
+         :for constructors_
+           := (cst:nthrest (if docstring 3 2) form)
+             :then (cst:rest constructors_)
+         :with ctors := nil
+         :while (cst:consp constructors_)
 
-       ;; check for duplicate docstrings
-       :when (and (cst:atom (cst:first constructors_))
-                  (stringp (cst:raw (cst:first constructors_)))
-                  (not (cst:null (cst:rest constructors_)))
-                  (cst:atom (cst:second constructors_))
-                  (stringp (cst:raw (cst:second constructors_))))
-         :do (parse-error (format nil "Malformed ~a definition" definition-category)
-                          (note source
-                                (cst:second constructors_)
-                                "only one docstring allowed per constructor"))
+         ;; check for duplicate docstrings
+         :when (and (cst:atom (cst:first constructors_))
+                    (stringp (cst:raw (cst:first constructors_)))
+                    (not (cst:null (cst:rest constructors_)))
+                    (cst:atom (cst:second constructors_))
+                    (stringp (cst:raw (cst:second constructors_))))
+           :do (parse-error (format nil "Malformed ~a definition" definition-category)
+                            (note source
+                                  (cst:second constructors_)
+                                  "only one docstring allowed per constructor"))
 
-             ;; collect constructors with docstrings if they follow
-       :do (let ((ctor-docstring (if (and (not (cst:null (cst:rest constructors_)))
-                                          (cst:atom (cst:second constructors_))
-                                          (stringp (cst:raw (cst:second constructors_))))
-                                     (cst:raw (cst:second constructors_))
-                                     nil)))
-             (unless (stringp (cst:raw (cst:first constructors_)))
-               (push
-                (parse-constructor (cst:first constructors_) form ctor-docstring source)
-                ctors)))
-       :finally (return ctors))
+         ;; collect constructors with docstrings if they follow
+         :do (let ((ctor-docstring (if (and (not (cst:null (cst:rest constructors_)))
+                                            (cst:atom (cst:second constructors_))
+                                            (stringp (cst:raw (cst:second constructors_))))
+                                       (cst:raw (cst:second constructors_))
+                                       nil)))
+               (unless (stringp (cst:raw (cst:first constructors_)))
+                 (let ((ctor (parse-constructor (cst:first constructors_) form name ctor-docstring source)))
+                   (if (constructor-gadt-p ctor)
+                       (setf has-gadt-ctor t)
+                       (setf has-adt-ctor t))
+                   (push ctor ctors))))
+         :finally (progn
+                    (when (and has-adt-ctor has-gadt-ctor)
+                      (parse-error (format nil "Malformed ~a definition" definition-category)
+                                   (note source form " cannot define implicitly and explicitly typed constructors")))
+                    (return ctors))))
      :repr nil
      :derive nil
      :location (form-location source form)
@@ -1447,7 +1473,7 @@ consume all attributes")))
        (parse-error "Malformed resumption definition"
                     (note source form "constructor expected"))))
 
-    (setf ctor (parse-constructor (cst:second form) form nil source))
+    (setf ctor (parse-constructor (cst:second form) form name nil source))
 
     ;; Optional docstring 
     (when (cst:consp (cst:rest (cst:rest form)))
@@ -1932,20 +1958,76 @@ consume all attributes")))
    :source-name (cst:raw form)
    :location (form-location source form)))
 
-(defun parse-constructor (form enclosing-form docstring source)
+(defun parse-constructor (form enclosing-form enclosing-type-name docstring source)
   (declare (type cst:cst form enclosing-form)
+           (type identifier-src enclosing-type-name)
            (values constructor))
 
   (let (unparsed-name
-        unparsed-fields)
+        unparsed-fields
+        signature)
 
     (cond
       ((cst:atom form)
        (setf unparsed-name form))
       (t
-       (progn
+       (let ((remaining-forms (cst:rest form)))
          (setf unparsed-name (cst:first form))
-         (setf unparsed-fields (cst:listify (cst:rest form))))))
+         (if (and (cst:consp remaining-forms)
+                  (cst:consp (cst:first remaining-forms))
+                  (eq 'coalton:Type (cst:raw (cst:first (cst:first remaining-forms)))))
+             ;; GADT Constructor - (Constr (Type (:a -> Data :a)))
+             (cond
+               ;; (Constr Type)
+               ((cst:atom (cst:rest (cst:first remaining-forms)))
+                (parse-error "Malformed GADT constructor"
+                             (note source remaining-forms "expected type signature")
+                             (secondary-note source
+                                             (cst:first remaining-forms)
+                                             "in this constructor definition")))
+               ;; (Constr (Type (:a -> Data :a)) String)
+               ((not (cst:null (cst:rest remaining-forms)))
+                (parse-error "Malformed GADT constructor"
+                             (note source (cst:first (cst:rest remaining-forms))
+                                   "unexpected trailing form ~S"
+                                   (cst:raw (cst:rest remaining-forms)))
+                             (secondary-note source
+                                             (cst:first remaining-forms)
+                                             "in this constructor definition")))
+               ;; (Constr (Type (:a -> Data :a) String))
+               ((not (cst:null (cst:nthrest 2 (cst:first remaining-forms))))
+                (parse-error "Malformed GADT constructor"
+                             (note source
+                                   (cst:first (cst:nthrest 2 (cst:first remaining-forms)))
+                                   "unexpected trailing form ~S"
+                                   (cst:raw (cst:first (cst:nthrest 2 (cst:first remaining-forms)))))
+                             (secondary-note source
+                                             (cst:first remaining-forms)
+                                             "in this constructor definition")))
+               (t
+                (let* ((signature_ (parse-qualified-type
+                                    (cst:rest (cst:first remaining-forms))
+                                    source))
+                       (signature-type (qualified-ty-type signature_))
+                       (result-type-head (or
+                                          (and (typep signature-type 'function-ty)
+                                               (function-ty-return-tycon-head
+                                                signature-type))
+                                          (and (typep signature-type 'ty)
+                                               (ty-tycon-head signature-type)))))
+                  (unless (and result-type-head
+                               (eq (tycon-name result-type-head)
+                                   (identifier-src-name enclosing-type-name)))
+                    (parse-error "Malformed GADT constructor"
+                                 (note source
+                                       unparsed-name
+                                       "GADT constructor must return ~S"
+                                       (identifier-src-name enclosing-type-name))
+                                 (secondary-note source (cst:first remaining-forms)
+                                                 "in this type definition")))
+                  (setf signature signature_))))
+             ;; ADT  Constructor - (Constr :a)
+             (setf unparsed-fields (cst:listify remaining-forms))))))
 
     (unless (cst:atom unparsed-name)
       (parse-error "Malformed constructor"
@@ -1964,6 +2046,7 @@ consume all attributes")))
             :name (cst:raw unparsed-name)
             :source-name (source:extract-source-text source (cst:source unparsed-name))
             :location (form-location source unparsed-name))
+     :signature signature
      :fields (loop :for field :in unparsed-fields
                    :collect (parse-type field source))
      :location (form-location source form)

--- a/src/parser/type-definition.lisp
+++ b/src/parser/type-definition.lisp
@@ -27,6 +27,7 @@
    #:type-definition-aliased-type       ; FUNCTION
    #:type-definition-ctors              ; FUNCTION
    #:type-definition-ctor-name          ; FUNCTION
+   #:type-definition-ctor-signature     ; FUNCTION
    #:type-definition-ctor-field-types   ; FUNCTION
    ))
 
@@ -158,6 +159,15 @@
   (:method ((ctor toplevel-define-struct))
     (declare (values identifier-src))
     (toplevel-define-struct-name ctor)))
+
+(defgeneric type-definition-ctor-signature (ctor)
+  (:method ((ctor constructor))
+    (declare (values (or null qualified-ty)))
+    (constructor-signature ctor))
+
+  (:method ((ctor toplevel-define-struct))
+    (declare (values null))
+    nil))
 
 (defgeneric type-definition-ctor-field-types (ctor)
   (:method ((ctor constructor))

--- a/src/parser/types.lisp
+++ b/src/parser/types.lisp
@@ -12,6 +12,7 @@
   (:export
    #:ty                                 ; STRUCT
    #:ty-list                            ; TYPE
+   #:ty-tycon-head                      ; FUNCTION
    #:tyvar                              ; STRUCT
    #:make-tyvar                         ; CONSTRUCTOR
    #:tyvar-p                            ; FUNCTION
@@ -38,6 +39,7 @@
    #:function-ty-positional-input-types ; ACCESSOR
    #:function-ty-keyword-input-types    ; ACCESSOR
    #:function-ty-output-types           ; ACCESSOR
+   #:function-ty-return-tycon-head      ; FUNCTION
    #:result-ty                          ; STRUCT
    #:make-result-ty                     ; CONSTRUCTOR
    #:result-ty-output-types             ; ACCESSOR
@@ -103,6 +105,14 @@
                (:copier nil))
   (location (util:required 'location) :type source:location :read-only t))
 
+(defun ty-tycon-head (ty)
+  "Return the tycon head of TY, or NIL."
+  (declare (type ty ty)
+           (values (or null tycon)))
+  (let ((head (first (flatten-type ty))))
+    (when (tycon-p head)
+      head)))
+
 (defmethod source:location ((self ty))
   (ty-location self))
 
@@ -166,6 +176,18 @@
   (positional-input-types (util:required 'positional-input-types) :type ty-list               :read-only t)
   (keyword-input-types    (util:required 'keyword-input-types)    :type keyword-ty-entry-list :read-only t)
   (output-types           (util:required 'output-types)           :type (or null ty-list)     :read-only t))
+
+(defun function-ty-return-tycon-head (ty)
+  "Return the head type constructor of TY's return value. Returns NIL if TY has
+multiple return values or a non-tycon-headed return."
+  (declare (type function-ty ty)
+           (values (or null tycon)))
+  (let ((outputs (function-ty-output-types ty)))
+    (declare (type cons outputs))
+    (when (alexandria:length= 1 outputs)
+      (let ((head (first (flatten-type (first outputs)))))
+        (when (tycon-p head)
+          head)))))
 
 (defstruct (result-ty (:include ty)
                       (:copier nil))

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -14,7 +14,8 @@
    (#:algo #:coalton-impl/algorithm)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker/stage-1)
-   (#:derive #:coalton-impl/typechecker/derive))
+   (#:derive #:coalton-impl/typechecker/derive)
+   (#:pt #:coalton-impl/typechecker/parse-type))
   (:export
    #:toplevel-define-type               ; FUNCTION
    #:type-definition                    ; STRUCT
@@ -31,6 +32,7 @@
    #:type-definition-constructors       ; ACCESSOR
    #:type-definition-constructor-types  ; ACCESSOR
    #:type-definition-docstring          ; ACCESSOR
+   #:type-definition-gadt-p             ; ACCESSOR
    #:type-definition-list               ; TYPE
    ))
 
@@ -62,7 +64,8 @@
   (docstring         (util:required 'docstring)         :type (or null string)          :read-only t)
   (location          (util:required 'location)          :type source:location           :read-only t)
   (exception-p       (util:required 'exception-p)       :type boolean                   :read-only t)
-  (resumption-p      (util:required 'resumption-p)      :type boolean                   :read-only t))
+  (resumption-p      (util:required 'resumption-p)      :type boolean                   :read-only t)
+  (gadt-p            (util:required 'gadt-p)            :type boolean                   :read-only t))
 
 (defmethod source:location ((self type-definition))
   (type-definition-location self))
@@ -419,7 +422,8 @@ This is conservative and intentionally aligns with mutable native wrappers."
           :docstring (source:docstring type)
           :location (source:location parsed-type)
           :exception-p (type-definition-exception-p type)
-          :resumption-p (type-definition-resumption-p type))))
+          :resumption-p (type-definition-resumption-p type)
+          :gadt-p (type-definition-gadt-p type))))
 
   ;; Define the type's constructors in the environment
   (loop :for ctor :in (type-definition-constructors type)
@@ -471,7 +475,9 @@ This is conservative and intentionally aligns with mutable native wrappers."
 
         (ctor-table (make-hash-table :test #'eq))
 
-        (alias-table (make-hash-table :test #'eq)))
+        (alias-table (make-hash-table :test #'eq))
+
+        (ctor-scheme-table (make-hash-table :test #'eq)))
 
     ;; Infer the kinds of each type
     (loop :for type :in types
@@ -480,14 +486,32 @@ This is conservative and intentionally aligns with mutable native wrappers."
                 :for ctor :in (parser:type-definition-ctors type)
                 :for ctor-name
                   := (parser:identifier-src-name (parser:type-definition-ctor-name ctor))
-                :for fields
-                  := (loop
-                       :for field :in (parser:type-definition-ctor-field-types ctor)
-                       :collect (multiple-value-bind (type ksubs_)
-                                    (parse-type field env ksubs)
-                                  (setf ksubs ksubs_)
-                                  type))
-                :do (setf (gethash ctor-name ctor-table) fields)))
+                :for ctor-signature
+                  := (parser:type-definition-ctor-signature ctor)
+                :do
+                   (cond
+                     ;; GADTs are typed by their function signature
+                     (ctor-signature
+                      (let ((branch-env (make-partial-type-env
+                                         :env (partial-type-env-env env)
+                                         :ty-table (alexandria:copy-hash-table (partial-type-env-ty-table env)))))
+                        (pt:seed-qualified-type-variables ctor-signature branch-env)
+                        (multiple-value-bind (qual-ty ksubs_)
+                            (infer-type-kinds ctor-signature tc:+kstar+ ksubs branch-env)
+                          (setf ksubs ksubs_)
+                          (setf (gethash ctor-name ctor-scheme-table) qual-ty)
+                          (setf (gethash ctor-name ctor-table)
+                                (tc:function-type-arguments qual-ty)))))
+
+                     ;; ADTs are typed by their constructor fields
+                     (t
+                      (let ((fields (loop
+                                      :for field :in (parser:type-definition-ctor-field-types ctor)
+                                      :collect (multiple-value-bind (type ksubs_)
+                                                   (parse-type field env ksubs)
+                                                 (setf ksubs ksubs_)
+                                                 type))))
+                        (setf (gethash ctor-name ctor-table) fields))))))
 
     ;; Infer the kinds of each type alias.
     (loop :for type :in types
@@ -581,37 +605,61 @@ This is conservative and intentionally aligns with mutable native wrappers."
          :for repr-arg
            := (and repr (eq repr-type :native) (cst:raw (parser:attribute-repr-arg repr)))
 
-
          :for constructor-args
            := (loop
                 :for ctor :in (parser:type-definition-ctors type)
+                :for ctor-name := (parser:identifier-src-name
+                                   (parser:type-definition-ctor-name ctor))
+                :for stored-scheme := (gethash ctor-name ctor-scheme-table)
                 :collect
-                (loop :for parser-field-type
-                        :in (parser:type-definition-ctor-field-types ctor)
-                      :collect (multiple-value-bind (field-type ignored-ksubs)
-                                   (parse-type parser-field-type alias-partial-env ksubs)
-                                 (declare (ignore ignored-ksubs))
-                                 field-type)))
+                (if stored-scheme
+                    ;; GADT constructor: arguments come from the expilict signature
+                    (tc:function-type-arguments
+                     (tc:apply-ksubstitution ksubs stored-scheme))
+
+                    ;; ADT constructor: arguments come from fiedl syntax
+                    (loop :for parser-field-type
+                            :in (parser:type-definition-ctor-field-types ctor)
+                          :collect (multiple-value-bind (field-type ignored-ksubs)
+                                       (parse-type parser-field-type alias-partial-env ksubs)
+                                     (declare (ignore ignored-ksubs))
+                                     field-type))))
 
          :for constructor-types
            := (loop
+                :for ctor :in (parser:type-definition-ctors type)
                 :for ctor-args :in constructor-args
-                :for ty
-                  := (tc:prepend-function-input-types
-                      ctor-args
-                      (tc:apply-type-argument-list
-                       (tc:apply-ksubstitution ksubs (gethash name (partial-type-env-ty-table env)))
-                       tvars))
-                :collect (tc:quantify-using-tvar-order tvars (tc:qualify nil ty)))
+                :for ctor-name := (parser:identifier-src-name
+                                   (parser:type-definition-ctor-name ctor))
+                :for stored-scheme := (gethash ctor-name ctor-scheme-table)
+                :collect
+                (if stored-scheme
+                    ;; GADT constructor: use the explicit constructor type
+                    (let* ((qual-ty (tc:apply-ksubstitution ksubs stored-scheme))
+                           (vars-in-qual (tc:type-variables qual-ty))
+                           (ordered-vars (append tvars
+                                                 (set-difference vars-in-qual
+                                                                 tvars
+                                                                 :test #'tc:ty=))))
+                      (tc:quantify-using-tvar-order ordered-vars qual-ty))
+
+                    ;; ADT constructor
+                    (let ((ty (tc:prepend-function-input-types
+                               ctor-args
+                               (tc:apply-type-argument-list
+                                (tc:apply-ksubstitution ksubs (gethash name (partial-type-env-ty-table env)))
+                                tvars))))
+                      (tc:quantify-using-tvar-order tvars (tc:qualify nil ty)))))
 
          ;; Check that repr :enum types do not have any constructors with fields
          :when (eq repr-type :enum)
            :do (loop
                  :for ctor :in (parser:toplevel-define-type-ctors type)
-                 :unless (endp (parser:constructor-fields ctor))
+                 :for ctor-name
+                   := (parser:identifier-src-name (parser:type-definition-ctor-name ctor))
+                 :unless (endp (gethash ctor-name ctor-table))
                    :do (tc-error "Invalid repr :enum attribute"
-                                 (tc-note (first (parser:constructor-fields ctor))
-                                          "constructors of repr :enum types cannot have fields")))
+                                 (tc-note ctor "Enum constructors cannot have arguments.")))
 
          ;; Check that repr :transparent types have a single constructor
          :when (eq repr-type :transparent)
@@ -640,13 +688,14 @@ This is conservative and intentionally aligns with mutable native wrappers."
                   :collect (tc:make-constructor-entry
                             :name ctor-name
                             :source-name (parser:identifier-src-source-name (parser:type-definition-ctor-name ctor))
-                            :arity (length (parser:type-definition-ctor-field-types ctor))
+                            :arity (length (gethash ctor-name ctor-table))
                             :constructs name
                             :classname classname
                             :docstring ctor-docstring
                             :compressed-repr (if (eq repr-type :enum)
                                                  classname
-                                                 nil))))
+                                                 nil)
+                            :gadt-p (not (null (gethash ctor-name ctor-scheme-table))))))
 
               (type-definition
                 (make-type-definition
@@ -679,7 +728,8 @@ This is conservative and intentionally aligns with mutable native wrappers."
                  :docstring (source:docstring type)
                  :location (source:location type)
                  :exception-p (parser:type-definition-exception-p type)
-                 :resumption-p (parser:type-definition-resumption-p type))))
+                 :resumption-p (parser:type-definition-resumption-p type)
+                 :gadt-p (not (null (some #'tc:constructor-entry-gadt-p ctors))))))
 
            (setf instances
                  ;; Some generated instances depend only on the raw type

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -1727,6 +1727,208 @@ lowered back to the ordinary nested-let representation and inferred there."
                      :last-node typed-inner-let))
              subs)))))))
 
+
+(defun delta-subs (after before)
+  "After checking this branch pattern/body, which subs were learned after BEFORE."
+  (declare (type tc:substitution-list after before)
+           (values tc:substitution-list))
+  (remove-if
+   (lambda (sub)
+     (find sub
+           before
+           :test #'tc:same-substitution-p))
+   after))
+
+(defun check-no-untouchable-refinement (subs untouchable-vars location)
+  "Ensure that no UNTOUCHABLE-VARS were refined by SUBS. Allows untouchable
+vars to be unified with another non-concrete var, but that var is added to
+the untouchable list.
+
+Returns an updated untouchable list, or errors.
+
+For example:
+  (declare hdn (Hidden -> Void))
+  (define (hdn (Hidden a)) ;; <--- :a from GADT arguments and not type, becomes untouchable
+    (id                    ;; <--- id type (:b -> :b)
+      a)                   ;; <--- :a unified with :b, :b added to the untouchable list
+    (values))
+
+  (declare hdn-fail (Hidden -> Void))
+  (define (hdn-fail (Hidden a))   ;; <--- :a from GADT arguments and not type, becomes untouchable
+    (let _ = (the Integer a))     ;; <--- :a unified with concrete Integer, errors.
+    (values))
+"
+  (declare (type tc:substitution-list subs)
+           (type tc:tyvar-list untouchable-vars)
+           (type source:location location)
+           (values tc:tyvar-list))
+  (let ((refined-vars (tc:refined-vars subs untouchable-vars))
+        (new-untouchable-vars untouchable-vars))
+    (loop :for refined-var :in refined-vars
+          :for refinement := (tc:apply-substitution subs refined-var)
+          :do (cond
+                ;; Refined to another type variable. Make it untouchable.
+                ((tc:tyvar-p refinement)
+                 (pushnew refinement new-untouchable-vars :test #'tc:ty=))
+
+                ;; Refined to a concrete type. Error.
+                (t
+                 (tc-error "Cannot refine existential type from GADT constructor arguments"
+                           (tc-note location
+                                    "Untouchable existential type '~A' was refined to '~A'"
+                                    (type-object-string refined-var)
+                                    (type-object-string refinement))))))
+    new-untouchable-vars))
+
+(defun check-no-untouchable-escape (type subs untouchable-vars location)
+  "Ensure that no UNTOUCHABLE-VARS appear in TYPE after applying SUBS.
+
+This catches values extracted from an existential GADT constructor argument
+escaping their pattern scope without being refined to a concrete type.
+
+For example:
+  (declare hdn-escape (Hidden -> Void))
+  (define (hdn-escape h)
+    (let improperly-escaped =
+      (match h ((Hidden a) a)))
+    (let _ = (the String improperly-escaped))
+    (values))
+"
+  (declare (type tc:ty type)
+           (type tc:substitution-list subs)
+           (type tc:tyvar-list untouchable-vars)
+           (type source:location location))
+  (let* ((type_ (tc:apply-substitution subs type))
+         (escaping-vars (intersection (tc:type-variables type_)
+                                      untouchable-vars
+                                      :test #'tc:ty=)))
+    (when escaping-vars
+      (tc-error "Untouchable existential type escapes GADT pattern scope"
+                (tc-note location
+                         "Existential type '~A' escapes through result type '~A'"
+                         (type-object-string (first escaping-vars))
+                         (type-object-string type_))))))
+
+(defun copy-branch-env (env &optional (ty-table (alexandria:copy-hash-table
+                                                 (tc-env-ty-table env))))
+  "Copy a branch environment from ENV and TY-TABLE."
+  (make-tc-env :env (tc-env-env env)
+               :ty-table ty-table
+               :typevar-table (alexandria:copy-hash-table
+                               (tc-env-typevar-table env))))
+
+(defun type-mentions-any-var-p (type vars)
+  (declare (type tc:ty type)
+           (type tc:tyvar-list vars)
+           (values boolean))
+  (not (null (intersection (tc:type-variables type)
+                           vars
+                           :test #'tc:ty=))))
+
+(defun remove-protected-subs (subs protected-vars base-subs)
+  "Remove SUBS whose from side is one of the protected scrutinee vars, whose to
+side still mentions one, or whose from side refines to one BASE-SUBS (the subs
+known before the branch-local block began)."
+  (declare (type tc:substitution-list subs base-subs)
+           (type tc:ty-list protected-vars)
+           (values tc:substitution-list))
+  (remove-if
+   (lambda (sub)
+     (let ((from (tc:substitution-from sub))
+           (to (tc:substitution-to sub)))
+       (or
+        ;; Directly refines protected variable
+        (find from protected-vars :test #'tc:ty=)
+
+        ;; TO side depends on protected variable
+        (type-mentions-any-var-p (tc:apply-substitution base-subs to)
+                                 protected-vars)
+
+        ;; FROM side refines to a type containing a protected variable
+        (type-mentions-any-var-p (tc:apply-substitution base-subs from)
+                                 protected-vars))))
+   subs))
+
+(defun branch-normalization-subs (local-delta protected-vars)
+  "In a GADT branch, Calculate substitutions to unify branch-specialized PROTECTED-VARS back
+to their outer tyvars."
+  (declare (type tc:substitution-list local-delta)
+           (type tc:ty-list protected-vars)
+           (values tc:substitution-list))
+  (loop :for var :in protected-vars
+        :nconc
+        (loop :for new-unification := (tc:apply-substitution local-delta var)
+                                   :then (tc:apply-substitution local-delta new-unification)
+              :and old-unification := var
+                                   :then new-unification
+              :for finished := (tc:ty= new-unification old-unification)
+              ;; If the protected var unifies to a concrete type, i.e. α -> Integer, discard
+              :when (not (tc:tyvar-p new-unification))
+                :return nil
+              :while (not finished)
+              :collect (tc:make-substitution :from new-unification :to var))))
+
+(defun normalize-branch-preds (local-delta protected-vars preds)
+  "In a GADT branch, normalize branch-specific PREDS to the corresponding out-of-branch tvar."
+  ;; Second, unify the branch-specific tvar to the protected tvar, to make a pred that is
+  ;; recognizeable to the outside.
+  (tc:apply-substitution
+   (branch-normalization-subs local-delta protected-vars)
+   ;; First, unify the fresh pred tyvar to the branch-specific tvar for the type variable
+   (tc:apply-substitution local-delta
+                          preds)))
+
+(defun pattern-contains-gadt-p (pattern env)
+  "Determine if the pattern contains a GADT constructor. Needs to recursively walk
+all constructors in the pattern."
+  (declare (type parser:pattern pattern)
+           (type tc-env env)
+           (values boolean))
+  (labels ((walk (pat)
+             (typecase pat
+               (parser:pattern-constructor
+                (let ((ctor (tc:lookup-constructor
+                             (tc-env-env env)
+                             (parser:pattern-constructor-name pat)
+                             :no-error t)))
+                  (or (and ctor
+                           (tc:constructor-entry-gadt-p ctor))
+                      (some #'walk
+                            (parser:pattern-constructor-patterns pat)))))
+               (parser:pattern-binding
+                (walk (parser:pattern-binding-pattern pat)))
+               (t
+                nil))))
+    (walk pattern)))
+
+(defun calculate-protected-vars (scrutinee-types expected-type base-subs)
+  (declare (type tc:ty-list scrutinee-types)
+           (type tc:ty expected-type)
+           (type tc:substitution-list base-subs)
+           (values tc:ty-list))
+  "A GADT branch needs to conduct branch-local refinements of pattern variables.
+These variables are 'protected' from branch-local refinement, and will not leak
+into other branches or out of the match."
+  (tc:union-tys
+   ;; Variables from the pattern's constructor, for example:
+   ;; constructor (Integer -> Box Integer) for (Box :a) protects :a
+   (mapcan (lambda (scrutinee-type)
+             (tc:union-tys
+              (tc:type-variables scrutinee-type)
+              (tc:type-variables
+               (tc:apply-substitution base-subs scrutinee-type))))
+           scrutinee-types)
+
+   ;; Also protect variables from the expected type.
+   ;; For example, in a function (Box :a -> Box :a),
+   ;; a top level match needs to be able to calculate a branch type:
+   ;; (match b
+   ;;   ((BInt x) x) <--- Branch has type (Box Integer -> Box Integer)
+   ;;   ((BStr s) s) <--- Branch has type (Box String -> Box String)
+   (tc:type-variables expected-type)
+   (tc:type-variables
+    (tc:apply-substitution base-subs expected-type))))
+
 (defgeneric infer-expression-type (node expected-type subs env)
   (:documentation "Infer the type of NODE and then unify against EXPECTED-TYPE
 
@@ -2036,12 +2238,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                              "expression produces ~A but a let binding requires a single value"
                              (type-object-string resolved-ty)))))
 
-      (multiple-value-bind (pat-ty pat-node subs)
+      (multiple-value-bind (pat-ty preds_ pat-node subs existentials)
           (infer-pattern-type (parser:node-bind-pattern node)
                               expr-ty   ; unify against expr-ty
                               subs
                               env)
-        (declare (ignore pat-ty))
+        (declare (ignore pat-ty preds_))
 
         (values nil         ; return nil as this is always thrown away
                 preds
@@ -2052,7 +2254,8 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  :location (source:location node)
                  :pattern pat-node
                  :expr expr-node)
-                subs))))
+                subs
+                existentials))))
 
   (:method ((node parser:node-values-bind) expected-type subs env)
     (declare (type tc:ty expected-type)
@@ -2094,9 +2297,9 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                        (tc-error "Invalid values binding pattern"
                                  (tc-note subpattern
                                           "`values` bindings only support variables and `_`")))
-                     (multiple-value-bind (_sub-ty sub-node subs_)
+                     (multiple-value-bind (_sub-ty preds_ sub-node subs_)
                          (infer-pattern-type subpattern component-type subs env)
-                       (declare (ignore _sub-ty))
+                       (declare (ignore _sub-ty preds_))
                        (setf subs subs_)
                        (push sub-node pattern-nodes)))
             (setf pattern-nodes (nreverse pattern-nodes))
@@ -2117,25 +2320,57 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
     (let* ((preds nil)
            (accessors nil)
+           ;; Any let binding on a GADT constructor can introduce untouchable existentials for
+           ;; the rest of the body form. Check them after each body node for more precise error
+           ;; reporting, then check again at the end to catch node-body-last-node.
+           ;; Example: (progn (let (Hidden a) = h) (let _ = (the Integer a)))
+           (untouchable-existentials nil)
 
            ;; Infer the type of each node
            (body-nodes
              (loop :for node_ :in (parser:node-body-nodes node)
-                   :collect (multiple-value-bind (node_ty_ preds_ accessors_ node_ subs_)
-                                (infer-expression-type node_
-                                                       (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
-                                                       subs
-                                                       env)
-                              (declare (ignore node_ty_))
-                              (setf subs subs_)
-                              (setf preds (append preds preds_))
-                              (setf accessors (append accessors accessors_))
-                              node_))))
+                   :collect
+                   (let ((subs-before-node subs))
+                   (multiple-value-bind (node_ty_ preds_ accessors_ node_ subs_ existentials_)
+                       (infer-expression-type node_
+                                              (tc:make-variable :kind tc:+kstar+ :allow-result-p t)
+                                              subs
+                                              env)
+                     (declare (ignore node_ty_))
+
+                     ;; Only check untouchable existential refinement for GADTs.
+                     (when (or existentials_ untouchable-existentials)
+                       (setf untouchable-existentials
+                             (check-no-untouchable-refinement
+                              (delta-subs subs_ subs-before-node)
+                              (append untouchable-existentials existentials_)
+                              (source:location node_)))
+                       (setf untouchable-existentials
+                             (tc:union-tys existentials_ untouchable-existentials)))
+
+                     (setf subs subs_)
+                     (setf preds (append preds preds_))
+                     (setf accessors (append accessors accessors_))
+                     node_))))
+
+           (subs-before-last-node subs))
 
       (multiple-value-bind (ty preds_ accessors_ last-node subs)
           (infer-expression-type (parser:node-body-last-node node) expected-type subs env)
         (setf preds (append preds preds_))
         (setf accessors (append accessors accessors_))
+
+        ;; Only check untouchable existential refinement for GADTs.
+        (when untouchable-existentials
+          (setf untouchable-existentials
+                (check-no-untouchable-refinement
+                 (delta-subs subs subs-before-last-node)
+                 untouchable-existentials
+                 (source:location last-node)))
+          (check-no-untouchable-escape ty
+                                       subs
+                                       untouchable-existentials
+                                       (source:location last-node)))
 
         (values
          ty
@@ -2168,89 +2403,174 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                            (type-object-string effective-expected-type)
                            (tc:function-input-arity effective-expected-type))))
 
-      (let* ((body-return-block
+      (let* (;; Save the function-level subs before GADT parameter refinements.
+             (abstraction-base-subs subs)
+             (local-subs subs)
+
+             (body-return-block
                (body-return-block-node (parser:node-abstraction-body node)))
-             (body-result-ty (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
+             ;; (body-result-ty (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
+             (expected-function-type (and (tc:function-type-p effective-expected-type)
+                                          effective-expected-type))
+             (body-result-ty (if expected-function-type
+                                 (tc:output-types-result-type (tc:function-ty-output-types
+                                                               expected-function-type))
+                                 (tc:make-variable :kind tc:+kstar+ :allow-result-p t)))
              (*return-blocks*
                (if body-return-block
                    (acons (parser:node-block-name body-return-block)
                           body-result-ty
                           *return-blocks*)
                    *return-blocks*))
-             (expected-function-type (and (tc:function-type-p effective-expected-type)
-                                          effective-expected-type))
              (expected-keyword-table (make-hash-table :test #'eq))
              (expected-positional-input-types
                (and expected-function-type
                     (copy-list (tc:function-type-arguments expected-function-type))))
+
              (positional-arg-tys
                (loop :for pattern :in positional-params
                      :for expected-arg-ty := (pop expected-positional-input-types)
-                     :collect (or expected-arg-ty
-                                  (tc:make-variable))))
-             (typed-positional-params
-               (loop :for pattern :in positional-params
-                     :for ty :in positional-arg-tys
-                     :collect (multiple-value-bind (ty_ pattern_ subs_)
-                                  (infer-pattern-type pattern ty subs env)
-                                (declare (ignore ty_))
-                                (setf subs subs_)
-                                pattern_))))
+                     :for ty := (or expected-arg-ty
+                                (tc:make-variable))
+                     :collect ty))
 
-        (when expected-function-type
-          (dolist (entry (tc:function-ty-keyword-input-types expected-function-type))
-            (setf (gethash (tc:keyword-ty-entry-keyword entry) expected-keyword-table) entry)))
+             (gadt-positional-param-tys
+               (remove-duplicates
+                (loop :for pattern :in positional-params
+                      :for ty :in positional-arg-tys
+                      :when (pattern-contains-gadt-p pattern env)
+                        :collect ty)
+                :test #'tc:ty=))
 
-        (multiple-value-bind (typed-keyword-params keyword-entry-types keyword-prefix-nodes
-                              default-preds default-accessors subs)
-            (infer-keyword-params keyword-params expected-keyword-table subs env)
+             (abstraction-gadt-p (not (null gadt-positional-param-tys)))
 
-          (multiple-value-bind (body-ty preds accessors body-node subs)
-              (infer-expression-type (parser:node-abstraction-body node)
-                                     body-result-ty
-                                     subs
-                                     env)
-            (setf preds (append default-preds preds))
-            (setf accessors (append default-accessors accessors))
-            (let* ((body-ty (tc:apply-substitution subs body-ty))
-                   (typed-body
-                     (merge-keyword-prefix-nodes-into-body
-                      (nreverse keyword-prefix-nodes)
-                      body-node))
-                   (output-types (inferred-node-output-types body-ty typed-body))
-                   (ty (tc:make-function-ty
-                        :positional-input-types positional-arg-tys
-                        :keyword-input-types (normalize-keyword-entries (nreverse keyword-entry-types))
-                        :keyword-open-p nil
-                        :output-types output-types)))
-              (handler-case
-                  (progn
-                    (let ((effective-expected-type (tc:apply-substitution subs expected-type)))
-                    (let ((type nil))
-                      (cond
-                        ((and (typep ty 'tc:function-ty)
-                              (typep effective-expected-type 'tc:function-ty))
-                         (multiple-value-bind (subs_ visible-type _effective-type _wrapper-needed-p)
-                             (coerce-function-value-type ty effective-expected-type subs)
-                           (declare (ignore _effective-type _wrapper-needed-p))
-                           (setf subs subs_)
-                           (setf type visible-type)))
-                        (t
-                         (setf subs (tc:unify subs ty effective-expected-type))
-                         (setf type (tc:apply-substitution subs ty))))
-                      (values
-                       type
-                       preds
-                       accessors
-                       (make-node-abstraction
-                        :type (tc:qualify nil type)
-                        :location (source:location node)
-                        :params typed-positional-params
-                        :keyword-params (nreverse typed-keyword-params)
-                        :body typed-body)
-                       subs))))
-                (tc:coalton-internal-type-error ()
-                  (standard-expression-type-mismatch-error node subs effective-expected-type ty)))))))))
+             ;; Collect untouchables from all patterns to check for invalid GADT existential refinement
+             (untouchable-existentials nil)
+             (typed-positional-params nil))
+
+        (loop :for pattern :in positional-params
+              :for ty :in positional-arg-tys
+              :do (multiple-value-bind (ty_ preds_ pattern_ subs_ existentials_)
+                      (infer-pattern-type pattern ty local-subs env)
+                    (declare (ignore ty_ preds_))
+                    (setf local-subs subs_)
+                    (setf untouchable-existentials
+                          (tc:union-tys existentials_ untouchable-existentials))
+                    (push pattern_ typed-positional-params)))
+        (setf typed-positional-params (nreverse typed-positional-params))
+
+        (let* ((protected-vars
+                 (and abstraction-gadt-p
+                      (calculate-protected-vars gadt-positional-param-tys
+                                                body-result-ty
+                                                abstraction-base-subs)))
+
+               ;; Keyword defaults can refine parameter existentials. Save pre-keyword subs for checking.
+               ;; Example: (define (foo (Hidden a) &key (x (the Integer a))) ...)
+               (subs-after-positional-patterns local-subs))
+
+          (when expected-function-type
+            (dolist (entry (tc:function-ty-keyword-input-types expected-function-type))
+              (setf (gethash (tc:keyword-ty-entry-keyword entry) expected-keyword-table) entry)))
+
+          (multiple-value-bind (typed-keyword-params keyword-entry-types keyword-prefix-nodes
+                                default-preds default-accessors local-subs)
+              (infer-keyword-params keyword-params expected-keyword-table local-subs env)
+
+            (when abstraction-gadt-p
+              (setf untouchable-existentials
+                    (check-no-untouchable-refinement
+                     (delta-subs local-subs subs-after-positional-patterns)
+                     untouchable-existentials
+                     (source:location node))))
+
+            (let ((subs-before-body local-subs))
+
+              (multiple-value-bind (body-ty preds accessors body-node local-subs)
+                  (infer-expression-type (parser:node-abstraction-body node)
+                                         body-result-ty
+                                         local-subs
+                                         env)
+                (setf preds (append default-preds preds))
+                (setf accessors (append default-accessors accessors))
+                (let* ((body-ty (tc:apply-substitution local-subs body-ty))
+
+                       (typed-body
+                         (merge-keyword-prefix-nodes-into-body
+                          (nreverse keyword-prefix-nodes)
+                          body-node))
+
+                       ;; What the body actually produced under local refinement
+                       (body-output-types (inferred-node-output-types body-ty typed-body))
+
+                       ;; What the abstraction is allowed to expose outward
+                       (visible-output-types (if abstraction-gadt-p
+                                                 (copy-list (tc:function-ty-output-types expected-function-type))
+                                                 body-output-types))
+
+                       (ty (tc:make-function-ty
+                            :positional-input-types positional-arg-tys
+                            :keyword-input-types (normalize-keyword-entries (nreverse keyword-entry-types))
+                            :keyword-open-p nil
+                            :output-types visible-output-types))
+
+                       ;; GADT: Subs calculated during this branch
+                       (local-delta (and abstraction-gadt-p
+                                         (delta-subs local-subs abstraction-base-subs)))
+
+                       ;; GADT: Transform branch-specific preds back to outward preds
+                       (normalized-preds
+                         (if abstraction-gadt-p
+                             (normalize-branch-preds local-delta protected-vars preds)
+                             preds))
+
+                       (outward-subs
+                         (if abstraction-gadt-p
+                             (let* ((outward-delta (remove-protected-subs local-delta
+                                                                          protected-vars
+                                                                          abstraction-base-subs)))
+                               (tc:compose-substitution-lists outward-delta
+                                                              abstraction-base-subs))
+                             local-subs)))
+
+                  (handler-case
+                      (progn
+                        (let ((effective-expected-type (tc:apply-substitution outward-subs expected-type)))
+                          (let ((type nil))
+                            (cond
+                              ((and (typep ty 'tc:function-ty)
+                                    (typep effective-expected-type 'tc:function-ty))
+                               (multiple-value-bind (subs_ visible-type _effective-type _wrapper-needed-p)
+                                   (coerce-function-value-type ty effective-expected-type outward-subs)
+                                 (declare (ignore _effective-type _wrapper-needed-p))
+                                 (setf outward-subs subs_)
+                                (setf type visible-type)))
+                              (t
+                               (setf outward-subs (tc:unify outward-subs ty effective-expected-type))
+                               (setf type (tc:apply-substitution outward-subs ty))))
+                            (when abstraction-gadt-p
+                              (setf untouchable-existentials
+                                    (check-no-untouchable-refinement
+                                     (delta-subs local-subs subs-before-body)
+                                     untouchable-existentials
+                                     (source:location node)))
+                              (check-no-untouchable-escape (tc:output-types-result-type body-output-types)
+                                                           local-subs
+                                                           untouchable-existentials
+                                                           (source:location node)))
+                            (values
+                             type
+                             normalized-preds
+                             accessors
+                             (make-node-abstraction
+                              :type (tc:qualify nil type)
+                              :location (source:location node)
+                              :params typed-positional-params
+                              :keyword-params (nreverse typed-keyword-params)
+                              :body typed-body)
+                             outward-subs))))
+                    (tc:coalton-internal-type-error ()
+                      (standard-expression-type-mismatch-error node outward-subs effective-expected-type ty)))))))))))
 
   (:method ((node parser:node-rec) expected-type subs env)
     (declare (type tc:ty expected-type)
@@ -2415,55 +2735,269 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                subs
                                env)
 
-      (let* (;; Infer the type of each pattern, unifying against expr-ty
-             (pat-nodes
-               (loop :for branch :in (parser:node-match-branches node)
-                     :for pattern := (parser:node-match-branch-pattern branch)
-                     :collect (multiple-value-bind (pat-ty pat-node subs_)
-                                  (infer-pattern-type pattern expr-ty subs env)
-                                (declare (ignore pat-ty))
-                                (setf subs subs_)
-                                pat-node)))
+      (let ((match-gadt-p
+              (some (lambda (branch)
+                      (pattern-contains-gadt-p
+                       (parser:node-match-branch-pattern branch)
+                       env))
+                    (parser:node-match-branches node))))
 
-             (ret-ty (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
+        (if (not match-gadt-p)
+            ;; Plain ADT or literal match
+            (let* (;; Infer the type of each pattern, unifying against expr-ty
+                   (pat-nodes
+                     (loop :for branch :in (parser:node-match-branches node)
+                           :for pattern := (parser:node-match-branch-pattern branch)
+                           :collect (multiple-value-bind (pat-ty pat-preds pat-node subs_ untouchable-existentials)
+                                        (infer-pattern-type pattern expr-ty subs env)
+                                      (declare (ignore pat-ty pat-preds untouchable-existentials))
+                                      (setf subs subs_)
+                                      pat-node)))
 
-             ;; Infer the type of each branch, unifying against ret-ty
-             (branch-body-nodes
-               (loop :for branch :in (parser:node-match-branches node)
-                     :for body := (parser:node-match-branch-body branch)
-                     :collect (multiple-value-bind (body-ty preds_ accessors_ body-node subs_)
-                                  (infer-expression-type body ret-ty subs env)
-                                (declare (ignore body-ty))
-                                (setf subs subs_)
-                                (setf preds (append preds preds_))
-                                (setf accessors (append accessors accessors_))
-                                body-node)))
+                   (ret-ty (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
 
-             (branch-nodes
-               (loop :for branch :in (parser:node-match-branches node)
-                     :for pat-node :in pat-nodes
-                     :for branch-body-node :in branch-body-nodes
-                     :collect (make-node-match-branch
-                               :pattern pat-node
-                               :body branch-body-node
-                               :location (source:location branch)))))
+                   ;; Infer the type of each branch, unifying against ret-ty
+                   (branch-body-nodes
+                     (loop :for branch :in (parser:node-match-branches node)
+                           :for body := (parser:node-match-branch-body branch)
+                           :collect (multiple-value-bind (body-ty preds_ accessors_ body-node subs_)
+                                        (infer-expression-type body ret-ty subs env)
+                                      (declare (ignore body-ty))
+                                      (setf subs subs_)
+                                      (setf preds (append preds preds_))
+                                      (setf accessors (append accessors accessors_))
+                                      body-node)))
 
-        (handler-case
-            (progn
-              (setf subs (tc:unify subs ret-ty expected-type))
-              (let ((type (tc:apply-substitution subs ret-ty)))
-                (values
-                 type
-                 preds
-                 accessors
-                 (make-node-match
-                  :type (tc:qualify nil type)
-                  :location (source:location node)
-                  :expr expr-node
-                  :branches branch-nodes)
-                 subs)))
-          (tc:coalton-internal-type-error ()
-            (standard-expression-type-mismatch-error node subs expected-type ret-ty))))))
+                   (branch-nodes
+                     (loop :for branch in (parser:node-match-branches node)
+                           :for pat-node :in pat-nodes
+                           :for branch-body-node :in branch-body-nodes
+                           :collect (make-node-match-branch
+                                     :pattern pat-node
+                                     :body branch-body-node
+                                     :location (source:location branch)))))
+
+              (handler-case
+                  (progn
+                    (setf subs (tc:unify subs ret-ty expected-type))
+                    (let ((type (tc:apply-substitution subs ret-ty)))
+                      (values
+                       type
+                       preds
+                       accessors
+                       (make-node-match
+                        :type (tc:qualify nil type)
+                        :location (source:location node)
+                        :expr expr-node
+                        :branches branch-nodes)
+                       subs)))
+                (tc:coalton-internal-type-error ()
+                  (standard-expression-type-mismatch-error node subs expected-type ret-ty))))
+
+            ;; GADT matches: check each branch independently from match-base-subs.
+            ;; Do not commit one branch's substitutions before checking the next branch.
+            (labels ((merge-gadt-branch-delta (subs delta branch-node)
+                       (dolist (sub delta subs)
+                         (let* ((from (tc:substitution-from sub))
+                                (to (tc:substitution-to sub))
+                                (existing (find from subs
+                                                :key #'tc:substitution-from
+                                                :test #'tc:ty=)))
+                           (if existing
+                               (handler-case
+                                   (setf subs
+                                         (tc:unify subs
+                                                   (tc:substitution-to existing)
+                                                   to))
+                                 (tc:coalton-internal-type-error ()
+                                   (standard-expression-type-mismatch-error
+                                    (node-body-last-node branch-node)
+                                    subs
+                                    (tc:substitution-to existing)
+                                    to)))
+                               (push sub subs))))))
+
+              (let* (;; Infer the type of each pattern, unifying against expr-ty,
+                     ;; specialized for any branch-specific refinements from a
+                     ;; GADT constructor.
+                     (match-base-subs subs)
+
+                     (branch-data
+                       (loop :for branch :in (parser:node-match-branches node)
+                             :for pattern := (parser:node-match-branch-pattern branch)
+                             :for branch-env := (copy-branch-env env)
+                             :collect
+                             (multiple-value-bind (pat-ty pat-preds pat-node pat-subs untouchable-existentials)
+                                 (infer-pattern-type pattern expr-ty subs branch-env)
+                               (declare (ignore pat-ty))
+                               (let ((branch-subs (delta-subs pat-subs match-base-subs)))
+                                 (setf untouchable-existentials
+                                       (check-no-untouchable-refinement
+                                        branch-subs
+                                        untouchable-existentials
+                                        (source:location branch)))
+                                 (list :pat-node pat-node
+                                       :branch-subs branch-subs
+                                       :branch-env branch-env
+                                       :pat-preds pat-preds
+                                       :pat-env-ty-table (tc-env-ty-table branch-env)
+                                       :untouchable-existentials untouchable-existentials)))))
+
+                     ;; A GADT branch needs to conduct branch-local refinements of
+                     ;; pattern variables. These variables are protected from
+                     ;; branch-local refinement and will not leak into other branches
+                     ;; or out of the match.
+                     (protected-vars
+                       (tc:union-tys
+                        (tc:type-variables expr-ty)
+                        (tc:type-variables
+                         (tc:apply-substitution match-base-subs expr-ty))))
+
+                     (branch-body-data
+                       (loop :for branch :in (parser:node-match-branches node)
+                             :for branch-dat :in branch-data
+                             :for branch-subs := (getf branch-dat :branch-subs)
+                             :for subs-for-branch-body := (tc:compose-substitution-lists
+                                                           branch-subs
+                                                           match-base-subs)
+                             :for pat-preds := (getf branch-dat :pat-preds)
+                             :for branch-env := (getf branch-dat :branch-env)
+                             :for branch-ret-ty := (tc:apply-substitution
+                                                    subs-for-branch-body
+                                                    expected-type)
+                             :for branch-table := (getf branch-dat :pat-env-ty-table)
+                             :for body := (parser:node-match-branch-body branch)
+
+                             ;; Update pattern-bound tvars and other branch-local names
+                             ;; with this branch's refinements before checking the body.
+                             :do (maphash (lambda (name scheme)
+                                            (setf (gethash name branch-table)
+                                                  (tc:apply-substitution
+                                                   subs-for-branch-body
+                                                   scheme)))
+                                          branch-table)
+
+                             :collect
+                               (multiple-value-bind (body-ty body-preds body-accessors body-node body-subs)
+                                   (infer-expression-type body
+                                                          branch-ret-ty
+                                                          subs-for-branch-body
+                                                          branch-env)
+
+                                 (let* (;; Subs learned while checking the branch body,
+                                        ;; after the pattern refinements were installed.
+                                        (subs-from-branch
+                                          (delta-subs body-subs subs-for-branch-body))
+
+                                        ;; Subs learned across the whole branch:
+                                        ;; pattern refinements plus body refinements.
+                                        ;;
+                                        ;; Used for predicate normalization, because
+                                        ;; predicates may need to unify:
+                                        ;;
+                                        ;; fresh pred var -> branch-specific var -> protected outer var
+                                        (branch-local-delta
+                                          (delta-subs body-subs match-base-subs))
+
+                                        (untouchable-existentials
+                                          (getf branch-dat :untouchable-existentials))
+
+                                        ;; Calculate subs that do not unify protected vars.
+                                        ;; Those are clean to send up to the calling block.
+                                        (branch-delta
+                                          (remove-protected-subs
+                                           subs-from-branch
+                                           protected-vars
+                                           match-base-subs))
+
+                                        ;; Rewrite branch representatives back to protected
+                                        ;; outer vars.
+                                        (normalization-subs
+                                          (branch-normalization-subs
+                                           branch-local-delta
+                                           protected-vars))
+
+                                        ;; Pattern predicates were produced in this branch
+                                        ;; by pattern checking, so they may need the full
+                                        ;; branch-local path.
+                                        (normalized-pattern-preds
+                                          (normalize-branch-preds
+                                           branch-local-delta
+                                           protected-vars
+                                           pat-preds))
+
+                                        ;; Body preds should only be fully applied by subs
+                                        ;; learned while checking the body, then normalized
+                                        ;; back through the GADT branch representatives.
+                                        (normalized-body-preds
+                                          (tc:apply-substitution
+                                           normalization-subs
+                                           (tc:apply-substitution
+                                            subs-from-branch
+                                            body-preds)))
+
+                                        (normalized-preds
+                                          (append normalized-body-preds
+                                                  normalized-pattern-preds)))
+
+                                   (setf untouchable-existentials
+                                         (check-no-untouchable-refinement
+                                          subs-from-branch
+                                          untouchable-existentials
+                                          (source:location branch)))
+                                   (check-no-untouchable-escape body-ty
+                                                                body-subs
+                                                                untouchable-existentials
+                                                                (source:location branch))
+                                   (setf preds (append preds normalized-preds))
+                                   (setf accessors (append accessors body-accessors))
+                                   (list :body-node body-node
+                                         :branch-delta branch-delta)))))
+
+                     ;; GADT branches were checked independently. Merge only the
+                     ;; non-protected subs learned by each branch. If ordinary
+                     ;; outer variables disagree across branges, the merge will fail.
+                     (_merge-branch-deltas
+                       (dolist (branch-body-dat branch-body-data subs)
+                         (setf subs
+                               (merge-gadt-branch-delta
+                                subs
+                                (getf branch-body-dat :branch-delta)
+                                (getf branch-body-dat :body-node)))))
+
+                     (branch-body-nodes (mapcar (lambda (branch-body-dat)
+                                                  (getf branch-body-dat :body-node))
+                                                branch-body-data))
+
+                     (branch-nodes
+                       (loop :for branch :in (parser:node-match-branches node)
+                             :for branch-dat :in branch-data
+                             :for pat-node := (getf branch-dat :pat-node)
+                             :for branch-body-node :in branch-body-nodes
+                             :collect (make-node-match-branch
+                                       :pattern pat-node
+                                       :body branch-body-node
+                                       :location (source:location branch)))))
+
+                (declare (ignore _merge-branch-deltas))
+                (handler-case
+                    (let ((type (tc:apply-substitution subs expected-type)))
+                      (values
+                       type
+                       preds
+                       accessors
+                       (make-node-match
+                        :type (tc:qualify nil type)
+                        :location (source:location node)
+                        :expr expr-node
+                        :branches branch-nodes)
+                       subs))
+                  (tc:coalton-internal-type-error ()
+                    (standard-expression-type-mismatch-error
+                     node
+                     subs
+                     expected-type
+                     expected-type)))))))))
 
   (:method ((node parser:node-catch) expected-type subs env)
     (declare (type tc:ty expected-type)
@@ -2481,12 +3015,15 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                  env)
         (declare (ignore expr-ty))
 
+        ;; NOTE: Currently, exceptions cannot be GADTs, so they don't need branch-local
+        ;; environments and untouchable tracking. If/when that gets implemented, then
+        ;; this should follow the patterns from the parser:node-match method.
         (let* (;; Infer type of each pattern, ensuring it is an exception type
                (branch-pat-nodes
                  (loop
                    :for branch :in (parser:node-catch-branches node)
                    :for pattern := (parser:node-catch-branch-pattern branch)
-                   :for (pat-ty pat-node subs_)
+                   :for (pat-ty pat-preds_ pat-node subs_)
                      := (multiple-value-list (infer-pattern-type pattern (tc:make-variable) subs env))
                    :unless (or (exception-type-p pat-ty env)
                                (typep pattern 'parser:pattern-wildcard))
@@ -2550,12 +3087,16 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                (tc:make-variable)
                                subs
                                env)
+
+      ;; NOTE: Currently, resumables cannot be GADTs, so they don't need branch-local
+      ;; environments and untouchable tracking. If/when that gets implemented, then
+      ;; this should follow the patterns from the parser:node-match method.
       (let* (;; infer type of each pattern, ensuring it is a resumption type
              (branch-pat-nodes
                (loop
                  :for branch :in (parser:node-resumable-branches node)
                  :for pattern := (parser:node-resumable-branch-pattern branch)
-                 :for (pat-ty pat-node subs_)
+                 :for (pat-ty preds_ pat-node subs_)
                    := (multiple-value-list (infer-pattern-type pattern (tc:make-variable) subs env))
                  :unless (resumption-type-p pat-ty env)
                    :do (tc-error "Invalid resumable case"
@@ -2678,6 +3219,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
     (let* ((block-type (tc:make-variable :kind tc:+kstar+ :allow-result-p t))
            (block-info (make-return-block-info :type block-type)))
+
+      (handler-case
+          (setf subs (tc:unify subs block-type expected-type))
+        (tc:coalton-internal-type-error ()
+          (standard-expression-type-mismatch-error node subs expected-type block-type)))
+
       (multiple-value-bind (body-ty preds accessors body-node subs)
           (let ((*return-blocks*
                   (acons (parser:node-block-name node)
@@ -3448,12 +3995,12 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                subs
                                env)
 
-      (multiple-value-bind (ty_ pattern subs)
+      (multiple-value-bind (ty_ preds_ pattern subs untouchable-existentials_)
           (infer-pattern-type (parser:node-do-bind-pattern node)
                               (tc:tapp-to (tc:apply-substitution subs expr-ty)) ; this should never fail
                               subs
                               env)
-        (declare (ignore ty_))
+        (declare (ignore ty_ preds_))
 
         (handler-case
             (progn
@@ -3466,7 +4013,8 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :pattern pattern
                 :expr expr-node
                 :location (source:location node))
-               subs))
+               subs
+               untouchable-existentials_))
           (tc:coalton-internal-type-error ()
             (tc-error "Type mismatch"
                       (tc-note node "Expected type '~A' but got '~A'"
@@ -3487,14 +4035,22 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
            (preds nil)
            (accessors nil)
 
+           ;; Any binding on a GADT constructor can introduce untouchable existentials for the
+           ;; rest of the do form. Check them after each node for more precise error reporting,
+           ;; then check again at the end to catch node-do-last-node.
+           ;; Example: (do ((Hidden a) <- m) ...) or (do (let (Hidden a) = h) ...)
+           (untouchable-existentials nil)
+
            (nodes
              (loop :for elem :in (parser:node-do-nodes node)
+                   :for subs-before-node := subs
+                   :for untouchables := nil
                    :collect (etypecase elem 
                               ;; Expressions are typechecked normally
                               ;; and then unified against "m a" where
                               ;; "a" is a fresh tyvar each time
                               (parser:node
-                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_)
+                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_ untouchables_)
                                    (infer-expression-type elem
                                                           (tc:make-tapp
                                                            :from m-type
@@ -3502,6 +4058,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                                           subs
                                                           env)
                                  (declare (ignore ty_))
+                                 (setf untouchables untouchables_)
                                  (setf preds (append preds preds_))
                                  (setf accessors (append accessors accessors_))
                                  (setf subs subs_)
@@ -3509,12 +4066,13 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
                               ;; Node-binds are typechecked normally
                               (parser:node-bind
-                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_)
+                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_ untouchables_)
                                    (infer-expression-type elem
                                                           (tc:make-variable)
                                                           subs
                                                           env)
                                  (declare (ignore ty_))
+                                 (setf untouchables untouchables_)
                                  (setf preds (append preds preds_))
                                  (setf accessors (append accessors accessors_))
                                  (setf subs subs_)
@@ -3522,12 +4080,13 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
                               ;; Values-binds are local bindings, not monadic binds
                               (parser:node-values-bind
-                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_)
+                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_ untouchables_)
                                    (infer-expression-type elem
                                                           (tc:make-variable)
                                                           subs
                                                           env)
                                  (declare (ignore ty_))
+                                 (setf untouchables untouchables_)
                                  (setf preds (append preds preds_))
                                  (setf accessors (append accessors accessors_))
                                  (setf subs subs_)
@@ -3535,7 +4094,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
                               ;; Node-do-binds are typechecked and unified against "m a"
                               (parser:node-do-bind
-                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_)
+                               (multiple-value-bind (ty_ preds_ accessors_ node_ subs_ untouchables_)
                                    (infer-expression-type elem
                                                           (tc:make-tapp
                                                            :from m-type
@@ -3543,44 +4102,62 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                                                           subs
                                                           env)
                                  (declare (ignore ty_))
+                                 (setf untouchables untouchables_)
                                  (setf preds (append preds preds_))
                                  (setf accessors (append accessors accessors_))
                                  (setf subs subs_)
-                                 node_))))))
+                                 node_)))
+                   :do
+                     (setf untouchable-existentials
+                           (check-no-untouchable-refinement
+                            (delta-subs subs subs-before-node)
+                            (append untouchable-existentials untouchables)
+                            (source:location elem))))))
 
-      (multiple-value-bind (ty preds_ accessors_ last-node subs)
-          (infer-expression-type (parser:node-do-last-node node)
-                                 (tc:make-tapp :from m-type
-                                               :to (tc:make-variable))
-                                 subs
-                                 env)
+      (let ((subs-before-last-node subs))
 
-        (setf preds (append preds preds_))
-        (setf accessors (append accessors accessors_))
+        (multiple-value-bind (ty preds_ accessors_ last-node subs)
+            (infer-expression-type (parser:node-do-last-node node)
+                                   (tc:make-tapp :from m-type
+                                                 :to (tc:make-variable))
+                                   subs
+                                   env)
 
-        (handler-case
-            (progn
-              (setf subs (tc:unify subs ty expected-type))
-              (values
-               ty
-               (cons
-                (tc:make-ty-predicate
-                 :class monad-symbol
-                 :types (list m-type)
-                 :location (source:location node))
-                preds)
-               accessors
-               (make-node-do
-                :type (tc:qualify nil ty)
-                :location (source:location node)
-                :nodes nodes
-                :last-node last-node) 
-               subs))
-          (tc:coalton-internal-type-error ()
-            (tc-error "Type mismatch"
-                      (tc-note node "Expected type '~A' but do expression has type '~A'"
-                               (type-object-string (tc:apply-substitution subs expected-type))
-                               (type-object-string (tc:apply-substitution subs ty))))))))))
+          (setf preds (append preds preds_))
+          (setf accessors (append accessors accessors_))
+
+          (handler-case
+              (progn
+                (setf subs (tc:unify subs ty expected-type))
+                (setf untouchable-existentials
+                      (check-no-untouchable-refinement
+                       (delta-subs subs subs-before-last-node)
+                       untouchable-existentials
+                       (source:location last-node)))
+                (check-no-untouchable-escape ty
+                                             subs
+                                             untouchable-existentials
+                                             (source:location last-node))
+                (values
+                 ty
+                 (cons
+                  (tc:make-ty-predicate
+                   :class monad-symbol
+                   :types (list m-type)
+                   :location (source:location node))
+                  preds)
+                 accessors
+                 (make-node-do
+                  :type (tc:qualify nil ty)
+                  :location (source:location node)
+                  :nodes nodes
+                  :last-node last-node)
+                 subs))
+            (tc:coalton-internal-type-error ()
+              (tc-error "Type mismatch"
+                        (tc-note node "Expected type '~A' but do expression has type '~A'"
+                                 (type-object-string (tc:apply-substitution subs expected-type))
+                                 (type-object-string (tc:apply-substitution subs ty)))))))))))
 
 ;;;
 ;;; Pattern Type Inference
@@ -3589,7 +4166,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 (defgeneric infer-pattern-type (pat expected-typ subs env)
   (:documentation "Infer the type of pattern PAT and then unify against EXPECTED-TYPE.
 
-Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
+Returns (VALUES INFERRED-TYPE PREDS NODE SUBSTITUTIONS EXISTENTIAL-VARS)")
   (:method :around (pat expected-type subs env)
     (declare (ignore pat expected-type subs))
     (with-type-string-environment (env)
@@ -3598,7 +4175,7 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (values tc:ty pattern-binding tc:substitution-list))
+             (values tc:ty tc:ty-predicate-list pattern-binding tc:substitution-list tc:tyvar-list))
 
     (check-duplicates (parser:pattern-variables pat)
                       #'parser:pattern-var-name
@@ -3607,24 +4184,29 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                                   (tc-note first "first definition here")
                                   (tc-note second "second definition here"))))
 
-    (multiple-value-bind (pat-ty bound subs)
+    (multiple-value-bind (pat-ty preds bound subs existentials)
         (infer-pattern-type (parser:pattern-binding-pattern pat) expected-type subs env)
-      (multiple-value-bind (pat-ty var subs)
+      (declare (ignore preds))
+
+      (multiple-value-bind (pat-ty preds var subs var-existentials)
           (infer-pattern-type (parser:pattern-binding-var pat) pat-ty subs env)
+        (declare (ignore preds))
 
         (values
          pat-ty
+         nil
          (make-pattern-binding
           :type (tc:qualify nil pat-ty)
           :var var
           :pattern bound)
-         subs))))
+         subs
+         (tc:union-tys existentials var-existentials)))))
 
   (:method ((pat parser:pattern-var) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (values tc:ty pattern-var tc:substitution-list))
+             (values tc:ty tc:ty-predicate-list pattern-var tc:substitution-list tc:tyvar-list))
 
     (let ((ty (tc-env-add-variable env (parser:pattern-var-name pat))))
 
@@ -3634,18 +4216,20 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
       (let ((type (tc:apply-substitution subs ty)))
         (values
          type
+         nil
          (make-pattern-var
           :type (tc:qualify nil type)
           :location (source:location pat)
           :name (parser:pattern-var-name pat)
           :orig-name (parser:pattern-var-orig-name pat))
-         subs))))
+         subs
+         nil))))
 
   (:method ((pat parser:pattern-literal) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (values tc:ty pattern-literal tc:substitution-list))
+             (values tc:ty tc:ty-predicate-list pattern-literal tc:substitution-list tc:tyvar-list))
 
     (let ((ty (etypecase (parser:pattern-literal-value pat)
                 (integer (let* ((num
@@ -3668,11 +4252,13 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
             (let ((type (tc:apply-substitution subs ty)))
               (values
                type
+               nil
                (make-pattern-literal
                 :type (tc:qualify nil type)
                 :location (source:location pat)
                 :value (parser:pattern-literal-value pat))
-               subs)))
+               subs
+               nil)))
         (tc:coalton-internal-type-error ()
           (tc-error "Type mismatch"
                     (tc-note pat "Expected type '~A' but pattern literal has type '~A'"
@@ -3683,20 +4269,22 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (values tc:ty pattern-wildcard tc:substitution-list))
+             (values tc:ty tc:ty-predicate-list pattern-wildcard tc:substitution-list tc:tyvar-list))
 
     (values
      expected-type
+     nil
      (make-pattern-wildcard
       :type (tc:qualify nil expected-type)
       :location (source:location pat))
-     subs))
+     subs
+     nil))
 
   (:method ((pat parser:pattern-constructor) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
              (type tc-env env)
-             (values tc:ty pattern-constructor tc:substitution-list))
+             (values tc:ty tc:ty-predicate-list pattern-constructor tc:substitution-list tc:tyvar-list))
 
     (let ((ctor (tc:lookup-constructor (tc-env-env env) (parser:pattern-constructor-name pat) :no-error t)))
 
@@ -3722,38 +4310,58 @@ Returns (VALUES INFERRED-TYPE NODE SUBSTITUTIONS)")
                              arity
                              num-args)))
 
-        (let* ((ctor-ty (tc:qualified-ty-type ;; NOTE: Constructors cannot have predicates
-                         (tc:fresh-inst
-                          (tc:lookup-value-type (tc-env-env env) (parser:pattern-constructor-name pat)))))
+        (multiple-value-bind (ctor-ty ctor-preds)
+            (tc-env-lookup-value-symbol env
+                                        (parser:pattern-constructor-name pat)
+                                        (source:location pat))
+          (let* ((pat-ty (tc:function-return-type ctor-ty))
 
-               (pat-ty (tc:function-return-type ctor-ty))
+                 (child-preds nil))
+            (handler-case
+                (progn
+                  (setf subs (tc:unify subs pat-ty expected-type))
+                  (setf ctor-ty (tc:apply-substitution subs ctor-ty))
+                  (setf pat-ty (tc:function-return-type ctor-ty)))
+              (tc:coalton-internal-type-error ()
+                (tc-error "Type mismatch"
+                          (tc-note pat "Expected type '~A' but pattern has type '~A'"
+                                   (type-object-string (tc:apply-substitution subs expected-type))
+                                   (type-object-string (tc:apply-substitution subs pat-ty))))))
 
-               (pattern-nodes
-                 (loop :for arg :in (parser:pattern-constructor-patterns pat)
-                       :for arg-ty :in (tc:function-type-arguments ctor-ty)
-                       :collect (multiple-value-bind (ty_ node_ subs_)
-                                    (infer-pattern-type arg arg-ty subs env)
-                                  (declare (ignore ty_))
-                                  (setf subs subs_)
-                                  node_))))
-
-          (handler-case
-              (progn
-                (setf subs (tc:unify subs pat-ty expected-type))
-                (let ((type (tc:apply-substitution subs pat-ty)))
-                  (values
-                   type
-                   (make-pattern-constructor
-                    :type (tc:qualify nil pat-ty)
-                    :location (source:location pat)
-                    :name (parser:pattern-constructor-name pat)
-                    :patterns pattern-nodes)
-                   subs)))
-            (tc:coalton-internal-type-error ()
-              (tc-error "Type mismatch"
-                        (tc-note pat "Expected type '~A' but pattern has type '~A'"
-                                 (type-object-string (tc:apply-substitution subs expected-type))
-                                 (type-object-string (tc:apply-substitution subs pat-ty)))))))))))
+            (let* ((ctor-preds (tc:apply-substitution subs ctor-preds))
+                   (ctor-vars (tc:type-variables (list ctor-ty ctor-preds)))
+                   (result-vars (tc:type-variables pat-ty))
+                   ;; For a GADT constructor like: (Type (:a -> Hidden)), collect :a
+                   ;; to prevent it from being refined by the branch.
+                   ;; For a GADT constructor like: (Type (:a -> Hidden :a)), drop :a
+                   ;; because the branch is allowed to refine it.
+                   (existentials (if (tc:constructor-entry-gadt-p ctor)
+                                         (set-difference ctor-vars result-vars
+                                                         :test #'tc:ty=)
+                                         nil))
+                   (pattern-nodes
+                     (loop :for arg :in (parser:pattern-constructor-patterns pat)
+                           :for arg-ty :in (tc:function-type-arguments ctor-ty)
+                           :collect (multiple-value-bind (ty_ child-preds_ node_ subs_ child-existentials_)
+                                        (infer-pattern-type arg arg-ty subs env)
+                                      (declare (ignore ty_))
+                                      (setf subs subs_)
+                                      (setf child-preds (nconc child-preds child-preds_))
+                                      (setf existentials
+                                            (nconc existentials child-existentials_))
+                                      node_))))
+              (let ((type (tc:apply-substitution subs pat-ty))
+                    (final-preds (tc:apply-substitution subs (nconc ctor-preds child-preds))))
+                (values
+                 type
+                 final-preds
+                 (make-pattern-constructor
+                  :type (tc:qualify nil pat-ty)
+                  :location (source:location pat)
+                  :name (parser:pattern-constructor-name pat)
+                  :patterns pattern-nodes)
+                 subs
+                 existentials)))))))))
 
 ;;;
 ;;; Binding Group Type Inference

--- a/src/typechecker/derive.lisp
+++ b/src/typechecker/derive.lisp
@@ -7,7 +7,8 @@
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker/stage-1)
    (#:env #:coalton-impl/typechecker/environment)
-   (#:pred #:coalton-impl/typechecker/predicate))
+   (#:pred #:coalton-impl/typechecker/predicate)
+   (#:top #:coalton-impl/parser/toplevel))
   (:export
    #:derive-class-instances              ;; FUNCTION
    #:derive-methods                      ;; GENERIC FUNCTION
@@ -79,6 +80,15 @@ EQL-specialize on symbol `class'."))
   (loop :for type :in (append types structs)
         :for derive := (parser:type-definition-derive type)
         :for classes := (and derive (parser:attribute-derive-classes derive))
+        :do (when (and (top:toplevel-define-type-p type)
+                       (top:toplevel-define-type-gadt-p type)
+                       classes)
+              (parser:parse-error "Invalid derive application"
+                                  (parser:note (source:location-source
+                                                (top:toplevel-define-type-head-location type))
+                                               (source:location-span
+                                                (top:toplevel-define-type-head-location type))
+                                               " cannot apply (derive) to a GADT definition")))
         :unless (null classes)
           :nconc (loop :for class :in (cst:raw classes)
                        :collect (make-toplevel-derivation

--- a/src/typechecker/environment.lisp
+++ b/src/typechecker/environment.lisp
@@ -48,6 +48,7 @@
    #:type-entry-newtype                     ; ACCESSOR
    #:type-entry-exception-p                 ; ACCESSOR
    #:type-entry-resumption-p                ; ACCESSOR
+   #:type-entry-gadt-p                      ; ACCESSOR
    #:type-environment                       ; STRUCT
    #:constructor-entry                      ; STRUCT
    #:make-constructor-entry                 ; ACCESSOR
@@ -57,6 +58,7 @@
    #:constructor-entry-constructs           ; ACCESSOR
    #:constructor-entry-classname            ; ACCESSOR
    #:constructor-entry-compressed-repr      ; ACCESSOR
+   #:constructor-entry-gadt-p               ; ACCESSOR
    #:constructor-entry-list                 ; TYPE
    #:constructor-environment                ; STRUCT
    #:type-alias-entry                       ; STRUCT
@@ -318,7 +320,8 @@
   (docstring  (util:required 'docstring)         :type (or null string)          :read-only t)
   (location   nil                                :type (or null source:location) :read-only t)
   (exception-p nil                               :type boolean                   :read-only nil)
-  (resumption-p nil                              :type boolean                   :read-only nil))
+  (resumption-p nil                              :type boolean                   :read-only nil)
+  (gadt-p       (util:required 'gadt-p)          :type boolean                   :read-only t))
 
 (defmethod source:location ((self type-entry))
   (type-entry-location self))
@@ -357,7 +360,8 @@
             :explicit-repr '(:native cl:boolean)
             :enum-repr t
             :newtype nil
-            :docstring "Either true or false, internally represented by `cl:t` and `cl:nil` respectively."))
+            :docstring "Either true or false, internally represented by `cl:t` and `cl:nil` respectively."
+            :gadt-p nil))
 
           ('coalton:Unit
            (make-type-entry
@@ -371,7 +375,8 @@
             :explicit-repr :enum
             :enum-repr t
             :newtype nil
-            :docstring "The \"unit\" type whose only member is the value `Unit`."))
+            :docstring "The \"unit\" type whose only member is the value `Unit`."
+            :gadt-p nil))
 
           ('coalton:Char
            (make-type-entry
@@ -385,7 +390,8 @@
             :explicit-repr '(:native cl:character)
             :enum-repr nil
             :newtype nil
-            :docstring "A character represented by a Common Lisp `cl:character`."))
+            :docstring "A character represented by a Common Lisp `cl:character`."
+            :gadt-p nil))
 
           ('coalton:Integer
            (make-type-entry
@@ -399,7 +405,8 @@
             :explicit-repr '(:native cl:integer)
             :enum-repr nil
             :newtype nil
-            :docstring "Integer of unbounded size. Represented by a Common Lisp `cl:integer`."))
+            :docstring "Integer of unbounded size. Represented by a Common Lisp `cl:integer`."
+            :gadt-p nil))
 
           ('coalton:F32
            (make-type-entry
@@ -413,7 +420,8 @@
             :explicit-repr '(:native cl:single-float)
             :enum-repr nil
             :newtype nil
-            :docstring "Single-precision floating point number (32 bits in size). Represented by a Common Lisp `cl:single-float`."))
+            :docstring "Single-precision floating point number (32 bits in size). Represented by a Common Lisp `cl:single-float`."
+            :gadt-p nil))
 
           ('coalton:F64
            (make-type-entry
@@ -427,7 +435,8 @@
             :explicit-repr '(:native cl:double-float)
             :enum-repr nil
             :newtype nil
-            :docstring "Double-precision floating point number (64 bits in size). Represented by a Common Lisp `cl:double-float`."))
+            :docstring "Double-precision floating point number (64 bits in size). Represented by a Common Lisp `cl:double-float`."
+            :gadt-p nil))
 
           ('coalton:String
            (make-type-entry
@@ -441,7 +450,8 @@
             :explicit-repr '(:native cl:string)
             :enum-repr nil
             :newtype nil
-            :docstring "String of characters. Represented by Common Lisp `cl:string`."))
+            :docstring "String of characters. Represented by Common Lisp `cl:string`."
+            :gadt-p nil))
 
           ('coalton:Fraction
            (make-type-entry
@@ -455,7 +465,8 @@
             :explicit-repr '(:native cl:rational)
             :enum-repr nil
             :newtype nil
-            :docstring "A ratio of integers always in reduced form. Represented by a Common Lisp `cl:rational`."))
+            :docstring "A ratio of integers always in reduced form. Represented by a Common Lisp `cl:rational`."
+            :gadt-p nil))
 
           ('coalton:Arrow
            (make-type-entry
@@ -469,7 +480,8 @@
             :explicit-repr nil
             :enum-repr nil
             :newtype nil
-            :docstring "A named constructor for function types. `Arrow :a :b` is equivalent to `:a -> :b`."))
+            :docstring "A named constructor for function types. `Arrow :a :b` is equivalent to `:a -> :b`."
+            :gadt-p nil))
 
           ('coalton:List
            (make-type-entry
@@ -483,7 +495,8 @@
             :explicit-repr '(:native cl:list)
             :enum-repr nil
             :newtype nil
-            :docstring "Homogeneous list of objects. Represented as a typical Common Lisp chain of `cl:cons` (or `cl:nil`)."))
+            :docstring "Homogeneous list of objects. Represented as a typical Common Lisp chain of `cl:cons` (or `cl:nil`)."
+            :gadt-p nil))
 
           ('coalton:Optional
            (make-type-entry
@@ -497,7 +510,8 @@
             :explicit-repr '(:native cl:t)
             :enum-repr nil
             :newtype nil
-            :docstring "A type that allows indicating the presence or absence of a value. The underlying representation does not allocate when a value is present (i.e., with `Some`).")))))
+            :docstring "A type that allows indicating the presence or absence of a value. The underlying representation does not allocate when a value is present (i.e., with `Some`)."
+            :gadt-p nil)))))
 
 ;;;
 ;;; Constructor environment
@@ -513,7 +527,8 @@
 
   ;; If this constructor constructs a compressed-repr type then
   ;; compressed-repr is the runtime value of this nullary constructor
-  (compressed-repr (util:required 'compressed-repr) :type t                              :read-only t))
+  (compressed-repr (util:required 'compressed-repr) :type t                              :read-only t)
+  (gadt-p          nil                              :type boolean                        :read-only t))
 
 (defmethod source:docstring ((self constructor-entry))
   (constructor-entry-docstring self))
@@ -546,7 +561,8 @@
             :constructs 'coalton:Boolean
             :classname 'coalton::Boolean/True
             :docstring "Boolean `True`"
-            :compressed-repr 't))
+            :compressed-repr 't
+            :gadt-p nil))
 
           ('coalton:False
            (make-constructor-entry
@@ -556,7 +572,8 @@
             :constructs 'coalton:Boolean
             :classname 'coalton::Boolean/False
             :docstring "Boolean `False`"
-            :compressed-repr 'nil))
+            :compressed-repr 'nil
+            :gadt-p nil))
 
           ('coalton:Unit
           (make-constructor-entry
@@ -566,7 +583,8 @@
             :constructs 'coalton:Unit
             :classname 'coalton::Unit/Unit
             :docstring "`Unit` is the explicit one-value unit type, distinct from zero-value returns `()`."
-            :compressed-repr coalton-impl/constants:+value-of-unit+))
+            :compressed-repr coalton-impl/constants:+value-of-unit+
+            :gadt-p nil))
 
           ('coalton:Cons
            (make-constructor-entry
@@ -576,7 +594,8 @@
             :constructs 'coalton:List
             :classname nil
             :docstring "`Cons` represents a `List` containing a first element (`car`) and a nested `Cons` (`cdr`)."
-            :compressed-repr 'nil))
+            :compressed-repr 'nil
+            :gadt-p nil))
 
           ('coalton:Nil
            (make-constructor-entry
@@ -586,7 +605,8 @@
             :constructs 'coalton:List
             :classname nil
             :docstring "`Nil` represents an empty `List`."
-            :compressed-repr 'nil))
+            :compressed-repr 'nil
+            :gadt-p nil))
 
           ('coalton:Some
            (make-constructor-entry
@@ -596,7 +616,8 @@
             :constructs 'coalton:Optional
             :classname nil
             :docstring "`Some` expresses the presence of a meaningful value."
-            :compressed-repr 'nil))
+            :compressed-repr 'nil
+            :gadt-p nil))
 
           ('coalton:None
            (make-constructor-entry
@@ -606,7 +627,8 @@
             :constructs 'coalton:Optional
             :classname nil
             :docstring "`None` expresses the absence of a meaningful value."
-            :compressed-repr 'nil)))))
+            :compressed-repr 'nil
+            :gadt-p nil)))))
 
 #+(and sbcl coalton-release)
 (declaim (sb-ext:freeze-type constructor-environment))

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -27,6 +27,7 @@
    #:parse-ty-scheme                    ; FUNCTION
    #:infer-type-kinds                   ; FUNCTION
    #:infer-predicate-kinds              ; FUNCTION
+   #:seed-qualified-type-variables      ; FUNCTION
    ))
 
 (in-package #:coalton-impl/typechecker/parse-type)
@@ -612,10 +613,17 @@ the substitution :b +-> T can be inferred.
             (setf ksubs (tc:kunify (tc:kind-of type_) expected-kind ksubs))
             (values (tc:apply-ksubstitution ksubs type_) ksubs))
         (tc:coalton-internal-type-error ()
-          (tc-error "Kind mismatch"
-                    (tc-note type "Expected kind '~S' but got kind '~S'"
-                             expected-kind
-                             (tc:kind-of type_)))))))
+          (let ((actual-kind
+                  (tc:apply-ksubstitution
+                   (tc:kind-monomorphize-subs
+                    (tc:kind-variables
+                     (tc:apply-ksubstitution ksubs (tc:kind-of type_)))
+                    ksubs)
+                   (tc:kind-of type_))))
+            (tc-error "Kind mismatch"
+                      (tc-note type "Expected kind '~S' but got kind '~S'"
+                               expected-kind
+                               actual-kind)))))))
 
   (:method ((type parser:tapp) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)

--- a/src/typechecker/substitutions.lisp
+++ b/src/typechecker/substitutions.lisp
@@ -14,6 +14,8 @@
    #:substitution-list                  ; TYPE
    #:merge-substitution-lists           ; FUNCTION
    #:compose-substitution-lists         ; FUNCTION
+   #:refined-vars                       ; FUNCTION
+   #:same-substitution-p                ; FUNCTION
    #:apply-substitution                 ; FUNCTION
    ))
 
@@ -114,7 +116,23 @@
   (:method (subst-list (type-list list))
     (mapcar (lambda (x) (apply-substitution subst-list x)) type-list)))
 
+(defun refined-vars (subs vars)
+  "Return tvarsr in VARS that are refined by SUBS."
+  (declare (type substitution-list subs)
+           (type tyvar-list vars)
+           (values tyvar-list))
+  (remove-if (lambda (var)
+               (ty= (apply-substitution subs var) var))
+             vars))
 
+(defun same-substitution-p (a b)
+  "Check if A and B are the same substitution."
+  (declare (type substitution a b)
+           (values boolean))
+  (and (ty= (substitution-from a)
+            (substitution-from b))
+       (ty= (substitution-to a)
+            (substitution-to b))))
 
 (defun pprint-substitution (stream sub &optional colon-p at-sign-p)
   (declare (ignore colon-p)

--- a/src/typechecker/tc-env.lisp
+++ b/src/typechecker/tc-env.lisp
@@ -23,6 +23,7 @@
    #:tc-env-extend-type-variable-scope  ; FUNCTION
    #:tc-env-shadow-definition           ; FUNCTION
    #:tc-env-replace-type                ; FUNCTION
+   #:tc-env-lookup-value-symbol         ; FUNCTION
    ))
 
 (in-package #:coalton-impl/typechecker/tc-env)
@@ -207,3 +208,21 @@ type variables instead of re-instantiating the declared scheme."
           :append (tc:type-variables ty))
     (tc-env-scoped-type-variables env))
    :test #'tc:ty=))
+
+(defun tc-env-lookup-value-symbol (env sym loc)
+  (declare (type tc-env env)
+           (type symbol sym)
+           (type (or source:location null) loc)
+           (values tc:ty tc:ty-predicate-list))
+
+  (let* ((scheme (or (gethash sym (tc-env-ty-table env))
+                     (tc:lookup-value-type (tc-env-env env) sym :no-error t))))
+    (unless scheme
+      (util:coalton-bug "Unknown variable ~a" sym))
+    (let ((q (tc:fresh-inst scheme)))
+      (values (tc:qualified-ty-type q)
+              (loop :for pred in (tc:qualified-ty-predicates q)
+                    :collect (tc:make-ty-predicate
+                              :class (tc:ty-predicate-class pred)
+                              :types (tc:ty-predicate-types pred)
+                              :location loc))))))

--- a/src/typechecker/types.lisp
+++ b/src/typechecker/types.lisp
@@ -55,6 +55,7 @@
    #:kind-of                            ; FUNCTION
    #:type-constructors                  ; FUNCTION
    #:ty=                                ; FUNCTION
+   #:union-tys                          ; FUNCTION
    #:*boolean-type*                     ; VARIABLE
    #:*unit-type*                        ; VARIABLE
    #:*char-type*                        ; VARIABLE
@@ -545,6 +546,12 @@ Examples:
   (:method (type1 type2)
     (declare (ignore type1 type2))
     nil))
+
+(defun union-tys (cl:&rest ty-lists)
+  "Calculate the union of ty lists, using ty=."
+  (declare (values ty-list))
+  (remove-duplicates (apply #'append ty-lists)
+                     :test #'ty=))
 
 ;;;
 ;;; Early types

--- a/src/typechecker/unify.lisp
+++ b/src/typechecker/unify.lisp
@@ -8,6 +8,7 @@
    #:coalton-impl/typechecker/predicate)
   (:export
    #:unify                              ; FUNCTION
+   #:try-unify                          ; FUNCTION
    #:match                              ; FUNCTION
    #:predicate-mgu                      ; FUNCTION
    #:predicate-match                    ; FUNCTION
@@ -27,6 +28,20 @@
   (let ((new-substs (mgu (apply-substitution substs type1)
                          (apply-substitution substs type2))))
     (compose-substitution-lists new-substs substs)))
+
+(defun try-unify (subs type1 type2)
+  "Try to unify TYPE1 and TYPE2 under SUBS.
+
+Returns two values:
+  1. The resulting substitutions, or the original substitutions on failure
+  2. Whether unification succeeded."
+  (declare (type substitution-list subs)
+           (type ty type1 type2)
+           (values substitution-list boolean))
+  (handler-case
+      (values (unify subs type1 type2) t)
+    (coalton-internal-type-error ()
+      (values subs nil))))
 
 (defun function-keyword-entry (entries keyword)
   (declare (type keyword keyword)

--- a/tests/coalton-tests.lisp
+++ b/tests/coalton-tests.lisp
@@ -15,6 +15,7 @@
   (%run-tests "define-instance.txt")
   (%run-tests "define-type.txt")
   (%run-tests "define-type-alias.txt")
+  (%run-tests "define-type-gadt.txt")
   (%run-tests "define.txt")
   (%run-tests "fundeps.txt")
   (%run-tests "hashtable.txt")

--- a/tests/gadt-tests.ct
+++ b/tests/gadt-tests.ct
@@ -1,0 +1,418 @@
+(in-package #:coalton-native-tests)
+
+;;;
+;;; Concrete Type with Unary Constructor
+;;;
+
+(coalton-toplevel
+
+  (define-type Gadt1
+    (Gadt1-1 (Type Gadt1)))
+
+  (declare gadt1-test-func (Gadt1 -> Boolean))
+  (define (gadt1-test-func (Gadt1-1))
+    True))
+
+(define-test test-gadt1-match ()
+  (let result =
+    (match Gadt1-1
+      ((Gadt1-1) True)))
+  (is result))
+
+(define-test test-gadt1-let ()
+  (let (Gadt1-1) = Gadt1-1)
+  (is True))
+
+(define-test test-gadt1-do ()
+  (let result =
+    (coalton/monad/identity:run-identity
+     (do
+      ((Gadt1-1) <- (pure Gadt1-1))
+      (let (Gadt1-1) = Gadt1-1)
+      (pure True))))
+  (is result))
+
+(define-test test-gadt1-func ()
+  (is (gadt1-test-func Gadt1-1)))
+
+;;;
+;;; Concrete Type w/ Single, Single-Arg Concrete Constructor
+;;;
+
+(coalton-toplevel
+
+  (define-type Gadt2
+    (Gadt2-1 (Type (String -> Gadt2))))
+
+  (declare gadt2-equals-str (Gadt2 * String -> Boolean))
+  (define (gadt2-equals-str (Gadt2-1 a) b)
+    (== a b)))
+
+(define-test test-gadt2-match ()
+  (let result =
+    (match (Gadt2-1 "test")
+      ((Gadt2-1 s) s)))
+  (is (== result "test")))
+
+(define-test test-gadt2-let ()
+  (let (Gadt2-1 s) = (Gadt2-1 "test"))
+  (is (== s "test")))
+
+(define-test test-gadt2-do ()
+  (let (Tuple s1 s2) =
+    (coalton/monad/identity:run-identity
+     (do
+      ((Gadt2-1 s1) <- (pure (Gadt2-1 "test1")))
+      (let (Gadt2-1 s2) = (Gadt2-1 "test2"))
+      (pure (Tuple s1 s2)))))
+  (is (== "test1" s1))
+  (is (== "test2" s2)))
+
+(define-test test-gadt2-func ()
+  (is (gadt2-equals-str (Gadt2-1 "test") "test")))
+
+;;;
+;;; Concrete Type w/ Single, Single-Arg Generic Constructor
+;;;
+
+(coalton-toplevel
+
+  (define-type Gadt3
+    (Gadt3-1 (Type (:a -> Gadt3))))
+
+  (declare gadt3-test-func (Gadt3 -> Boolean))
+  (define (gadt3-test-func (Gadt3-1 a))
+    (id a)
+    True))
+
+(define-test test-gadt3-match ()
+  (let result =
+    (match (Gadt3-1 "test")
+      ((Gadt3-1 s)
+       (id s)
+       True)))
+  (is result))
+
+(define-test test-gadt3-let ()
+  (let (Gadt3-1 s) = (Gadt3-1 "test"))
+  (id s)
+  (is True))
+
+(define-test test-gadt3-do ()
+  (let result =
+    (coalton/monad/identity:run-identity
+     (do
+      ((Gadt3-1 s1) <- (pure (Gadt3-1 "test1")))
+      (pure (id s1))
+      (let (Gadt3-1 s2) = (Gadt3-1 "test2"))
+      (pure (id s2))
+      (pure True))))
+  (is result))
+
+(define-test test-gadt3-func ()
+  (is (gadt3-test-func (Gadt3-1 "test"))))
+
+;;;
+;;; Type with One Arg w/ Single, Single-Arg Concrete Constructor
+;;;
+
+(coalton-toplevel
+
+  (define-type (Gadt4 :a)
+    (Gadt4-1 (Type (Integer -> Gadt4 Integer))))
+
+  (declare gadt4-add1->int-match (Gadt4 :a -> Integer))
+  (define (gadt4-add1->int-match g)
+    (match g
+      ((Gadt4-1 x) (1+ x))))
+
+  (declare gadt4-add1->int-abstr (Gadt4 :a -> Integer))
+  (define (gadt4-add1->int-abstr (Gadt4-1 x))
+    (1+ x))
+
+  (declare gadt4-add1->gadt-match (Gadt4 :a -> Gadt4 :a))
+  (define (gadt4-add1->gadt-match g)
+    (match g
+      ((Gadt4-1 x) (Gadt4-1 (1+ x)))))
+
+  (declare gadt4-add1->gadt-abstr (Gadt4 :a -> Gadt4 :a))
+  (define (gadt4-add1->gadt-abstr (Gadt4-1 x))
+    (Gadt4-1 (1+ x)))
+
+  (declare gadt4-add1->gadt-int-match (Gadt4 Integer -> Gadt4 Integer))
+  (define (gadt4-add1->gadt-int-match g)
+    (match g
+      ((Gadt4-1 x) (Gadt4-1 (1+ x)))))
+
+  (declare gadt4-add1->gadt-int-abstr (Gadt4 Integer -> Gadt4 Integer))
+  (define (gadt4-add1->gadt-int-abstr (Gadt4-1 x))
+    (Gadt4-1 (1+ x)))
+  )
+
+(define-test test-gadt4-concrete-match ()
+  (let result = (gadt4-add1->int-match (Gadt4-1 0)))
+  (is (== result 1)))
+
+(define-test test-gadt4-concrete-abstr ()
+  (let result = (gadt4-add1->int-abstr (Gadt4-1 0)))
+  (is (== result 1)))
+
+(define-test test-gadt4-gadt-match ()
+  (let (Gadt4-1 result) = (gadt4-add1->gadt-match (Gadt4-1 0)))
+  (is (== result 1)))
+
+(define-test test-gadt4-gadt-abstr ()
+  (let (Gadt4-1 result) = (gadt4-add1->gadt-abstr (Gadt4-1 0)))
+  (is (== result 1)))
+
+(define-test test-gadt4-gadt-let ()
+  (let (Gadt4-1 result) = (Gadt4-1 0))
+  (is (== result 0)))
+
+(define-test test-gadt4-gadt-do ()
+  (let result =
+    (coalton/monad/identity:run-identity
+     (do
+      ((Gadt4-1 a) <- (pure (Gadt4-1 0)))
+      (let (Gadt4-1 b) = (Gadt4-1 (1+ a)))
+      (pure b))))
+  (is (== result 1)))
+
+(define-test test-gadt4-specifc-type-match ()
+  (let (Gadt4-1 result) = (gadt4-add1->gadt-int-match (Gadt4-1 0)))
+  (is (== result 1)))
+
+(define-test test-gadt4-specific-type-abstr ()
+  (let (Gadt4-1 result) = (gadt4-add1->gadt-int-abstr (Gadt4-1 0)))
+  (is (== result 1)))
+
+;;;
+;;; Type with No Args w/ Multiple Single-Arg Constructors
+;;;
+
+(coalton-toplevel
+  (define-type Gadt5
+    (Gadt5-Int (Type (Integer -> Gadt5)))
+    (Gadt5-Str (Type (String -> Gadt5)))
+    (Gadt5-Any (Type (:a -> Gadt5))))
+
+  (declare gadt5->int (Gadt5 -> Integer))
+  (define (gadt5->int g)
+    (match g
+      ((Gadt5-Int x) x)
+      ((Gadt5-Str s) (as Integer (string:length s)))
+      ((Gadt5-Any _) 0))))
+
+(define-test test-gadt5-match ()
+  (is (== 10 (gadt5->int (Gadt5-Int 10))))
+  (is (== 5 (gadt5->int (Gadt5-Str "12345"))))
+  (is (== 0 (gadt5->int (Gadt5-Any (Some 100))))))
+
+;;;
+;;; Type with Arg w/ Multiple Single-Arg, Concrete Constructors
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt6 :a)
+    (Gadt6-Int (Type (Integer -> Gadt6 Integer)))
+    (Gadt6-Str (Type (String -> Gadt6 String))))
+
+  (declare gadt6-unwrap-int-abstr (Gadt6 Integer -> Integer))
+  (define (gadt6-unwrap-int-abstr (Gadt6-Int x))
+    x)
+
+  (declare gadt6-unwrap-int-match (Gadt6 Integer -> Integer))
+  (define (gadt6-unwrap-int-match g)
+    (match g
+      ((Gadt6-Int x) x)))
+
+  (declare gadt6->int (Gadt6 :a -> Integer))
+  (define (gadt6->int g)
+    (match g
+      ((Gadt6-Int x) x)
+      ((Gadt6-Str s) (as Integer (string:length s))))))
+
+(define-test test-gadt6-unwrap-abstr ()
+  (is (== 10 (gadt6-unwrap-int-abstr (Gadt6-Int 10)))))
+
+(define-test test-gadt6-unwrap-match ()
+  (is (== 10 (gadt6-unwrap-int-match (Gadt6-Int 10)))))
+
+(define-test test-gadt6-match-multiple-noinline ()
+  (is (== 10 (noinline (gadt6->int (Gadt6-Int 10)))))
+  (is (== 5 (noinline (gadt6->int (Gadt6-Str "12345"))))))
+
+(define-test test-gadt6-match-multiple-inline ()
+  (is (== 10 (inline (gadt6->int (Gadt6-Int 10)))))
+  (is (== 5 (inline (gadt6->int (Gadt6-Str "12345"))))))
+
+;;;
+;;; Type with Arg w/ One, Single-Arg, Generic Constructor
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt7 :a)
+    (Gadt7 (Type (:a -> Gadt7 :a))))
+
+  (declare gadt7-unwrap-int-match (Gadt7 Integer -> Integer))
+  (define (gadt7-unwrap-int-match g)
+    (match g
+      ((Gadt7 x) x)))
+
+  (declare gadt7-unwrap-int-abstr (Gadt7 Integer -> Integer))
+  (define (gadt7-unwrap-int-abstr (Gadt7 x))
+    x))
+
+(define-test test-gadt7-unwrap-match ()
+  (is (== 10 (gadt7-unwrap-int-match (Gadt7 10)))))
+
+(define-test test-gadt7-unwrap-abstr ()
+  (is (== 10 (gadt7-unwrap-int-abstr (Gadt7 10)))))
+
+;;;
+;;; Type with Arg w/ Multiple Single-Arg Constructors, including one non-concrete
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt8 :a)
+    (Gadt8-Int (Type (Integer -> Gadt8 Integer)))
+    (Gadt8-Str (Type (String -> Gadt8 String)))
+    (Gadt8-Any (Type (:a -> Gadt8 :a))))
+
+  (declare gadt8->int (Gadt8 :a -> Integer))
+  (define (gadt8->int g)
+    (match g
+      ((Gadt8-Int x) x)
+      ((Gadt8-Str s) (as Integer (string:length s)))
+      ((Gadt8-Any _) 0)))
+
+  (declare gadt8-unwrap-int (Gadt8 Integer -> Integer))
+  (define (gadt8-unwrap-int g)
+    (match g
+      ((Gadt8-Int x) x)
+      ((Gadt8-Any x) x))))
+
+(define-test test-gadt8-match-multiple ()
+  (is (== 10 (gadt8->int (Gadt8-Int 10))))
+  (is (== 5 (gadt8->int (Gadt8-Str "12345"))))
+  (is (== 0 (gadt8->int (Gadt8-Any 10)))))
+
+(define-test test-gadt8-unwrap-narrowed-type ()
+  (is (== 10 (gadt8-unwrap-int (Gadt8-Int 10))))
+  (is (== 10 (gadt8-unwrap-int (Gadt8-Any 10)))))
+
+;;;
+;;; Type with Arg w/ Multiple Single-Arg Concrete Constructors and Polymorphic Return
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt9 :a)
+    (Gadt9-Int (Type (Integer -> Gadt9 Integer)))
+    (Gadt9-Str (Type (String -> Gadt9 String))))
+
+  (declare gadt9-unbox (Gadt9 :a -> :a))
+  (define (gadt9-unbox g)
+    (match g
+      ((Gadt9-Int x) x)
+      ((Gadt9-Str s) s))))
+
+(define-test test-gadt9-polymorphic-unbox ()
+  (is (== 10 (gadt9-unbox (Gadt9-Int 10))))
+  (is (== "abc" (gadt9-unbox (Gadt9-Str "abc")))))
+
+;;;
+;;; Type with Arg w/ Concrete and Generic Constructors
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt10 :a)
+    (Gadt10-Int (Type (Integer -> Gadt10 Integer)))
+    (Gadt10-Str (Type (String -> Gadt10 String)))
+    (Gadt10-Any (Type (:a -> Gadt10 :a))))
+
+  (declare gadt10-unwrap-int-tagged (Gadt10 Integer -> (Tuple Integer Integer)))
+  (define (gadt10-unwrap-int-tagged g)
+    (match g
+      ((Gadt10-Int x) (Tuple 0 x))
+      ((Gadt10-Any x) (Tuple 1 x)))))
+
+(define-test test-gadt10-generic-plus-concrete ()
+  (let (Tuple tag1 value1) = (gadt10-unwrap-int-tagged (Gadt10-Int 10)))
+  (let (Tuple tag2 value2) = (gadt10-unwrap-int-tagged (Gadt10-Any 20)))
+  (is (== 0 tag1))
+  (is (== 10 value1))
+  (is (== 1 tag2))
+  (is (== 20 value2)))
+
+;;;
+;;; Type with Arg w/ Multi-Argument Constructor
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt11 :a)
+    (Gadt11-Multi (Type (Integer * String * Boolean -> Gadt11 Integer))))
+
+  (declare gadt11-fields (Gadt11 Integer -> (Tuple3 Integer String Boolean)))
+  (define (gadt11-fields g)
+    (match g
+      ((Gadt11-Multi i s b) (Tuple3 i s b)))))
+
+(define-test test-gadt11-multi-argument-constructor ()
+  (let (Tuple3 i s b) = (gadt11-fields (Gadt11-Multi 7 "seven" True)))
+  (is (== 7 i))
+  (is (== "seven" s))
+  (is b))
+
+;;;
+;;; Nested GADT Pattern inside Tuple
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt12 :a)
+    (Gadt12-Int (Type (Integer -> Gadt12 Integer)))
+    (Gadt12-Str (Type (String -> Gadt12 String))))
+
+  (declare gadt12-nested-tuple ((Tuple (Gadt12 Integer) (Gadt12 String)) -> (Tuple Integer Integer)))
+  (define (gadt12-nested-tuple pair)
+    (match pair
+      ((Tuple (Gadt12-Int i) (Gadt12-Str s))
+       (Tuple (1+ i) (as Integer (coalton/string:length s)))))))
+
+(define-test test-gadt12-nested-gadt-inside-tuple ()
+  (let (Tuple i len) = (gadt12-nested-tuple (Tuple (Gadt12-Int 10) (Gadt12-Str "abc"))))
+  (is (== 11 i))
+  (is (== 3 len)))
+
+;;;
+;;; Typed Expression Evaluator with If Constructor
+;;;
+
+(coalton-toplevel
+  (define-type (Gadt13-Expr :a)
+    (Gadt13-Int (Type (Integer -> Gadt13-Expr Integer)))
+    (Gadt13-Bool (Type (Boolean -> Gadt13-Expr Boolean)))
+    (Gadt13-Str (Type (String -> Gadt13-Expr String)))
+    (Gadt13-If (Type (Gadt13-Expr Boolean * Gadt13-Expr :a * Gadt13-Expr :a -> Gadt13-Expr :a))))
+
+  (declare gadt13-eval (Gadt13-Expr :a -> :a))
+  (define (gadt13-eval expr)
+    (match expr
+      ((Gadt13-Int i) i)
+      ((Gadt13-Bool b) b)
+      ((Gadt13-Str s) s)
+      ((Gadt13-If test then else)
+       (if (gadt13-eval test)
+           (gadt13-eval then)
+           (gadt13-eval else))))))
+
+(define-test test-gadt13-typed-expression-evaluator-if ()
+  (is (== 1
+          (gadt13-eval
+           (Gadt13-If (Gadt13-Bool True)
+                      (Gadt13-Int 1)
+                      (Gadt13-Int 2)))))
+  (is (== "right"
+          (gadt13-eval
+           (Gadt13-If (Gadt13-Bool False)
+                      (Gadt13-Str "left")
+                      (Gadt13-Str "right"))))))

--- a/tests/test-files/define-type-gadt.txt
+++ b/tests/test-files/define-type-gadt.txt
@@ -1,0 +1,1019 @@
+================================================================================
+1 Define Mixed ADT/GADT
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg1
+  (T-dtg1-1 (Type T-dtg1))
+  T-dtg1-2)
+
+--------------------------------------------------------------------------------
+
+error: Malformed type definition
+  --> test:3:0
+   |
+ 3 |   (define-type T-dtg1
+   |  _^
+ 4 | |   (T-dtg1-1 (Type T-dtg1))
+ 5 | |   T-dtg1-2)
+   | |___________^  cannot define implicitly and explicitly typed constructors
+
+================================================================================
+2 GADT Non-Exhaustive Match
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg2
+  (T2-Int (Type (Integer -> T-dtg2)))
+  (T2-Str (Type (String -> T-dtg2))))
+
+(declare t-dtg2->int (T-dtg2 -> Integer))
+(define (t-dtg2->int g)
+  (match g
+    ((T2-Int x) x)))
+
+--------------------------------------------------------------------------------
+
+warn: non-exhaustive match
+  --> test:9:2
+    |
+ 9  |      (match g
+    |  ____^
+    | | ___-
+ 10 | ||     ((T2-Int x) x)))
+    | ||___________________- missing case (T2-STR "_")
+    | |____________________^ non-exhaustive match
+
+================================================================================
+3 GADT Non-Exhaustive Abstraction
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg3
+  (T3-Int (Type (Integer -> T-dtg3)))
+  (T3-Str (Type (String -> T-dtg3))))
+
+(declare t-dtg3->int-abstr (T-dtg3 -> Integer))
+(define (t-dtg3->int-abstr (T3-Int x))
+  x)
+
+--------------------------------------------------------------------------------
+
+error: Non-exhaustive match
+  --> test:8:27
+   |
+ 8 |  (define (t-dtg3->int-abstr (T3-Int x))
+   |                             ---------- missing case (T3-STR "_")
+
+================================================================================
+4 GADT Improper Constructor Return Type
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg4
+  (T4-Good (Type (Integer -> T-dtg4)))
+  (T4-Bad (Type (Integer -> String))))
+
+--------------------------------------------------------------------------------
+
+error: Malformed GADT constructor
+  --> test:5:3
+   |
+ 5 |    (T4-Bad (Type (Integer -> String))))
+   |     ^^^^^^ GADT constructor must return T-DTG4
+   |            -------------------------- in this type definition
+
+================================================================================
+5 GADT Improper Nullary Constructor
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg5
+  (T5-Good (Type (Integer -> T-dtg5)))
+  (T5-Bad (Type String)))
+
+--------------------------------------------------------------------------------
+
+error: Malformed GADT constructor
+  --> test:5:3
+   |
+ 5 |    (T5-Bad (Type String)))
+   |     ^^^^^^ GADT constructor must return T-DTG5
+   |            ------------- in this type definition
+
+================================================================================
+6 GADT Impossible Match Branch
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg6 :a)
+  (T6-Int (Type (Integer -> T-dtg6 Integer)))
+  (T6-Str (Type (String -> T-dtg6 String))))
+
+(declare 6-unwrap-int (T-dtg6 Integer -> Integer))
+(define (6-unwrap-int g)
+  (match g
+    ((T6-Int x) x)
+    ((T6-Str _) 0)))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:11:5
+    |
+ 11 |      ((T6-Str _) 0)))
+    |       ^^^^^^^^^^ Expected type 'T-dtg6 Integer' but pattern has type 'T-dtg6 String'
+
+================================================================================
+7 GADT Constraint Predicate Normalization
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg7 :a)
+  (T7-Gadt (Type (:a -> T-dtg7 :a))))
+
+(define-class (C-dtg7 :a)
+  (method-dtg7
+   (:a -> :a)))
+
+(declare t-dtg7-constraint-match (C-dtg7 :a => T-dtg7 :a -> T-dtg7 :a))
+(define (t-dtg7-constraint-match x)
+  (match x
+    ((T7-Gadt a)
+     (T7-Gadt (method-dtg7 a)))))
+
+(declare t-dtg7-constraint-let (C-dtg7 :a => T-dtg7 :a -> T-dtg7 :a))
+(define (t-dtg7-constraint-let x)
+  (let (T7-Gadt a) = x)
+  (T7-Gadt (method-dtg7 a)))
+
+(declare t-dtg7-constraint-do ((coalton/classes:Monad :m) (C-dtg7 :a) => :m (T-dtg7 :a) -> :m (T-dtg7 :a)))
+(define (t-dtg7-constraint-do m)
+  (do
+   ((T7-Gadt a) <- m)
+   (coalton/classes:pure (T7-Gadt (method-dtg7 a)))))
+
+(declare t-dtg7-constraint-abstr (C-dtg7 :a => T-dtg7 :a -> T-dtg7 :a))
+(define (t-dtg7-constraint-abstr (T7-Gadt a))
+  (T7-Gadt (method-dtg7 a)))
+
+================================================================================
+8 GADT Constructor With Trailing Form
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg8
+  (T8-Bad (Type (Integer -> T-dtg8)) String))
+
+--------------------------------------------------------------------------------
+
+error: Malformed GADT constructor
+  --> test:4:37
+   |
+ 4 |    (T8-Bad (Type (Integer -> T-dtg8)) String))
+   |            -------------------------- in this constructor definition
+   |                                       ^^^^^^ unexpected trailing form (STRING)
+
+================================================================================
+9 GADT Constructor With Inner Trailing Form
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg9
+  (T9-Bad (Type (Integer -> T-dtg9) String)))
+
+--------------------------------------------------------------------------------
+
+error: Malformed GADT constructor
+  --> test:4:36
+   |
+ 4 |    (T9-Bad (Type (Integer -> T-dtg9) String)))
+   |            --------------------------------- in this constructor definition
+   |                                      ^^^^^^ unexpected trailing form STRING
+
+================================================================================
+10 GADT Constructor With Empty Type Signature
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg10
+  (T10-Bad (Type)))
+
+--------------------------------------------------------------------------------
+
+error: Malformed GADT constructor
+  --> test:4:2
+   |
+ 4 |    (T10-Bad (Type)))
+   |    ^^^^^^^^^^^^^^^^ expected type signature
+   |             ------ in this constructor definition
+
+================================================================================
+11 GADT Nullary Constructor Result With Wrong Arity
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg11 :a)
+  (T11-Bad (Type T-dtg11)))
+
+--------------------------------------------------------------------------------
+
+error: Kind mismatch
+  --> test:4:17
+   |
+ 4 |    (T11-Bad (Type T-dtg11)))
+   |                   ^^^^^^^ Expected kind '*' but got kind '* -> *'
+
+================================================================================
+12 GADT Constructor Result With Too Many Type Arguments
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg12 :a)
+  (T12-Bad (Type (T-dtg12 Integer String))))
+
+--------------------------------------------------------------------------------
+
+error: Kind mismatch
+  --> test:4:17
+   |
+ 4 |    (T12-Bad (Type (T-dtg12 Integer String))))
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ Expected kind '* -> *' but got kind '*'
+
+================================================================================
+13 GADT Constructor Returning Multiple Values
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg13
+  (T13-Bad (Type (Integer -> T-dtg13 * T-dtg13))))
+
+--------------------------------------------------------------------------------
+
+error: Malformed GADT constructor
+  --> test:4:3
+   |
+ 4 |    (T13-Bad (Type (Integer -> T-dtg13 * T-dtg13))))
+   |     ^^^^^^^ GADT constructor must return T-DTG13
+   |             ------------------------------------- in this type definition
+
+================================================================================
+14 Derive On GADT
+================================================================================
+
+(package test-package)
+
+(derive coalton/classes:Eq)
+(define-type T-dtg14
+  (T14-Bad (Type (Integer -> T-dtg14))))
+
+--------------------------------------------------------------------------------
+
+error: Invalid derive application
+  --> test:4:13
+   |
+ 4 |  (define-type T-dtg14
+   |               ^^^^^^^  cannot apply (derive) to a GADT definition
+
+================================================================================
+15 Enum Repr On GADT Constructor With Arguments
+================================================================================
+
+(package test-package)
+
+(repr :enum)
+(define-type T-dtg15
+  (T15-Bad (Type (Integer -> T-dtg15))))
+
+--------------------------------------------------------------------------------
+
+error: Invalid repr :enum attribute
+  --> test:5:2
+   |
+ 5 |    (T15-Bad (Type (Integer -> T-dtg15))))
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum constructors cannot have arguments.
+
+================================================================================
+16 GADT Constructor Call With Too Few Arguments
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg16 :a :b)
+  (T16-Pair (Type (Integer * String -> T-dtg16 Integer String))))
+
+(declare t-dtg16-bad (T-dtg16 Integer String))
+(define t-dtg16-bad
+  (T16-Pair 1))
+
+--------------------------------------------------------------------------------
+
+error: Argument error
+  --> test:8:2
+   |
+ 8 |    (T16-Pair 1))
+   |    ^^^^^^^^^^^^ Function call has 1 positional arguments but inferred type 'Integer * String -> T-dtg16 Integer String' takes 2
+
+================================================================================
+17 GADT Constructor Pattern With Too Few Arguments
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg17 :a :b)
+  (T17-Pair (Type (Integer * String -> T-dtg17 Integer String))))
+
+(declare t-dtg17-bad (T-dtg17 Integer String -> Integer))
+(define (t-dtg17-bad g)
+  (match g
+    ((T17-Pair x) x)))
+
+--------------------------------------------------------------------------------
+
+error: Argument mismatch
+  --> test:9:5
+   |
+ 9 |      ((T17-Pair x) x)))
+   |       ^^^^^^^^^^^^ Constructor T17-PAIR takes 2 arguments but is given 1
+
+================================================================================
+18 GADT Refined Constructor On Wrong Type
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg18 :a)
+  (T18-Int (Type (Integer -> T-dtg18 Integer)))
+  (T18-Str (Type (String -> T-dtg18 String))))
+
+(declare t-dtg18-bad (T-dtg18 String))
+(define t-dtg18-bad
+  (T18-Int 3))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:9:2
+   |
+ 9 |    (T18-Int 3))
+   |    ^^^^^^^^^^^ Expected type 'T-dtg18 String' but got 'T-dtg18 Integer'
+
+================================================================================
+19 GADT Single of Multiple Constructors In Let Pattern
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg19 :a)
+  (T19-Str1 (Type (String -> T-dtg19 String)))
+  (T19-Str2 (Type (String -> T-dtg19 String))))
+
+(declare t-dtg19-bad (T-dtg19 String -> String))
+(define (t-dtg19-bad x)
+  (let (T19-Str1 s) = x)
+  s)
+
+--------------------------------------------------------------------------------
+
+error: Non-exhaustive match
+  --> test:9:7
+   |
+ 9 |    (let (T19-Str1 s) = x)
+   |         ------------ missing case (T19-STR2 "_")
+
+================================================================================
+20 GADT Single of Multiple Constructors In Abstraction
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg20 :a)
+  (T20-Str1 (Type (String -> T-dtg20 String)))
+  (T20-Str2 (Type (String -> T-dtg20 String))))
+
+(declare t-dtg20-bad (T-dtg20 String -> String))
+(define (t-dtg20-bad (T20-Str1 s))
+  s)
+
+--------------------------------------------------------------------------------
+
+error: Non-exhaustive match
+  --> test:8:21
+   |
+ 8 |  (define (t-dtg20-bad (T20-Str1 s))
+   |                       ------------ missing case (T20-STR2 "_")
+
+================================================================================
+21 GADT Polymorphic Unbox
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg21 :a)
+  (T21-Int (Type (Integer -> T-dtg21 Integer)))
+  (T21-Str (Type (String -> T-dtg21 String))))
+
+(declare t-dtg21-unbox (T-dtg21 :a -> :a))
+(define (t-dtg21-unbox g)
+  (match g
+    ((T21-Int x) x)
+    ((T21-Str s) s)))
+
+================================================================================
+22 GADT Wrong Polymorphic Unbox
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg22 :a)
+  (T22-Int (Type (Integer -> T-dtg22 Integer)))
+  (T22-Str (Type (String -> T-dtg22 String))))
+
+(declare t-dtg22-unbox (T-dtg22 :a -> :a))
+(define (t-dtg22-unbox g)
+  (match g
+    ((T22-Int _) "")
+    ((T22-Str s) s)))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:10:17
+    |
+ 10 |      ((T22-Int _) "")
+    |                   ^^ Expected type 'Integer' but got 'String'
+
+================================================================================
+23 GADT Branch Refinement Does Not Refine Unrelated Return
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg23 :a)
+  (T23-Int (Type (Integer -> T-dtg23 Integer)))
+  (T23-Str (Type (String -> T-dtg23 String))))
+
+(declare t-dtg23-bad (T-dtg23 :a -> :b))
+(define (t-dtg23-bad g)
+  (match g
+    ((T23-Int x) x)
+    ((T23-Str s) s)))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:11:17
+    |
+ 11 |      ((T23-Str s) s)))
+    |                   ^ Expected type 'Integer' but got 'String'
+
+================================================================================
+24 GADT Scrutinee Refinement Refines Same Type Argument
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg24 :a)
+  (T24-Int (Type (Integer -> T-dtg24 Integer)))
+  (T24-Str (Type (String -> T-dtg24 String))))
+
+(declare t-dtg24-good (T-dtg24 :a * :a -> :a))
+(define (t-dtg24-good g x)
+  (match g
+    ((T24-Int _) x)
+    ((T24-Str _) x)))
+
+================================================================================
+25 GADT Scrutinee Refinement Does Not Refine Unrelated Argument
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg25 :a)
+  (T25-Int (Type (Integer -> T-dtg25 Integer)))
+  (T25-Str (Type (String -> T-dtg25 String))))
+
+(declare t-dtg25-bad (T-dtg25 :a * :b -> :b))
+(define (t-dtg25-bad g x)
+  (match g
+    ((T25-Int _) (the Integer x))
+    ((T25-Str _) (the String x))))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:11:29
+    |
+ 11 |      ((T25-Str _) (the String x))))
+    |                               ^ Expected type 'Integer' but got 'String'
+
+================================================================================
+26 GADT Independent Parameters Refine Independently
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg26 :a)
+  (T26-Int (Type (Integer -> T-dtg26 Integer)))
+  (T26-Str (Type (String -> T-dtg26 String))))
+
+(declare t-dtg26-good (T-dtg26 :a * T-dtg26 :b -> Integer))
+(define (t-dtg26-good g h)
+  (match g
+    ((T26-Int x)
+     (match h
+      ((T26-Int y)
+       (let _ = (the Integer x))
+       (let _ = (the Integer y))
+       0)
+      ((T26-Str y)
+       (let _ = (the Integer x))
+       (let _ = (the String y))
+       0)))
+    ((T26-Str x)
+     (match h
+      ((T26-Int y)
+       (let _ = (the String x))
+       (let _ = (the Integer y))
+       0)
+      ((T26-Str y)
+       (let _ = (the String x))
+       (let _ = (the String y))
+       0)))))
+
+================================================================================
+27 GADT Conflicting Parameter Refinements
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg27 :a)
+  (T27-Int (Type (Integer -> T-dtg27 Integer)))
+  (T27-Str (Type (String -> T-dtg27 String))))
+
+(declare t-dtg27-bad (T-dtg27 :a * T-dtg27 :a -> Integer))
+(define (t-dtg27-bad (T27-Int x) (T27-Str _))
+  x)
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:8:33
+   |
+ 8 |  (define (t-dtg27-bad (T27-Int x) (T27-Str _))
+   |                                   ^^^^^^^^^^^ Expected type 'T-dtg27 Integer' but pattern has type 'T-dtg27 String'
+
+================================================================================
+28 GADT Binding Pattern Preserves Refined Whole
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg28 :a)
+  (T28-Int (Type (Integer -> T-dtg28 Integer)))
+  (T28-Str (Type (String -> T-dtg28 String))))
+
+(declare t-dtg28-require-int (T-dtg28 Integer -> Integer))
+(define (t-dtg28-require-int (T28-Int x))
+  x)
+
+(declare t-dtg28-good (T-dtg28 :a -> Integer))
+(define (t-dtg28-good g)
+  (match g
+    ((= whole (T28-Int x))
+     (let _ = (the Integer x))
+     (t-dtg28-require-int whole))
+    ((T28-Str s)
+     (let _ = (the String s))
+     0)))
+
+================================================================================
+29 GADT Binding Pattern With Impossible Refined Whole
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg29 :a)
+  (T29-Int (Type (Integer -> T-dtg29 Integer)))
+  (T29-Str (Type (String -> T-dtg29 String))))
+
+(declare t-dtg29-require-str (T-dtg29 String -> String))
+(define (t-dtg29-require-str (T29-Str s))
+  s)
+
+(declare t-dtg29-bad (T-dtg29 :a -> String))
+(define (t-dtg29-bad g)
+  (match g
+    ((= whole (T29-Int _))
+     (t-dtg29-require-str whole))
+    ((T29-Str s)
+     s)))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:15:26
+    |
+ 15 |       (t-dtg29-require-str whole))
+    |                            ^^^^^ Expected type 'T-dtg29 String' but got 'T-dtg29 Integer'
+
+================================================================================
+30 GADT Existential Must Not Escape Directly
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg30-Hidden
+  (T30-Hidden (Type (:a -> T-dtg30-Hidden))))
+
+(declare t-dtg30-bad (T-dtg30-Hidden -> :a))
+(define (t-dtg30-bad (T30-Hidden x))
+  x)
+
+--------------------------------------------------------------------------------
+
+error: Untouchable existential type escapes GADT pattern scope
+  --> test:7:0
+   |
+ 7 |   (define (t-dtg30-bad (T30-Hidden x))
+   |  _^
+ 8 | |   x)
+   | |____^ Existential type ':A' escapes through result type ':A'
+
+================================================================================
+31 GADT Existential Must Not Escape Through Wrapping Type
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg31-Hidden
+  (T31-Hidden (Type (:a -> T-dtg31-Hidden))))
+
+(declare t-dtg31-bad (T-dtg31-Hidden -> Optional :a))
+(define (t-dtg31-bad (T31-Hidden x))
+  (Some x))
+
+--------------------------------------------------------------------------------
+
+error: Untouchable existential type escapes GADT pattern scope
+  --> test:7:0
+   |
+ 7 |   (define (t-dtg31-bad (T31-Hidden x))
+   |  _^
+ 8 | |   (Some x))
+   | |___________^ Existential type ':A' escapes through result type 'Optional :A'
+
+================================================================================
+32 GADT Existential Must Not Escape Through Closure
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg32-Hidden
+  (T32-Hidden (Type (:a -> T-dtg32-Hidden))))
+
+(declare t-dtg32-bad (T-dtg32-Hidden -> (Void -> :a)))
+(define (t-dtg32-bad (T32-Hidden x))
+  (fn () x))
+
+--------------------------------------------------------------------------------
+
+error: Untouchable existential type escapes GADT pattern scope
+  --> test:7:0
+   |
+ 7 |   (define (t-dtg32-bad (T32-Hidden x))
+   |  _^
+ 8 | |   (fn () x))
+   | |____________^ Existential type ':A' escapes through result type 'Void -> :A'
+
+================================================================================
+33 GADT Existential Must Not Refine To Concrete Type
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg33-Hidden
+  (T33-Hidden (Type (:a -> T-dtg33-Hidden))))
+
+(declare t-gadt33-use-int (Integer -> Unit))
+(define (t-gadt33-use-int _)
+  Unit)
+
+(declare t-dtg33-bad (T-dtg33-Hidden -> Unit))
+(define (t-dtg33-bad (T33-Hidden x))
+  (t-gadt33-use-int x)
+  Unit)
+
+--------------------------------------------------------------------------------
+
+error: Cannot refine existential type from GADT constructor arguments
+  --> test:11:0
+    |
+ 11 |   (define (t-dtg33-bad (T33-Hidden x))
+    |  _^
+ 12 | |   (t-gadt33-use-int x)
+ 13 | |   Unit)
+    | |_______^ Untouchable existential type ':A' was refined to 'Integer'
+
+================================================================================
+34 GADT Existential May Be Passed Through Id And Discarded
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg34-Hidden
+  (T34-Hidden (Type (:a -> T-dtg34-Hidden))))
+
+(declare t-dtg34-good (T-dtg34-Hidden -> Unit))
+(define (t-dtg34-good (T34-Hidden x))
+  (coalton/functions:id x)
+  Unit)
+
+================================================================================
+35 GADT Existential May Be Repacked
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg35-Hidden
+  (T35-Hidden (Type (:a -> T-dtg35-Hidden))))
+
+(declare t-dtg35-good (T-dtg35-Hidden -> T-dtg35-Hidden))
+(define (t-dtg35-good (T35-Hidden x))
+  (T35-Hidden x))
+
+================================================================================
+36 GADT Existential From Nested Pattern Must Be Untouchable
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg37-Hidden
+  (T37-Hidden (Type (:a -> T-dtg37-Hidden))))
+
+(define-type T-dtg37-Outer
+  (T37-Outer T-dtg37-Hidden))
+
+(declare t-dtg37-bad (T-dtg37-Outer -> Unit))
+(define (t-dtg37-bad (T37-Outer (T37-Hidden x)))
+  (let _ = (the Integer x))
+  Unit)
+
+--------------------------------------------------------------------------------
+
+error: Cannot refine existential type from GADT constructor arguments
+  --> test:10:0
+    |
+ 10 |   (define (t-dtg37-bad (T37-Outer (T37-Hidden x)))
+    |  _^
+ 11 | |   (let _ = (the Integer x))
+ 12 | |   Unit)
+    | |_______^ Untouchable existential type ':A' was refined to 'Integer'
+
+================================================================================
+37 GADT Existential In Do Pattern May Be Consumed
+================================================================================
+
+(package test-package)
+
+(define-type T-dtg38-Hidden
+  (T38-Hidden (Type (:a -> T-dtg38-Hidden))))
+
+(declare t-dtg38-good ((coalton/classes:Monad :m) => :m T-dtg38-Hidden -> :m Unit))
+(define (t-dtg38-good m)
+  (do
+   ((T38-Hidden x) <- m)
+   (coalton/classes:pure
+    (coalton/functions:id x))
+   (coalton/classes:pure Unit)))
+
+================================================================================
+38 GADT Narrowed Match Does Not Require Impossible Constructors
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg38 :a)
+  (T38-Int (Type (Integer -> T-dtg38 Integer)))
+  (T38-Str (Type (String -> T-dtg38 String))))
+
+(declare t-dtg38-good (T-dtg38 Integer -> Integer))
+(define (t-dtg38-good g)
+  (match g
+    ((T38-Int x) x)))
+
+================================================================================
+39 GADT Polymorphic Match Warns About Possible Constructors
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg39 :a)
+  (T39-Int (Type (Integer -> T-dtg39 Integer)))
+  (T39-Str (Type (String -> T-dtg39 String))))
+
+(declare t-dtg39-warn (T-dtg39 :a -> Integer))
+(define (t-dtg39-warn g)
+  (match g
+    ((T39-Int x) x)))
+
+--------------------------------------------------------------------------------
+
+warn: non-exhaustive match
+  --> test:9:2
+    |
+ 9  |      (match g
+    |  ____^
+    | | ___-
+ 10 | ||     ((T39-Int x) x)))
+    | ||____________________- missing case (T39-STR "_")
+    | |_____________________^ non-exhaustive match
+
+================================================================================
+40 GADT Wildcard After Exhaustive Narrowed Constructor Is Useless
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg40 :a)
+  (T40-Int (Type (Integer -> T-dtg40 Integer)))
+  (T40-Str (Type (String -> T-dtg40 String))))
+
+(declare t-dtg40-warn (T-dtg40 Integer -> Integer))
+(define (t-dtg40-warn g)
+  (match g
+    ((T40-Int x) x)
+    (_ 0)))
+
+--------------------------------------------------------------------------------
+
+warn: Useless match case
+  --> test:11:5
+    |
+ 9  |     (match g
+    |  ___^
+ 10 | |     ((T40-Int x) x)
+ 11 | |     (_ 0)))
+    | |      ^ useless match case
+    | |__________^ in this match
+
+================================================================================
+41 GADT Impossible Constructor Branch Is An Error
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg41 :a)
+  (T41-Int (Type (Integer -> T-dtg41 Integer)))
+  (T41-Str (Type (String -> T-dtg41 String))))
+
+(declare t-dtg41-bad (T-dtg41 Integer -> Integer))
+(define (t-dtg41-bad g)
+  (match g
+    ((T41-Str _) 0)))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:10:5
+    |
+ 10 |      ((T41-Str _) 0)))
+    |       ^^^^^^^^^^^ Expected type 'T-dtg41 Integer' but pattern has type 'T-dtg41 String'
+
+================================================================================
+42 GADT Generic Constructor Required for Exhaustiveness
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg42 :a)
+  (T42-Int (Type (Integer -> T-dtg42 Integer)))
+  (T42-Str (Type (String -> T-dtg42 String)))
+  (T42-Any (Type (:a -> T-dtg42 :a))))
+
+(declare t-dtg42-warn (T-dtg42 Integer -> Integer))
+(define (t-dtg42-warn g)
+  (match g
+    ((T42-Int x) x)))
+
+--------------------------------------------------------------------------------
+
+warn: non-exhaustive match
+  --> test:10:2
+    |
+ 10 |      (match g
+    |  ____^
+    | | ___-
+ 11 | ||     ((T42-Int x) x)))
+    | ||____________________- missing case (T42-ANY "_")
+    | |_____________________^ non-exhaustive match
+
+================================================================================
+43 GADT Generic And Concrete Constructors Exhaust Narrowed Match
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg43 :a)
+  (T43-Int (Type (Integer -> T-dtg43 Integer)))
+  (T43-Str (Type (String -> T-dtg43 String)))
+  (T43-Any (Type (:a -> T-dtg43 :a))))
+
+(declare t-dtg43-good (T-dtg43 Integer -> Integer))
+(define (t-dtg43-good g)
+  (match g
+    ((T43-Int x) x)
+    ((T43-Any x) x)))
+
+================================================================================
+44 GADT Nested Pattern Exhaustiveness in Abstraction Respects Inner Refinements
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg44 :a)
+  (T44-Int (Type (Integer -> T-dtg44 Integer)))
+  (T44-Str (Type (String -> T-dtg44 String))))
+
+(declare t-dtg44-good (T-dtg44 Integer * T-dtg44 String -> Integer))
+(define (t-dtg44-good (T44-Int x) (T44-Str _))
+  x)
+
+================================================================================
+45 GADT Nested Pattern Exhaustiveness in Match Respects Inner Refinements
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg44 :a)
+  (T44-Int (Type (Integer -> T-dtg44 Integer)))
+  (T44-Str (Type (String -> T-dtg44 String))))
+
+(declare t-dtg44-good (T-dtg44 Integer * T-dtg44 String -> Integer))
+(define (t-dtg44-good a b)
+  (match a
+    ((T44-Int x)
+     (match b
+       ((T44-Str _)
+        x)))))
+
+================================================================================
+46 GADT Nested Pattern Rejects Impossible Inner Combination in Match
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg46 :a)
+  (T46-Int (Type (Integer -> T-dtg46 Integer)))
+  (T46-Str (Type (String -> T-dtg46 String))))
+
+(declare t-dtg46-bad (T-dtg46 Integer * T-dtg46 String -> Integer))
+(define (t-dtg46-bad a b)
+  (match a
+    ((T46-Int x)
+     (match b
+      ((T46-Int _)
+       x)))))
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:12:7
+    |
+ 12 |        ((T46-Int _)
+    |         ^^^^^^^^^^^ Expected type 'T-dtg46 String' but pattern has type 'T-dtg46 Integer'
+
+================================================================================
+47 GADT Nested Pattern Rejects Impossible Inner Combination in Abstraction
+================================================================================
+
+(package test-package)
+
+(define-type (T-dtg47 :a)
+  (T47-Int (Type (Integer -> T-dtg47 Integer)))
+  (T47-Str (Type (String -> T-dtg47 String))))
+
+(declare t-dtg47-bad (T-dtg47 Integer * T-dtg47 String -> Integer))
+(define (t-dtg47-bad (T47-Int x) (T47-Int _))
+  x)
+
+--------------------------------------------------------------------------------
+
+error: Type mismatch
+  --> test:8:33
+   |
+ 8 |  (define (t-dtg47-bad (T47-Int x) (T47-Int _))
+   |                                   ^^^^^^^^^^^ Expected type 'T-dtg47 String' but pattern has type 'T-dtg47 Integer'


### PR DESCRIPTION
## PR Status
With the exception of typeclass constraints (mentioned below), the PR is ready for review. I've already written a decently thorough test suite of the feature, which are all passing.

### Subsequent PRs
I've left the following for later PRs:
1. Adding documentation. I'd like to add reference-style documentation to the manual.
2. Typeclass constraints on GADT constructors. This is a really nice feature to have, and I certainly want to get to this. But the current PR is already a significant body of work, and I thought it would make sense to come back and add these on later.
3. Writing a more explanatory/tutorial style blog post to go deeper into GADTs (and ADTs as well) than the manual documentation.

## This PR

This PR adds GADT support to Coalton. The proposed syntax looks like this:
```lisp
  (define-type (Gadt8 :a)
    (Gadt8-Int (Type (Integer -> Gadt8 Integer)))
    (Gadt8-Str (Type (String -> Gadt8 String)))
    (Gadt8-Any (Type (:a -> Gadt8 :a))))
```
GADTs can be narrowed in a match/abstraction clause. In this example, the type of `g` is pegged to `Gadt8 Integer`. It knows that the `Gadt8-Str` constructor cannot produce a `Gadt8 Integer` type, so it is not required to be matched against. (In fact, that would fail to compile.) It's also able to refine the type of the parameter inside each constructor to an `Integer` within each respective branch:
```lisp
  (declare gadt8-unwrap-int (Gadt8 Integer -> Integer))
  (define (gadt8-unwrap-int g)
    (match g
      ((Gadt8-Int x) x)
      ((Gadt8-Any x) x)))
```

The PR is split into about 1,500 lines that implement GADTs, and about 1,400 lines of tests.

## Example

For fun, here is a more involved example using GADTs to implement a little SQL query DSL. (The output is a bit garbled, but I think that's a problem with some of the `Show` instances that `format` is using.)

```lisp
(cl:in-package :cl-user)
(defpackage :gadt
  (:use #:coalton #:coalton-prelude)
  (:local-nicknames
   (:f #:coalton/format)))

(in-package :gadt)

(named-readtables:in-readtable coalton:coalton)

(coalton-toplevel

  ;;
  ;; Column ADT with a Phantom Type Representing the Column Type
  ;; 
  (define-type (Column :a)
    (Column String))

  (declare int-column (String -> Column Integer))
  (define (int-column col-name)
    (Column col-name))

  (declare str-column (String -> Column String))
  (define (str-column col-name)
    (Column col-name))

  (declare bool-column (String -> Column Boolean))
  (define (bool-column col-name)
    (Column col-name))

  ;;
  ;; SQL Expression GADT
  ;; 

  (define-type (SqlExpr :a)
    (IntVal  (Type (Integer                           -> SqlExpr Integer)))
    (StrVal  (Type (String                            -> SqlExpr String)))
    (BoolVal (Type (Boolean                           -> SqlExpr Boolean)))

    (ColVal  (Type (Column :a                         -> SqlExpr :a)))

    (Eq_     (Type (SqlExpr :a      * SqlExpr :a      -> SqlExpr Boolean)))
    (Gt_     (Type (SqlExpr Integer * SqlExpr Integer -> SqlExpr Boolean)))

    (And_    (Type (SqlExpr Boolean * SqlExpr Boolean -> SqlExpr Boolean)))
    (Or_     (Type (SqlExpr Boolean * SqlExpr Boolean -> SqlExpr Boolean))))
  
  ;;
  ;; Query Writer
  ;;

  (declare render-sql-expr (SqlExpr :a -> String))
  (define (render-sql-expr expr)
    (match expr
      ((IntVal x) (as String x))
      ((StrVal s) s)
      ((BoolVal b) (if b "TRUE" "FALSE"))
      ((ColVal (Column col-name))
       (f:format f:Str "'~a'" col-name))
      ((Eq_ expr-a expr-b)
       (f:format f:Str "(~a = ~a)" (render-sql-expr expr-a) (render-sql-expr expr-b)))
      ((Gt_ expr-a expr-b)
       (f:format f:Str "(~a > ~a)" (render-sql-expr expr-a) (render-sql-expr expr-b)))
      ((And_ expr-a expr-b)
       (f:format f:Str "(~a AND ~a)" (render-sql-expr expr-a) (render-sql-expr expr-b)))
      ((Or_ expr-a expr-b)
       (f:format f:Str "(~a OR ~a)" (render-sql-expr expr-a) (render-sql-expr expr-b)))))
  
  (declare write-select-query (String * String * SqlExpr Boolean -> String))
  (define (write-select-query select-clause table-name where-clause)
    (f:format
     f:Str
     "SELECT ~a~%FROM ~a~%WHERE ~a;"
     select-clause
     table-name
     (render-sql-expr where-clause))))

(coalton-toplevel

  (define UserName (str-column "name"))
  (define UserBalance (int-column "balance"))
  (define UserVerified (bool-column "verified"))

  (declare select-verified-and-positive String)
  (define select-verified-and-positive
    (write-select-query
     "*"
     "users"
     (And_ (Gt_ (ColVal UserBalance)
                (IntVal 0))
           (ColVal UserVerified))))
  )
```