### PR TITLE
Fix define type repr native

### DIFF
--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -605,7 +605,7 @@ This is conservative and intentionally aligns with mutable native wrappers."
                 :collect (tc:quantify-using-tvar-order tvars (tc:qualify nil ty)))
 
          ;; Check that repr :enum types do not have any constructors with fields
-         :when (eq repr-type :enum)
+         :when (eq repr-type ':enum)
            :do (loop
                  :for ctor :in (parser:toplevel-define-type-ctors type)
                  :unless (endp (parser:constructor-fields ctor))
@@ -614,21 +614,21 @@ This is conservative and intentionally aligns with mutable native wrappers."
                                           "constructors of repr :enum types cannot have fields")))
 
          ;; Check that repr :transparent types have a single constructor
-         :when (eq repr-type :transparent)
+         :when (eq repr-type ':transparent)
            :do (unless (= 1 (length (parser:type-definition-ctors type)))
                  (tc-error "Invalid repr :transparent attribute"
                            (tc-note type
                                     "repr :transparent types must have a single constructor")))
 
          ;; Check that the single constructor of a repr :transparent type has a single field
-         :when (eq repr-type :transparent)
+         :when (eq repr-type ':transparent)
            :do (unless (= 1 (length (parser:type-definition-ctor-field-types (first (parser:type-definition-ctors type)))))
                  (tc-error "Invalid repr :transparent attribute"
                            (tc-note (first (parser:type-definition-ctors type))
                                     "constructors of repr :transparent types must have a single field")))
 
          ;; Check that repr :native types has no constructor
-         :when (eq repr-type :native)
+         :when (eq repr-type ':native)
            :do (unless (endp (parser:type-definition-ctors type))
                  (tc-error "Invalid repr :native attribute"
                            (tc-note type
@@ -661,24 +661,24 @@ This is conservative and intentionally aligns with mutable native wrappers."
                  :name name
                  :type (gethash name (partial-type-env-ty-table env))
                  :runtime-type (cond
-                                 ((eq repr-type :transparent)
+                                 ((eq repr-type ':transparent)
                                   (tc:lisp-type
                                    (tc:function-type-from
                                     (tc:qualified-ty-type
                                      (tc:fresh-inst (first constructor-types))))
                                    (partial-type-env-env env)))
-                                 ((eq repr-type :native)
+                                 ((eq repr-type ':native)
                                   repr-arg)
-                                 ((eq repr-type :enum)
+                                 ((eq repr-type ':enum)
                                   `(member ,@(mapcar #'tc:constructor-entry-compressed-repr ctors)))
                                  (t
                                   name))
                  :aliased-type (gethash name alias-table)
-                 :explicit-repr (if (eq repr-type :native)
+                 :explicit-repr (if (eq repr-type ':native)
                                     (list repr-type repr-arg)
                                     repr-type)
-                 :enum-repr (eq repr-type :enum)
-                 :newtype (eq repr-type :transparent)
+                 :enum-repr (eq repr-type ':enum)
+                 :newtype (eq repr-type ':transparent)
 
                  :constructors ctors
 

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -626,6 +626,14 @@ This is conservative and intentionally aligns with mutable native wrappers."
                  (tc-error "Invalid repr :transparent attribute"
                            (tc-note (first (parser:type-definition-ctors type))
                                     "constructors of repr :transparent types must have a single field")))
+
+         ;; Check that repr :native types has no constructor
+         :when (eq repr-type :native)
+           :do (unless (endp (parser:type-definition-ctors type))
+                 (tc-error "Invalid repr :native attribute"
+                           (tc-note type
+                                    "repr :native types cannot have constructors")))
+
          :collect
          (let*
              ((ctors

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -4845,7 +4845,7 @@ as a recursive function rather than a recursive value."
 
                ;; IN-CONSTRUCTOR: True if the node is within a constructor application,
                ;; allowing deferred recursive references.
-               (valid-recursive-value-p (node in-constructor &optional (visited nil))
+               (valid-recursive-value-p (node &optional in-constructor (visited nil))
                  "Returns t if NODE is a valid subcomponent in a recursive value binding group"
 
                  (when (member node visited :test #'eq)

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -4845,7 +4845,7 @@ as a recursive function rather than a recursive value."
 
                ;; IN-CONSTRUCTOR: True if the node is within a constructor application,
                ;; allowing deferred recursive references.
-               (valid-recursive-value-p (node &optional in-constructor (visited nil))
+               (valid-recursive-value-p (node in-constructor &optional (visited nil))
                  "Returns t if NODE is a valid subcomponent in a recursive value binding group"
 
                  (when (member node visited :test #'eq)

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -1801,7 +1801,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              (type tc:substitution-list subs)
              (type tc-env env)
              (values tc:ty tc:ty-predicate-list accessor-list node-integer-literal tc:substitution-list &optional))
-    
+
     (let* ((num
              (util:find-symbol "NUM" "COALTON/CLASSES"))
            (tvar
@@ -2544,7 +2544,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
              (type tc:substitution-list subs)
              (type tc-env env)
              (values tc:ty tc:ty-predicate-list accessor-list node-resumable tc:substitution-list &optional))
-    
+
     (multiple-value-bind (expr-ty preds accessors expr-node subs)
         (infer-expression-type (parser:node-resumable-expr node)
                                (tc:make-variable)
@@ -2560,7 +2560,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                  :unless (resumption-type-p pat-ty env)
                    :do (tc-error "Invalid resumable case"
                                  (tc-note pat-node "case pattern must construct a resumption type."))
-                 :else 
+                 :else
                    :do (setf subs subs_)
                    :and :collect pat-node))
              ;; Infer type of each branch body, it should unify with the expr/expected type
@@ -2890,7 +2890,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
          (tc-note
           expr-node
           "Not Yet Supported: throw polymorphism.")))
-      
+
       (values
        expected-type
        preds
@@ -2917,7 +2917,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
         (tc-error "Invalid resume-to"
                   (tc-note node "Argument to `resume-to` be a known resumption.")
                   (tc-note node "Not Yet Supported: resume-to polymorphism.")))
-      
+
       (values
        expected-type
        preds
@@ -2967,7 +2967,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                     (tc-note node "Expected type '~A' but 'or' evaluates to '~A'"
                              (type-object-string (tc:apply-substitution subs expected-type))
                              (type-object-string tc:*boolean-type*)))))))
-  
+
   (:method ((node parser:node-and) expected-type subs env)
     (declare (type tc:ty expected-type)
              (type tc:substitution-list subs)
@@ -3489,7 +3489,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
 
            (nodes
              (loop :for elem :in (parser:node-do-nodes node)
-                   :collect (etypecase elem 
+                   :collect (etypecase elem
                               ;; Expressions are typechecked normally
                               ;; and then unified against "m a" where
                               ;; "a" is a fresh tyvar each time
@@ -3574,7 +3574,7 @@ Returns (VALUES INFERRED-TYPE PREDICATES NODE SUBSTITUTIONS)")
                 :type (tc:qualify nil ty)
                 :location (source:location node)
                 :nodes nodes
-                :last-node last-node) 
+                :last-node last-node)
                subs))
           (tc:coalton-internal-type-error ()
             (tc-error "Type mismatch"
@@ -4295,7 +4295,7 @@ as a recursive function rather than a recursive value."
                    (or toplevel-define node-let-binding instance-method-definition)
                    tc:substitution-list
                    &optional))
-  
+
   (with-type-string-environment (env)
     ;; Top-level and instance bindings are validated with typed information so that
     ;; implicit dictionary arguments are treated as function parameters.
@@ -4827,26 +4827,36 @@ as a recursive function rather than a recursive value."
                           (let ((type (tc:lookup-type env (tc:constructor-entry-constructs ctor))))
 
                             ;; Recursive constructors are valid on types
-                            ;; without reprs, types with repr lisp and
+                            ;; without reprs AND the constructor is not recursive,
+                            ;; types with repr lisp and
                             ;; the type "List"
-                            (when (or (null (tc:type-entry-explicit-repr type))
+                            (when (or (and (null (tc:type-entry-explicit-repr type))
+                                           (not (eq (tc:constructor-entry-constructs ctor)
+                                                    (tc:type-entry-name type))))
                                       (eq :lisp (tc:type-entry-explicit-repr type))
                                       (eq 'coalton:List (tc:type-entry-name type)))
                               (return-from valid-recursive-constructor-call-p
                                 (reduce
                                  (lambda (a b) (and a b))
                                  (parser:node-application-rands node)
-                                 :key #'valid-recursive-value-p
+                                 :key (lambda (n) (valid-recursive-value-p n t))
                                  :initial-value t))))))))))
 
-               (valid-recursive-value-p (node)
+
+               ;; IN-CONSTRUCTOR: True if the node is within a constructor application,
+               ;; allowing deferred recursive references.
+               (valid-recursive-value-p (node &optional in-constructor)
                  "Returns t if NODE is a valid subcomponent in a recursive value binding group"
-                 ;; Variables are valid nodes
-                 (when (typep node 'parser:node-variable)
-                   (return-from valid-recursive-value-p t))
 
                  (when (valid-recursive-constructor-call-p node)
                    (return-from valid-recursive-value-p t))
+
+                 ;; Variables are valid if we are already inside a constructor call
+                 ;; or if the variable is not being defined in the current recursive group.
+                 (when (typep node 'parser:node-variable)
+                   (return-from valid-recursive-value-p
+                     (or in-constructor
+                         (not (member (parser:node-variable-name node) binding-names :test #'eq)))))
 
                  ;; Nodes are valid if they do not reference variables in the current binding group
                  (not

--- a/src/typechecker/define.lisp
+++ b/src/typechecker/define.lisp
@@ -4845,8 +4845,11 @@ as a recursive function rather than a recursive value."
 
                ;; IN-CONSTRUCTOR: True if the node is within a constructor application,
                ;; allowing deferred recursive references.
-               (valid-recursive-value-p (node &optional in-constructor)
+               (valid-recursive-value-p (node &optional in-constructor (visited nil))
                  "Returns t if NODE is a valid subcomponent in a recursive value binding group"
+
+                 (when (member node visited :test #'eq)
+                   (return-from valid-recursive-value-p t))
 
                  (when (valid-recursive-constructor-call-p node)
                    (return-from valid-recursive-value-p t))
@@ -4859,12 +4862,13 @@ as a recursive function rather than a recursive value."
                          (not (member (parser:node-variable-name node) binding-names :test #'eq)))))
 
                  ;; Nodes are valid if they do not reference variables in the current binding group
-                 (not
-                  (intersection
-                   binding-names
-                   (mapcar #'parser:node-variable-name
-                           (parser:collect-variables node))
-                   :test #'eq))))
+                 (let ((new-visited (cons node visited)))
+                   (not
+                    (intersection
+                     binding-names
+                     (dolist (var-node (parser:collect-variables node))
+                       (unless (valid-recursive-value-p var-node in-constructor new-visited)
+                         (return-from valid-recursive-value-p nil))))))))
 
         (when (every (alexandria:compose #'valid-recursive-constructor-call-p #'parser:binding-value) bindings)
           (return-from check-for-invalid-recursive-scc))

--- a/tests/test-files/native-repr.txt
+++ b/tests/test-files/native-repr.txt
@@ -1,0 +1,29 @@
+================================================================================
+Issue: 2028 repr :native types shouldn't allow constructors
+================================================================================
+
+(package test-package
+  (import coalton-prelude))
+
+(repr :native cl:string)
+(define-type Test
+  (TestConstructor Integer))
+
+--------------------------------------------------------------------------------
+
+error: Invalid repr :native attribute
+  --> test:6:2
+ 6 |     (define-type Test
+   |  ___^
+ 7 | |     (TestConstructor Integer))
+   | |______________________________^ repr :native types cannot have constructors
+
+================================================================================
+repr :native success case
+================================================================================
+
+(package test-package
+  (import coalton-prelude))
+
+(repr :native cl:string)
+(define-type Test)

--- a/tests/test-files/recursive-let.txt
+++ b/tests/test-files/recursive-let.txt
@@ -56,9 +56,9 @@ error: Invalid recursive bindings
 --------------------------------------------------------------------------------
 
 error: Invalid recursive bindings
-  --> test:9:9
+  --> test:8:9
    |
- 9 |    (let ((lp (MyLoop lp)))
+ 8 |    (let ((lp (MyLoop lp)))
    |           ^^ invalid recursive variable bindings
 
 ================================================================================

--- a/tests/test-files/recursive-let.txt
+++ b/tests/test-files/recursive-let.txt
@@ -45,7 +45,6 @@ error: Invalid recursive bindings
 
 (package coalton-unit-tests/recursive-let)
 
-(repr :native (cl:or cl:null mynullableloop))
 (define-type (MyNullableLoop :elt)
   (NonNull :elt)
   (MyLoop (MyNullableLoop :elt)))


### PR DESCRIPTION
This PR introduces a validation check to ensure that define-type with (repr :native ...) does not include constructors.(Ref: https://github.com/coalton-lang/coalton/issues/2028)

Since :native types are intended to map directly to Lisp types, allowing constructors creates a design conflict within Coalton's type system. This validation enforces consistency by raising a compile-time error when such a definition is encountered.

Impact on Tests:

    Added native-repr-invalid.txt to verify that constructors for :native types are correctly rejected.

    Added native-repr-valid.txt to confirm that valid :native definitions are still supported.

    Note: This change identified a design conflict in recursive-let.txt, where a :native type was used with constructors. I have removed the :native attribute to align with the new validation rule.

Discussion Point:
During the implementation, I found that recursive-let.txt relied on :native as a workaround to provide Lisp-level type hints (declaim) while maintaining recursive structure.

    Should we migrate such patterns to standard Coalton types?

    Or, is there a need for a formal repr (e.g., :lisp-struct) to support recursive types with native-hinted representations?

I would appreciate your feedback on the preferred design direction for such cases.