### PR TITLE
Define IntoIterator instance for FileStream

### DIFF
--- a/library/file.ct
+++ b/library/file.ct
@@ -543,7 +543,16 @@ Automatically returns the lisp condition if one is thrown."
     (define (read fs)
       (read-char fs))
     (define (write fs data)
-      (write-char fs data))))
+      (write-char fs data)))
+
+  (define-instance (iter:IntoIterator (FileStream Char) Char)
+    (define (iter:into-iter file)
+      (iter:new
+       (fn ()
+         (match (read file)
+           ((Ok char) (Some char))
+           ((Err (EOF)) None)
+           ((Err the-error) (error the-error))))))))
 
 ;;;
 ;;; File instances for supported Integer/Byte types
@@ -559,7 +568,15 @@ Automatically returns the lisp condition if one is thrown."
               (define (read fs)
                 (%read-byte fs))
               (define (write fs data)
-                (%write-byte fs data))))))
+                (%write-byte fs data)))
+            (define-instance (iter:IntoIterator (FileStream ,type) ,type)
+              (define (iter:into-iter file)
+                (iter:new
+                 (fn ()
+                   (match (read file)
+                     ((Ok data) (Some data))
+                     ((Err (EOF)) None)
+                     ((Err the-error) (error the-error))))))))))
 
 (coalton-toplevel
   (define-file-type IFix)


### PR DESCRIPTION
I've been working on [coalton-utf-8](https://git.sr.ht/~dieggsy/coalton-utf-8) and thought it would be useful to have an iterator instance on FileStream. That way the rich iterator library or anything else that works on iterators can be used on files.

I'm not sure if signalling an error is the "right thing" here, but in any case I felt an iterator on the direct data was more useful than one on Result.

Side question: any plans to support general non-file streams (in the CL sense, e.g. string stream, concatenated stream, broadcast stream)?