### PR TITLE
docs: fix collection builder semantics

### DIFF
--- a/docs/manual/site/operators/collection-builder.md
+++ b/docs/manual/site/operators/collection-builder.md
@@ -25,10 +25,10 @@ comprehensions.
   collection-like types.
 - `[]` is an empty collection builder.
 - Collection builders and comprehensions must be finite.
-- Keys must all have the same type, and values must all have the same type.
-- Without a more specific expected type, association builders default to `Seq :t`.
+- Elements must all have the same type.
+- Without a more specific expected type, collection builders default to `Seq :t`.
 - Collection builders, especially empty ones, often need [`the`](/manual/operators/the/)
-  to fix the intended key and value types.
+  to fix the intended element type.
 
 ## Options
 
@@ -36,7 +36,8 @@ comprehensions.
 - `:for ⟨var⟩ :in ⟨iter⟩` iterates over an iterator.
 - `:with ⟨var⟩ = ⟨expr⟩` introduces a lexical binding for the remaining clauses.
 - `:when ⟨expr⟩` guards emitted entries.
-- New types can opt-in to this syntax by defining instance of `FromItemizedCollection` and `FromCollectionComprehension`.
+- New types can opt in to this syntax by defining instances of
+  `FromItemizedCollection` and `FromCollectionComprehension`.
 
 ## Example
 


### PR DESCRIPTION
Fixes #2041

Replaces association-builder wording on the collection-builder manual page with the correct homogeneous element, default sequence, element type, and trait-instance descriptions.

This is a documentation-only change; the final page was checked for remaining association, key, and value terminology.
