### PR TITLE
Change String Show instance to output string

### DIFF
--- a/library/show.ct
+++ b/library/show.ct
@@ -117,6 +117,11 @@ This is not necessarily identical to `(the String (into x))`."
     (define (show-to f x)
       (f (if x "True" "False"))))
 
+  (define-instance (Show String)
+    (inline)
+    (define (show-to f s)
+      (f s)))
+
   (define-instance (Show :a => Show (Optional :a))
     (define (show-to f x)
       (match x
@@ -179,7 +184,6 @@ This is not necessarily identical to `(the String (into x))`."
 
 (define-show-instance "Fraction")
 
-(define-show-instance "String")
 (define-show-instance "Char")
 
 #+sb-package-locks

--- a/tests/hashtable-tests.lisp
+++ b/tests/hashtable-tests.lisp
@@ -81,5 +81,5 @@
   (is (== "#<HashTable [=>]>"
           (show-as-string (the (Hashtable String Integer) (hashtable:new)))))
   (hashtable:set! ht "alpha" 1)
-  (is (== "#<HashTable [\"alpha\" => 1]>"
+  (is (== "#<HashTable [alpha => 1]>"
           (show-as-string ht))))


### PR DESCRIPTION
This PR changes the `(Show String)` instance to simply output the string.

Practically, the current definition of `(Show String)` makes it difficult to use in cases where you need to rely on nesting calls to `show-as-string`. It tends to return noisy output. Here are some examples:

```lisp:
(coalton
 (show
  (show-as-string "hi")))
;; => "\"hi\""

(coalton
 (format Out
         "~a ~a"
         (format Str "~a" "hi")
         10))
 ;; => #A((4) BASE-CHAR . "\"hi\"") 10
```

Theoretically, there have been several conversations about the proper role of `Show` and what it should be doing. It seems like the agreed long-term design to move to is to use `Show` to produce user-readable output, and to make another typeclass to create Common Lisp `read`able output. This is the definition of `(Show String)` that fits that role.