### PR TITLE
Remove the `make` macro; convert library/list.ct to bracket syntax

### DIFF
--- a/docs/intro-to-coalton.ja.md
+++ b/docs/intro-to-coalton.ja.md
@@ -156,7 +156,7 @@ Coalton パッケージ（`#:coalton-user` を含む）は、`#:common-lisp`/`#:
   (define x (addTwo 3))
 
   ;; 無名関数はfnで定義できます
-  (define z (map (fn (x) (+ 2 x)) (make-list 1 2 3 4))))
+  (define z (map (fn (x) (+ 2 x)) [1 2 3 4])))
 ```
 
 ### 関数とカリー化
@@ -195,8 +195,8 @@ Coaltonでは、この機能を最適化して、可能な限りクロージャ�
 
 ```lisp
 (coalton-toplevel
-  ;; リストはmake-listマクロで作れます
-  (define nums (make-list 2 3 4 5)))
+  ;; リストは角括弧構文で作れます
+  (define nums [2 3 4 5]))
 
 (coalton
   ;; Coaltonでは関数はカリー化されます
@@ -397,7 +397,7 @@ COALTON-USER> (describe-type-alias 'Pair)
 フィールドアクセサは値として関数に渡すこともできます:
 
 ```
-(coalton (map .x (make-list (Point 1 2) (Point 2 3))))
+(coalton (map .x [(Point 1 2) (Point 2 3)]))
 ```
 
 構造体にも型パラメータをつけられます：
@@ -753,19 +753,19 @@ COALTON/MATH/REAL> (coalton (the F32 (fromfrac 999/1000)))
 
 ## リスト
 
-Coaltonは内部でLispのリストを使用しています。リストは`make-list`で作成できます。
+Coaltonは内部でLispのリストを使用しています。リストは角括弧構文で作成できます。
 
 ```lisp
 (coalton-toplevel
-  (define x (make-list 1 2 3))
-  (define y (make-list "a" "b" "c")))
+  (define x [1 2 3])
+  (define y ["a" "b" "c"]))
 ```
 
 リストのすべての要素の型は同じでなければいけません。つまり、以下のコードは型エラーを引き起こします。
 
 ```
 COALTON-USER> (coalton-toplevel
-                (define wut (make-list 1.0d0 2.0d0 3.0)))
+                (define wut [1.0d0 2.0d0 3.0]))
 ; error: Type mismatch
 ;   --> repl input:3:4
 ;    |
@@ -1194,7 +1194,7 @@ Coaltonには、Haskellの `do` 表現と類似した動作をする`do`マク�
       (pure c)))
 
     ;; [6+3, 5+3, 4+3, 6+2, 5+2, 4+2, 6+1, 5+1, 4+1]
-   (define xs (f (make-list 1 2 3) (make-list 4 5 6))))
+   (define xs (f [1 2 3] [4 5 6])))
 ```
 
 ## インライン型アノテーション

--- a/docs/intro-to-coalton.ru.md
+++ b/docs/intro-to-coalton.ru.md
@@ -152,7 +152,7 @@ Coalton использует стандартные пакеты Common Lisp (и
   (define x (addTwo 3))
 
   ;; Анонимные функции могут быть определены с помощью fn
-  (define z (map (fn (x) (+ 2 x)) (make-list 1 2 3 4))))
+  (define z (map (fn (x) (+ 2 x)) [1 2 3 4])))
 ```
 
 
@@ -192,8 +192,8 @@ Coalton работает над оптимизацией этих функций
 
 ```lisp
 (coalton-toplevel
-  ;; Списки могут быть созданы с помощью макроса make-list
-  (define nums (make-list 2 3 4 5)))
+  ;; Списки могут быть созданы с помощью синтаксиса скобок
+  (define nums [2 3 4 5]))
 
 (coalton
   ;; Функции в Coalton каррированы
@@ -394,7 +394,7 @@ COALTON-USER> (describe-type-alias 'Pair)
 Доступ к полям структуры может быть передан по значению:
 
 ```lisp
