### PR TITLE
Docs: Split Whirlwind Tour into "Language Guide" and "Advanced Features"

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Coalton is currently used in production to build defense and [quantum computing 
 > [!NOTE] 
 > Running the Coalton test suite on SBCL requires [GNU MPFR](https://www.mpfr.org/mpfr-current/mpfr.html#Installing-MPFR) in order to run `Big-Float` tests. If you would like to run tests without installing `gnu-mpfr`, you can use Coalton's portable `Big-Float` implementation by running `(pushnew :coalton-portable-bigfloat *features*)` before loading Coalton.
 
-**Learn**: Start with [*Whirlwind Tour of Coalton*](docs/manual/site/topics/whirlwind-tour.md), the [language manual](https://coalton-lang.github.io/manual/), and the [standard library reference](https://coalton-lang.github.io/reference/), and then take a peek at the [examples directory](examples/). It may also be helpful to check out the [introductory blog post](https://coalton-lang.github.io/20211010-introducing-coalton/).
+**Learn**: Start with [*Coalton Language Guide*](docs/manual/site/topics/language-guide.md), the [language manual](https://coalton-lang.github.io/manual/), and the [standard library reference](https://coalton-lang.github.io/reference/), and then take a peek at the [examples directory](examples/). It may also be helpful to check out the [introductory blog post](https://coalton-lang.github.io/20211010-introducing-coalton/).
 
 **Open Source Community**: [Awesome Coalton](https://github.com/Jason94/awesome-coalton) has a list of community-built libraries, applications, and examples, that you can use in your own projects or as examples to learn from.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Coalton Docs
 
 ## Tutorials
-* [Coalton Language guide](./manual/site/topics/language-guide.md) ([Japanese](./intro-to-coalton.ja.md), [Ukrainian](./intro-to-coalton.ua.md), [Russian](./intro-to-coalton.ru.md))
+* [Coalton Language Guide](./manual/site/topics/language-guide.md) ([Japanese](./intro-to-coalton.ja.md), [Ukrainian](./intro-to-coalton.ua.md), [Russian](./intro-to-coalton.ru.md))
 * [Language Manual source](./manual/site/_index.md) - synced to the website in CI
 * [Glossary of Terms](./glossary.md)
 * [Using Common Lisp Libraries from Coalton](https://coalton-lang.github.io/20250812-lisp-libraries/) - external

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Coalton Docs
 
 ## Tutorials
-* [Whirlwind Tour of Coalton](./manual/site/topics/whirlwind-tour.md) ([Japanese](./intro-to-coalton.ja.md), [Ukrainian](./intro-to-coalton.ua.md), [Russian](./intro-to-coalton.ru.md))
+* [Coalton Language guide](./manual/site/topics/language-guide.md) ([Japanese](./intro-to-coalton.ja.md), [Ukrainian](./intro-to-coalton.ua.md), [Russian](./intro-to-coalton.ru.md))
 * [Language Manual source](./manual/site/_index.md) - synced to the website in CI
 * [Glossary of Terms](./glossary.md)
 * [Using Common Lisp Libraries from Coalton](https://coalton-lang.github.io/20250812-lisp-libraries/) - external

--- a/docs/intro-to-coalton-testing.md
+++ b/docs/intro-to-coalton-testing.md
@@ -1,6 +1,6 @@
 # Testing Your Coalton Code
 
-By now, hopefully, you've read the [Whirlwind Tour of Coalton](manual/site/topics/whirlwind-tour.md) and
+By now, hopefully, you've read the [Coalton Language Guide](manual/site/topics/language-guide.md) and
 written some non-trivial Coalton code. Now the question is, "how do I know it works?"
 
 The fact that your code type-checks and compiles should assure you that it's free from a

--- a/docs/manual/site/_index.md
+++ b/docs/manual/site/_index.md
@@ -15,7 +15,7 @@ an error or or something is unclear, please fix it and submit a PR.
 ## Articles
 
 - [Introduction and Getting Started](/manual/topics/introduction/)
-- [Whirlwind Tour of Coalton](/manual/topics/whirlwind-tour/)
+- [Coalton Language Guide](/manual/topics/language-guide/)
 - [Configuring Coalton](/manual/topics/configuring-coalton/)
 - [Macros](/manual/topics/macros/)
 - [Lisp Interop](/manual/topics/lisp-interop/)

--- a/docs/manual/site/_index.md
+++ b/docs/manual/site/_index.md
@@ -16,6 +16,7 @@ an error or or something is unclear, please fix it and submit a PR.
 
 - [Introduction and Getting Started](/manual/topics/introduction/)
 - [Coalton Language Guide](/manual/topics/language-guide/)
+- [Advanced Coalton Features](/manual/topics/advanced-features/)
 - [Configuring Coalton](/manual/topics/configuring-coalton/)
 - [Macros](/manual/topics/macros/)
 - [Lisp Interop](/manual/topics/lisp-interop/)

--- a/docs/manual/site/topics/advanced-features.md
+++ b/docs/manual/site/topics/advanced-features.md
@@ -1,0 +1,80 @@
+---
+title: "Advanced Coalton Features"
+description: "Guide to advanced Coalton features."
+hideMeta: true
+weight: 20
+---
+
+Coalton contains several advanced features. These can be used to create powerful and expressive code, but they require a good understanding of Coalton's fundamentals to use. Before reading this document, make sure that you have a good grasp of the [Coalton Language Guide](./manual/site/topics/language-guide.md). In particular, these features build on Algebraic Data Types (uses of `define-type`) and Typeclasses (uses of `define-class`).
+
+{{<toc>}}
+
+## Instance Defaulting
+
+Coalton has a similar [type defaulting system](https://www.haskell.org/onlinereport/decls.html#sect4.3.4) as Haskell. Type defaulting is invoked on implicitly typed definitions and code compiled with the `coalton` macro. Defaulting is applied to a set of ambiguous predicates, with the goal to resolve an ambiguous type variable to a valid type. Coalton defaults ambiguous numeric variables by trying `Integer`, then `F64`, then `F32`, taking the first type that satisfies the relevant predicates. Unlike Haskell 98, Coalton can still default some predicates involving multi-parameter classes or more structured types, provided the ambiguous predicates do not introduce any other type variables.
+
+
+Differences from Haskell 98. Haskell would consider `Num (List :a)` to be ambiguous, Coalton would default it to `Num Integer`. Haskell would consider (`Num :a` `CustomTypeClass :a`) to be ambiguous, Coalton would default to (`Num Integer` `CustomTypeClass Integer`) assuming `CustomTypeClass Integer` was a valid instance.
+
+## Functional Dependencies
+
+Functional dependencies allow enforcing relations on the type variables of a class to improve type inference.
+
+A class `C` can be given a functional dependency `(:a -> :b)` like so:
+
+`(define-class (C :a :b (:a -> :b)))`
+
+`(:a -> :b)` can be read as: foreach `:a` there will be only one `:b` or alternatively the value of `:b` is uniquely determined by `:a`. 
+
+If the instance `(C String Integer)` was defined, then it would be invalid to define `(C String Char)` because there are multiple values of `:b` for the same value of `:a`.
+
+Classes can have multiple functional dependencies, each dependency can list multiple class variables on each side `(:a :b -> :c :d :e)`, and dependencies can be recursive `(:a -> :b) (:b -> :a)`.
+
+## Specialization
+
+Coalton supports optimistic type based function specialization. Function specializations are declared with a `specialize` form:
+
+```
+(coalton-toplevel
+  (declare inc (Num :a => :a -> :a))
+  (define (inc x)
+    (trace "standard call")
+    (+ x 1))
+
+  (declare inc-int (Integer -> Integer))
+  (define (inc-int x)
+    (trace "int specialized call")
+    (+ x 1))
+
+  (specialize inc inc-int (Integer -> Integer)))
+```
+
+When `inc` is called with an integer, the call will be transparently rewritten to call `inc-int`.
+
+```
+COALTON-USER> (coalton (inc 1.2))
+standard call
+2.2
+COALTON-USER> (coalton (inc 1))
+int specialized call
+2
+```
+
+Specialization can only apply when the argument types at a call site are known. Because specialization is not guaranteed, specialized functions must have the same behavior as their unspecialized variants. Specialization should only be used for performance. See the following example:
+
+```
+(coalton-toplevel
+  (declare inc2 (Num :a => :a -> :a))
+  (define (inc2 x)
+    (inc x)))
+```
+
+Because the type of `x` in the body of `inc2` is not known, specialization will not apply.
+
+```
+COALTON-USER> (coalton (inc2 1))
+standard call
+2
+```
+
+Specialization can be listed in the repl with `print-specializations`.

--- a/docs/manual/site/topics/language-guide.md
+++ b/docs/manual/site/topics/language-guide.md
@@ -7,7 +7,7 @@ weight: 20
 
 Coalton is a statically typed language that is embedded in, and compiles to, Common Lisp.
 
-This document is aimed toward people who are already familiar with functional programming languages. If you are already familiar with Common Lisp, the [glossary](https://github.com/coalton-lang/coalton/blob/main/docs/glossary.md) may be useful.
+This document is aimed toward people who are already familiar with functional programming languages. If you are already familiar with Common Lisp, the [glossary](https://github.com/coalton-lang/coalton/blob/main/docs/glossary.md) may be useful. When you've finished reading the language guide, you might want to check out [Advanced Coalton Features](./manual/site/topics/advanced-features.md).
 
 {{<toc>}}
 
@@ -1969,76 +1969,6 @@ The following functions all take an optional package parameter.
 * `print-value-db` - print the type of every toplevel value
 * `print-class-db` - print every class and their methods
 * `print-instance-db` - print the instances of every class
-
-## Instance Defaulting
-
-Coalton has a similar [type defaulting system](https://www.haskell.org/onlinereport/decls.html#sect4.3.4) as Haskell. Type defaulting is invoked on implicitly typed definitions and code compiled with the `coalton` macro. Defaulting is applied to a set of ambiguous predicates, with the goal to resolve an ambiguous type variable to a valid type. Coalton defaults ambiguous numeric variables by trying `Integer`, then `F64`, then `F32`, taking the first type that satisfies the relevant predicates. Unlike Haskell 98, Coalton can still default some predicates involving multi-parameter classes or more structured types, provided the ambiguous predicates do not introduce any other type variables.
-
-
-Differences from Haskell 98. Haskell would consider `Num (List :a)` to be ambiguous, Coalton would default it to `Num Integer`. Haskell would consider (`Num :a` `CustomTypeClass :a`) to be ambiguous, Coalton would default to (`Num Integer` `CustomTypeClass Integer`) assuming `CustomTypeClass Integer` was a valid instance.
-
-## Functional Dependencies
-
-Functional dependencies allow enforcing relations on the type variables of a class to improve type inference.
-
-A class `C` can be given a functional dependency `(:a -> :b)` like so:
-
-`(define-class (C :a :b (:a -> :b)))`
-
-`(:a -> :b)` can be read as: foreach `:a` there will be only one `:b` or alternatively the value of `:b` is uniquely determined by `:a`. 
-
-If the instance `(C String Integer)` was defined, then it would be invalid to define `(C String Char)` because there are multiple values of `:b` for the same value of `:a`.
-
-Classes can have multiple functional dependencies, each dependency can list multiple class variables on each side `(:a :b -> :c :d :e)`, and dependencies can be recursive `(:a -> :b) (:b -> :a)`.
-
-## Specialization
-
-Coalton supports optimistic type based function specialization. Function specializations are declared with a `specialize` form:
-
-```
-(coalton-toplevel
-  (declare inc (Num :a => :a -> :a))
-  (define (inc x)
-    (trace "standard call")
-    (+ x 1))
-
-  (declare inc-int (Integer -> Integer))
-  (define (inc-int x)
-    (trace "int specialized call")
-    (+ x 1))
-
-  (specialize inc inc-int (Integer -> Integer)))
-```
-
-When `inc` is called with an integer, the call will be transparently rewritten to call `inc-int`.
-
-```
-COALTON-USER> (coalton (inc 1.2))
-standard call
-2.2
-COALTON-USER> (coalton (inc 1))
-int specialized call
-2
-```
-
-Specialization can only apply when the argument types at a call site are known. Because specialization is not guaranteed, specialized functions must have the same behavior as their unspecialized variants. Specialization should only be used for performance. See the following example:
-
-```
-(coalton-toplevel
-  (declare inc2 (Num :a => :a -> :a))
-  (define (inc2 x)
-    (inc x)))
-```
-
-Because the type of `x` in the body of `inc2` is not known, specialization will not apply.
-
-```
-COALTON-USER> (coalton (inc2 1))
-standard call
-2
-```
-
-Specialization can be listed in the repl with `print-specializations`.
 
 ## Quirks and Differences from Common Lisp
 

--- a/docs/manual/site/topics/language-guide.md
+++ b/docs/manual/site/topics/language-guide.md
@@ -1,5 +1,5 @@
 ---
-title: "Whirlwind Tour of Coalton"
+title: "Coalton Language Guide"
 description: "A broad, practical tour of Coalton's core language and workflow."
 hideMeta: true
 weight: 20


### PR DESCRIPTION
This PR splits the "Whirlwind Tour of Coalton" into two pages: the "Coalton Language Guide" and the "Advanced Coalton Features Guide".

I thought that the following sections in the whirlwind tour are pretty advanced, and moved them to the new doc:
* instance defaulting
* functional dependencies
* specialization

This is also somewhat in anticipation of the GADT PR, since I think that GADTs definitely belong in the "advanced" section. Most users probably don't need to even worry about GADTs.