### PR TITLE
doc: Fix export of instances on private types.

### DIFF
--- a/src/doc/base.lisp
+++ b/src/doc/base.lisp
@@ -13,7 +13,8 @@
    #:*remote*
    #:*local*
 
-   #:exported-symbol-p))
+   #:exported-symbol-p
+   #:stdlib-p))
 
 (in-package #:coalton/doc/base)
 
@@ -64,3 +65,17 @@ matching unrelated symbols from other packages that merely share the same name."
          (eq resolved symbol)
          (or (not check-package)
              (eq (symbol-package symbol) package)))))
+
+(defun stdlib-p (symbol)
+  "T if SYMBOL is exported from a standard library package.
+
+A standard library package is any package with the exact name 'coalton' or whose name starts with 'coalton/'.
+One exception: COALTON/UTILS, this package is internal to the standard library."
+  
+  (let ((pkg (symbol-package symbol)))
+    (unless (null pkg)
+      (let ((name (package-name pkg)))
+        (and (not (string-equal name "COALTON/UTILS"))
+             (or (string-equal name "COALTON")
+                 (eql 0 (search "COALTON/" name)))
+             (exported-symbol-p symbol pkg))))))

--- a/src/doc/environment.lisp
+++ b/src/doc/environment.lisp
@@ -108,9 +108,22 @@ If non-nil, restrict to names defined in PACKAGE."
 By default the global environment is queried.
 If non-nil, restrict to instances defined in PACKAGE."
   (remove-if (lambda (class-instance)
-               (and package
-                    (not (exported-symbol-p (tc:ty-predicate-class
-                                             (tc:ty-class-instance-predicate class-instance))
-                                            package t))))
+               (let ((symbol (tc:ty-predicate-class
+                              (tc:ty-class-instance-predicate class-instance)))
+                     (types (mapcan #'tc:flatten-type
+                                    (tc:ty-predicate-types
+                                     (tc:ty-class-instance-predicate class-instance)))))
+                 
+                 (not
+                  (if package
+                      (exported-symbol-p symbol package t)
+                      (labels ((all-in-stdlib-p (ty)
+                                               (typecase ty
+                                                 ((or tc:tyvar tc:function-ty) t)
+                                                 (tc:tycon (stdlib-p (tc:tycon-name ty)))
+                                                 (tc:tapp (every #'all-in-stdlib-p (tc:flatten-type ty)))
+                                                 (t (stdlib-p ty)))))
+                             (every #'all-in-stdlib-p
+                              (cons symbol types)))))))
              (%lm-values (tc:instance-environment-instances
                           (tc:environment-instance-environment environment)))))

--- a/src/doc/environment.lisp
+++ b/src/doc/environment.lisp
@@ -102,28 +102,27 @@ If non-nil, restrict to names defined in PACKAGE."
              (%values (tc:environment-name-environment environment))))
 
 (defun find-instances (&key (environment entry:*global-environment*)
-                            (package nil))
+                         (package nil))
   "Return all instances in ENVIRONMENT.
 
 By default the global environment is queried.
 If non-nil, restrict to instances defined in PACKAGE."
