### PR TITLE
fix dynamic variable mis-alias

### DIFF
--- a/docs/manual/site/operators/define.md
+++ b/docs/manual/site/operators/define.md
@@ -1,50 +1,91 @@
 ---
 title: "define"
-description: "Value and function definition form."
+description: "Top-level value, function, and dynamic variable definition form."
 hideMeta: true
 weight: 40
 ---
 
-`define` introduces top-level values and functions.
+`define` introduces top-level values, functions, and dynamic variables.
 
 ## Syntax
 
 ```lisp
-⟨monomorphize-directive⟩?
-⟨inline-directive⟩?
-⟨declare-directive⟩?
-(define ⟨def⟩ ⟨docstring⟩? ⟨expr⟩)
+;; Ordinary top-level value
+(define ⟨name⟩ ⟨docstring⟩? ⟨expr⟩)
 
-;; ⟨def⟩ := ⟨name⟩
-;;        | *⟨name⟩*
-;;        | (⟨name⟩ ⟨arg⟩...)
-;;
-;; ⟨arg⟩ := ⟨name⟩
-;;        | _
-;;        | ⟨pattern⟩
+;; Function
+(define (⟨name⟩ ⟨arg⟩...)
+  ⟨docstring⟩?
+  ⟨body⟩...)
+
+;; Dynamic variable
+(define *⟨name⟩* ⟨docstring⟩? ⟨expr⟩)
+
+;; ⟨arg⟩ := ⟨name⟩ | _ | ⟨pattern⟩
 ```
 
-## Semantics
+## Ordinary top-level values
 
-- Defines a new value or function.
-- Type is automatically inferred, but a `declare` is recommended.
-- Exported top-level definitions without a matching `declare` signal a
-  `coalton:deprecation-warning`; this is planned to become an error.
-- Can be inlined, monomorphized, or specialized.
-- Parameters which are not referenced can be named `_` or `_x` where `x` can be
-  any name.
-- If an argument is a data type with one constructor, a direct pattern match
-  can be used.
-- The body of a function definition can `return` explicitly.
-- When `⟨name⟩` begins and ends with `*`, as in `*base*`, then `define` defines
-  a dynamic variable. Otherwise, it defines an ordinary lexical variable.
-
-## Example
+- An ordinary name creates a top-level value binding.
+- A local lexical binding may shadow a top-level value.
 
 ```lisp
+(declare answer Integer)
+(define answer 42)
+```
+
+## Functions
+
+- Function syntax places the name and arguments in a list.
+- Arguments may be names, `_`, or patterns.
+- An unused named argument may begin with `_`, such as `_state`.
+- A direct argument pattern may be used when its type has one constructor.
+- The body is an implicit [`progn`](/manual/operators/progn/) and may use
+  [`return`](/manual/operators/return/).
+- A function may instead be defined as a value using
+  [`fn`](/manual/operators/fn/).
+
+```lisp
+(declare add2 (Integer -> Integer))
 (define (add2 x)
   (+ x 2))
-
-;; dynamic variable
-(define *base* 10)
 ```
+
+## Dynamic variables
+
+- A name beginning and ending with `*` defines a dynamic variable. It must
+  contain at least one non-`*` character.
+- Earmuffs are syntactic: ordinary parameters, patterns, and lexical bindings
+  cannot use dynamic-variable names.
+- The definition supplies the top-level value. Each reference reads the value
+  from the current dynamic environment.
+- [`dynamic-bind`](/manual/operators/dynamic-bind/) temporarily rebinds a
+  dynamic variable. Called functions observe the rebinding.
+- A rebinding must preserve the variable's type. Multiple bindings are
+  parallel and their initializers are evaluated in the outer environment.
+- Dynamic variables may have any Coalton type, including function types.
+  Function-valued dynamic variables use value syntax with
+  [`fn`](/manual/operators/fn/); function syntax cannot use a dynamic name.
+- Dynamic variables cannot be marked [`inline`](/manual/operators/inline/).
+
+```lisp
+(declare *base* Integer)
+(define *base* 10)
+
+(define (base-value)
+  *base*)
+
+(dynamic-bind ((*base* 20))
+  (base-value))              ; => 20
+```
+
+## Common semantics
+
+- Types are inferred, but an explicit `declare` is recommended.
+- Exported definitions without a matching declaration signal a
+  `coalton:deprecation-warning`; this is planned to become an error.
+- A docstring appears after the name or argument list and before the expression
+  or body.
+- Ordinary functions may use [`inline`](/manual/operators/inline/),
+  [`monomorphize`](/manual/operators/monomorphize/), and
+  [`specialize`](/manual/operators/specialize/) optimization facilities.