-(coalton (map .x (make-list (Point 1 2) (Point 2 3))))
+(coalton (map .x [(Point 1 2) (Point 2 3)]))
 ```
 
 Структуры также могут быть параметрическими:
@@ -756,12 +756,12 @@ COALTON/MATH/REAL> (coalton (the F32 (fromfrac 999/1000)))
 
 ## Списки
 
-Coalton использует списки Lisp "под капотом". Списки можно создавать с помощью `make-list`.
+Coalton использует списки Lisp "под капотом". Списки можно создавать с помощью синтаксиса скобок.
 
 ```lisp
 (coalton-toplevel
-  (define x (make-list 1 2 3))
-  (define y (make-list "a" "b" "c")))
+  (define x [1 2 3])
+  (define y ["a" "b" "c"]))
 ```
 
 
@@ -769,7 +769,7 @@ Coalton использует списки Lisp "под капотом". Спис
 
 ```
 COALTON-USER> (coalton-toplevel
-                (define wut (make-list 1.0d0 2.0d0 3.0)))
+                (define wut [1.0d0 2.0d0 3.0]))
 ; error: Type mismatch
 ;   --> repl input:3:4
 ;    |
@@ -1204,7 +1204,7 @@ Coalton поддерживает классы типов.
       (pure c)))
 
     ;; [6+3, 5+3, 4+3, 6+2, 5+2, 4+2, 6+1, 5+1, 4+1]
-   (define xs (f (make-list 1 2 3) (make-list 4 5 6))))
+   (define xs (f [1 2 3] [4 5 6])))
 ```
 
 ## Встраивание аннотации типов

--- a/docs/intro-to-coalton.ua.md
+++ b/docs/intro-to-coalton.ua.md
@@ -152,7 +152,7 @@ Coalton використовує стандартні пакети Common Lisp (
   (define x (addTwo 3))
 
   ;; Анонімні функції можна визначити за допомогою fn
-  (define z (map (fn (x) (+ 2 x)) (make-list 1 2 3 4))))
+  (define z (map (fn (x) (+ 2 x)) [1 2 3 4])))
 ```
 
 
@@ -192,8 +192,8 @@ Coalton працює над оптимізацією цих функцій, що
 
 ```lisp
 (coalton-toplevel
-  ;; Списки можна створювати за допомогою макросу make-list
-  (define nums (make-list 2 3 4 5)))
+  ;; Списки можна створювати за допомогою синтаксису дужок
+  (define nums [2 3 4 5]))
 
 (coalton
   ;; Функції в Coalton є каррованими
@@ -393,7 +393,7 @@ COALTON-USER> (describe-type-alias 'Pair)
 Доступ до полів структури може бути переданий за значенням:
 
 ```lisp
-(coalton (map .x (make-list (Point 1 2) (Point 2 3))))
+(coalton (map .x [(Point 1 2) (Point 2 3)]))
 ```
 
 Структури також можуть бути параметричними:
@@ -754,12 +754,12 @@ COALTON/MATH/REAL> (coalton (the F32 (fromfrac 999/1000)))
 
 ## Списки
 
-Coalton використовує списки Lisp "під капотом". Списки можна створювати за допомогою `make-list`.
+Coalton використовує списки Lisp "під капотом". Списки можна створювати за допомогою синтаксису дужок.
 
 ```lisp
 (coalton-toplevel
-  (define x (make-list 1 2 3))
-  (define y (make-list "a" "b" "c")))
+  (define x [1 2 3])
+  (define y ["a" "b" "c"]))
 ```
 
 
@@ -767,7 +767,7 @@ Coalton використовує списки Lisp "під капотом". Сп
 
 ```
 COALTON-USER> (coalton-toplevel
-                (define wut (make-list 1.0d0 2.0d0 3.0)))
+                (define wut [1.0d0 2.0d0 3.0]))
 ; error: Type mismatch
 ;   --> repl input:3:4
 ;    |
@@ -1202,7 +1202,7 @@ Coalton підтримує класи типів.
       (pure c)))
 
     ;; [6+3, 5+3, 4+3, 6+2, 5+2, 4+2, 6+1, 5+1, 4+1]
