### PR TITLE
Renamed elements, to distinguish them from the sets.

### DIFF
--- a/src/source.lisp
+++ b/src/source.lisp
@@ -792,10 +792,10 @@ CR characters elsewhere, including at EOF, are preserved."
       (print-empty-line stream state)
       (with-slots (help context last-line) state
         (print-notes stream state)
-        (loop :for help :in help
-              :do (print-help stream state help))
-        (loop :for context :in context
-              :do (format stream "note: ~A~%" context))))))
+        (loop :for help-elem :in help
+              :do (print-help stream state help-elem))
+        (loop :for context-elem :in context
+              :do (format stream "note: ~A~%" context-elem))))))
 
 ;; API
 


### PR DESCRIPTION
Loop variable and set on which it iterates were named the same. The behaviour is correct in sbcl/ccl/ecl/clasp but abcl couldn't handle it ([filed an issue there](https://github.com/armedbear/abcl/issues/753)).

But mainly suggesting this as a (minimal) edit, to make the code clearer (changing `:for set :in set` to `:for elem :in set`).

Not sure if it's the best way to resolve it - one may have chosen to rename the original sets (slots `help` and `context`) themselves so that it's clearer they contain multiple elements instead of just one value. Chose not to do it so as to keep the change as local as possible.