--- a/src/codegen/ast-substitutions.lisp
+++ b/src/codegen/ast-substitutions.lisp
@@ -49,7 +49,7 @@ is true."
   (traverse
    node
    (list
-    (action (:after node-variable node new-subs)
+    (action (:after node-local-variable node new-subs)
       (alexandria:when-let
           ((res (or (find (node-variable-value node) subs :key #'ast-substitution-from)
                     (find (node-variable-value node) new-subs :key #'ast-substitution-from))))
@@ -60,7 +60,7 @@ is true."
                 :for new-var := (gensym (symbol-name coalton-var))
                 :for res := (or (find coalton-var subs :key #'ast-substitution-from)
                                 (find coalton-var new-subs :key #'ast-substitution-from))
-                :if (and res (node-variable-p (ast-substitution-to res)))
+                :if (and res (node-local-variable-p (ast-substitution-to res)))
                   :collect (cons lisp-var (node-variable-value (ast-substitution-to res)))
                     :into lisp-var-bindings
                 :else :if res
@@ -103,7 +103,7 @@ is true."
             :do (when rename-bound-variables
                   (push (make-ast-substitution
                          :from name
-                         :to (make-node-variable
+                         :to (make-node-local-variable
                               :type (node-type expr)
                               :value (gensym (symbol-name name))))
                         new-subs)))
@@ -130,7 +130,7 @@ is true."
               :do (when rename-bound-variables
                     (push (make-ast-substitution
                            :from name
-                           :to (make-node-variable
+                           :to (make-node-local-variable
                                 :type (pop components)
                                 :value (gensym (symbol-name name))))
                           new-subs))))
@@ -155,7 +155,7 @@ is true."
               :do (when rename-bound-variables
                     (push (make-ast-substitution
                            :from name
-                           :to (make-node-variable
+                           :to (make-node-local-variable
                                 :type (node-for-binding-type binding)
                                 :value (gensym (symbol-name name))))
                           loop-subs)))

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -18,9 +18,16 @@
    #:node-literal-p                     ; FUNCTION
    #:node-literal-value                 ; READER
    #:node-variable                      ; STRUCT
-   #:make-node-variable                 ; CONSTRUCTOR
-   #:node-variable-p                    ; FUNCTION
    #:node-variable-value                ; READER
+   #:node-local-variable                ; STRUCT
+   #:make-node-local-variable           ; CONSTRUCTOR
+   #:node-local-variable-p              ; FUNCTION
+   #:node-global-variable               ; STRUCT
+   #:make-node-global-variable          ; CONSTRUCTOR
+   #:node-global-variable-p             ; FUNCTION
+   #:node-dynamic-variable              ; STRUCT
+   #:make-node-dynamic-variable         ; CONSTRUCTOR
+   #:node-dynamic-variable-p            ; FUNCTION
    #:node-application                   ; STRUCT
    #:make-node-application              ; CONSTRUCTOR
    #:node-application-p                 ; FUNCTION
@@ -253,9 +260,21 @@ coalton symbols (`parser:identifier`)"
   "Literal values like 1 or \"hello\""
   (value (util:required 'value) :type util:literal-value :read-only t))
 
-(defstruct (node-variable (:include node))
-  "Variables like x or y"
+(defstruct (node-variable
+            (:include node)
+            (:constructor nil)
+            (:predicate nil))
+  "Shared representation for variable references."
   (value (util:required 'value) :type parser:identifier :read-only t))
+
+(defstruct (node-local-variable (:include node-variable))
+  "A reference to a local lexically scoped variable.")
+
+(defstruct (node-global-variable (:include node-variable))
+  "A reference to a statically known global variable.")
+
+(defstruct (node-dynamic-variable (:include node-variable))
+  "A runtime read of a dynamically scoped variable.")
 
 (defstruct keyword-param
   "A keyword parameter in a compiled lambda list."
@@ -521,7 +540,7 @@ coalton symbols (`parser:identifier`)"
      (node-application-rands node))))
 
 (defun node-rator-name (node)
-  "Returns the name of the function being called if it is known"
+  "Return the stable local or global callee name when it is known."
   (declare (type (or node-application node-direct-application))
            (values (or null parser:identifier) &optional))
 
@@ -530,8 +549,11 @@ coalton symbols (`parser:identifier`)"
      (node-direct-application-rator node))
 
     (node-application
-     (when (node-variable-p (node-application-rator node))
-       (node-variable-value (node-application-rator node))))))
+     (typecase (node-application-rator node)
+       ((or node-local-variable node-global-variable)
+        (node-variable-value (node-application-rator node)))
+       (t
+        nil)))))
 
 (defun node-rator-type (node)
   (declare (type (or node-application node-direct-application))

--- a/src/codegen/ast.lisp
+++ b/src/codegen/ast.lisp
@@ -18,9 +18,16 @@
    #:node-literal-p                     ; FUNCTION
    #:node-literal-value                 ; READER
    #:node-variable                      ; STRUCT
-   #:make-node-variable                 ; CONSTRUCTOR
-   #:node-variable-p                    ; FUNCTION
    #:node-variable-value                ; READER
+   #:node-local-variable              ; STRUCT
+   #:make-node-local-variable         ; CONSTRUCTOR
+   #:node-local-variable-p            ; FUNCTION
+   #:node-global-variable               ; STRUCT
+   #:make-node-global-variable          ; CONSTRUCTOR
+   #:node-global-variable-p             ; FUNCTION
+   #:node-dynamic-variable              ; STRUCT
+   #:make-node-dynamic-variable         ; CONSTRUCTOR
+   #:node-dynamic-variable-p            ; FUNCTION
    #:node-application                   ; STRUCT
    #:make-node-application              ; CONSTRUCTOR
    #:node-application-p                 ; FUNCTION
@@ -253,9 +260,21 @@ coalton symbols (`parser:identifier`)"
   "Literal values like 1 or \"hello\""
   (value (util:required 'value) :type util:literal-value :read-only t))
 
-(defstruct (node-variable (:include node))
-  "Variables like x or y"
+(defstruct (node-variable
+            (:include node)
+            (:constructor nil)
+            (:predicate nil))
+  "Shared representation for variable references."
   (value (util:required 'value) :type parser:identifier :read-only t))
+
+(defstruct (node-local-variable (:include node-variable))
+  "A reference to a local lexically scoped variable.")
+
+(defstruct (node-global-variable (:include node-variable))
+  "A reference to a statically known global variable.")
+
+(defstruct (node-dynamic-variable (:include node-variable))
+  "A runtime read of a dynamically scoped variable.")
 
 (defstruct keyword-param
   "A keyword parameter in a compiled lambda list."
@@ -521,7 +540,7 @@ coalton symbols (`parser:identifier`)"
      (node-application-rands node))))
 
 (defun node-rator-name (node)
-  "Returns the name of the function being called if it is known"
+  "Return the stable local or global callee name when it is known."
   (declare (type (or node-application node-direct-application))
            (values (or null parser:identifier) &optional))
 
@@ -530,8 +549,11 @@ coalton symbols (`parser:identifier`)"
      (node-direct-application-rator node))
 
     (node-application
-     (when (node-variable-p (node-application-rator node))
-       (node-variable-value (node-application-rator node))))))
+     (typecase (node-application-rator node)
+       ((or node-local-variable node-global-variable)
+        (node-variable-value (node-application-rator node)))
+       (t
+        nil)))))
 
 (defun node-rator-type (node)
   (declare (type (or node-application node-direct-application))

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -222,7 +222,15 @@
              (ignore env))
     (node-literal-value node))
 
-  (:method ((node node-variable) env)
+  (:method ((node node-local-variable) env)
+    (declare (type tc:environment env)
+             (ignore env))
+    (let ((value (node-variable-value node)))
+      (if (local-function-value-reference-p value)
+          (local-function-value-form value)
+          value)))
+
+  (:method ((node node-global-variable) env)
     (declare (type tc:environment env))
     (let ((value (node-variable-value node)))
       (case value
@@ -230,16 +238,17 @@
         ((coalton:True coalton:False coalton:Nil coalton:Unit)
          `(quote ,(eval value)))
         (otherwise
-         (if (local-function-value-reference-p value)
-             (local-function-value-form value)
-             ;; General case: Emit the symbol itself.
-             (alexandria:if-let ((entry (and (not (util:dynamic-variable-name-p value))
-                                             (tc:lookup-function env value :no-error t))))
-               (if (and (not (tc:function-type-p (node-type node)))
-                        (zerop (tc:function-env-entry-arity entry)))
-                   `(funcall ,value)
-                   value)
-               value))))))
+         (alexandria:if-let ((entry (tc:lookup-function env value :no-error t)))
+           (if (and (not (tc:function-type-p (node-type node)))
+                    (zerop (tc:function-env-entry-arity entry)))
+               `(funcall ,value)
+               value)
+           value)))))
+
+  (:method ((node node-dynamic-variable) env)
+    (declare (type tc:environment env)
+             (ignore env))
+    (node-variable-value node))
 
   ;; Keyword dispatch for indirect calls through first-class function values.
   ;; The parallel logic for direct calls is in the node-direct-application

--- a/src/codegen/codegen-expression.lisp
+++ b/src/codegen/codegen-expression.lisp
@@ -205,7 +205,15 @@
              (ignore env))
     (node-literal-value node))
 
-  (:method ((node node-variable) env)
+  (:method ((node node-local-variable) env)
+    (declare (type tc:environment env)
+             (ignore env))
+    (let ((value (node-variable-value node)))
+      (if (local-function-value-reference-p value)
+          (local-function-value-form value)
+          value)))
+
+  (:method ((node node-global-variable) env)
     (declare (type tc:environment env))
     (let ((value (node-variable-value node)))
       (case value
@@ -213,16 +221,17 @@
         ((coalton:True coalton:False coalton:Nil coalton:Unit)
          `(quote ,(eval value)))
         (otherwise
-         (if (local-function-value-reference-p value)
-             (local-function-value-form value)
-             ;; General case: Emit the symbol itself.
-             (alexandria:if-let ((entry (and (not (util:dynamic-variable-name-p value))
-                                             (tc:lookup-function env value :no-error t))))
-               (if (and (not (tc:function-type-p (node-type node)))
-                        (zerop (tc:function-env-entry-arity entry)))
-                   `(funcall ,value)
-                   value)
-               value))))))
+         (alexandria:if-let ((entry (tc:lookup-function env value :no-error t)))
+           (if (and (not (tc:function-type-p (node-type node)))
+                    (zerop (tc:function-env-entry-arity entry)))
+               `(funcall ,value)
+               value)
+           value)))))
+
+  (:method ((node node-dynamic-variable) env)
+    (declare (type tc:environment env)
+             (ignore env))
+    (node-variable-value node))
 
   ;; Keyword dispatch for indirect calls through first-class function values.
   ;; The parallel logic for direct calls is in the node-direct-application

--- a/src/codegen/constant-propagation.lisp
+++ b/src/codegen/constant-propagation.lisp
@@ -39,14 +39,15 @@ If not, returns NIL"
          (if (or (numberp (node-literal-value node)) (characterp (node-literal-value node)))
              node
              nil))
-        ((node-variable-p node)
+        ((node-global-variable-p node)
          (cond ((and (eq 'coalton:Boolean (node-type node))
                      (member (node-variable-value node) '(coalton:True coalton:False)))
                 node)
                ((tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t)
                 node)
-               (t
-                (constant-var-value (node-variable-value node) constant-bindings :no-error t))))
+               (t nil)))
+        ((node-local-variable-p node)
+         (constant-var-value (node-variable-value node) constant-bindings :no-error t))
         ((node-lisp-p node)
          (if (cl:constantp (node-lisp-form node))
              node
@@ -184,7 +185,8 @@ If not, returns NIL"
     (traverse
      node
      (list
-      (action (:after node-variable) #'propagate-constants-node-variable)
+      (action (:after node-local-variable) #'propagate-constants-node-variable)
+      (action (:after node-global-variable) #'propagate-constants-node-variable)
       (action (:traverse node-let) #'propagate-constants-node-let)
       (action (:after node-lisp) #'propagate-constants-node-lisp)
       (action (:after node-direct-application) #'direct-application-better-infer-types))

--- a/src/codegen/hoister.lisp
+++ b/src/codegen/hoister.lisp
@@ -37,12 +37,12 @@
     nil))
 
 (defun hoist-point-add (node package hoist-point)
-  (declare (values node-variable))
+  (declare (values node-local-variable))
   (if (gethash node (hoist-point-definitions hoist-point))
       (values (gethash node (hoist-point-definitions hoist-point)))
       (progn
         (setf (gethash node (hoist-point-definitions hoist-point))
-              (make-node-variable
+              (make-node-local-variable
                :type (node-type node)
                :value (gentemp "hoisted_" package)))
         (values (gethash node (hoist-point-definitions hoist-point))))))
@@ -84,7 +84,7 @@
   (declare (type node node)
            (type package package)
            (type hoister hoister)
-           (values node-variable &optional))
+           (values node-local-variable &optional))
   (loop :for hoist-point :in (hoister-hoist-points hoister)
         :if (hoist-point-blocks node hoist-point)
           :do (return-from hoist-definition (hoist-point-add node package hoist-point)))

--- a/src/codegen/inliner.lisp
+++ b/src/codegen/inliner.lisp
@@ -120,10 +120,8 @@ controlled by `settings:*print-inlining-occurences*' is enabled."
            (values (or null ast:node-abstraction) &optional))
 
   (a:if-let ((name (ast:node-rator-name application)))
-    (if (util:dynamic-variable-name-p name)
-        nil
-        (let ((abstraction (tc:lookup-code env name :no-error t)))
-          (if (ast:node-abstraction-p abstraction) abstraction nil)))
+    (let ((abstraction (tc:lookup-code env name :no-error t)))
+      (if (ast:node-abstraction-p abstraction) abstraction nil))
     nil))
 
 (defun lookup-anonymous-application-body (application)
@@ -219,7 +217,7 @@ controlled by `settings:*print-inlining-occurences*' is enabled."
                      bindings)
                (push (substitutions:make-ast-substitution
                       :from var
-                      :to (ast:make-node-variable
+                      :to (ast:make-node-local-variable
                            :type binding-type
                            :value new-var))
                      substitutions)))
@@ -328,12 +326,12 @@ is appropriate."
            (values (or null parser:identifier) ast:node-list &optional))
 
   (cond
-    ((ast:node-variable-p (first rands))
+    ((ast:node-global-variable-p (first rands))
      (values (ast:node-variable-value (first rands))
              (rest rands)))
 
     ((and (ast:node-application-p (first rands))
-          (ast:node-variable-p (ast:node-application-rator (first rands))))
+          (ast:node-global-variable-p (ast:node-application-rator (first rands))))
      (values (ast:node-variable-value (ast:node-application-rator (first rands)))
              (append (ast:node-application-rands (first rands)) (rest rands))))
 
@@ -349,7 +347,7 @@ is appropriate."
            (values ast:node &optional))
   (labels ((make-nullary-call (rator)
              (if (and direct-p
-                      (ast:node-variable-p rator))
+                      (ast:node-global-variable-p rator))
                  (ast:make-node-direct-application
                   :type result-type
                   :properties properties
@@ -367,7 +365,7 @@ is appropriate."
       ;; first-class function value. In that case we want the resolved method
       ;; binding itself, not a call to it.
       ((tc:function-type-p result-type)
-       (ast:make-node-variable
+       (ast:make-node-global-variable
         :type result-type
         :value method-name))
 
@@ -380,7 +378,7 @@ is appropriate."
 
       (t
        (make-nullary-call
-        (ast:make-node-variable
+        (ast:make-node-global-variable
          :type (tc:make-function-type* nil result-type)
          :value method-name)))))))
 
@@ -399,7 +397,7 @@ is appropriate."
   (let ((rator (ast:node-application-rator node))
         (rands (ast:node-application-rands node)))
     (multiple-value-bind (dict inner-rands) (extract-dict rands)
-      (if (or (null dict) (not (ast:node-variable-p rator)))
+      (if (or (null dict) (not (ast:node-global-variable-p rator)))
           node
           (let ((method-name (tc:lookup-method-inline env (ast:node-variable-value rator) dict :no-error t)))
             (cond
@@ -422,7 +420,7 @@ is appropriate."
                (ast:make-node-application
                 :type (ast:node-type node)
                 :properties (ast:node-properties node)
-                :rator (ast:make-node-variable
+                :rator (ast:make-node-global-variable
                         :type (tc:make-function-type*
                                (mapcar #'ast:node-type inner-rands)
                                (ast:node-type node))
@@ -466,7 +464,7 @@ is appropriate."
                (ast:make-node-application
                 :type (ast:node-type node)
                 :properties (ast:node-properties node)
-                :rator (ast:make-node-variable
+                :rator (ast:make-node-global-variable
                         :type (tc:make-function-type*
                                (mapcar #'ast:node-type inner-rands)
                                (ast:node-type node))

--- a/src/codegen/lawnmower.lisp
+++ b/src/codegen/lawnmower.lisp
@@ -10,6 +10,7 @@ later passes and Lisp compilers see simpler code.")
    #:coalton-impl/codegen/ast)
   (:import-from
    #:coalton-impl/codegen/transformations
+   #:node-dynamic-variables
    #:node-variables)
   (:import-from
    #:coalton-impl/codegen/traverse
@@ -18,8 +19,7 @@ later passes and Lisp compilers see simpler code.")
    #:traverse-with-binding-list)
   (:local-nicknames
    (#:parser #:coalton-impl/parser)
-   (#:tc #:coalton-impl/typechecker)
-   (#:util #:coalton-impl/util))
+   (#:tc #:coalton-impl/typechecker))
   (:export
    #:lawnmow))
 
@@ -151,29 +151,21 @@ push OUTER-BRANCHES into the inner match branches."
               outer-scope-vars))
            (node-match-branches inner-match))))
 
-(defun dynamic-variable-node-p (node)
-  "Return true when NODE reads a dynamically scoped variable."
-  (declare (type node node)
-           (values boolean &optional))
-  (and (node-variable-p node)
-       (util:dynamic-variable-name-p (node-variable-value node))))
-
 (defun alias-binding-target (binding)
   "Return the target variable node for a LET binding of the form (ALIAS TARGET)."
   (declare (type cons binding)
-           (values (or null node-variable) &optional))
+           (values (or null node-local-variable node-global-variable) &optional))
   (let ((name (car binding))
         (expr (cdr binding)))
-    (when (and (node-variable-p expr)
-               (not (eq name (node-variable-value expr)))
-               (not (dynamic-variable-node-p expr)))
+    (when (and (typep expr '(or node-local-variable node-global-variable))
+               (not (eq name (node-variable-value expr))))
       expr)))
 
 (defun resolve-alias-target (name aliases)
   "Resolve NAME through ALIASES, returning NIL for cyclic alias chains."
   (declare (type parser:identifier name)
            (type list aliases)
-           (values (or null node-variable) &optional))
+           (values (or null node-local-variable node-global-variable) &optional))
   (labels ((resolve (name seen)
              (let ((target (cdr (assoc name aliases :test #'eq))))
                (when target
@@ -205,7 +197,7 @@ push OUTER-BRANCHES into the inner match branches."
 (defun alias-substitution-target (name aliases)
   (declare (type parser:identifier name)
            (type list aliases)
-           (values (or null node-variable) &optional))
+           (values (or null node-local-variable node-global-variable) &optional))
   (cdr (assoc name aliases :test #'eq)))
 
 (defun substitute-aliases (node aliases)
@@ -218,7 +210,7 @@ The replacement is skipped inside nested binders for the same name."
   (traverse-with-binding-list
    node
    (list
-    (action (:after node-variable node bound-variables)
+    (action (:after node-local-variable node bound-variables)
       (let ((name (node-variable-value node)))
         (unless (member name bound-variables :test #'eq)
           (alexandria:when-let ((target (alias-substitution-target name aliases)))
@@ -246,7 +238,7 @@ The replacement is skipped inside nested binders for the same name."
     (traverse-with-binding-list
      body
      (list
-      (action (:after node-variable node bound-variables)
+      (action (:after node-local-variable node bound-variables)
         (when (and (eq name (node-variable-value node))
                    (not (member name bound-variables :test #'eq))
                    (member target bound-variables :test #'eq))
@@ -378,7 +370,7 @@ The replacement is skipped inside nested binders for the same name."
     (traverse-with-binding-list
      body
      (list
-      (action (:after node-variable node bound-variables)
+      (action (:after node-local-variable node bound-variables)
         (when (and (eq name (node-variable-value node))
                    (not (member name bound-variables :test #'eq)))
           (incf count)
@@ -400,7 +392,7 @@ The replacement is skipped inside nested binders for the same name."
   (traverse-with-binding-list
    body
    (list
-    (action (:after node-variable node bound-variables)
+    (action (:after node-local-variable node bound-variables)
       (when (and (eq name (node-variable-value node))
                  (not (member name bound-variables :test #'eq)))
         (copy-node value (node-type node)))))))
@@ -412,7 +404,7 @@ The replacement is skipped inside nested binders for the same name."
   (multiple-value-bind (count unsafe?) (variable-substitution-info body name value)
     (if (and (= 1 count)
              (not unsafe?)
-             (not (dynamic-variable-node-p value)))
+             (null (node-dynamic-variables value)))
         (substitute-variable-node body name value)
         (make-node-bind
          :type (node-type body)
@@ -608,7 +600,7 @@ Returns a status keyword and a replacement body. Status is one of:
            (type node subexpr)
            (values (or null node-match) &optional))
   (when (and (typep subexpr 'node-match)
-             (node-variable-p (node-match-expr subexpr))
+             (node-local-variable-p (node-match-expr subexpr))
              (eq name (node-variable-value (node-match-expr subexpr)))
              (not (member name (match-free-variables subexpr) :test #'eq)))
     subexpr))
@@ -628,7 +620,7 @@ Returns a status keyword and a replacement body. Status is one of:
     (traverse
      node
      (list
-      (action (:after node-variable node)
+      (action (:after node-local-variable node)
         (when (eq name (node-variable-value node))
           (incf count))
         (values))
@@ -705,7 +697,7 @@ Returns a status keyword and a replacement body. Status is one of:
   (let ((bindings (node-let-bindings node))
         (subexpr (node-let-subexpr node)))
     (unless (and (typep subexpr 'node-match)
-                 (node-variable-p (node-match-expr subexpr)))
+                 (node-local-variable-p (node-match-expr subexpr)))
       (return-from maybe-inline-let-bound-match-scrutinee
         (values node nil)))
     (let* ((name (node-variable-value (node-match-expr subexpr)))
@@ -783,15 +775,14 @@ Returns a status keyword and a replacement body. Status is one of:
         (body (node-bind-body node)))
     (cond
       ;; (bind x e x) -> e
-      ((and (node-variable-p body)
+      ((and (node-local-variable-p body)
             (eq name (node-variable-value body))
             (not (member name (node-variables expr) :test #'eq)))
        (values (copy-node expr (node-type node)) t))
 
       ;; (bind x y body[x]) -> body[y]
-      ((and (node-variable-p expr)
+      ((and (typep expr '(or node-local-variable node-global-variable))
             (not (eq name (node-variable-value expr)))
-            (not (dynamic-variable-node-p expr))
             (alias-bind-safe-p name (node-variable-value expr) body))
        (values
         (substitute-aliases body (list (cons name expr)))
@@ -829,7 +820,7 @@ Returns a status keyword and a replacement body. Status is one of:
         (subexpr (node-let-subexpr node)))
     ;; (let ((x e)) x) -> e
     (if (and (null (cdr bindings))
-             (node-variable-p subexpr)
+             (node-local-variable-p subexpr)
              (eq (caar bindings)
                  (node-variable-value subexpr))
              (not (member (caar bindings)

--- a/src/codegen/lawnmower.lisp
+++ b/src/codegen/lawnmower.lisp
@@ -18,7 +18,8 @@ later passes and Lisp compilers see simpler code.")
    #:traverse-with-binding-list)
   (:local-nicknames
    (#:parser #:coalton-impl/parser)
-   (#:tc #:coalton-impl/typechecker))
+   (#:tc #:coalton-impl/typechecker)
+   (#:util #:coalton-impl/util))
   (:export
    #:lawnmow))
 
@@ -150,6 +151,13 @@ push OUTER-BRANCHES into the inner match branches."
               outer-scope-vars))
            (node-match-branches inner-match))))
 
+(defun dynamic-variable-node-p (node)
+  "Return true when NODE reads a dynamically scoped variable."
+  (declare (type node node)
+           (values boolean &optional))
+  (and (node-variable-p node)
+       (util:dynamic-variable-name-p (node-variable-value node))))
+
 (defun alias-binding-target (binding)
   "Return the target variable node for a LET binding of the form (ALIAS TARGET)."
   (declare (type cons binding)
@@ -157,7 +165,8 @@ push OUTER-BRANCHES into the inner match branches."
   (let ((name (car binding))
         (expr (cdr binding)))
     (when (and (node-variable-p expr)
-               (not (eq name (node-variable-value expr))))
+               (not (eq name (node-variable-value expr)))
+               (not (dynamic-variable-node-p expr)))
       expr)))
 
 (defun resolve-alias-target (name aliases)
@@ -401,7 +410,9 @@ The replacement is skipped inside nested binders for the same name."
            (type node value body)
            (values node &optional))
   (multiple-value-bind (count unsafe?) (variable-substitution-info body name value)
-    (if (and (= 1 count) (not unsafe?))
+    (if (and (= 1 count)
+             (not unsafe?)
+             (not (dynamic-variable-node-p value)))
         (substitute-variable-node body name value)
         (make-node-bind
          :type (node-type body)
@@ -780,6 +791,7 @@ Returns a status keyword and a replacement body. Status is one of:
       ;; (bind x y body[x]) -> body[y]
       ((and (node-variable-p expr)
             (not (eq name (node-variable-value expr)))
+            (not (dynamic-variable-node-p expr))
             (alias-bind-safe-p name (node-variable-value expr) body))
        (values
         (substitute-aliases body (list (cons name expr)))

--- a/src/codegen/lawnmower.lisp
+++ b/src/codegen/lawnmower.lisp
@@ -10,6 +10,7 @@ later passes and Lisp compilers see simpler code.")
    #:coalton-impl/codegen/ast)
   (:import-from
    #:coalton-impl/codegen/transformations
+   #:node-dynamic-variables
    #:node-variables)
   (:import-from
    #:coalton-impl/codegen/traverse
@@ -18,8 +19,7 @@ later passes and Lisp compilers see simpler code.")
    #:traverse-with-binding-list)
   (:local-nicknames
    (#:parser #:coalton-impl/parser)
-   (#:tc #:coalton-impl/typechecker)
-   (#:util #:coalton-impl/util))
+   (#:tc #:coalton-impl/typechecker))
   (:export
    #:lawnmow))
 
@@ -151,29 +151,21 @@ push OUTER-BRANCHES into the inner match branches."
               outer-scope-vars))
            (node-match-branches inner-match))))
 
-(defun dynamic-variable-node-p (node)
-  "Return true when NODE reads a dynamically scoped variable."
-  (declare (type node node)
-           (values boolean &optional))
-  (and (node-variable-p node)
-       (util:dynamic-variable-name-p (node-variable-value node))))
-
 (defun alias-binding-target (binding)
   "Return the target variable node for a LET binding of the form (ALIAS TARGET)."
   (declare (type cons binding)
-           (values (or null node-variable) &optional))
+           (values (or null node-local-variable node-global-variable) &optional))
   (let ((name (car binding))
         (expr (cdr binding)))
-    (when (and (node-variable-p expr)
-               (not (eq name (node-variable-value expr)))
-               (not (dynamic-variable-node-p expr)))
+    (when (and (typep expr '(or node-local-variable node-global-variable))
+               (not (eq name (node-variable-value expr))))
       expr)))
 
 (defun resolve-alias-target (name aliases)
   "Resolve NAME through ALIASES, returning NIL for cyclic alias chains."
   (declare (type parser:identifier name)
            (type list aliases)
-           (values (or null node-variable) &optional))
+           (values (or null node-local-variable node-global-variable) &optional))
   (labels ((resolve (name seen)
              (let ((target (cdr (assoc name aliases :test #'eq))))
                (when target
@@ -205,7 +197,7 @@ push OUTER-BRANCHES into the inner match branches."
 (defun alias-substitution-target (name aliases)
   (declare (type parser:identifier name)
            (type list aliases)
-           (values (or null node-variable) &optional))
+           (values (or null node-local-variable node-global-variable) &optional))
   (cdr (assoc name aliases :test #'eq)))
 
 (defun substitute-aliases (node aliases)
@@ -218,7 +210,7 @@ The replacement is skipped inside nested binders for the same name."
   (traverse-with-binding-list
    node
    (list
-    (action (:after node-variable node bound-variables)
+    (action (:after node-local-variable node bound-variables)
       (let ((name (node-variable-value node)))
         (unless (member name bound-variables :test #'eq)
           (alexandria:when-let ((target (alias-substitution-target name aliases)))
@@ -246,7 +238,7 @@ The replacement is skipped inside nested binders for the same name."
     (traverse-with-binding-list
      body
      (list
-      (action (:after node-variable node bound-variables)
+      (action (:after node-local-variable node bound-variables)
         (when (and (eq name (node-variable-value node))
                    (not (member name bound-variables :test #'eq))
                    (member target bound-variables :test #'eq))
@@ -378,7 +370,7 @@ The replacement is skipped inside nested binders for the same name."
     (traverse-with-binding-list
      body
      (list
-      (action (:after node-variable node bound-variables)
+      (action (:after node-local-variable node bound-variables)
         (when (and (eq name (node-variable-value node))
                    (not (member name bound-variables :test #'eq)))
           (incf count)
@@ -400,7 +392,7 @@ The replacement is skipped inside nested binders for the same name."
   (traverse-with-binding-list
    body
    (list
-    (action (:after node-variable node bound-variables)
+    (action (:after node-local-variable node bound-variables)
       (when (and (eq name (node-variable-value node))
                  (not (member name bound-variables :test #'eq)))
         (copy-node value (node-type node)))))))
@@ -412,7 +404,7 @@ The replacement is skipped inside nested binders for the same name."
   (multiple-value-bind (count unsafe?) (variable-substitution-info body name value)
     (if (and (= 1 count)
              (not unsafe?)
-             (not (dynamic-variable-node-p value)))
+             (null (node-dynamic-variables value)))
         (substitute-variable-node body name value)
         (make-node-bind
          :type (node-type body)
@@ -607,7 +599,7 @@ Returns a status keyword and a replacement body. Status is one of:
            (type node subexpr)
            (values (or null node-match) &optional))
   (when (and (typep subexpr 'node-match)
-             (node-variable-p (node-match-expr subexpr))
+             (node-local-variable-p (node-match-expr subexpr))
              (eq name (node-variable-value (node-match-expr subexpr)))
              (not (member name (match-free-variables subexpr) :test #'eq)))
     subexpr))
@@ -627,7 +619,7 @@ Returns a status keyword and a replacement body. Status is one of:
     (traverse
      node
      (list
-      (action (:after node-variable node)
+      (action (:after node-local-variable node)
         (when (eq name (node-variable-value node))
           (incf count))
         (values))
@@ -704,7 +696,7 @@ Returns a status keyword and a replacement body. Status is one of:
   (let ((bindings (node-let-bindings node))
         (subexpr (node-let-subexpr node)))
     (unless (and (typep subexpr 'node-match)
-                 (node-variable-p (node-match-expr subexpr)))
+                 (node-local-variable-p (node-match-expr subexpr)))
       (return-from maybe-inline-let-bound-match-scrutinee
         (values node nil)))
     (let* ((name (node-variable-value (node-match-expr subexpr)))
@@ -782,15 +774,14 @@ Returns a status keyword and a replacement body. Status is one of:
         (body (node-bind-body node)))
     (cond
       ;; (bind x e x) -> e
-      ((and (node-variable-p body)
+      ((and (node-local-variable-p body)
             (eq name (node-variable-value body))
             (not (member name (node-variables expr) :test #'eq)))
        (values (copy-node expr (node-type node)) t))
 
       ;; (bind x y body[x]) -> body[y]
-      ((and (node-variable-p expr)
+      ((and (typep expr '(or node-local-variable node-global-variable))
             (not (eq name (node-variable-value expr)))
-            (not (dynamic-variable-node-p expr))
             (alias-bind-safe-p name (node-variable-value expr) body))
        (values
         (substitute-aliases body (list (cons name expr)))
@@ -828,7 +819,7 @@ Returns a status keyword and a replacement body. Status is one of:
         (subexpr (node-let-subexpr node)))
     ;; (let ((x e)) x) -> e
     (if (and (null (cdr bindings))
-             (node-variable-p subexpr)
+             (node-local-variable-p subexpr)
              (eq (caar bindings)
                  (node-variable-value subexpr))
              (not (member (caar bindings)

--- a/src/codegen/lawnmower.lisp
+++ b/src/codegen/lawnmower.lisp
@@ -18,7 +18,8 @@ later passes and Lisp compilers see simpler code.")
    #:traverse-with-binding-list)
   (:local-nicknames
    (#:parser #:coalton-impl/parser)
-   (#:tc #:coalton-impl/typechecker))
+   (#:tc #:coalton-impl/typechecker)
+   (#:util #:coalton-impl/util))
   (:export
    #:lawnmow))
 
@@ -150,6 +151,13 @@ push OUTER-BRANCHES into the inner match branches."
               outer-scope-vars))
            (node-match-branches inner-match))))
 
+(defun dynamic-variable-node-p (node)
+  "Return true when NODE reads a dynamically scoped variable."
+  (declare (type node node)
+           (values boolean &optional))
+  (and (node-variable-p node)
+       (util:dynamic-variable-name-p (node-variable-value node))))
+
 (defun alias-binding-target (binding)
   "Return the target variable node for a LET binding of the form (ALIAS TARGET)."
   (declare (type cons binding)
@@ -157,7 +165,8 @@ push OUTER-BRANCHES into the inner match branches."
   (let ((name (car binding))
         (expr (cdr binding)))
     (when (and (node-variable-p expr)
-               (not (eq name (node-variable-value expr))))
+               (not (eq name (node-variable-value expr)))
+               (not (dynamic-variable-node-p expr)))
       expr)))
 
 (defun resolve-alias-target (name aliases)
@@ -401,7 +410,9 @@ The replacement is skipped inside nested binders for the same name."
            (type node value body)
            (values node &optional))
   (multiple-value-bind (count unsafe?) (variable-substitution-info body name value)
-    (if (and (= 1 count) (not unsafe?))
+    (if (and (= 1 count)
+             (not unsafe?)
+             (not (dynamic-variable-node-p value)))
         (substitute-variable-node body name value)
         (make-node-bind
          :type (node-type body)
@@ -779,6 +790,7 @@ Returns a status keyword and a replacement body. Status is one of:
       ;; (bind x y body[x]) -> body[y]
       ((and (node-variable-p expr)
             (not (eq name (node-variable-value expr)))
+            (not (dynamic-variable-node-p expr))
             (alias-bind-safe-p name (node-variable-value expr) body))
        (values
         (substitute-aliases body (list (cons name expr)))

--- a/src/codegen/monomorphize.lisp
+++ b/src/codegen/monomorphize.lisp
@@ -104,7 +104,7 @@ ARGUMENTS some of which are statically known dictionaries."
   "Does NODE represent an instance dictionary?"
   (cond
     ((and
-      (node-variable-p node)
+      (node-global-variable-p node)
       (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t))
      t)
 
@@ -115,7 +115,7 @@ ARGUMENTS some of which are statically known dictionaries."
 
     ((and
       (node-application-p node)
-      (node-variable-p (node-application-rator node))
+      (node-global-variable-p (node-application-rator node))
       (tc:lookup-instance-by-codegen-sym env (node-variable-value (node-application-rator node)) :no-error t))
      t)
 
@@ -285,7 +285,7 @@ recompilation, and also maintains a stack of uncompiled candidates."
                              :rator subexpr
                              :rands (loop :for name :in remaining-names
                                           :for ty :in remaining-types
-                                          :collect (make-node-variable
+                                          :collect (make-node-local-variable
                                                     :type ty
                                                     :value name)))))))
               ;; Underapplication
@@ -320,7 +320,7 @@ propagate dictionaries that have been moved by the hoister."
            (type hash-table resolve-table)
            (values node))
 
-  (unless (node-variable-p node)
+  (unless (node-local-variable-p node)
     (return-from resolve-var node))
 
   (let ((resolved (gethash (node-variable-value node) resolve-table)))
@@ -344,9 +344,6 @@ propagate dictionaries that have been moved by the hoister."
                    (rands (node-rands node)))
 
                (unless name
-                 (return-from validate-candidate nil))
-
-               (when (util:dynamic-variable-name-p name)
                  (return-from validate-candidate nil))
 
                (let ((candidate
@@ -391,9 +388,6 @@ propagate dictionaries that have been moved by the hoister."
                (unless name
                  (return-from apply-candidate nil))
 
-               (when (util:dynamic-variable-name-p name)
-                 (return-from apply-candidate nil))
-
                (let ((candidate (valid-candidate-p
                                  name
                                  (loop :for rand :in rands
@@ -422,13 +416,13 @@ propagate dictionaries that have been moved by the hoister."
                                 :do (setf new-type (tc:function-type-to new-type)))))
 
                    (if (null args)
-                       (make-node-variable
+                       (make-node-global-variable
                         :type new-type
                         :value function-name)
                        (make-node-application
                         :type (node-type node)
                         :properties '()
-                        :rator (make-node-variable
+                        :rator (make-node-global-variable
                                 :type (tc:prepend-function-input-types
                                        (reverse arg-tys)
                                        new-type)

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -204,7 +204,8 @@ arity. TABLE will be mutated with additional entries."
            (type hash-table table)      ; Name -> Integer
            (values node &optional))
   (labels ((rewrite-direct-application (node)
-             (when (node-variable-p (node-application-rator node))
+             (when (typep (node-application-rator node)
+                          '(or node-local-variable node-global-variable))
                (let ((name (node-variable-value (node-application-rator node))))
                  (when (and (gethash name table)
                             (= (gethash name table)
@@ -312,7 +313,7 @@ ENV. Return a new node which is optimized."
            (values boolean &optional))
   (let ((escaped? nil))
     (labels ((tracked-variable-p (node bound-variables)
-               (and (node-variable-p node)
+               (and (node-local-variable-p node)
                     (member (node-variable-value node) variables :test #'eq)
                     (not (member (node-variable-value node)
                                  bound-variables
@@ -336,7 +337,7 @@ ENV. Return a new node which is optimized."
         (traverse-with-binding-list
          body
          (list
-          (action (:after node-variable node bound-variables)
+          (action (:after node-local-variable node bound-variables)
             (when (tracked-variable-p node bound-variables)
               (setf escaped? t))
             (values))
@@ -383,7 +384,7 @@ speaking, the following kinds of transformations happen:
   (let (function args num-params)
     (cond
       ;; Node must be a variable of type function
-      ((node-variable-p node)
+      ((typep node '(or node-local-variable node-global-variable))
        (unless (tc:function-type-p (node-type node))
          (return-from pointfree node))
        (setf function node)
@@ -391,7 +392,8 @@ speaking, the following kinds of transformations happen:
 
       ;; Or an application on a function
       ((node-application-p node)
-       (unless (node-variable-p (node-application-rator node))
+       (unless (typep (node-application-rator node)
+                      '(or node-local-variable node-global-variable))
          (return-from pointfree node))
 
        ;; The application must be on a known function
@@ -408,7 +410,7 @@ speaking, the following kinds of transformations happen:
                            (values boolean))
                   (cond
                     ;; Valid pointfree arguments are instances dictionaries
-                    ((node-variable-p node)
+                    ((node-global-variable-p node)
                      (and (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t) t))
 
                     ;; And expressions that build instance dictionaries
@@ -458,7 +460,7 @@ speaking, the following kinds of transformations happen:
 
            (param-nodes (loop :for name :in param-names
                               :for ty :in param-types
-                              :collect (make-node-variable
+                              :collect (make-node-local-variable
                                         :type ty
                                         :value name)))
 
@@ -485,7 +487,7 @@ speaking, the following kinds of transformations happen:
   (labels ((lift-static-dict (node)
              (unless (and
                       ;; The function is a variable
-                      (node-variable-p (node-application-rator node))
+                      (node-global-variable-p (node-application-rator node))
 
                       ;; The function constructs a typeclass dictionary
                       (tc:lookup-instance-by-codegen-sym
@@ -527,10 +529,10 @@ speaking, the following kinds of transformations happen:
       (action (:after node-abstraction) #'handle-pop-hoist-point)))))
 
 (defun resolve-compount-superclass (node env)
-  (declare (type (or node-application node-direct-application node-variable) node)
+  (declare (type (or node-application node-direct-application node-global-variable) node)
            (type tc:environment env))
 
-  (when (node-variable-p node)
+  (when (node-global-variable-p node)
     (let ((instance (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t)))
       (cond
         ((null instance)
@@ -583,7 +585,7 @@ speaking, the following kinds of transformations happen:
            (handle-static-superclass (node bound-variables)
              (declare (type util:symbol-list bound-variables))
 
-             (unless (or (node-variable-p (node-field-dict node))
+             (unless (or (node-global-variable-p (node-field-dict node))
                          (node-application-p (node-field-dict node))
                          (node-direct-application-p (node-field-dict node)))
                (return-from handle-static-superclass))
@@ -674,7 +676,7 @@ when possible."
                         :node (node-match-expr node)
                         :body (make-node-match
                                :type (node-type node)
-                               :expr (make-node-variable :type (node-type (node-match-expr node)) :value name)
+                               :expr (make-node-local-variable :type (node-type (node-match-expr node)) :value name)
                                :branches (node-match-branches node))))))))))
 
     (traverse

--- a/src/codegen/optimizer.lisp
+++ b/src/codegen/optimizer.lisp
@@ -204,7 +204,8 @@ arity. TABLE will be mutated with additional entries."
            (type hash-table table)      ; Name -> Integer
            (values node &optional))
   (labels ((rewrite-direct-application (node)
-             (when (node-variable-p (node-application-rator node))
+             (when (typep (node-application-rator node)
+                          '(or node-local-variable node-global-variable))
                (let ((name (node-variable-value (node-application-rator node))))
                  (when (and (gethash name table)
                             (= (gethash name table)
@@ -312,7 +313,7 @@ ENV. Return a new node which is optimized."
            (values boolean &optional))
   (let ((escaped? nil))
     (labels ((tracked-variable-p (node bound-variables)
-               (and (node-variable-p node)
+               (and (node-local-variable-p node)
                     (member (node-variable-value node) variables :test #'eq)
                     (not (member (node-variable-value node)
                                  bound-variables
@@ -336,7 +337,7 @@ ENV. Return a new node which is optimized."
         (traverse-with-binding-list
          body
          (list
-          (action (:after node-variable node bound-variables)
+          (action (:after node-local-variable node bound-variables)
             (when (tracked-variable-p node bound-variables)
               (setf escaped? t))
             (values))
@@ -383,7 +384,7 @@ speaking, the following kinds of transformations happen:
   (let (function args num-params)
     (cond
       ;; Node must be a variable of type function
-      ((node-variable-p node)
+      ((typep node '(or node-local-variable node-global-variable))
        (unless (tc:function-type-p (node-type node))
          (return-from pointfree node))
        (setf function node)
@@ -391,7 +392,8 @@ speaking, the following kinds of transformations happen:
 
       ;; Or an application on a function
       ((node-application-p node)
-       (unless (node-variable-p (node-application-rator node))
+       (unless (typep (node-application-rator node)
+                      '(or node-local-variable node-global-variable))
          (return-from pointfree node))
 
        ;; The application must be on a known function
@@ -408,7 +410,7 @@ speaking, the following kinds of transformations happen:
                            (values boolean))
                   (cond
                     ;; Valid pointfree arguments are instances dictionaries
-                    ((node-variable-p node)
+                    ((node-global-variable-p node)
                      (and (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t) t))
 
                     ;; And expressions that build instance dictionaries
@@ -458,7 +460,7 @@ speaking, the following kinds of transformations happen:
 
            (param-nodes (loop :for name :in param-names
                               :for ty :in param-types
-                              :collect (make-node-variable
+                              :collect (make-node-local-variable
                                         :type ty
                                         :value name)))
 
@@ -485,7 +487,7 @@ speaking, the following kinds of transformations happen:
   (labels ((lift-static-dict (node)
              (unless (and
                       ;; The function is a variable
-                      (node-variable-p (node-application-rator node))
+                      (node-global-variable-p (node-application-rator node))
 
                       ;; The function constructs a typeclass dictionary
                       (tc:lookup-instance-by-codegen-sym
@@ -527,10 +529,10 @@ speaking, the following kinds of transformations happen:
       (action (:after node-abstraction) #'handle-pop-hoist-point)))))
 
 (defun resolve-compount-superclass (node env)
-  (declare (type (or node-application node-direct-application node-variable) node)
+  (declare (type (or node-application node-direct-application node-global-variable) node)
            (type tc:environment env))
 
-  (when (node-variable-p node)
+  (when (node-global-variable-p node)
     (let ((instance (tc:lookup-instance-by-codegen-sym env (node-variable-value node) :no-error t)))
       (cond
         ((null instance)
@@ -583,7 +585,7 @@ speaking, the following kinds of transformations happen:
            (handle-static-superclass (node bound-variables)
              (declare (type util:symbol-list bound-variables))
 
-             (unless (or (node-variable-p (node-field-dict node))
+             (unless (or (node-global-variable-p (node-field-dict node))
                          (node-application-p (node-field-dict node))
                          (node-direct-application-p (node-field-dict node)))
                (return-from handle-static-superclass))
@@ -670,7 +672,7 @@ when possible."
                         :node (node-match-expr node)
                         :body (make-node-match
                                :type (node-type node)
-                               :expr (make-node-variable :type (node-type (node-match-expr node)) :value name)
+                               :expr (make-node-local-variable :type (node-type (node-match-expr node)) :value name)
                                :branches (node-match-branches node))))))))))
 
     (traverse

--- a/src/codegen/resolve-instance-synthesized.lisp
+++ b/src/codegen/resolve-instance-synthesized.lisp
@@ -75,7 +75,7 @@
     (make-node-application
      :type (pred-type pred env)
      :properties '()
-     :rator (make-node-variable
+     :rator (make-node-global-variable
              :type (tc:make-function-type (node-type method-node) (pred-type pred env))
              :value (tc:ty-class-codegen-sym runtime-repr-class))
      :rands (list method-node)

--- a/src/codegen/resolve-instance.lisp
+++ b/src/codegen/resolve-instance.lisp
@@ -94,7 +94,7 @@
 
          (if (null subdicts)
              ;; If the instance has no superclasses return a variable
-             (make-node-variable
+             (make-node-global-variable
               :type (pred-type pred env)
               :value (tc:ty-class-instance-codegen-sym instance))
 
@@ -102,7 +102,7 @@
              (make-node-application
               :type (pred-type pred env)
               :properties '()
-              :rator (make-node-variable
+              :rator (make-node-global-variable
                       :type (tc:make-function-type* arg-types (pred-type pred env))
                       :value (tc:ty-class-instance-codegen-sym instance))
               :rands subdicts))))
@@ -155,7 +155,7 @@
            (values list &optional))
 
   (when (matching-context-predicate-p pred ctx-pred)
-    (return-from lookup-pred (list (make-node-variable
+    (return-from lookup-pred (list (make-node-global-variable
                                     :type (tc:make-function-type
                                            (pred-type sub-pred env)
                                            (pred-type pred env))
@@ -165,7 +165,7 @@
 
     (when superclass-ret
       (cons
-       (make-node-variable
+       (make-node-global-variable
         :type (tc:make-function-type
                (pred-type sub-pred env)
                (pred-type ctx-pred env))
@@ -175,14 +175,14 @@
 (defun lookup-pred-base (pred ctx-pred ctx-name env)
   (when (matching-context-predicate-p pred ctx-pred)
     (return-from lookup-pred-base
-      (list (make-node-variable
+      (list (make-node-local-variable
              :type (pred-type pred env)
              :value ctx-name))))
 
   (let ((superclass-ret (superclass-accessors pred ctx-pred env)))
     (when superclass-ret
       (cons
-       (make-node-variable
+       (make-node-local-variable
         :type (pred-type ctx-pred env)
         :value ctx-name)
        superclass-ret))))

--- a/src/codegen/specializer.lisp
+++ b/src/codegen/specializer.lisp
@@ -29,9 +29,6 @@
                (unless rator-name
                  (return-from apply-specialization))
 
-               (when (util:dynamic-variable-name-p rator-name)
-                 (return-from apply-specialization))
-
                (let ((from-ty (tc:lookup-value-type env rator-name :no-error t)))
                  (unless from-ty
                    (return-from apply-specialization))
@@ -77,7 +74,7 @@
                              (tc:specialization-entry-to specialization)))
                    (cond
                      ((= num-preds (length (node-rands node)))
-                      (make-node-variable
+                      (make-node-global-variable
                        :type rator-type
                        :value (tc:specialization-entry-to specialization)))
 
@@ -85,7 +82,7 @@
                      (make-node-application
                        :type (node-type node)
                        :properties (node-properties node)
-                       :rator (make-node-variable
+                       :rator (make-node-global-variable
                                :type rator-type
                                :value (tc:specialization-entry-to specialization))
                        :rands (subseq (node-rands node) num-preds)

--- a/src/codegen/specializer.lisp
+++ b/src/codegen/specializer.lisp
@@ -29,9 +29,6 @@
                (unless rator-name
                  (return-from apply-specialization))
 
-               (when (util:dynamic-variable-name-p rator-name)
-                 (return-from apply-specialization))
-
                (let ((from-ty (tc:lookup-value-type env rator-name :no-error t)))
                  (unless from-ty
                    (return-from apply-specialization))
@@ -71,7 +68,7 @@
                              (tc:specialization-entry-to specialization)))
                    (cond
                      ((= num-preds (length (node-rands node)))
-                      (make-node-variable
+                      (make-node-global-variable
                        :type rator-type
                        :value (tc:specialization-entry-to specialization)))
 
@@ -79,7 +76,7 @@
                      (make-node-application
                        :type (node-type node)
                        :properties (node-properties node)
-                       :rator (make-node-variable
+                       :rator (make-node-global-variable
                                :type rator-type
                                :value (tc:specialization-entry-to specialization))
                        :rands (subseq (node-rands node) num-preds)

--- a/src/codegen/transformations.lisp
+++ b/src/codegen/transformations.lisp
@@ -10,6 +10,7 @@
   (:export
    #:rename-type-variables
    #:node-variables
+   #:node-dynamic-variables
    #:node-free-p))
 
 (in-package #:coalton-impl/codegen/transformations)
@@ -91,23 +92,40 @@ both CL namespaces appearing in `node`"
            (type boolean variable-namespace-only)
            (values parser:identifier-list &optional))
   (let ((node-vars nil))
+    (flet ((collect-variable (node)
+             (setf node-vars
+                   (adjoin (node-variable-value node) node-vars))
+             (values)))
+      (traverse
+       node
+       (list
+        (action (:after node-local-variable) #'collect-variable)
+        (action (:after node-global-variable) #'collect-variable)
+        (action (:after node-dynamic-variable) #'collect-variable)
+        (action (:after node-direct-application node)
+          (unless variable-namespace-only
+            (setf node-vars
+                  (adjoin (node-direct-application-rator node) node-vars)))
+          (values))
+        (action (:after node-lisp node)
+          (alexandria:unionf node-vars
+                             (mapcar #'cdr (node-lisp-vars node)))
+          (values)))))
+    node-vars))
+
+(defun node-dynamic-variables (node)
+  "Return a deduplicated list of dynamically scoped variables read by NODE."
+  (declare (type node node)
+           (values parser:identifier-list &optional))
+  (let ((dynamic-vars nil))
     (traverse
      node
      (list
-      (action (:after node-variable node)
-        (setf node-vars
-              (adjoin (node-variable-value node) node-vars))
-        (values))
-      (action (:after node-direct-application node)
-        (unless variable-namespace-only
-          (setf node-vars
-                (adjoin (node-direct-application-rator node) node-vars)))
-        (values))
-      (action (:after node-lisp node)
-        (alexandria:unionf node-vars
-                           (mapcar #'cdr (node-lisp-vars node)))
+      (action (:after node-dynamic-variable node)
+        (setf dynamic-vars
+              (adjoin (node-variable-value node) dynamic-vars))
         (values))))
-    node-vars))
+    dynamic-vars))
 
 (defun node-free-p (node bound-variables)
   "Return true if every variable in `node` is free with respect to

--- a/src/codegen/transformations.lisp
+++ b/src/codegen/transformations.lisp
@@ -10,6 +10,7 @@
   (:export
    #:rename-type-variables
    #:node-variables
+   #:node-dynamic-variables
    #:node-free-p))
 
 (in-package #:coalton-impl/codegen/transformations)
@@ -89,23 +90,40 @@ both CL namespaces appearing in `node`"
            (type boolean variable-namespace-only)
            (values parser:identifier-list &optional))
   (let ((node-vars nil))
+    (flet ((collect-variable (node)
+             (setf node-vars
+                   (adjoin (node-variable-value node) node-vars))
+             (values)))
+      (traverse
+       node
+       (list
+        (action (:after node-local-variable) #'collect-variable)
+        (action (:after node-global-variable) #'collect-variable)
+        (action (:after node-dynamic-variable) #'collect-variable)
+        (action (:after node-direct-application node)
+          (unless variable-namespace-only
+            (setf node-vars
+                  (adjoin (node-direct-application-rator node) node-vars)))
+          (values))
+        (action (:after node-lisp node)
+          (alexandria:unionf node-vars
+                             (mapcar #'cdr (node-lisp-vars node)))
+          (values)))))
+    node-vars))
+
+(defun node-dynamic-variables (node)
+  "Return a deduplicated list of dynamically scoped variables read by NODE."
+  (declare (type node node)
+           (values parser:identifier-list &optional))
+  (let ((dynamic-vars nil))
     (traverse
      node
      (list
-      (action (:after node-variable node)
-        (setf node-vars
-              (adjoin (node-variable-value node) node-vars))
-        (values))
-      (action (:after node-direct-application node)
-        (unless variable-namespace-only
-          (setf node-vars
-                (adjoin (node-direct-application-rator node) node-vars)))
-        (values))
-      (action (:after node-lisp node)
-        (alexandria:unionf node-vars
-                           (mapcar #'cdr (node-lisp-vars node)))
+      (action (:after node-dynamic-variable node)
+        (setf dynamic-vars
+              (adjoin (node-variable-value node) dynamic-vars))
         (values))))
-    node-vars))
+    dynamic-vars))
 
 (defun node-free-p (node bound-variables)
   "Return true if every variable in `node` is free with respect to

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -32,6 +32,20 @@
 
 (in-package #:coalton-impl/codegen/translate-expression)
 
+(defun make-translated-variable (type name env)
+  "Construct the codegen variable reference denoted by a typechecker name."
+  (declare (type tc:ty type)
+           (type symbol name)
+           (type tc:environment env)
+           (values node-variable &optional))
+  (cond
+    ((util:dynamic-variable-name-p name)
+     (make-node-dynamic-variable :type type :value name))
+    ((tc:lookup-function env name :no-error t)
+     (make-node-global-variable :type type :value name))
+    (t
+     (make-node-local-variable :type type :value name))))
+
 (defun physical-callable-type (type)
   (declare (type tc:ty type)
            (values tc:ty &optional))
@@ -76,10 +90,10 @@ preserve a nested function-valued result."
       (let* ((keyword (tc:keyword-ty-entry-keyword entry))
              (value-var (gensym "KEYWORD-ARG-"))
              (supplied-p-var (gensym "KEYWORD-SUPPLIED-P-"))
-             (value-node (make-node-variable
+             (value-node (make-node-local-variable
                           :type (tc:keyword-ty-entry-type entry)
                           :value value-var))
-             (supplied-p-node (make-node-variable
+             (supplied-p-node (make-node-local-variable
                                :type tc:*boolean-type*
                                :value supplied-p-var)))
         (push (make-keyword-param
@@ -129,17 +143,17 @@ preserve a nested function-valued result."
                   (make-node-application
                    :type (tc:function-return-type visible-type)
                    :properties '()
-                   :rator (make-node-variable
+                   :rator (make-node-local-variable
                            :type (node-type inner-node)
                            :value function-var)
                    :rands
                    (append
                     (loop :for (var . hidden-node) :in hidden-bindings
-                          :collect (make-node-variable
+                          :collect (make-node-local-variable
                                     :type (node-type hidden-node)
                                     :value var))
                     (loop :for (var . input-type) :in visible-bindings
-                          :collect (make-node-variable
+                          :collect (make-node-local-variable
                                     :type input-type
                                     :value var)))
                    :keyword-rands keyword-rands)))))
@@ -199,12 +213,13 @@ preserve a nested function-valued result."
     (make-node-application
      :type result-type
      :properties '()
-     :rator (make-node-variable
-             :type (physical-callable-type
-                    (prepend-codegen-hidden-input-types
-                     dict-types
-                     (tc:qualified-ty-type qual-ty)))
-             :value (tc:node-variable-name expr))
+     :rator (make-translated-variable
+             (physical-callable-type
+              (prepend-codegen-hidden-input-types
+               dict-types
+               (tc:qualified-ty-type qual-ty)))
+             (tc:node-variable-name expr)
+             env)
      :rands (append dicts rands)
      :keyword-rands keyword-rands)))
 
@@ -410,7 +425,7 @@ needs to synthesize those trailing parameters explicitly."
          (eta-rands
            (loop :for var :in eta-vars
                  :for ty :in eta-arg-types
-                 :collect (make-node-variable
+                 :collect (make-node-local-variable
                            :type ty
                            :value var))))
     (cond
@@ -625,7 +640,7 @@ Returns a `node'.")
                  (make-node-application
                   :type (tc:qualified-ty-type qual-ty)
                   :properties '()
-                  :rator (make-node-variable
+                  :rator (make-node-global-variable
                           :type (tc:make-function-type*
                                  (list
                                   (pred-type num-pred env)
@@ -698,11 +713,11 @@ Returns a `node'.")
 
           (if (tc:type-entry-newtype type-entry)
               ;; If the struct is a newtype, then return 'id' as the accessor
-              (make-node-variable
+              (make-node-global-variable
                :type ty
                :value (util:find-symbol "ID" "COALTON/FUNCTIONS"))
 
-              (make-node-variable
+              (make-node-global-variable
                :type ty
                :value (alexandria:format-symbol
                        (symbol-package (tc:tycon-name from-ty))
@@ -825,7 +840,7 @@ Returns a `node'.")
                 :do (setf inner
                           (make-node-match
                            :type (node-type inner)
-                           :expr (make-node-variable
+                           :expr (make-node-local-variable
                                   :type (tc:qualified-ty-type (tc:pattern-type pattern))
                                   :value name)
                            :branches
@@ -1082,7 +1097,7 @@ Returns a `node'.")
            (rev-children (reverse (tc:node-or-nodes expr))))
 
       (if (null rev-children)
-          (make-node-variable
+          (make-node-global-variable
            :type tc:*boolean-type*
            :value false-value)
           (loop :with out-node := (translate-expression (car rev-children)
@@ -1098,7 +1113,7 @@ Returns a `node'.")
                                                :type tc:*boolean-type*
                                                :name true-value
                                                :patterns nil)
-                                     :body (make-node-variable
+                                     :body (make-node-global-variable
                                             :type tc:*boolean-type*
                                             :value true-value))
                                     (make-match-branch
@@ -1120,7 +1135,7 @@ Returns a `node'.")
            (rev-children (reverse (tc:node-and-nodes expr))))
 
       (if (null rev-children)
-          (make-node-variable
+          (make-node-global-variable
            :type tc:*boolean-type*
            :value true-value)
           (loop :with out-node := (translate-expression (car rev-children)
@@ -1136,7 +1151,7 @@ Returns a `node'.")
                                                :type tc:*boolean-type*
                                                :name false-value
                                                :patterns nil)
-                                     :body (make-node-variable
+                                     :body (make-node-global-variable
                                             :type tc:*boolean-type*
                                             :value false-value))
                                     (make-match-branch
@@ -1395,7 +1410,7 @@ Returns a `node'.")
                            (make-node-application
                             :type (node-type out-node)
                             :properties '()
-                            :rator (make-node-variable
+                            :rator (make-node-global-variable
                                     :type (tc:make-function-type* ; (Monad :m => m :a -> (:a -> :m :b) -> :m :b)
                                            (list (pred-type pred env)
                                                  (tc:qualified-ty-type (tc:node-type (tc:node-do-bind-expr elem)))
@@ -1410,7 +1425,7 @@ Returns a `node'.")
                                      :vars (list var-name)
                                      :subexpr (make-node-match
                                                :type (node-type out-node)
-                                               :expr (make-node-variable
+                                               :expr (make-node-local-variable
                                                       :type var-type
                                                       :value var-name)
                                                :branches (list
@@ -1432,7 +1447,7 @@ Returns a `node'.")
                            (make-node-application
                             :type (node-type out-node)
                             :properties '()
-                            :rator (make-node-variable
+                            :rator (make-node-global-variable
                                     :type (tc:make-function-type* ; (Monad :m => m :a -> (:a -> :m :b) -> :m :b)
                                            (list (pred-type pred env)
                                                  (tc:qualified-ty-type (tc:node-type elem))
@@ -1460,11 +1475,11 @@ Returns a `node'.")
      :subexpr
      (make-node-application
       :type tc:*boolean-type* :properties nil
-      :rator (make-node-variable
+      :rator (make-node-global-variable
               :type (tc:make-function-type* (list (pred-type eq-pred env) type type) tc:*boolean-type*)
               :value (util:find-symbol "==" "COALTON/CLASSES"))
       :rands (list (resolve-dict eq-pred ctx env)
-                   (make-node-variable :type type :value arg)
+                   (make-node-local-variable :type type :value arg)
                    (translate-expression
                     (tc:make-node-integer-literal
                      :type (tc:qualify nil type)
@@ -1541,9 +1556,10 @@ dictionaries applied."
          (inner-node
            (typecase expr
              (tc:node-variable
-              (make-node-variable
-               :type var-type
-               :value (tc:node-variable-name expr)))
+              (make-translated-variable
+               var-type
+               (tc:node-variable-name expr)
+               env))
              (t
               (translate-expression expr ctx env)))))
     (cond
@@ -1556,9 +1572,10 @@ dictionaries applied."
                  (make-node-application
                   :type (tc:qualified-ty-type qual-ty)
                   :properties '()
-                  :rator (make-node-variable
-                          :type (tc:make-function-type* nil (tc:qualified-ty-type qual-ty))
-                          :value (tc:node-variable-name expr))
+                  :rator (make-translated-variable
+                          (tc:make-function-type* nil (tc:qualified-ty-type qual-ty))
+                          (tc:node-variable-name expr)
+                          env)
                   :rands nil
                   :keyword-rands nil)
                  inner-node)
@@ -1586,7 +1603,7 @@ dictionaries applied."
 
         :do (setf inner (make-node-match
                          :type (node-type inner)
-                         :expr (make-node-variable
+                         :expr (make-node-local-variable
                                 :type (tc:qualified-ty-type (tc:pattern-type pattern))
                                 :value name)
                          :branches

--- a/src/codegen/translate-expression.lisp
+++ b/src/codegen/translate-expression.lisp
@@ -32,6 +32,20 @@
 
 (in-package #:coalton-impl/codegen/translate-expression)
 
+(defun make-translated-variable (type name env)
+  "Construct the codegen variable reference denoted by a typechecker name."
+  (declare (type tc:ty type)
+           (type symbol name)
+           (type tc:environment env)
+           (values node-variable &optional))
+  (cond
+    ((util:dynamic-variable-name-p name)
+     (make-node-dynamic-variable :type type :value name))
+    ((tc:lookup-function env name :no-error t)
+     (make-node-global-variable :type type :value name))
+    (t
+     (make-node-local-variable :type type :value name))))
+
 (defun physical-callable-type (type)
   (declare (type tc:ty type)
            (values tc:ty &optional))
@@ -76,10 +90,10 @@ preserve a nested function-valued result."
       (let* ((keyword (tc:keyword-ty-entry-keyword entry))
              (value-var (gensym "KEYWORD-ARG-"))
              (supplied-p-var (gensym "KEYWORD-SUPPLIED-P-"))
-             (value-node (make-node-variable
+             (value-node (make-node-local-variable
                           :type (tc:keyword-ty-entry-type entry)
                           :value value-var))
-             (supplied-p-node (make-node-variable
+             (supplied-p-node (make-node-local-variable
                                :type tc:*boolean-type*
                                :value supplied-p-var)))
         (push (make-keyword-param
@@ -129,17 +143,17 @@ preserve a nested function-valued result."
                   (make-node-application
                    :type (tc:function-return-type visible-type)
                    :properties '()
-                   :rator (make-node-variable
+                   :rator (make-node-local-variable
                            :type (node-type inner-node)
                            :value function-var)
                    :rands
                    (append
                     (loop :for (var . hidden-node) :in hidden-bindings
-                          :collect (make-node-variable
+                          :collect (make-node-local-variable
                                     :type (node-type hidden-node)
                                     :value var))
                     (loop :for (var . input-type) :in visible-bindings
-                          :collect (make-node-variable
+                          :collect (make-node-local-variable
                                     :type input-type
                                     :value var)))
                    :keyword-rands keyword-rands)))))
@@ -199,12 +213,13 @@ preserve a nested function-valued result."
     (make-node-application
      :type result-type
      :properties '()
-     :rator (make-node-variable
-             :type (physical-callable-type
-                    (prepend-codegen-hidden-input-types
-                     dict-types
-                     (tc:qualified-ty-type qual-ty)))
-             :value (tc:node-variable-name expr))
+     :rator (make-translated-variable
+             (physical-callable-type
+              (prepend-codegen-hidden-input-types
+               dict-types
+               (tc:qualified-ty-type qual-ty)))
+             (tc:node-variable-name expr)
+             env)
      :rands (append dicts rands)
      :keyword-rands keyword-rands)))
 
@@ -410,7 +425,7 @@ needs to synthesize those trailing parameters explicitly."
          (eta-rands
            (loop :for var :in eta-vars
                  :for ty :in eta-arg-types
-                 :collect (make-node-variable
+                 :collect (make-node-local-variable
                            :type ty
                            :value var))))
     (cond
@@ -623,7 +638,7 @@ Returns a `node'.")
                  (make-node-application
                   :type (tc:qualified-ty-type qual-ty)
                   :properties '()
-                  :rator (make-node-variable
+                  :rator (make-node-global-variable
                           :type (tc:make-function-type*
                                  (list
                                   (pred-type num-pred env)
@@ -696,11 +711,11 @@ Returns a `node'.")
 
           (if (tc:type-entry-newtype type-entry)
               ;; If the struct is a newtype, then return 'id' as the accessor
-              (make-node-variable
+              (make-node-global-variable
                :type ty
                :value (util:find-symbol "ID" "COALTON/FUNCTIONS"))
 
-              (make-node-variable
+              (make-node-global-variable
                :type ty
                :value (alexandria:format-symbol
                        (symbol-package (tc:tycon-name from-ty))
@@ -823,7 +838,7 @@ Returns a `node'.")
                 :do (setf inner
                           (make-node-match
                            :type (node-type inner)
-                           :expr (make-node-variable
+                           :expr (make-node-local-variable
                                   :type (tc:qualified-ty-type (tc:pattern-type pattern))
                                   :value name)
                            :branches
@@ -1080,7 +1095,7 @@ Returns a `node'.")
            (rev-children (reverse (tc:node-or-nodes expr))))
 
       (if (null rev-children)
-          (make-node-variable
+          (make-node-global-variable
            :type tc:*boolean-type*
            :value false-value)
           (loop :with out-node := (translate-expression (car rev-children)
@@ -1096,7 +1111,7 @@ Returns a `node'.")
                                                :type tc:*boolean-type*
                                                :name true-value
                                                :patterns nil)
-                                     :body (make-node-variable
+                                     :body (make-node-global-variable
                                             :type tc:*boolean-type*
                                             :value true-value))
                                     (make-match-branch
@@ -1118,7 +1133,7 @@ Returns a `node'.")
            (rev-children (reverse (tc:node-and-nodes expr))))
 
       (if (null rev-children)
-          (make-node-variable
+          (make-node-global-variable
            :type tc:*boolean-type*
            :value true-value)
           (loop :with out-node := (translate-expression (car rev-children)
@@ -1134,7 +1149,7 @@ Returns a `node'.")
                                                :type tc:*boolean-type*
                                                :name false-value
                                                :patterns nil)
-                                     :body (make-node-variable
+                                     :body (make-node-global-variable
                                             :type tc:*boolean-type*
                                             :value false-value))
                                     (make-match-branch
@@ -1393,7 +1408,7 @@ Returns a `node'.")
                            (make-node-application
                             :type (node-type out-node)
                             :properties '()
-                            :rator (make-node-variable
+                            :rator (make-node-global-variable
                                     :type (tc:make-function-type* ; (Monad :m => m :a -> (:a -> :m :b) -> :m :b)
                                            (list (pred-type pred env)
                                                  (tc:qualified-ty-type (tc:node-type (tc:node-do-bind-expr elem)))
@@ -1408,7 +1423,7 @@ Returns a `node'.")
                                      :vars (list var-name)
                                      :subexpr (make-node-match
                                                :type (node-type out-node)
-                                               :expr (make-node-variable
+                                               :expr (make-node-local-variable
                                                       :type var-type
                                                       :value var-name)
                                                :branches (list
@@ -1430,7 +1445,7 @@ Returns a `node'.")
                            (make-node-application
                             :type (node-type out-node)
                             :properties '()
-                            :rator (make-node-variable
+                            :rator (make-node-global-variable
                                     :type (tc:make-function-type* ; (Monad :m => m :a -> (:a -> :m :b) -> :m :b)
                                            (list (pred-type pred env)
                                                  (tc:qualified-ty-type (tc:node-type elem))
@@ -1514,9 +1529,10 @@ dictionaries applied."
          (inner-node
            (typecase expr
              (tc:node-variable
-              (make-node-variable
-               :type var-type
-               :value (tc:node-variable-name expr)))
+              (make-translated-variable
+               var-type
+               (tc:node-variable-name expr)
+               env))
              (t
               (translate-expression expr ctx env)))))
     (cond
@@ -1529,9 +1545,10 @@ dictionaries applied."
                  (make-node-application
                   :type (tc:qualified-ty-type qual-ty)
                   :properties '()
-                  :rator (make-node-variable
-                          :type (tc:make-function-type* nil (tc:qualified-ty-type qual-ty))
-                          :value (tc:node-variable-name expr))
+                  :rator (make-translated-variable
+                          (tc:make-function-type* nil (tc:qualified-ty-type qual-ty))
+                          (tc:node-variable-name expr)
+                          env)
                   :rands nil
                   :keyword-rands nil)
                  inner-node)
@@ -1559,7 +1576,7 @@ dictionaries applied."
 
         :do (setf inner (make-node-match
                          :type (node-type inner)
-                         :expr (make-node-variable
+                         :expr (make-node-local-variable
                                 :type (tc:qualified-ty-type (tc:pattern-type pattern))
                                 :value name)
                          :branches

--- a/src/codegen/translate-instance.lisp
+++ b/src/codegen/translate-instance.lisp
@@ -29,7 +29,7 @@
            (type tc:ty qual-type visible-type)
            (type list dict-nodes)
            (values node &optional))
-  (let ((rator (make-node-variable
+  (let ((rator (make-node-global-variable
                 :type qual-type
                 :value qual-sym)))
     (if (tc:function-type-p visible-type)
@@ -91,7 +91,7 @@
          (ctx-nodes
            (loop :for (pred . ctx-var) :in ctx
                  :for ctx-ty := (pred-type pred env)
-                 :collect (make-node-variable
+                 :collect (make-node-local-variable
                            :type ctx-ty
                            :value ctx-var)))
 
@@ -135,7 +135,7 @@
              ((null ctx)
               (loop :for sym :in method-codegen-syms
                     :for ty :in method-ty
-                    :collect (make-node-variable
+                    :collect (make-node-global-variable
                               :type ty
                               :value sym)))
              (t
@@ -151,7 +151,7 @@
 
          ;; Initial node
          (var-node
-           (make-node-variable
+           (make-node-global-variable
             :type (tc:merge-function-input-types
                    (append
                     superclass-ty

--- a/src/codegen/traverse.lisp
+++ b/src/codegen/traverse.lisp
@@ -316,9 +316,9 @@ Note that the wrapped traversal pipes the node through three actions
 corresponding to its original class, so it is important to not define
 any node-specific actions that will run after another action which may
 return a node of a different type. For example, if there is an action
-on `:traverse 'node-variable` to substitute variables with arbitrary
+on `:traverse 'node-local-variable` to substitute variables with arbitrary
 other nodes, then it would be inappropriate to also define an action
-`:after 'node-variable`."
+`:after 'node-local-variable`."
   (declare (type node        initial-node)
            (type action-list custom-actions)
            (type list        initial-args)
@@ -433,15 +433,21 @@ bound at the given point."
                          :collect (cons name (funcall *traverse* node new-bound-variables)))
          :subexpr (funcall *traverse* (node-let-subexpr node) new-bound-variables))))
     (action (:traverse node-dynamic-let node bound-variables)
-      (make-node-dynamic-let
-       :type (node-type node)
-       :bindings (loop :for binding :in (node-dynamic-let-bindings node)
-                       :collect (make-node-dynamic-binding
-                                 :name (node-dynamic-binding-name binding)
-                                 :value (funcall *traverse*
-                                                 (node-dynamic-binding-value binding)
-                                                 bound-variables)))
-       :subexpr (funcall *traverse* (node-dynamic-let-subexpr node) bound-variables)))
+      (let ((new-bound-variables
+              (append (mapcar #'node-dynamic-binding-name
+                              (node-dynamic-let-bindings node))
+                      bound-variables)))
+        (make-node-dynamic-let
+         :type (node-type node)
+         :bindings (loop :for binding :in (node-dynamic-let-bindings node)
+                         :collect (make-node-dynamic-binding
+                                   :name (node-dynamic-binding-name binding)
+                                   :value (funcall *traverse*
+                                                   (node-dynamic-binding-value binding)
+                                                   bound-variables)))
+         :subexpr (funcall *traverse*
+                           (node-dynamic-let-subexpr node)
+                           new-bound-variables))))
     (action (:traverse node-match node bound-variables)
       (make-node-match
        :type (node-type node)

--- a/src/codegen/traverse.lisp
+++ b/src/codegen/traverse.lisp
@@ -313,9 +313,9 @@ Note that the wrapped traversal pipes the node through three actions
 corresponding to its original class, so it is important to not define
 any node-specific actions that will run after another action which may
 return a node of a different type. For example, if there is an action
-on `:traverse 'node-variable` to substitute variables with arbitrary
+on `:traverse 'node-local-variable` to substitute variables with arbitrary
 other nodes, then it would be inappropriate to also define an action
-`:after 'node-variable`."
+`:after 'node-local-variable`."
   (declare (type node        initial-node)
            (type action-list custom-actions)
            (type list        initial-args)
@@ -430,15 +430,21 @@ bound at the given point."
                          :collect (cons name (funcall *traverse* node new-bound-variables)))
          :subexpr (funcall *traverse* (node-let-subexpr node) new-bound-variables))))
     (action (:traverse node-dynamic-let node bound-variables)
-      (make-node-dynamic-let
-       :type (node-type node)
-       :bindings (loop :for binding :in (node-dynamic-let-bindings node)
-                       :collect (make-node-dynamic-binding
-                                 :name (node-dynamic-binding-name binding)
-                                 :value (funcall *traverse*
-                                                 (node-dynamic-binding-value binding)
-                                                 bound-variables)))
-       :subexpr (funcall *traverse* (node-dynamic-let-subexpr node) bound-variables)))
+      (let ((new-bound-variables
+              (append (mapcar #'node-dynamic-binding-name
+                              (node-dynamic-let-bindings node))
+                      bound-variables)))
+        (make-node-dynamic-let
+         :type (node-type node)
+         :bindings (loop :for binding :in (node-dynamic-let-bindings node)
+                         :collect (make-node-dynamic-binding
+                                   :name (node-dynamic-binding-name binding)
+                                   :value (funcall *traverse*
+                                                   (node-dynamic-binding-value binding)
+                                                   bound-variables)))
+         :subexpr (funcall *traverse*
+                           (node-dynamic-let-subexpr node)
+                           new-bound-variables))))
     (action (:traverse node-match node bound-variables)
       (make-node-match
        :type (node-type node)

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -942,6 +942,14 @@ If the attribute is not unique, or a repr attribute is present, signal a parse e
       ((:monomorphize) monomorphize)
       ((:inline) inline))))
 
+(defun forbid-inline-dynamic-variable (inline name)
+  "Signal a parse error when INLINE targets the dynamic variable NAME."
+  (when (and inline
+             (util:dynamic-variable-name-p name))
+    (parse-error "Invalid target for inline attribute"
+                 (source:note inline
+                              "dynamic variables cannot be declared inline"))))
+
 (defun forbid-attributes (attributes form source)
   "If ATTRIBUTES is non-zero length, signal a parse error using FORM and SOURCE for location context."
   (unless (zerop (length attributes))
@@ -1020,6 +1028,9 @@ If the parsed form is an attribute (e.g., repr or monomorphize), add it to to AT
      (let* ((define (parse-define form source))
             (monomorphize (consume-optimize-attribute :monomorphize attributes define "when parsing define"))
             (inline (consume-optimize-attribute :inline attributes define "when parsing define")))
+       (forbid-inline-dynamic-variable
+        inline
+        (node-variable-name (toplevel-define-name define)))
        (setf (toplevel-define-monomorphize define) monomorphize)
        (setf (toplevel-define-inline define) inline)
        (setf (fill-pointer attributes) 0)
@@ -1030,6 +1041,9 @@ If the parsed form is an attribute (e.g., repr or monomorphize), add it to to AT
      (let* ((declare (parse-declare form source))
             (monomorphize (consume-optimize-attribute :monomorphize attributes declare "when parsing declare"))
             (inline (consume-optimize-attribute :inline attributes declare "when parsing declare")))
+       (forbid-inline-dynamic-variable
+        inline
+        (identifier-src-name (toplevel-declare-name declare)))
        (setf (toplevel-declare-monomorphize declare) monomorphize)
        (setf (toplevel-declare-inline declare) inline)
        (setf (fill-pointer attributes) 0)

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -931,6 +931,14 @@ If the attribute is not unique, or a repr attribute is present, signal a parse e
       ((:monomorphize) monomorphize)
       ((:inline) inline))))
 
+(defun forbid-inline-dynamic-variable (inline name)
+  "Signal a parse error when INLINE targets the dynamic variable NAME."
+  (when (and inline
+             (util:dynamic-variable-name-p name))
+    (parse-error "Invalid target for inline attribute"
+                 (source:note inline
+                              "dynamic variables cannot be declared inline"))))
+
 (defun forbid-attributes (attributes form source)
   "If ATTRIBUTES is non-zero length, signal a parse error using FORM and SOURCE for location context."
   (unless (zerop (length attributes))
@@ -1001,6 +1009,9 @@ If the parsed form is an attribute (e.g., repr or monomorphize), add it to to AT
      (let* ((define (parse-define form source))
             (monomorphize (consume-optimize-attribute :monomorphize attributes define "when parsing define"))
             (inline (consume-optimize-attribute :inline attributes define "when parsing define")))
+       (forbid-inline-dynamic-variable
+        inline
+        (node-variable-name (toplevel-define-name define)))
        (setf (toplevel-define-monomorphize define) monomorphize)
        (setf (toplevel-define-inline define) inline)
        (setf (fill-pointer attributes) 0)
@@ -1011,6 +1022,9 @@ If the parsed form is an attribute (e.g., repr or monomorphize), add it to to AT
      (let* ((declare (parse-declare form source))
             (monomorphize (consume-optimize-attribute :monomorphize attributes declare "when parsing declare"))
             (inline (consume-optimize-attribute :inline attributes declare "when parsing declare")))
+       (forbid-inline-dynamic-variable
+        inline
+        (identifier-src-name (toplevel-declare-name declare)))
        (setf (toplevel-declare-monomorphize declare) monomorphize)
        (setf (toplevel-declare-inline declare) inline)
        (setf (fill-pointer attributes) 0)

--- a/tests/inliner-tests.ct
+++ b/tests/inliner-tests.ct
@@ -494,7 +494,10 @@
 (defun direct-variable-rand-call-to-p (node name)
   (and (typep node '(or ast:node-application ast:node-direct-application))
        (eq (ast:node-rator-name node) name)
-       (every #'ast:node-variable-p (ast:node-rands node))))
+       (every (lambda (rand)
+                (typep rand '(or ast:node-local-variable
+                                 ast:node-global-variable)))
+              (ast:node-rands node))))
 
 (defun application-rands-have-no-abstractions-p (node)
   (every (lambda (rand)
@@ -553,7 +556,8 @@
        (let* ((binding (first (ast:node-let-bindings node)))
               (bound-value (cdr binding))
               (call (ast:node-let-subexpr node)))
-         (is (typep bound-value 'ast:node-variable))
+         (is (typep bound-value '(or ast:node-local-variable
+                                     ast:node-global-variable)))
          (is (not (typep bound-value 'ast:node-abstraction)))
          (is (typep call '(or ast:node-application ast:node-direct-application))))))))
 
@@ -575,7 +579,8 @@
               (call (ast:node-let-subexpr node)))
          (is (not (typep bound-value 'ast:node-abstraction)))
          (is (or (wrapped-nullary-function-wrapper-p bound-value)
-                 (and (typep bound-value 'ast:node-variable)
+                 (and (typep bound-value '(or ast:node-local-variable
+                                              ast:node-global-variable))
                       (direct-variable-rand-call-to-p
                        call
                        'coalton-native-tests::constrained-keyword-nullary-pointfree-target))))
@@ -639,7 +644,7 @@
     (traverse:traverse
      (ast:node-let-subexpr let-node)
      (list
-      (traverse:action (:after ast:node-variable node)
+      (traverse:action (:after ast:node-local-variable node)
         (let ((expected-type
                 (gethash (ast:node-variable-value node) binding-types)))
           (when (and expected-type
@@ -647,6 +652,18 @@
             (incf mismatch-count)))
         (values))))
     mismatch-count))
+
+(deftest let-binding-type-mismatch-detection-test ()
+  (let* ((name (gensym "BOUND-VALUE"))
+         (node (ast:make-node-let
+                :type tc:*boolean-type*
+                :bindings (list (cons name (ast:make-node-literal
+                                            :type tc:*integer-type*
+                                            :value 1)))
+                :subexpr (ast:make-node-local-variable
+                          :type tc:*boolean-type*
+                          :value name))))
+    (is (= 1 (count-let-binding-type-mismatches node)))))
 
 (defun count-let-binding-type-mismatches-in-node (node)
   "Count mismatched let-bound variable uses in all LETs under NODE."

--- a/tests/inliner-tests.ct
+++ b/tests/inliner-tests.ct
@@ -494,7 +494,10 @@
 (defun direct-variable-rand-call-to-p (node name)
   (and (typep node '(or ast:node-application ast:node-direct-application))
        (eq (ast:node-rator-name node) name)
-       (every #'ast:node-variable-p (ast:node-rands node))))
+       (every (lambda (rand)
+                (typep rand '(or ast:node-local-variable
+                                 ast:node-global-variable)))
+              (ast:node-rands node))))
 
 (defun application-rands-have-no-abstractions-p (node)
   (every (lambda (rand)
@@ -553,7 +556,8 @@
        (let* ((binding (first (ast:node-let-bindings node)))
               (bound-value (cdr binding))
               (call (ast:node-let-subexpr node)))
-         (is (typep bound-value 'ast:node-variable))
+         (is (typep bound-value '(or ast:node-local-variable
+                                     ast:node-global-variable)))
          (is (not (typep bound-value 'ast:node-abstraction)))
          (is (typep call '(or ast:node-application ast:node-direct-application))))))))
 
@@ -575,7 +579,8 @@
               (call (ast:node-let-subexpr node)))
          (is (not (typep bound-value 'ast:node-abstraction)))
          (is (or (wrapped-nullary-function-wrapper-p bound-value)
-                 (and (typep bound-value 'ast:node-variable)
+                 (and (typep bound-value '(or ast:node-local-variable
+                                              ast:node-global-variable))
                       (direct-variable-rand-call-to-p
                        call
                        'coalton-native-tests::constrained-keyword-nullary-pointfree-target))))

--- a/tests/lawnmower-tests.ct
+++ b/tests/lawnmower-tests.ct
@@ -38,17 +38,17 @@
             :bindings
             (list
              (cons alias
-                   (ast:make-node-variable
+                   (ast:make-node-local-variable
                     :type ty
                     :value target)))
             :subexpr
-            (ast:make-node-variable
+            (ast:make-node-local-variable
              :type ty
              :value alias))))
     (multiple-value-bind (new-node changedp)
         (coalton-impl/codegen/lawnmower:lawnmow node)
       (is changedp)
-      (is (typep new-node 'ast:node-variable))
+      (is (typep new-node 'ast:node-local-variable))
       (is (eq target (ast:node-variable-value new-node))))))
 
 (deftest lawnmower-collapses-let-alias-chain ()
@@ -68,11 +68,11 @@
                     :type ty
                     :value 1))
              (cons alias-1
-                   (ast:make-node-variable
+                   (ast:make-node-local-variable
                     :type ty
                     :value value-name))
              (cons alias-2
-                   (ast:make-node-variable
+                   (ast:make-node-local-variable
                     :type ty
                     :value alias-1)))
             :subexpr
@@ -80,12 +80,12 @@
              :type ty
              :properties nil
              :rator
-             (ast:make-node-variable
+             (ast:make-node-local-variable
               :type fn-ty
               :value function-name)
              :rands
              (list
-              (ast:make-node-variable
+              (ast:make-node-local-variable
                :type ty
                :value alias-2))))))
     (multiple-value-bind (new-node changedp)
@@ -99,7 +99,7 @@
               (first
                (ast:node-application-rands
                 (ast:node-let-subexpr new-node)))))
-        (is (typep rand 'ast:node-variable))
+        (is (typep rand 'ast:node-local-variable))
         (is (eq value-name (ast:node-variable-value rand)))))))
 
 (deftest lawnmower-collapses-bind-alias ()
@@ -113,7 +113,7 @@
             :type ty
             :name alias
             :expr
-            (ast:make-node-variable
+            (ast:make-node-local-variable
              :type ty
              :value target)
             :body
@@ -121,12 +121,12 @@
              :type ty
              :properties nil
              :rator
-             (ast:make-node-variable
+             (ast:make-node-local-variable
               :type fn-ty
               :value function-name)
              :rands
              (list
-              (ast:make-node-variable
+              (ast:make-node-local-variable
                :type ty
                :value alias))))))
     (multiple-value-bind (new-node changed?)
@@ -134,7 +134,7 @@
       (is changed?)
       (is (typep new-node 'ast:node-application))
       (let ((rand (first (ast:node-application-rands new-node))))
-        (is (typep rand 'ast:node-variable))
+        (is (typep rand 'ast:node-local-variable))
         (is (eq target (ast:node-variable-value rand)))))))
 
 (deftest lawnmower-sinks-application-through-let-rator ()
@@ -145,7 +145,7 @@
            (ast:make-node-abstraction
             :type fn-ty
             :vars nil
-            :subexpr (ast:make-node-variable
+            :subexpr (ast:make-node-local-variable
                       :type ty
                       :value alias)))
          (node
@@ -194,12 +194,12 @@
                      :type ty
                      :value 1)))
              :subexpr
-             (ast:make-node-variable
+             (ast:make-node-local-variable
               :type fn-ty
               :value target))
             :rands
             (list
-             (ast:make-node-variable
+             (ast:make-node-local-variable
               :type ty
               :value alias)))))
     (multiple-value-bind (new-node changedp)
@@ -221,7 +221,7 @@
             :rator
             (ast:make-node-match
              :type fn-ty
-             :expr (ast:make-node-variable
+             :expr (ast:make-node-local-variable
                     :type ty
                     :value target)
              :branches
@@ -233,7 +233,7 @@
                 :name constructor
                 :patterns nil)
                :body
-               (ast:make-node-variable
+               (ast:make-node-local-variable
                 :type fn-ty
                 :value function-name))))
             :rands nil)))
@@ -262,7 +262,7 @@
                     :type ty
                     :value 1)))
             :subexpr
-            (ast:make-node-variable
+            (ast:make-node-local-variable
              :type ty
              :value name))))
     (multiple-value-bind (new-node changed?)
@@ -289,7 +289,7 @@
              (ast:make-match-branch
               :pattern (lawnmower-constructor-pattern constructor field)
               :body
-              (ast:make-node-variable
+              (ast:make-node-local-variable
                :type ty
                :value field))))))
     (multiple-value-bind (new-node changed?)
@@ -333,7 +333,7 @@
                :type ty
                :properties nil
                :rator
-               (ast:make-node-variable
+               (ast:make-node-local-variable
                 :type fn-ty
                 :value field)
                :rands nil))))))
@@ -363,7 +363,7 @@
              :subexpr
              (lawnmower-constructor-node
               constructor
-              (ast:make-node-variable
+              (ast:make-node-local-variable
                :type ty
                :value inner)))
             :branches
@@ -371,7 +371,7 @@
              (ast:make-match-branch
               :pattern (lawnmower-constructor-pattern constructor field)
               :body
-              (ast:make-node-variable
+              (ast:make-node-local-variable
                :type ty
                :value field))))))
     (multiple-value-bind (new-node changed?)
@@ -408,7 +408,7 @@
              (ast:make-match-branch
               :pattern (lawnmower-constructor-pattern constructor field)
               :body
-              (ast:make-node-variable
+              (ast:make-node-local-variable
                :type ty
                :value captured))))))
     (multiple-value-bind (new-node changed?)
@@ -442,7 +442,7 @@
                :type fn-ty
                :vars nil
                :subexpr
-               (ast:make-node-variable
+               (ast:make-node-local-variable
                 :type ty
                 :value captured))
               ty))
@@ -494,7 +494,7 @@
              :type ty
              :properties nil
              :rator
-             (ast:make-node-variable
+             (ast:make-node-local-variable
               :type fn-ty
               :value function-name)
              :rands nil))))
@@ -503,3 +503,164 @@
       (is changed?)
       (is (typep new-node 'ast:node-literal))
       (is (= 1 (ast:node-literal-value new-node))))))
+
+(deftest codegen-variable-kinds-are-manifest ()
+  (let* ((ty tc:*integer-type*)
+         (name 'coalton-native-tests::*lawnmower-dynamic*)
+         (local (ast:make-node-local-variable :type ty :value name))
+         (global (ast:make-node-global-variable :type ty :value name))
+         (dynamic (ast:make-node-dynamic-variable :type ty :value name)))
+    (is (typep local 'ast:node-variable))
+    (is (typep global 'ast:node-variable))
+    (is (typep dynamic 'ast:node-variable))
+    (is (ast:node-local-variable-p local))
+    (is (ast:node-global-variable-p global))
+    (is (ast:node-dynamic-variable-p dynamic))))
+
+(deftest translation-makes-dynamic-and-local-references-manifest ()
+  (let ((dynamic-count 0)
+        (local-count 0))
+    (traverse:traverse
+     (coalton:lookup-code 'coalton-native-tests::dynamic-runtime-call)
+     (list
+      (traverse:action (:after ast:node-dynamic-variable node)
+        (declare (ignore node))
+        (incf dynamic-count)
+        (values))
+      (traverse:action (:after ast:node-local-variable node)
+        (declare (ignore node))
+        (incf local-count)
+        (values))))
+    (is (= 1 dynamic-count))
+    (is (= 1 local-count))))
+
+(deftest node-dynamic-variables-finds-composite-reads ()
+  (let* ((ty tc:*integer-type*)
+         (fn-ty (tc:make-function-type* (list ty ty) ty))
+         (dynamic-name 'coalton-native-tests::*lawnmower-dynamic*)
+         (node
+           (ast:make-node-application
+            :type ty
+            :properties nil
+            :rator (ast:make-node-global-variable
+                    :type fn-ty
+                    :value 'coalton-native-tests::lawnmower-function)
+            :rands
+            (list
+             (ast:make-node-dynamic-variable
+              :type ty
+              :value dynamic-name)
+             (ast:make-node-application
+              :type ty
+              :properties nil
+              :rator (ast:make-node-global-variable
+                      :type fn-ty
+                      :value 'coalton-native-tests::lawnmower-function)
+              :rands
+              (list
+               (ast:make-node-local-variable
+                :type ty
+                :value 'coalton-native-tests::lawnmower-local)
+               (ast:make-node-dynamic-variable
+                :type ty
+                :value dynamic-name)))))))
+    (is (equal (list dynamic-name)
+               (coalton-impl/codegen/transformations:node-dynamic-variables node)))))
+
+(deftest binding-traversal-tracks-dynamic-rebindings ()
+  (let* ((ty tc:*integer-type*)
+         (dynamic-name 'coalton-native-tests::*lawnmower-dynamic*)
+         (seen-bound-variables nil)
+         (node
+           (ast:make-node-dynamic-let
+            :type ty
+            :bindings
+            (list
+             (ast:make-node-dynamic-binding
+              :name dynamic-name
+              :value (ast:make-node-literal :type ty :value 20)))
+            :subexpr
+            (ast:make-node-dynamic-variable
+             :type ty
+             :value dynamic-name))))
+    (traverse:traverse-with-binding-list
+     node
+     (list
+      (traverse:action (:after ast:node-dynamic-variable node bound-variables)
+        (declare (ignore node))
+        (setf seen-bound-variables bound-variables)
+        (values))))
+    (is (member dynamic-name seen-bound-variables :test #'eq))))
+
+(deftest lawnmower-does-not-alias-dynamic-variables ()
+  (let* ((ty tc:*integer-type*)
+         (alias 'coalton-native-tests::lawnmower-alias)
+         (dynamic-name 'coalton-native-tests::*lawnmower-dynamic*)
+         (node
+           (ast:make-node-bind
+            :type ty
+            :name alias
+            :expr (ast:make-node-dynamic-variable
+                   :type ty
+                   :value dynamic-name)
+            :body
+            (ast:make-node-dynamic-let
+             :type ty
+             :bindings
+             (list
+              (ast:make-node-dynamic-binding
+               :name dynamic-name
+               :value (ast:make-node-literal :type ty :value 20)))
+             :subexpr
+             (ast:make-node-local-variable
+              :type ty
+              :value alias)))))
+    (multiple-value-bind (new-node changed?)
+        (lawnmow-fixed-point node)
+      (declare (ignore changed?))
+      (is (typep new-node 'ast:node-bind))
+      (is (ast:node-dynamic-variable-p (ast:node-bind-expr new-node))))))
+
+(deftest lawnmower-materializes-composite-dynamic-pattern-fields ()
+  (let* ((ty tc:*integer-type*)
+         (fn-ty (tc:make-function-type* (list ty ty) ty))
+         (constructor 'coalton-native-tests::lawnmower-constructor)
+         (field 'coalton-native-tests::lawnmower-field)
+         (dynamic-name 'coalton-native-tests::*lawnmower-dynamic*)
+         (field-value
+           (ast:make-node-application
+            :type ty
+            :properties nil
+            :rator (ast:make-node-global-variable
+                    :type fn-ty
+                    :value 'coalton-native-tests::lawnmower-function)
+            :rands
+            (list
+             (ast:make-node-dynamic-variable :type ty :value dynamic-name)
+             (ast:make-node-literal :type ty :value 0))))
+         (node
+           (ast:make-node-match
+            :type ty
+            :expr (lawnmower-constructor-node constructor field-value)
+            :branches
+            (list
+             (ast:make-match-branch
+              :pattern (lawnmower-constructor-pattern constructor field)
+              :body
+              (ast:make-node-dynamic-let
+               :type ty
+               :bindings
+               (list
+                (ast:make-node-dynamic-binding
+                 :name dynamic-name
+                 :value (ast:make-node-literal :type ty :value 20)))
+               :subexpr
+               (ast:make-node-local-variable :type ty :value field)))))))
+    (multiple-value-bind (new-node changed?)
+        (lawnmow-fixed-point node)
+      (is changed?)
+      (is (typep new-node 'ast:node-bind))
+      (is (equal (list dynamic-name)
+                 (coalton-impl/codegen/transformations:node-dynamic-variables
+                  (ast:node-bind-expr new-node))))
+      (is (typep (ast:node-bind-body new-node) 'ast:node-dynamic-let)))))

--- a/tests/overlap-tests.lisp
+++ b/tests/overlap-tests.lisp
@@ -203,10 +203,10 @@
     (let* ((env entry:*global-environment*)
            (dict-ty (coalton-impl/codegen/resolve-instance:pred-type
                      (tc:make-ty-predicate :class (intern "PICK") :types (list tc:*integer-type*)) env))
-           (dict (ast:make-node-variable :type dict-ty :value (gensym "PASSED-DICT")))
+           (dict (ast:make-node-local-variable :type dict-ty :value (gensym "PASSED-DICT")))
            (call (ast:make-node-application
                   :type tc:*integer-type* :properties nil
-                  :rator (ast:make-node-variable
+                  :rator (ast:make-node-global-variable
                           :value (intern "FORWARD")
                           :type (tc:make-function-type* (list dict-ty tc:*integer-type*) tc:*integer-type*))
                   :rands (list dict (ast:make-node-literal :type tc:*integer-type* :value 42))))
@@ -252,11 +252,12 @@
            (sub (first (tc:lookup-class-instances env (intern "SUB"))))
            (dict (ast:make-node-application
                   :type sub-ty :properties nil
-                  :rator (ast:make-node-variable
+                  :rator (ast:make-node-global-variable
                           :type (tc:make-function-type pick-ty sub-ty)
                           :value (tc:ty-class-instance-codegen-sym sub))
-                  :rands (list (ast:make-node-variable :type pick-ty
-                                                      :value (tc:ty-class-instance-codegen-sym general)))))
+                  :rands (list (ast:make-node-global-variable
+                                :type pick-ty
+                                :value (tc:ty-class-instance-codegen-sym general)))))
            (projection (ast:make-node-field
                         :type pick-ty :dict dict
                         :name (caar (tc:ty-class-superclass-map (tc:lookup-class env (intern "SUB"))))))

--- a/tests/runtime-tests.ct
+++ b/tests/runtime-tests.ct
@@ -586,6 +586,9 @@
   (declare *dynamic-runtime-fn* (Integer -> Integer))
   (define *dynamic-runtime-fn* (fn (x) x))
 
+  (declare *dynamic-runtime-captured* Integer)
+  (define *dynamic-runtime-captured* 10)
+
   (define (dynamic-runtime-increment)
     (dynamic-bind ((*dynamic-runtime-counter* (+ *dynamic-runtime-counter* 1)))
       *dynamic-runtime-counter*))
@@ -604,7 +607,18 @@
 
   (define (dynamic-runtime-call n)
     (dynamic-bind ((*dynamic-runtime-fn* (fn (x) (+ x 1))))
-      (*dynamic-runtime-fn* n))))
+      (*dynamic-runtime-fn* n)))
+
+  (define (dynamic-runtime-capture)
+    (let captured = *dynamic-runtime-captured*)
+    (dynamic-bind ((*dynamic-runtime-captured* (* 2 captured)))
+      (Tuple *dynamic-runtime-captured* captured)))
+
+  (define (dynamic-runtime-match-capture)
+    (match *dynamic-runtime-captured*
+      (captured
+       (dynamic-bind ((*dynamic-runtime-captured* (* 2 captured)))
+         (Tuple *dynamic-runtime-captured* captured))))))
 
 (define-test test-dynamic-variables-runtime ()
   (is (== 2 (dynamic-runtime-increment)))
@@ -612,7 +626,9 @@
   (is (== 2 (dynamic-runtime-short-let)))
   (is (== 1 (dynamic-runtime-counter)))
   (is (== (Tuple 20 10) (dynamic-runtime-swap)))
-  (is (== 6 (dynamic-runtime-call 5))))
+  (is (== 6 (dynamic-runtime-call 5)))
+  (is (== (Tuple 20 10) (dynamic-runtime-capture)))
+  (is (== (Tuple 20 10) (dynamic-runtime-match-capture))))
 
 (cl:defpackage #:tail-call-elimination-tests
   (:use #:coalton #:coalton-prelude)

--- a/tests/runtime-tests.ct
+++ b/tests/runtime-tests.ct
@@ -589,6 +589,9 @@
   (declare *dynamic-runtime-captured* Integer)
   (define *dynamic-runtime-captured* 10)
 
+  (declare dynamic-runtime-captured-fn (Integer -> Integer))
+  (define dynamic-runtime-captured-fn *dynamic-runtime-fn*)
+
   (define (dynamic-runtime-increment)
     (dynamic-bind ((*dynamic-runtime-counter* (+ *dynamic-runtime-counter* 1)))
       *dynamic-runtime-counter*))
@@ -618,7 +621,24 @@
     (match *dynamic-runtime-captured*
       (captured
        (dynamic-bind ((*dynamic-runtime-captured* (* 2 captured)))
-         (Tuple *dynamic-runtime-captured* captured))))))
+         (Tuple *dynamic-runtime-captured* captured)))))
+
+  (define (dynamic-runtime-pointfree-capture)
+    (dynamic-bind ((*dynamic-runtime-fn* (fn (x) (+ x 1))))
+      (dynamic-runtime-captured-fn 5)))
+
+  (define (dynamic-runtime-composite-match-capture)
+    (match (Tuple (+ *dynamic-runtime-captured* 0) Unit)
+      ((Tuple captured _)
+       (dynamic-bind ((*dynamic-runtime-captured* 20))
+         captured))))
+
+  (define (dynamic-runtime-composite-closure-capture)
+    (match (Tuple (+ *dynamic-runtime-captured* 0) Unit)
+      ((Tuple captured _)
+       (let get-captured = (fn () captured))
+       (dynamic-bind ((*dynamic-runtime-captured* 20))
+         (get-captured))))))
 
 (define-test test-dynamic-variables-runtime ()
   (is (== 2 (dynamic-runtime-increment)))
@@ -628,7 +648,10 @@
   (is (== (Tuple 20 10) (dynamic-runtime-swap)))
   (is (== 6 (dynamic-runtime-call 5)))
   (is (== (Tuple 20 10) (dynamic-runtime-capture)))
-  (is (== (Tuple 20 10) (dynamic-runtime-match-capture))))
+  (is (== (Tuple 20 10) (dynamic-runtime-match-capture)))
+  (is (== 5 (dynamic-runtime-pointfree-capture)))
+  (is (== 10 (dynamic-runtime-composite-match-capture)))
+  (is (== 10 (dynamic-runtime-composite-closure-capture))))
 
 (cl:defpackage #:tail-call-elimination-tests
   (:use #:coalton #:coalton-prelude)

--- a/tests/test-files/parse-dynamic.txt
+++ b/tests/test-files/parse-dynamic.txt
@@ -109,3 +109,37 @@ error: Invalid pattern
    |
  5 |      (*x* *x*)))
    |       ^^^ pattern variables cannot use dynamic-variable earmuffs
+
+================================================================================
+104 Dynamic variable definitions cannot be declared inline
+================================================================================
+
+(package test-package)
+
+(inline)
+(define *x* 1)
+
+--------------------------------------------------------------------------------
+
+error: Invalid target for inline attribute
+  --> test:3:0
+   |
+ 3 |  (inline)
+   |  ^^^^^^^^ dynamic variables cannot be declared inline
+
+================================================================================
+105 Dynamic variable declarations cannot be declared inline
+================================================================================
+
+(package test-package)
+
+(inline)
+(declare *x* Integer)
+
+--------------------------------------------------------------------------------
+
+error: Invalid target for inline attribute
+  --> test:3:0
+   |
+ 3 |  (inline)
+   |  ^^^^^^^^ dynamic variables cannot be declared inline


### PR DESCRIPTION
Fix #2037 by preventing the lawnmower optimizer from treating dynamic-variable reads as stable aliases. This preserves captured values across dynamic-bind scopes for let, internal bindings, and pattern bindings.