-   (define xs (f (make-list 1 2 3) (make-list 4 5 6))))
+   (define xs (f [1 2 3] [4 5 6])))
 ```
 
 ## Вбудовування анотації типів

--- a/docs/iterator-protocol.md
+++ b/docs/iterator-protocol.md
@@ -22,7 +22,7 @@ Any type that implements `IntoIterator` can be converted into an iterator with `
 
 ```lisp
 (coalton-toplevel
-  (define list-iter (iter:into-iter (make-list 1 2 3)))
+  (define list-iter (iter:into-iter [1 2 3]))
   (define vec-iter  (iter:into-iter (vec:make 10 20 30)))
   (define str-iter  (iter:into-iter "hello")))
 ```
@@ -105,11 +105,11 @@ Iterators are consumed by calling `next!` repeatedly. Most users will not call `
 
 ```lisp
 ;; Find the first even number
-(iter:find! even? (iter:into-iter (make-list 1 3 4 5)))
+(iter:find! even? (iter:into-iter [1 3 4 5]))
 ;; => (Some 4)
 
 ;; Find the index of an element
-(iter:index-of! (== 3) (iter:into-iter (make-list 1 2 3 4)))
+(iter:index-of! (== 3) (iter:into-iter [1 2 3 4]))
 ;; => (Some 2)
 ```
 
@@ -119,8 +119,8 @@ Iterators are consumed by calling `next!` repeatedly. Most users will not call `
 (iter:count!  (iter:up-to 10))               ;; => 10
 (iter:every!  positive? (iter:up-to 10))      ;; => False (0 is not positive)
 (iter:any!    even? (iter:up-to 10))          ;; => True
-(iter:max!    (iter:into-iter (make-list 3 1 4 1 5)))  ;; => (Some 5)
-(iter:min!    (iter:into-iter (make-list 3 1 4 1 5)))  ;; => (Some 1)
+(iter:max!    (iter:into-iter [3 1 4 1 5]))  ;; => (Some 5)
+(iter:min!    (iter:into-iter [3 1 4 1 5]))  ;; => (Some 1)
 ```
 
 ## Transforming Iterators
@@ -163,7 +163,7 @@ Transformations create new iterators that lazily apply operations as elements ar
 ;; Zip two iterators into pairs
 (iter:collect!
   (iter:zip! (iter:up-to 3)
-             (iter:into-iter (make-list "a" "b" "c"))))
+             (iter:into-iter ["a" "b" "c"])))
 ;; => ((Tuple 0 "a") (Tuple 1 "b") (Tuple 2 "c"))
 
 ;; Zip with a custom combiner
@@ -182,13 +182,13 @@ Transformations create new iterators that lazily apply operations as elements ar
 ;; Flatten nested iterators
 (iter:collect!
   (iter:flatten! (map (fn (x) (iter:up-to x))
-                      (iter:into-iter (make-list 1 2 3)))))
+                      (iter:into-iter [1 2 3]))))
 ;; => (0 0 1 0 1 2)
 
 ;; Flat-map (map then flatten)
 (iter:collect!
   (iter:flat-map! (fn (x) (iter:repeat-for 2 x))
-                  (iter:into-iter (make-list 1 2 3))))
+                  (iter:into-iter [1 2 3])))
 ;; => (1 1 2 2 3 3)
 ```
 