-  (remove-if (lambda (class-instance)
-               (let ((symbol (tc:ty-predicate-class
-                              (tc:ty-class-instance-predicate class-instance)))
-                     (types (mapcan #'tc:flatten-type
-                                    (tc:ty-predicate-types
-                                     (tc:ty-class-instance-predicate class-instance)))))
-                 
-                 (not
-                  (if package
-                      (exported-symbol-p symbol package t)
-                      (labels ((all-in-stdlib-p (ty)
-                                               (typecase ty
-                                                 ((or tc:tyvar tc:function-ty) t)
-                                                 (tc:tycon (stdlib-p (tc:tycon-name ty)))
-                                                 (tc:tapp (every #'all-in-stdlib-p (tc:flatten-type ty)))
-                                                 (t (stdlib-p ty)))))
-                             (every #'all-in-stdlib-p
-                              (cons symbol types)))))))
-             (%lm-values (tc:instance-environment-instances
-                          (tc:environment-instance-environment environment)))))
+  (labels
+      ((public-ty-p (ty)
+         (typecase ty
+           ((or tc:tyvar tc:function-ty) t)
+           (tc:tycon (stdlib-p (tc:tycon-name ty)))
+           (tc:tapp (every #'public-ty-p (tc:flatten-type ty)))
+           (t (stdlib-p ty)))))
+
+    (remove-if-not (lambda (instance &aux
+                                       (predicate (tc:ty-class-instance-predicate instance))
+                                       (class (tc:ty-predicate-class predicate)))
+                     (if package
+                         (exported-symbol-p class package t)
+                         (every #'public-ty-p
+                                (cons class
+                                      (mapcan #'tc:flatten-type (tc:ty-predicate-types predicate))))))
+
+                   (%lm-values (tc:instance-environment-instances
+                                (tc:environment-instance-environment environment))))))

--- a/src/doc/environment.lisp
+++ b/src/doc/environment.lisp
@@ -101,28 +101,27 @@ If non-nil, restrict to names defined in PACKAGE."
                         (not (exported-symbol-p (tc:name-entry-name entry) package (not reexported-symbols))))))
              (%values (tc:environment-name-environment environment))))
 
+(defun public? (ty)
+  "T if TY is public.
+Public means each symbolic component is exported from a standard library package."
+  (etypecase ty
+    ((or tc:tyvar tc:function-ty) t)
+    (tc:tycon (stdlib-p (tc:tycon-name ty)))
+    (tc:ty-predicate (and (stdlib-p (tc:ty-predicate-class ty))
+                          (every #'public? (mapcan #'tc:flatten-type (tc:ty-predicate-types ty)))))
+    (tc:tapp (every #'public? (tc:flatten-type ty)))
+    (symbol (stdlib-p ty))))
+
 (defun find-instances (&key (environment entry:*global-environment*)
                          (package nil))
   "Return all instances in ENVIRONMENT.
 
 By default the global environment is queried.
 If non-nil, restrict to instances defined in PACKAGE."
-  (labels
-      ((public-ty-p (ty)
-         (typecase ty
-           ((or tc:tyvar tc:function-ty) t)
-           (tc:tycon (stdlib-p (tc:tycon-name ty)))
-           (tc:tapp (every #'public-ty-p (tc:flatten-type ty)))
-           (t (stdlib-p ty)))))
-
-    (remove-if-not (lambda (instance &aux
-                                       (predicate (tc:ty-class-instance-predicate instance))
-                                       (class (tc:ty-predicate-class predicate)))
+  (remove-if-not (lambda (instance)
+                   (let ((predicate (tc:ty-class-instance-predicate instance)))
                      (if package
-                         (exported-symbol-p class package t)
-                         (every #'public-ty-p
-                                (cons class
-                                      (mapcan #'tc:flatten-type (tc:ty-predicate-types predicate))))))
-
-                   (%lm-values (tc:instance-environment-instances
-                                (tc:environment-instance-environment environment))))))
+                         (exported-symbol-p (tc:ty-predicate-class predicate) package t)
+                         (public? predicate))))
+                 (%lm-values (tc:instance-environment-instances
+                              (tc:environment-instance-environment environment)))))

--- a/src/doc/model.lisp
+++ b/src/doc/model.lisp
@@ -390,16 +390,6 @@
   (eq (tc:constructor-entry-constructs constructor-entry)
       (tc:type-entry-name type-entry)))
 
-(defun stdlib-p (symbol)
-  "A standard library package is any package with the exact name 'coalton' or whose name starts with 'coalton/'.
-One exception: COALTON/UTILS, this package is internal to the standard library."
-  (let ((pkg (symbol-package symbol)))
-    (unless (null pkg)
-        (let ((name (package-name pkg)))
-          (and (not (string-equal name "COALTON/UTILS"))
-           (or (string-equal name "COALTON")
-               (eql 0 (search "COALTON/" name))))))))
-
 ;;; class coalton-macro
 
 (defclass coalton-macro (coalton-object)


### PR DESCRIPTION
In the stdlib documentation generator,
do not list class instances on types with a private/non-exported component.

This is achieved by recursively calling stdlib-p on the symbol of each type that makes up the overall instance type.

Closes #1991.