### PR TITLE
Fix reader error spans to use character offsets

### DIFF
--- a/src/parser/reader.lisp
+++ b/src/parser/reader.lisp
@@ -640,6 +640,11 @@ Returns (VALUES FORM PRESENTP EOFP)"
             (read-char stream)
             (return (values nil nil nil)))
 
+          ;; PEEK-CHAR above skipped leading whitespace, so the next form
+          ;; starts here. Reporting the offset from before the skip would
+          ;; start the span on the previous line.
+          (setf begin (file-position stream))
+
           ;; Otherwise, try to read in the next form
           (multiple-value-call
               (lambda (form type &optional parse-result)
@@ -661,12 +666,15 @@ Returns (VALUES FORM PRESENTP EOFP)"
              stream
              nil 'eof)))
       (eclector.reader:unterminated-list ()
-        (let ((end (file-position stream)))
+        (let ((span (source:stream-span-to-char-span
+                     stream source (cons begin (file-position stream)))))
           (parse-error "Unterminated form"
-                       (source:note (source:make-location source (cons begin end))
-                                    "Missing close parenthesis for form starting at offset ~a" begin))))
+                       (source:note (source:make-location source span)
+                                    "Missing close parenthesis for form starting at offset ~a"
+                                    (source:span-start span)))))
       (error (condition)
-        (let ((end (file-position stream)))
+        (let ((span (source:stream-span-to-char-span
+                     stream source (cons begin (file-position stream)))))
           (parse-error "Reader error"
-                       (source:note (source:make-location source (cons begin end))
+                       (source:note (source:make-location source span)
                                     "reader error: ~a" condition)))))))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -132,30 +132,6 @@ SOURCE provides metadata for the stream argument, for error messages."
         (t
          (read-lisp stream source first-form))))))
 