--- a/docs/manual/site/topics/lisp-interop.md
+++ b/docs/manual/site/topics/lisp-interop.md
@@ -137,7 +137,7 @@ For example, we could represent the class of plane traveler like so:
 These will be compiled into symbols:
 
 ```
-COALTON-USER> (coalton (make-list Economy Business First))
+COALTON-USER> (coalton [Economy Business First])
 (TRAVELERCLASS/ECONOMY TRAVELERCLASS/BUSINESS TRAVELERCLASS/FIRST)
 COALTON-USER> cl::(mapcar #'type-of *)
 (COMMON-LISP:SYMBOL COMMON-LISP:SYMBOL COMMON-LISP:SYMBOL)

--- a/docs/manual/site/topics/whirlwind-tour.md
+++ b/docs/manual/site/topics/whirlwind-tour.md
@@ -208,10 +208,10 @@ Functions are defined similarly to variables. Unlike Common Lisp, Coalton functi
   (define x (addTwo 3))
 
   ;; Anonymous functions can be defined with fn
-  (define z (map (fn (x) (+ 2 x)) (make-list 1 2 3 4)))
+  (define z (map (fn (x) (+ 2 x)) [1 2 3 4]))
 
   ;; ƒ is short fn syntax
-  (define z-short (map ƒx.(+ 2 x) (make-list 1 2 3 4))))
+  (define z-short (map ƒx.(+ 2 x) [1 2 3 4])))
 ```
 
 ### Top-Level Type Declarations
@@ -270,8 +270,8 @@ Here is an example of using an explicitly constructed function to transform a li
 
 ```lisp
 (coalton-toplevel
-  ;; Lists can be created with the make-list macro
-  (define nums (make-list 2 3 4 5))
+  ;; Lists can be created with bracket syntax
+  (define nums [2 3 4 5])
 
   (define add2
     (fn (x)
@@ -545,7 +545,7 @@ Field accessors can be used to read individual fields:
 Field accessors can be passed by value:
 
 ```lisp
-(coalton (map .x (make-list (Point 1 2) (Point 2 3))))
+(coalton (map .x [(Point 1 2) (Point 2 3)]))
 ```
 
 Structs can also be parametric:
@@ -1047,12 +1047,12 @@ COALTON/MATH/REAL> (coalton (the F32 (fromfrac 999/1000)))
 
 ## Lists
 
-Coalton uses Lisp lists under the hood. Lists can be constructed with `make-list`.
+Coalton uses Lisp lists under the hood. Lists can be constructed with bracket syntax.
 
 ```lisp
 (coalton-toplevel
-  (define x (make-list 1 2 3))
-  (define y (make-list "a" "b" "c")))
+  (define x [1 2 3])
+  (define y ["a" "b" "c"]))
 ```
 
 
@@ -1060,7 +1060,7 @@ Lists must be homogeneous. This means the following produces a type error.
 
 ```
 COALTON-USER> (coalton-toplevel
-                (define wut (make-list 1.0d0 2.0d0 3.0)))
+                (define wut [1.0d0 2.0d0 3.0]))
 ; error: Type mismatch
 ;   --> repl input:3:4
 ;    |
@@ -1863,7 +1863,7 @@ Coalton has a `do` macro that works similarly to do notation in Haskell.
       (pure c)))
 
     ;; [6+3, 5+3, 4+3, 6+2, 5+2, 4+2, 6+1, 5+1, 4+1]
