### PR TITLE
Hide instances involving unexported types in documentation

### DIFF
--- a/src/doc/environment.lisp
+++ b/src/doc/environment.lisp
@@ -41,10 +41,19 @@
   (tc:lookup-value-type entry:*global-environment*
                         (tc:name-entry-name name-entry)))
 
+(defun instance-types-exported-p (instance)
+  "T if every type constructor in INSTANCE's head is exported."
+  (every (lambda (name)
+           (let ((package (symbol-package name)))
+             (and package (exported-symbol-p name package))))
+         (tc:type-constructors
+          (tc:ty-predicate-types (tc:ty-class-instance-predicate instance)))))
+
 (defun class-instances (ty-class)
-  (tc:lookup-class-instances entry:*global-environment*
-                             (tc:ty-class-name ty-class)
-                             :no-error t))
+  (remove-if-not #'instance-types-exported-p
+                 (tc:lookup-class-instances entry:*global-environment*
+                                            (tc:ty-class-name ty-class)
+                                            :no-error t)))
 
 (defun struct-entry-p (type-entry)
   (let ((name (tc:type-entry-name type-entry)))
@@ -103,14 +112,15 @@ If non-nil, restrict to names defined in PACKAGE."
 
 (defun find-instances (&key (environment entry:*global-environment*)
                             (package nil))
-  "Return all instances in ENVIRONMENT.
+  "Return instances in ENVIRONMENT whose head types are exported.
 
 By default the global environment is queried.
 If non-nil, restrict to instances defined in PACKAGE."
   (remove-if (lambda (class-instance)
-               (and package
-                    (not (exported-symbol-p (tc:ty-predicate-class
-                                             (tc:ty-class-instance-predicate class-instance))
-                                            package t))))
+               (or (not (instance-types-exported-p class-instance))
+                   (and package
+                        (not (exported-symbol-p (tc:ty-predicate-class
+                                                 (tc:ty-class-instance-predicate class-instance))
+                                                package t)))))
              (%lm-values (tc:instance-environment-instances
                           (tc:environment-instance-environment environment)))))

--- a/tests/doc-tests.lisp
+++ b/tests/doc-tests.lisp
@@ -62,3 +62,88 @@
     (is (string=
          "<a href=\"#coalton-list-type\">List</a> (<a href=\"#coalton-seq-seq-type\">Seq</a> <a href=\"#coalton-integer-type\">Integer</a>) &rarr; <a href=\"#coalton-classes-tuple-type\">Tuple</a> <a href=\"#coalton-boolean-type\">Boolean</a> <a href=\"#coalton-string-type\">String</a>"
          nested-markdown-render))))
+
+(deftest test-doc-private-parser-instances ()
+  (let* ((class (tc:lookup-class entry:*global-environment* 'coalton/classes:Alternative))
+         (instances (coalton/doc/environment:class-instances class))
+         (coalton/doc/base:*local* (namestring (asdf:system-source-directory "coalton"))))
+    ;; The compiler must retain the internal instances used by FORMAT.
+    (is (some (lambda (instance)
+                (member 'coalton/format::Parser
+                        (tc:type-constructors (tc:ty-predicate-types
+                                               (tc:ty-class-instance-predicate instance)))))
+              (tc:lookup-class-instances entry:*global-environment* 'coalton/classes:Alternative)))
+    (is (not (some (lambda (instance)
+                     (member 'coalton/format::Parser
+                             (tc:type-constructors (tc:ty-predicate-types
+                                                    (tc:ty-class-instance-predicate instance)))))
+                   instances)))
+    (is (some (lambda (instance)
+                (member 'coalton:Optional
+                        (tc:type-constructors (tc:ty-predicate-types
+                                               (tc:ty-class-instance-predicate instance)))))
+              instances))
+    (dolist (backend '(:markdown :html :hugo))
+      (let ((output
+              (with-output-to-string (stream)
+                (coalton/doc/base:write-packages
+                 (coalton/doc/base:make-backend backend stream)
+                 (list (coalton/doc/model::make-coalton-package
+                        (find-package "COALTON/CLASSES")))))))
+        (is (not (search "Parser" output)))
+        (is (search "Optional" output))))))
+
+(deftest test-doc-instance-type-visibility ()
+  (let ((*package* (make-package "COALTON-DOC-INSTANCE-TEST-PACKAGE"
+                                :use '("COALTON" "COALTON-PRELUDE"))))
+    (unwind-protect
+         (let ((source
+                 (source:make-source-string
+                  "(define-type Public Public)
+                   (define-type Private Private)
+                   (define-class (DocClass :a))
+                   (define-class (DocMultiClass :a :b))
+                   (define-instance (DocClass Public))
+                   (define-instance (DocClass Private))
+                   (define-instance (DocClass (List Public)))
+                   (define-instance (DocClass (List Private)))
+                   (define-instance (DocClass (Optional :a)))
+                   (define-instance (DocMultiClass Public Private))
+                   (define-instance (DocMultiClass Private Public))
+                   (define-instance (DocMultiClass Public Public))")))
+           (with-open-stream (stream (source:source-stream source))
+             (let ((program (parser:with-reader-context stream
+                              (parser:read-program stream source))))
+               (multiple-value-bind (program env) (entry:entry-point program)
+                 (declare (ignore program))
+                 (export (mapcar (lambda (name) (find-symbol name *package*))
+                                 '("PUBLIC" "DOCCLASS" "DOCMULTICLASS")))
+                 (let* ((entry:*global-environment* env)
+                        (objects (coalton/doc/model:find-objects :package *package*))
+                        (class (find "DocClass" objects :test #'string=
+                                                       :key #'coalton/doc/model:object-name))
+                        (multi-class (find "DocMultiClass" objects :test #'string=
+                                                                  :key #'coalton/doc/model:object-name))
+                        (public-type (find "Public" objects :test #'string=
+                                                           :key #'coalton/doc/model:object-name))
+                        (private (find-symbol "PRIVATE" *package*)))
+                   (flet ((instance-names (object)
+                            (mapcar #'coalton/doc/model:object-name
+                                    (coalton/doc/model:sort-objects
+                                     (coalton/doc/model:object-instances object)))))
+                     (is (equal '("DocClass (List Public)"
+                                  "DocClass (Optional :A)"
+                                  "DocClass Public")
+                                (instance-names class)))
+                     (is (equal '("DocMultiClass Public Public")
+                                (instance-names multi-class)))
+                     ;; Type documentation must use the same visibility rules.
+                     (is (member "DocClass Public" (instance-names public-type) :test #'string=))
+                     (is (member "DocMultiClass Public Public" (instance-names public-type) :test #'string=)))
+                   (is (not (some (lambda (instance)
+                                    (member private
+                                            (tc:type-constructors
+                                             (tc:ty-predicate-types
+                                              (tc:ty-class-instance-predicate instance)))))
+                                  (coalton/doc/model:object-instances public-type)))))))))
+      (delete-package *package*))))


### PR DESCRIPTION
Filter class and type instance lists using the exported status of every referenced type constructor. Cover private, nested, and multi-parameter types while preserving public polymorphic instances.

Fixes #2047