### PR TITLE
Fix documentation quibbles

### DIFF
--- a/src/doc/markdown.lisp
+++ b/src/doc/markdown.lisp
@@ -178,7 +178,7 @@
             :for (name type docstring) :in (struct-fields object)
             :for symbol := (concatenate 'string "." name)
             :when (eq ':external (nth-value 1 (find-symbol symbol package)))
-              :do (format stream "- <code>~A :: ~S</code>~A~%"
+              :do (format stream "- <code>~A :: ~A</code>~A~%"
                           name
                           type
                           (if docstring

--- a/src/doc/model.lisp
+++ b/src/doc/model.lisp
@@ -21,6 +21,7 @@
    #:coalton/doc/base)
   (:local-nicknames
    (#:tc #:coalton-impl/typechecker)
+   (#:type-string #:coalton-impl/typechecker/type-string)
    (#:source #:coalton-impl/source)
    (#:env #:coalton/doc/environment)
    (#:entry #:coalton-impl/entry))
@@ -227,7 +228,7 @@
   (let ((struct-entry (%struct-entry (type-entry coalton-struct))))
     (mapcar (lambda (field)
               (list (tc:struct-field-name field)
-                    (tc:struct-field-type field)
+                    (type-string:type-to-string (tc:struct-field-type field))
                     (source:docstring field)))
             (tc:struct-entry-fields struct-entry))))
 
@@ -238,7 +239,7 @@
                           (symbol-name name))))
     (format nil "~A~{ ~S~}"
             source-name
-            (tc:type-entry-tyvars entry))))
+            (mapcar #'tc:tyvar-source-name (tc:type-entry-tyvars entry)))))
 
 (defmethod object-type ((self coalton-struct))
   "STRUCT")

--- a/src/doc/model.lisp
+++ b/src/doc/model.lisp
@@ -391,13 +391,14 @@
       (tc:type-entry-name type-entry)))
 
 (defun stdlib-p (symbol)
-  "A standard library package is any package with the exact name 'coalton' or whose name starts with 'coalton/'."
+  "A standard library package is any package with the exact name 'coalton' or whose name starts with 'coalton/'.
+One exception: COALTON/UTILS, this package is internal to the standard library."
   (let ((pkg (symbol-package symbol)))
-    (if (null pkg)
-        nil
+    (unless (null pkg)
         (let ((name (package-name pkg)))
-          (or (string-equal name "COALTON")
-              (eql 0 (search "COALTON/" name)))))))
+          (and (not (string-equal name "COALTON/UTILS"))
+           (or (string-equal name "COALTON")
+               (eql 0 (search "COALTON/" name))))))))
 
 ;;; class coalton-macro
 


### PR DESCRIPTION
Intended to resolve:
- #1985
- #1986
- #1991

All but #1991 are resolved.

For #1985, I excluded the library by adjusting `stdlib-p` to filter it out.
It might be better to rename coalton/utils, I chose the smaller diff.