### PR TITLE
Fix READ-END-OF-FILE when compiling .ct files with multibyte content on SBCL

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -326,6 +326,7 @@
                (:file "inliner-tests-1") ; must come after inliner-tests
                (:ct-file "deriver-tests")
                (:ct-file "file-tests")
+               (:ct-file "multibyte-tests")
                (:ct-file "experimental-tests")
                (:file "exceptions")
                (:module "monad"

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -77,7 +77,7 @@
     (position-spec (stream char-position-stream))
   (file-position (inner-stream stream) 0)
   (dotimes (i position-spec)
-    (read-char (inner-stream stream)))
+    (read-char (inner-stream stream) nil nil))
   (setf (character-position stream) position-spec))
 
 ;;; Docstrings

--- a/tests/multibyte-tests.ct
+++ b/tests/multibyte-tests.ct
@@ -1,0 +1,26 @@
+(cl:in-package #:coalton-native-tests)
+
+;;; Regression test: compiling a .ct file containing multibyte characters
+;;; on SBCL used to signal READ-END-OF-FILE on the last toplevel form.
+;;;
+;;; On SBCL, file-position on character streams returns byte offsets, so
+;;; the deferred reader records source spans in bytes, but span
+;;; verification seeks treating them as character offsets. A form whose
+;;; byte offset exceeds the file's character count then seeks past EOF.
+;;;
+;;; The block of multibyte comments below is what triggers the bug: it
+;;; must contain more multibyte characters than the last toplevel form
+;;; has characters. Keep it intact.
+
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+;;; 中文注释：多字节内容使文件字节偏移超过字符偏移，从而触发上述路径。
+
+(coalton-toplevel
+  (define (multibyte-answer)
+    42))


### PR DESCRIPTION
### Summary

Compiling a `.ct` file containing multibyte characters (e.g. CJK comments) on SBCL signals `READ-END-OF-FILE` on the last toplevel form:

```
COMMON-LISP:READ error during COMMON-LISP:COMPILE-FILE:
  end of file on #<SB-SYS:FD-STREAM for "file .../repro.ct">
```

### Root cause

On SBCL, `file-position` on a character stream returns **byte** offsets. The deferred reader records source spans in bytes, but span verification (`source-span-matches-mode-p`) seeks treating them as **character** offsets; when a form's byte offset exceeds the file's character count, the seek runs past EOF and `read-char` (default `eof-error-p` T) signals.

### Fix

`src/source.lisp`, `(setf trivial-gray-streams:stream-file-position)`: seek with `eof-error-p` NIL so running past EOF is a no-op and the existing byte→char fallback recovers the correct span.

```diff
-    (read-char (inner-stream stream)))
+    (read-char (inner-stream stream) nil nil))
```

### Test

`tests/multibyte-tests.ct` reproduces the crash without the fix (verified on SBCL 2.4.9) and compiles cleanly with it. Note: keep `stream-read-char`'s `:eof` sentinel — SBCL's gray-stream contract requires it.