-(defun utf-8-char-width (char)
-  "Return the number of UTF-8 octets required to encode CHAR."
-  (let ((code (char-code char)))
-    (cond
-      ((<= code #x7F) 1)
-      ((<= code #x7FF) 2)
-      ((<= code #xFFFF) 3)
-      (t 4))))
-
-(defun file-byte-offset-to-char-offset (file byte-offset)
-  "Convert BYTE-OFFSET in FILE to the corresponding character offset."
-  (with-open-file (stream file
-                          :direction ':input
-                          :element-type 'character
-                          :external-format (source:source-external-format))
-    (loop :with bytes := 0
-          :with chars := 0
-          :while (< bytes byte-offset)
-          :for char := (read-char stream nil nil)
-          :while char
-          :do (incf bytes (utf-8-char-width char))
-              (incf chars)
-          :finally (return chars))))
-
 (defun source-span-matches-mode-p (source mode span)
   "Return true when SPAN in SOURCE starts with MODE."
   (declare (type deferred-coalton-mode mode))
@@ -178,8 +154,8 @@ SOURCE provides metadata for the stream argument, for error messages."
             span
             (let* ((file (source::input-name source))
                    (normalized-span
-                     (cons (file-byte-offset-to-char-offset file start)
-                           (file-byte-offset-to-char-offset file end))))
+                     (cons (source:file-byte-offset-to-char-offset file start)
+                           (source:file-byte-offset-to-char-offset file end))))
               (if (source-span-matches-mode-p source mode normalized-span)
                   normalized-span
                   (util:coalton-bug "Unable to recover source span for ~S in ~A"

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -19,6 +19,7 @@
    #:make-location
    #:make-source-error
    #:extract-source-text
+   #:file-byte-offset-to-char-offset
    #:make-source-file
    #:make-source-string
    #:message
@@ -35,6 +36,7 @@
    #:source-external-format
    #:source-stream
    #:source-warning
+   #:stream-span-to-char-span
    #:deprecation-warn
    #:span
    #:span-end
@@ -79,6 +81,48 @@
   (dotimes (i position-spec)
     (read-char (inner-stream stream) nil nil))
   (setf (character-position stream) position-spec))
+
+(defun utf-8-char-width (char)
+  "Return the number of UTF-8 octets required to encode CHAR."
+  (let ((code (char-code char)))
+    (cond
+      ((<= code #x7F) 1)
+      ((<= code #x7FF) 2)
+      ((<= code #xFFFF) 3)
+      (t 4))))
+
+(defun file-byte-offset-to-char-offset (file byte-offset)
+  "Convert BYTE-OFFSET in FILE to the corresponding character offset.
+
+FILE-POSITION reports byte offsets on the streams COMPILE-FILE reads source
+from, while the offsets stored in a location's span are character offsets.
+This converts between the two."
+  (with-open-file (stream file
+                          :direction ':input
+                          :element-type 'character
+                          :external-format (source-external-format))
+    (loop :with bytes := 0
+          :with chars := 0
+          :while (< bytes byte-offset)
+          :for char := (read-char stream nil nil)
+          :while char
+          :do (incf bytes (utf-8-char-width char))
+              (incf chars)
+          :finally (return chars))))
+
+(defun stream-span-to-char-span (stream source span)
+  "Return SPAN expressed in character offsets.
+
+SPAN holds offsets reported by FILE-POSITION on STREAM. Only a
+CHAR-POSITION-STREAM counts characters; other streams positioned over a
+file-backed SOURCE report bytes, and spans are always character offsets, so
+those offsets must be converted."
+  (if (or (typep stream 'char-position-stream)
+          (not (typep source 'source-file)))
+      span
+      (let ((file (input-name source)))
+        (cons (file-byte-offset-to-char-offset file (car span))
+              (file-byte-offset-to-char-offset file (cdr span))))))
 
 ;;; Docstrings
 

--- a/tests/source-tests.lisp
+++ b/tests/source-tests.lisp
@@ -24,6 +24,46 @@
                    (cdr (nth 71 chars)))
             "Second kanji is at char offset, not byte offset")))))
 
+(deftest test-reader-error-reports-character-offsets ()
+  "A reader error in a file with multibyte characters must report character offsets.
+
+FILE-POSITION on the stream COMPILE-FILE reads source from counts bytes, so the
+offsets have to be converted before they can be used as character offsets."
+  (uiop:with-temporary-file (:stream out :pathname path :type "ct"
+                             :direction :output
+                             :external-format :utf-8)
+    (write-string (format nil ";; ~A~%(declare x Char)~%(define x #\\Delete)~%"
+                          "中文中文中文中文中文中文中文中文中文中文")
+                  out)
+    :close-stream
+    (let* ((text (with-open-file (in path :external-format :utf-8)
+                   (let (chars)
+                     (loop :for char := (read-char in nil nil)
+                           :while char
+                           :do (push char chars))
+                     (coerce (nreverse chars) 'string))))
+           (token "#\\Delete")
+           (token-end (+ (search token text) (length token)))
+           (source (source:make-source-file path))
+           (span nil))
+      (handler-case
+          (with-open-stream (stream (source:source-stream source))
+            (loop :do (multiple-value-bind (form presentp)
+                          (parser:maybe-read-form stream source)
+                        (declare (ignore form))
+                        (unless presentp (return)))))
+        (error (condition)
+          (setf span (source:location-span
+                      (source:location (first (source:notes condition)))))))
+      (is (not (null span)) "Expected reading #\\Delete to signal a reader error")
+      (when span
+        (is (= token-end (cdr span))
+            "Reader error end should be the character offset just past ~A, got ~S"
+            token span)
+        (is (char= #\( (char text (car span)))
+            "Reader error span should begin at the offending form's open paren, got ~S"
+            span)))))
+
 (deftest test-source-stream-preserves-crlf-characters ()
   (flet ((stream-contents (stream)
            (loop :for char := (read-char stream nil nil)

--- a/tests/test-files/parse-expression.txt
+++ b/tests/test-files/parse-expression.txt
@@ -323,13 +323,10 @@ warn: non-exhaustive match
 --------------------------------------------------------------------------------
 
 error: Reader error
-  --> test:1:22
+  --> test:3:0
    |
- 1 |   (package test-package)
-   |  _______________________^
- 2 | | 
- 3 | | (define x [x :for x])
-   | |____________________^ reader error: Malformed collection comprehension: missing :IN or :BELOW after :FOR binder
+ 3 |  (define x [x :for x])
+   |  ^^^^^^^^^^^^^^^^^^^^ reader error: Malformed collection comprehension: missing :IN or :BELOW after :FOR binder
 
 ================================================================================
 107 Malformed collection comprehension
@@ -342,13 +339,10 @@ error: Reader error
 --------------------------------------------------------------------------------
 
 error: Reader error
-  --> test:1:22
+  --> test:3:0
    |
- 1 |   (package test-package)
-   |  _______________________^
- 2 | | 
- 3 | | (define x [x :with y])
-   | |_____________________^ reader error: Malformed collection comprehension: missing = after :WITH binder
+ 3 |  (define x [x :with y])
+   |  ^^^^^^^^^^^^^^^^^^^^^ reader error: Malformed collection comprehension: missing = after :WITH binder
 
 ================================================================================
 108 Parse expression
@@ -372,13 +366,10 @@ error: Reader error
 --------------------------------------------------------------------------------
 
 error: Reader error
-  --> test:1:22
+  --> test:3:0
    |
- 1 |   (package test-package)
-   |  _______________________^
- 2 | | 
- 3 | | (define x [x => x :when])
-   | |________________________^ reader error: Malformed association comprehension: missing :WHEN predicate
+ 3 |  (define x [x => x :when])
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^ reader error: Malformed association comprehension: missing :WHEN predicate
 
 ================================================================================
 110 Parse expression


### PR DESCRIPTION
## Problem

When a source file contains multibyte characters, reader errors are reported
past the offending form. In a 10-line file whose `#\Delete` is on line 10, the
error is reported on line 11 at column 1976:

```
error: Reader error
  --> verify.ct:11:1976
   |
11 |  ...
   |  ^^^^^^^^^^^^^^^^^^^^^ reader error: Unrecognized character name: "Delete"
```

Sources that are pure ASCII are unaffected, which is why this went unnoticed.

## Cause

`FILE-POSITION` returns byte offsets on the stream `COMPILE-FILE` reads source
from, but the offsets stored in a location's span are character offsets:
`CHAR-POSITION-STREAM` counts characters, and the line/column lookup in
`source.lisp` walks the source one character at a time.

Measured on a file whose first line is `;; ` followed by ten CJK characters:
after reading 12 characters, `FILE-POSITION` is `12` on a
`CHAR-POSITION-STREAM` and `30` on the raw stream.

`MAYBE-READ-FORM` built its reader-error and unterminated-form spans straight
from `FILE-POSITION` values, without converting them:

```lisp
(error (condition)
  (let ((end (file-position stream)))
    (parse-error "Reader error"
                 (source:note (source:make-location source (cons begin end)) ...))))
```

`NORMALIZED-SOURCE-SPAN`, in the same file, already converts byte offsets to
character offsets for the deferred path, so the mismatch was known; the reader
error path simply missed it.

## Changes

- **`src/source.lisp`**: move `UTF-8-CHAR-WIDTH` and
  `FILE-BYTE-OFFSET-TO-CHAR-OFFSET` from `COALTON-IMPL/READER` to
  `COALTON-IMPL/SOURCE`, next to `CHAR-POSITION-STREAM`; their bodies are
  unchanged. Add and export `STREAM-SPAN-TO-CHAR-SPAN`, which converts only
  when the stream is not a `CHAR-POSITION-STREAM` and the source is
  file-backed. `COALTON-IMPL/SOURCE` is where these belong because
  `COALTON-IMPL/PARSER` cannot depend on `COALTON-IMPL/READER`.
- **`src/reader.lisp`**: drop the now-duplicate definitions and have
  `NORMALIZED-SOURCE-SPAN` call `source:file-byte-offset-to-char-offset`.
- **`src/parser/reader.lisp`**: use `STREAM-SPAN-TO-CHAR-SPAN` in both
  `MAYBE-READ-FORM` error branches. Also take the span start after `PEEK-CHAR`
  has skipped leading whitespace; it previously sat on the newline that
  terminated the preceding form, so an error was attributed to the previous
  line.
- **`tests/source-tests.lisp`**: add
  `TEST-READER-ERROR-REPORTS-CHARACTER-OFFSETS`, which writes a source file
  containing multibyte characters, forces a reader error, and asserts that the
  span ends immediately past the offending token and begins at the offending
  form's open parenthesis. Before this change the span is `(80 . 99)` where it
  should be `(41 . 59)`.
- **`tests/test-files/parse-expression.txt`**: the three reader-error cases
  move from `test:1:22`, spanning from the previous form, to `test:3:0`. The
  unterminated-form case in `package.txt` starts at offset 0 and is unaffected.

## Result

| | reported position |
| --- | --- |
| before | `11:1976` |
| after | `10:2` |