-   (define xs (f (make-list 1 2 3) (make-list 4 5 6))))
+   (define xs (f [1 2 3] [4 5 6])))
 ```
 
 ## Inline Type Annotations

--- a/library/list.ct
+++ b/library/list.ct
@@ -75,8 +75,7 @@
    #:split-around
    #:perms
    #:combs
-   #:combsOf
-   #:make))
+   #:combsOf))
 
 (in-package #:coalton/list)
 
@@ -536,7 +535,7 @@
     "Returns a new list by inserting `e` between every element of `xs`."
     (match xs
       ((Nil)       Nil)
-      ((Cons x xs) (Cons x (concatMap (fn (y) (make-list e y)) xs)))))
+      ((Cons x xs) (Cons x (concatMap (fn (y) [e y]) xs)))))
 
   (declare intercalate ((List :a) * (List (List :a)) -> (List :a)))
   (define (intercalate xs xss)
@@ -547,11 +546,11 @@
   (define (insertions a l)
     "Produce a list of copies of `l`, each with A inserted at a possible position.
 
-    (insertions 0 (make-list 1 2))
+    (insertions 0 [1 2])
     ;; => ((0 1 2) (1 0 2) (1 2 0))
 "
     (match l
-      ((Nil)       (make-list (make-list a)))
+      ((Nil)       [[a]])
       ((Cons x ls) (Cons (Cons a l)
                          (map (fn (ys) (Cons x ys))
                               (insertions a ls))))))
@@ -665,7 +664,7 @@
     "Produce all permutations of the list L."
     (foldr (fn (x acc)
              (concatMap (fn (ys) (insertions x ys)) acc))
-           (make-list Nil)
+           [Nil]
            l))
 
   (declare combs (List :a -> (List (List :a))))
@@ -675,9 +674,9 @@
 The ordering of elements of `l` is preserved in the ordering of elements in each list produced by this function."
     (match l
       ((Nil)
-       (make-list Nil))
+       [Nil])
       ((Cons x xs)
-       (concatMap (fn (y) (make-list y (Cons x y))) (combs xs)))))
+       (concatMap (fn (y) [y (Cons x y)]) (combs xs)))))
 
   (declare combsOf (UFix * List :a -> (List (List :a))))
   (define (combsOf n l)
@@ -687,7 +686,7 @@ The ordering of elements of `l` is preserved in the ordering of elements in each
 
 This function is equivalent to all size-`n` elements of `(combs l)`."
 
-    (cond ((== 0 n) (make-list Nil))
+    (cond ((== 0 n) [Nil])
           ((== 1 n) (map singleton l))
           (True (match l
                   ((Nil) Nil)
@@ -854,10 +853,6 @@ This function is equivalent to all size-`n` elements of `(combs l)`."
 
   (define-instance (Default (List :a))
     (define (default) Nil)))
-
-(define-expression-macro make (cl:&rest elements)
-  "Make a homogeneous list of `elements`. Synonym for `coalton:make-list`."
-  `(coalton:make-list ,@elements))
 
 #+sb-package-locks
 (sb-ext:lock-package "COALTON/LIST")

--- a/src/language-macros.lisp
+++ b/src/language-macros.lisp
@@ -135,7 +135,7 @@ the value. The composition is thus the reverse order of `compose`.
 
 (define-expression-macro make-list (cl:&rest forms)
   "Create a heterogeneous Coalton `List` of objects. This macro is
-deprecated; use `coalton/list:make`."
+deprecated; use `[]` syntax instead."
   (cl:labels
       ((list-helper (forms)
          (cl:if (cl:endp forms)


### PR DESCRIPTION
## Summary

Partial progress on #1846 ("remove `make-list` and `make` macros when they can be replaced with `[]` and `[=>]` syntax").

- Removes the `make` macro from `library/list.ct` (a trivial synonym for `make-list`, unused anywhere else) and its export.
- Converts `library/list.ct`'s own `make-list` call sites to `[]` bracket syntax (7 call sites + one docstring example).
- Updates the whirlwind tour, translated intro docs (ru/ja/ua), the iterator protocol doc, and the lisp-interop doc to stop teaching `make-list` where `[]` now reads more idiomatically.
- Updates `make-list`'s own deprecation docstring to point at `[]` syntax instead of the now-removed `make`.

`make-list` itself is intentionally left in place. I audited the full tree and `make-list` is actually used in ~400 call sites across `library/`, `tests/`, `docs/`, and the example sub-projects that share this build (`examples/thih`, `examples/quil-coalton`, `mine/`). Removing the macro outright requires converting all of those first or the build breaks. That's a much larger, separately-reviewable mechanical change, so I've kept this PR focused on the parts of the issue I could land safely and modularly. Happy to follow up with the full removal in a subsequent PR if that's the direction you'd like — let me know.

## Test plan

- [x] `(ql:quickload :coalton/tests)` and `(asdf:test-system :coalton/tests)` — full suite passes with no failures (includes `quil-coalton`, `thih-coalton`, and all `coalton/tests` cases).
- [x] Manually verified `library/list.ct`'s changed functions (`insertions`, `permutations`, `combs`, `combsOf`) still compile and behave identically — the bracket forms are structurally identical expansions of the removed `make-list` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)